### PR TITLE
Change weekly backup schedule from Sunday 3am to Saturday 4am

### DIFF
--- a/docs/20-operations/guides/backup-strategy.md
+++ b/docs/20-operations/guides/backup-strategy.md
@@ -37,12 +37,12 @@ This guide documents the automated BTRFS snapshot and backup strategy, optimized
 
 | Tier | Subvolume | Local Frequency | Local Retention | External Frequency | External Retention |
 |------|-----------|-----------------|-----------------|-------------------|-------------------|
-| 1 | htpc-home | Daily (02:00) | 7 days | Weekly (Sunday 03:00) | 8 weekly + 12 monthly |
-| 1 | subvol3-opptak | Daily (02:00) | 7 days | Weekly (Sunday 03:00) | 8 weekly + 12 monthly |
-| 1 | subvol7-containers | Daily (02:00) | 7 days | Weekly (Sunday 03:00) | 4 weekly + 6 monthly |
-| 2 | subvol1-docs | Daily (02:00) | 7 days | Weekly (Sunday 03:00) | 8 weekly + 6 monthly |
+| 1 | htpc-home | Daily (02:00) | 7 days | Weekly (Saturday 04:00) | 8 weekly + 12 monthly |
+| 1 | subvol3-opptak | Daily (02:00) | 7 days | Weekly (Saturday 04:00) | 8 weekly + 12 monthly |
+| 1 | subvol7-containers | Daily (02:00) | 7 days | Weekly (Saturday 04:00) | 4 weekly + 6 monthly |
+| 2 | subvol1-docs | Daily (02:00) | 7 days | Weekly (Saturday 04:00) | 8 weekly + 6 monthly |
 | 2 | htpc-root | Monthly (1st, 04:00) | 1 month | Monthly | 6 monthly |
-| 3 | subvol2-pics | Weekly (Sunday 02:00) | 4 weeks | Monthly (1st Sunday) | 12 monthly |
+| 3 | subvol2-pics | Weekly (Saturday 02:00) | 4 weeks | Monthly (1st Saturday) | 12 monthly |
 
 ---
 
@@ -122,10 +122,10 @@ TIER2_DOCS_ENABLED=false
 
 ```bash
 # In backup_tier1_home() function (around line 280)
-# Remove the Sunday check:
+# Remove the Saturday check:
 
 # BEFORE:
-if [[ $(date +%u) -eq 7 ]]; then  # Sunday
+if [[ $(date +%u) -eq 6 ]]; then  # Saturday
     check_external_mounted || return 1
     ...
 fi
@@ -140,8 +140,14 @@ check_external_mounted || return 1
 **To decrease frequency (e.g., monthly instead of weekly):**
 
 ```bash
-# Change the day check:
+# Change the day check (e.g., for monthly instead of weekly):
 if [[ $(date +%d) -eq 01 ]]; then  # 1st of month
+    check_external_mounted || return 1
+    ...
+fi
+
+# Or change the day of week (current: Saturday = 6):
+if [[ $(date +%u) -eq 1 ]]; then  # Monday
     check_external_mounted || return 1
     ...
 fi
@@ -189,7 +195,7 @@ backup_tier2_projects() {
     fi
 
     # Send to external (weekly)
-    if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%u) -eq 7 ]]; then
+    if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%u) -eq 6 ]]; then
         check_external_mounted || return 1
 
         local parent=$(get_latest_snapshot "$TIER2_PROJECTS_EXTERNAL_DIR" "*-projects")
@@ -423,7 +429,7 @@ Description=Weekly BTRFS External Backup Timer
 Requires=btrfs-backup-weekly.service
 
 [Timer]
-OnCalendar=Sun 03:00
+OnCalendar=Sat 04:00
 Persistent=true
 
 [Install]

--- a/scripts/btrfs-snapshot-backup.sh
+++ b/scripts/btrfs-snapshot-backup.sh
@@ -21,7 +21,7 @@
 #
 # Schedule (via systemd timers):
 #   - Daily:   02:00 AM - Tier 1 local snapshots + cleanup
-#   - Weekly:  Sunday 03:00 AM - All tiers external backup
+#   - Weekly:  Saturday 04:00 AM - All tiers external backup
 #   - Monthly: 1st of month 04:00 AM - Monthly snapshots + external
 #
 ################################################################################
@@ -315,7 +315,7 @@ backup_tier1_home() {
     # Send to external (weekly)
     if [[ "$LOCAL_ONLY" != "true" ]] && [[ "$TIER1_HOME_SCHEDULE" == "daily" ]]; then
         # Only send on the designated weekly backup day
-        if [[ $(date +%u) -eq 7 ]]; then  # Sunday
+        if [[ $(date +%u) -eq 6 ]]; then  # Saturday
             check_external_mounted || return 1
 
             local parent=$(get_latest_snapshot "$TIER1_HOME_EXTERNAL_DIR" "*-htpc-home")
@@ -349,7 +349,7 @@ backup_tier1_opptak() {
     fi
 
     # Send to external (weekly)
-    if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%u) -eq 7 ]]; then
+    if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%u) -eq 6 ]]; then
         check_external_mounted || return 1
 
         local parent=$(get_latest_snapshot "$TIER1_OPPTAK_EXTERNAL_DIR" "*-opptak")
@@ -382,7 +382,7 @@ backup_tier1_containers() {
     fi
 
     # Send to external (weekly)
-    if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%u) -eq 7 ]]; then
+    if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%u) -eq 6 ]]; then
         check_external_mounted || return 1
 
         local parent=$(get_latest_snapshot "$TIER1_CONTAINERS_EXTERNAL_DIR" "*-containers")
@@ -415,7 +415,7 @@ backup_tier2_docs() {
     fi
 
     # Send to external (weekly)
-    if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%u) -eq 7 ]]; then
+    if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%u) -eq 6 ]]; then
         check_external_mounted || return 1
 
         local parent=$(get_latest_snapshot "$TIER2_DOCS_EXTERNAL_DIR" "*-docs")
@@ -479,8 +479,8 @@ backup_tier3_pics() {
     fi
 
     # Weekly local snapshots
-    if [[ $(date +%u) -ne 7 ]]; then
-        log INFO "subvol2-pics local backup runs on Sundays only, skipping"
+    if [[ $(date +%u) -ne 6 ]]; then
+        log INFO "subvol2-pics local backup runs on Saturdays only, skipping"
         return 0
     fi
 


### PR DESCRIPTION
- Updated systemd timer: OnCalendar=Sat 04:00
- Updated backup script: all day-of-week checks from 7 (Sunday) to 6 (Saturday)
- Updated documentation to reflect new schedule
- Sequential execution already confirmed (no changes needed)

Affected files:
- scripts/btrfs-snapshot-backup.sh (header + 5 day checks)
- docs/20-operations/guides/backup-strategy.md (schedule table + examples)
- ~/.config/systemd/user/btrfs-backup-weekly.timer (timer schedule)

Next run: Saturday 2025-11-29 04:00 CET

🤖 Generated with [Claude Code](https://claude.com/claude-code)