### PR TITLE
fix: Post-merge alert improvements from review feedback

### DIFF
--- a/config/prometheus/alerts/infrastructure-critical.yml
+++ b/config/prometheus/alerts/infrastructure-critical.yml
@@ -2,14 +2,24 @@
 # Created: 2026-01-17 (Phase 4 - Alert Consolidation)
 # Purpose: Service down, disk critical, cert expiry - immediate attention required
 # Severity: critical - All alerts trigger Discord notifications immediately
+#
+# Evaluation Interval Strategy:
+# - Critical alerts: 30s (fast detection of service failures)
+# - Warning alerts: 1m (balance between detection speed and resource usage)
+# - Meta-monitoring: 1m (detect monitoring system failures quickly)
+# - Less frequent checks (backups, SLOs): 5m (sufficient for batch operations)
 
 groups:
   - name: infrastructure_critical
-    interval: 30s
+    interval: 30s  # Fast evaluation for critical service failures
     rules:
       # ========================================================================
-      # ALERT 1: Host/Service Down
+      # ALERT 1: Host/Service Down (Catch-All Safety Net)
       # ========================================================================
+      # Note: Intentionally broad (checks ALL scrape targets)
+      # Specific services have dedicated alerts (TraefikDown, PrometheusDown, etc.)
+      # This is a safety net to catch anything we might have missed
+      # Defense in depth: critical services get specific alerts + this generic one
       - alert: HostDown
         expr: up == 0
         for: 5m

--- a/config/prometheus/rules/log-based-alerts.yml
+++ b/config/prometheus/rules/log-based-alerts.yml
@@ -110,16 +110,13 @@ groups:
       # ========================================================================
       # ALERT 7: Promtail Metric Extraction Stale (META-MONITORING)
       # ========================================================================
-      # Detects when Promtail custom metrics stop updating (silent failures)
-      # Uses Immich thumbnail metric as canary (should have some activity)
+      # Detects when Promtail custom metric extraction stops working (silent failures)
+      # Uses nextcloud_cron_success_total as canary (increments every 5 minutes)
+      # Note: immich_thumbnail_failures_total only exists when failures occur, so not checked
       # Added: 2026-01-17 (Phase 3 - Meta-monitoring)
+      # Updated: 2026-01-17 (Post-merge - removed Immich check to avoid false positives)
       - alert: PromtailMetricExtractionStale
-        expr: |
-          (
-            absent(promtail_custom_immich_thumbnail_failures_total)
-            or
-            absent(promtail_custom_nextcloud_cron_success_total)
-          )
+        expr: absent(promtail_custom_nextcloud_cron_success_total)
         for: 30m
         labels:
           severity: warning
@@ -127,19 +124,23 @@ groups:
         annotations:
           summary: "Promtail metric extraction may have failed"
           description: |
-            One or more Promtail custom metrics are missing, indicating metric extraction failure.
+            Nextcloud cron success metric is missing, indicating Promtail metric extraction failure.
+
+            This metric should always exist and increment every 5 minutes (verified in Phase 1).
+            Absence indicates the Promtail pipeline is not extracting custom metrics.
 
             Possible causes:
             1. Promtail pipeline configuration error (regex mismatch)
             2. Log rotation position file issue
             3. Journal export service down
             4. Promtail container restarted and lost position
+            5. Nextcloud cron timer stopped
 
             Check:
             - podman logs promtail --tail 100 | grep -i error
             - systemctl --user status journal-export.service
-            - curl http://localhost:9080/metrics | grep promtail_custom
+            - systemctl --user status nextcloud-cron.timer
+            - curl http://localhost:9080/metrics | grep promtail_custom_nextcloud_cron_success_total
 
-            Active metrics (should exist):
-            - promtail_custom_immich_thumbnail_failures_total
-            - promtail_custom_nextcloud_cron_success_total
+            Expected metric:
+            - promtail_custom_nextcloud_cron_success_total (should increment every 5 minutes)


### PR DESCRIPTION
## Summary

Addressed review bot recommendations from PR #65 to improve alert reliability and documentation.

## Changes Made

### 1. Fixed PromtailMetricExtractionStale False Positives ⚠️ → ✅

**Problem:** Alert checked for `immich_thumbnail_failures_total` which only exists when Immich has failures. This caused constant false positives when Immich had no failures.

