### PR TITLE
fix: Recalibrate SwapThrashing alert for zram swap

### DIFF
--- a/config/prometheus/alerts/infrastructure-warnings.yml
+++ b/config/prometheus/alerts/infrastructure-warnings.yml
@@ -137,17 +137,51 @@ groups:
       # ========================================================================
       # ALERT 7: Swap Thrashing
       # ========================================================================
-      # Detects performance degradation from swap I/O (zram swap can be near-full normally)
+      # Calibrated for zram (compressed in-memory swap):
+      # - Baseline zram activity: ~230 pages/sec (normal)
+      # - Alert threshold: 1000 pages/sec (indicates actual problem)
+      # - Hysteresis: Fire at 1000, resolve at 600 (prevents flapping)
+      # - Requires system impact: High load OR memory pressure to confirm degradation
+      #
+      # Note: zram swap I/O is CPU-bound compression, NOT disk I/O.
+      # High page rates without load impact are normal zram behavior.
       - alert: SwapThrashing
-        expr: rate(node_vmstat_pswpin[5m]) > 300 or rate(node_vmstat_pswpout[5m]) > 300
+        expr: |
+          (
+            (
+              rate(node_vmstat_pswpin[5m]) > 1000 or rate(node_vmstat_pswpout[5m]) > 1000
+            )
+            and
+            (
+              node_load5 / count(node_cpu_seconds_total{mode="idle"}) > 0.7
+              or
+              node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes < 0.15
+            )
+            and
+            ALERTS{alertname="SwapThrashing"} != 1
+          )
+          or
+          (
+            (
+              rate(node_vmstat_pswpin[5m]) > 600 or rate(node_vmstat_pswpout[5m]) > 600
+            )
+            and
+            (
+              node_load5 / count(node_cpu_seconds_total{mode="idle"}) > 0.5
+              or
+              node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes < 0.20
+            )
+            and
+            ALERTS{alertname="SwapThrashing"} == 1
+          )
         for: 10m
         labels:
           severity: warning
           category: performance
           component: system
         annotations:
-          summary: "System is swap thrashing"
-          description: "High swap I/O detected ({{ $value | humanize }} pages/sec). Performance degradation likely. Consider adding RAM or reducing container memory usage."
+          summary: "System is swap thrashing with performance impact"
+          description: "Swap I/O is {{ $value | humanize }} pages/sec with elevated system load. This indicates memory pressure causing actual performance degradation. Check for memory-hungry processes or abnormal virtual memory allocation (e.g., browser tab explosion)."
 
       # ========================================================================
       # ALERT 8: High System Load

--- a/docs/98-journals/2026-01-23-swap-thrashing-investigation-alert-recalibration.md
+++ b/docs/98-journals/2026-01-23-swap-thrashing-investigation-alert-recalibration.md
@@ -1,0 +1,169 @@
+# Swap Thrashing Investigation & Alert Recalibration
+
+**Date:** 2026-01-23
+**Type:** Investigation + Bug Fix
+**Status:** ✅ ALERT FIXED | ⚠️ ROOT CAUSE UNCLEAR
+
+## Problem Summary
+
+Daily SwapThrashing alerts firing since at least 2026-01-17, despite system showing:
+- 32GB RAM with only 39% usage (12GB used, 18GB available)
+- Swappiness=10 (should avoid swapping)
+- Configured container memory limits
+- No performance degradation observed
+
+Paradox: Plenty of free RAM but persistent swap activity above alert threshold (300 pages/sec).
+
+## Investigation Findings
+
+### Finding 1: Vivaldi Virtual Memory Anomaly
+
+**Observation:**
+```
+Physical RAM:     32GB (30.9GB available to OS)
+RAM usage:        39.4% (12GB used, 18GB available)
+Memory overcommit: +0.8GB (system committed 32.2GB)
+
+Vivaldi VSZ:      14.13 TB across 25 processes
+Jellyfin VSZ:     275 GB
+Claude VSZ:       75 GB
+```
+
+**User behavior:** 1-2 browser tabs, 4 extensions (well-maintained, highly rated)
+
+**Skepticism required:** The 14TB number is **extremely abnormal** for 1-2 tabs. Typical Chromium behavior:
+- 10 tabs: 50-200GB VSZ
+- 50 tabs: 300-600GB VSZ
+- **This case: 1-2 tabs = 14TB VSZ** ← Measurement error? Bug? Needs validation.
+
+**Hypothesis:** Vivaldi's VSZ caused memory overcommit → kernel page table overhead → swap pressure despite "free" RAM.
+
+**Test:** Closed Vivaldi at 14:02. Result: 1h40m with zero new alerts.
+
+**Impact:**
+- Memory overcommit resolved immediately (+0.8GB → -9.4GB)
+- Page table overhead reduced (120MB → 93MB)
+- No new alerts fired
+
+### Finding 2: Alert Miscalibration for Zram
+
+**System uses zram (compressed in-memory swap), not disk swap.**
+
+```
+Baseline swap activity: 230 pages/sec (normal)
+Old alert threshold:    300 pages/sec (designed for disk)
+Observed activity:      500-700 pages/sec spikes (no system impact)
+
+System behavior during "thrashing":
+- Load: 0.08 per CPU (idle)
+- CPU wait: 0% (no I/O blocking)
+- Memory available: 64.8%
+- System responsiveness: Normal
+```
+
+**Root cause:** Alert threshold designed for disk swap I/O (expensive, blocks CPU). Zram swap is CPU-bound compression - much higher rates are normal and non-harmful.
+
+**Evidence:** System lifetime average swap rate = 231 pages/sec (chronically near threshold).
+
+## Solution Implemented
+
+**File:** `config/prometheus/alerts/infrastructure-warnings.yml` (lines 137-182)
+
+**Changes:**
+```yaml
+Old: rate(node_vmstat_pswpin[5m]) > 300
+New: rate(node_vmstat_pswpin[5m]) > 1000 (fire) / > 600 (resolve)
+
+Added conditions:
+- High load: >0.7 per CPU, OR
+- Low memory: <15% available
+
+Added hysteresis to prevent flapping
+```
+
+**Rationale:**
+- Threshold increased to account for normal zram baseline
+- Requires actual system impact (load OR memory pressure) to fire
+- Follows existing alert pattern (HighSystemLoad hysteresis)
+
+**Validation:**
+```
+Current system state:
+- Swap: 744 pages/sec
+- Load: 0.08 per CPU
+- RAM: 64.8% available
+
+Old alert: Would fire (false positive)
+New alert: Silent (correct)
+```
+
+## Open Questions & Further Investigation
+
+### 1. Vivaldi 14TB VSZ Anomaly
+
+**The 14TB measurement seems implausible for 1-2 tabs.** Possible explanations:
+- Measurement error (ps VSZ reporting bug?)
+- Flatpak isolation issue (sandboxing artifact?)
+- Site isolation bug (iframes spawning excessive renderers?)
+- Extension bug (one of 4 extensions leaking processes?)
+- Profile corruption (3.2GB profile for 2 tabs is large)
+
+**Recommended validation when restarting Vivaldi:**
+```bash
+# Monitor process count in real-time
+watch -n 2 'ps aux | grep vivaldi | wc -l'
+
+# Check memory maps detail
+cat /proc/$(pgrep vivaldi | head -1)/maps | wc -l
+
+# Test with fresh profile
+flatpak run --command=vivaldi com.vivaldi.Vivaldi --user-data-dir=/tmp/test
+
+# Compare VSZ calculation methods
+ps aux | grep vivaldi  # VSZ column
+pmap $(pgrep vivaldi | head -1) | tail -1  # total mapping
+```
+
+**If 14TB is real:** This represents a serious Vivaldi/Flatpak bug warranting upstream report.
+**If 14TB is measurement error:** Need to identify actual root cause of swap pressure.
+
+### 2. Why Did Closing Vivaldi Stop Alerts?
+
+Two possibilities:
+1. **Vivaldi was the cause** - VSZ overhead triggered kernel pressure (hypothesis)
+2. **Correlation not causation** - Timing coincidence, or simply reducing active processes lowered baseline swap activity below new threshold
+
+**Test:** Restart Vivaldi with monitoring. If alerts return immediately, confirms causal relationship.
+
+### 3. Was Alert Miscalibration the Primary Issue?
+
+**Conservative interpretation:** The old 300 pages/sec threshold may have been appropriate for detecting *abnormal* zram activity. The fact that baseline is 230 pages/sec suggests the system is chronically swap-reliant.
+
+**Alternative hypothesis:** Both issues were real:
+- Vivaldi caused temporary spikes >300 (acute problem)
+- System baseline 230 pages/sec indicates architectural issue (chronic problem)
+
+Closing Vivaldi may have addressed acute spikes while missing chronic swap dependency.
+
+## Lessons Learned
+
+1. **Alert thresholds must match storage technology** - Disk vs zram swap have different performance characteristics
+2. **High virtual memory ≠ high physical memory** - But extreme VSZ (14TB) can still cause kernel pressure
+3. **Multi-condition alerts reduce false positives** - Swap rate alone insufficient, need system impact confirmation
+4. **Skepticism required for extreme measurements** - 14TB VSZ warrants validation before drawing conclusions
+
+## Action Items
+
+- [x] Fix SwapThrashing alert threshold and add impact conditions
+- [ ] Monitor Vivaldi behavior on next startup (process count, VSZ, extensions)
+- [ ] Validate 14TB VSZ measurement with alternative tools
+- [ ] Consider if 230 pages/sec baseline indicates need for architectural changes
+- [ ] Document zram vs disk swap differences in memory-management.md
+
+## References
+
+- Alert rule: `config/prometheus/alerts/infrastructure-warnings.yml:137-182`
+- Investigation started: 2026-01-23 13:43
+- Vivaldi closed: 2026-01-23 14:02
+- Alert fix deployed: 2026-01-23 14:41
+- Last alert before fix: 2026-01-17 (at least, possibly earlier)