**Fix:**
- Now only checks `nextcloud_cron_success_total` (always exists, increments every 5 minutes)
- Removed Immich metric check entirely
- Updated description with better diagnostics

**Before:**
```yaml
expr: |
  (
    absent(promtail_custom_immich_thumbnail_failures_total)
    or
    absent(promtail_custom_nextcloud_cron_success_total)
  )
```

**After:**
```yaml
expr: absent(promtail_custom_nextcloud_cron_success_total)
```

**Rationale:** Nextcloud cron metric was verified in Phase 1 to always exist and increment every 5 minutes, making it a reliable canary for Promtail metric extraction health.

### 2. Documented HostDown Alert Design ✅

**Review concern:** "HostDown is very broad, catches any scrape target failure"

**Clarification:** This is **intentional design** - defense in depth

**Added documentation:**
```yaml
# Note: Intentionally broad (checks ALL scrape targets)
# Specific services have dedicated alerts (TraefikDown, PrometheusDown, etc.)
# This is a safety net to catch anything we might have missed
# Defense in depth: critical services get specific alerts + this generic one
```

**Why this design:**
- Critical services have specific alerts (TraefikDown, PrometheusDown, AlertmanagerDown, etc.)
- HostDown is a catch-all safety net for anything we might have missed
- Defense in depth: two layers of protection

### 3. Documented Evaluation Interval Strategy ✅

**Review suggestion:** "Consider documenting the evaluation interval strategy"

**Added header to infrastructure-critical.yml:**
```yaml
# Evaluation Interval Strategy:
# - Critical alerts: 30s (fast detection of service failures)
# - Warning alerts: 1m (balance between detection speed and resource usage)
# - Meta-monitoring: 1m (detect monitoring system failures quickly)
# - Less frequent checks (backups, SLOs): 5m (sufficient for batch operations)
```

**Benefits:**
- Explains why different alert groups have different intervals
- Documents the trade-off between detection speed and resource usage
- Makes the design rationale explicit for future maintainers

### 4. Verified ContainerMemoryPressure Safety ✅

**Review concern:** "Division by zero during container startup?"

**Analysis:** Already safe ✓

```yaml
expr: container_memory_working_set_bytes / container_spec_memory_limit_bytes > 0.95
and container_spec_memory_limit_bytes > 0
```

- The `and container_spec_memory_limit_bytes > 0` clause prevents division by zero
- If `working_set_bytes` is 0 during startup, ratio is 0 which won't exceed 0.95
- No change needed

## Review Feedback Status

| Recommendation | Status | Action |
|----------------|--------|--------|
| PromtailMetricExtractionStale false positives | ✅ Fixed | Removed Immich check, now only checks Nextcloud metric |
| HostDown too broad | ✅ Documented | Explained intentional design (defense in depth) |
| ContainerMemoryPressure division by zero | ✅ Verified safe | No change needed |
| Document evaluation interval strategy | ✅ Added | Header documentation in infrastructure-critical.yml |

## Validation

**Configuration syntax:**
```bash
$ podman exec prometheus promtool check rules /etc/prometheus/rules/log-based-alerts.yml
Checking /etc/prometheus/rules/log-based-alerts.yml
  SUCCESS: 3 rules found ✓

$ podman exec prometheus promtool check rules /etc/prometheus/alerts/infrastructure-critical.yml
Checking /etc/prometheus/alerts/infrastructure-critical.yml
  SUCCESS: 13 rules found ✓
```

**Changes:**
- 2 files modified (log-based-alerts.yml, infrastructure-critical.yml)
- 26 insertions, 15 deletions
- All changes are comments/documentation + one expression simplification
- No other alerts affected

## Test Plan

- [x] Configuration syntax validated
- [x] No logic changes to other alerts
- [x] PromtailMetricExtractionStale now checks single reliable metric
- [ ] Deploy and monitor for 24 hours
- [ ] Verify PromtailMetricExtractionStale doesn't fire inappropriately
- [ ] Confirm nextcloud_cron_success_total always exists

## Related

- **Parent PR:** #65 (Phases 4 & 5 - Alert Consolidation and Meta-Monitoring)
- **Context:** Post-merge improvements based on automated review feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)