### PR DESCRIPTION
## Summary

Fixes daily false-positive SwapThrashing alerts by recalibrating threshold for zram (compressed in-memory swap) instead of disk swap.

**Problem:** Alerts firing since 2026-01-17+ despite:
- 32GB RAM with 60% available (18GB free)
- Swappiness=10 (configured to avoid swapping)
- No observable performance degradation
- System idle (load 0.08 per CPU)

**Root cause:** Alert threshold (300 pages/sec) designed for disk swap. Zram baseline activity is 230 pages/sec, making the alert chronically sensitive to normal compression/decompression activity.

## Changes

### Alert Configuration (`infrastructure-warnings.yml`)

**Threshold adjustment:**
- Old: 300 pages/sec (disk swap threshold)
- New: 1000 pages/sec (fire), 600 pages/sec (resolve)

**Added multi-condition logic:**
```yaml
Requires BOTH:
1. High swap activity (>1000 p/s fire, >600 p/s resolve)
2. System impact:
   - High load: >0.7 per CPU (fire) OR >0.5 (resolve)
   - OR low memory: <15% available (fire) OR <20% (resolve)
```

**Added hysteresis:** Prevents alert flapping (same pattern as HighSystemLoad)

### Investigation Journal

New journal entry documents:
- Systematic debugging process (4 phases)
- Vivaldi virtual memory anomaly (14TB VSZ for 1-2 tabs - needs validation)
- Zram vs disk swap characteristics
- Open questions for further investigation
- Healthy skepticism about measurements

## Investigation Findings

### Finding 1: Vivaldi Virtual Memory Anomaly

```
Vivaldi VSZ: 14.13 TB across 25 processes
User behavior: 1-2 browser tabs, 4 extensions
Memory overcommit: +0.8GB → resolved to -9.4GB after closing

Test: Vivaldi closed at 14:02 → 1h40m zero alerts
```

**Note:** 14TB seems implausible for 1-2 tabs. Typical Chromium: 10 tabs = 50-200GB VSZ. Warrants further investigation when browser restarts.

### Finding 2: Alert Miscalibration (Primary Fix)

```
Zram characteristics:
- Baseline: 230 pages/sec (normal operation)
- Observed: 500-700 pages/sec (no system impact)
- System during "thrashing": Load 0.08, 64% RAM free, 0% wait

Old alert: Fires at 300 p/s (false positive)
New alert: Fires at 1000 p/s + system impact (correct)
```

## Verification

**Alert rule validation:**
```bash
✓ Syntax check: promtool reports "SUCCESS: 8 rules found"
✓ Prometheus reload: Completed 2026-01-23 14:41
✓ Current behavior: 744 p/s activity, no alert (correct)
```

**Test case:**
```
System state:
- Swap I/O: 744 pages/sec
- Load: 0.08 per CPU (idle)
- Memory: 64.8% available

Old alert: Would fire ❌ (false positive)
New alert: Silent ✅ (correct - no performance impact)
```

## Design Rationale

Follows Google SRE alerting principles:
- ✅ Alert on symptoms, not causes (performance impact, not metrics)
- ✅ Multi-condition reduces false positives (swap + load/memory)
- ✅ Hysteresis prevents flapping (1000 fire, 600 resolve)
- ✅ Context-aware (zram vs disk characteristics)
- ✅ Actionable description (investigation guidance)

## Test Plan

- [x] Validate alert syntax with promtool
- [x] Reload Prometheus configuration
- [x] Verify current system state doesn't trigger false alert
- [ ] Monitor for 48 hours - should have zero false positives
- [ ] When Vivaldi restarts - validate if 14TB VSZ reproduces
- [ ] Test alert fires correctly during actual memory pressure

## Open Questions

1. **Vivaldi 14TB VSZ**: Measurement needs validation - is this real or reporting bug?
2. **Baseline 230 p/s**: Does chronic swap activity indicate architectural issue?
3. **Correlation vs causation**: Was Vivaldi the cause or timing coincidence?

See journal for detailed investigation commands and follow-up actions.

## Related

- Journal: `docs/98-journals/2026-01-23-swap-thrashing-investigation-alert-recalibration.md`
- Alert history: Daily alerts since at least 2026-01-17
- Investigation: Systematic debugging methodology (4 phases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)