### PR TITLE
docs: Comprehensive documentation accuracy audit and Feb 2026 baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,99 +1,98 @@
 # Fedora Homelab: Self-Hosted Services with Podman
 
-A learning-focused homelab project documenting the journey of building a production-ready, self-hosted infrastructure using Podman containers managed through systemd quadlets.
+A learning-focused homelab project documenting the journey of building production-ready, self-hosted infrastructure using rootless Podman containers managed through systemd quadlets.
 
-**Latest Milestone:** Complete Disaster Recovery Capability Achieved - Verified external backup restore from WD-18TB drive (81,716 files), confirmed off-site mirror exists. Full protection from hardware failures and location-level disasters. (2026-01-03)
-
-## Systems
+## Infrastructure
 
 | Host | Platform | Role | Storage |
 |------|----------|------|---------|
-| **fedora-htpc** | Fedora Workstation 42 | Services host | BTRFS (SSD + HDD pool) |
-| **fedora-jern** | Fedora Workstation 43 | Control center | Encrypted BTRFS with snapshots |
-| **raspberrypi** | Debian 12 (PiOS) | DNS / Pi-hole | SD card |
-| **MacBook Air** | macOS | Command center | Time Machine backups |
+| Primary server | Fedora Workstation 43 | Container host (28 containers) | BTRFS (SSD + 14.5TB HDD pool) |
+| Control center | Fedora Workstation 43 | Workstation | Encrypted BTRFS |
+| DNS server | Debian 12 (PiOS) | Pi-hole | SD card |
+| Laptop | macOS | Command center | Time Machine |
 
-## Services
-
-### Operational
-- **SSH** - Hardware-secured ssh with YubiKey FIDO2 across all systems
-- **Pi-hole** - DNS and ad-blocking (raspberrypi)
-
-### Configured (fedora-htpc) - all services reachable through *.patriark.org domains registered with hostinger.com and external DNS from Cloudflare.
+## Services (14 groups, 28 containers)
 
 **Core Infrastructure:**
 - **Traefik** - Reverse proxy with Let's Encrypt SSL and layered middleware
-- **Authelia** - SSO server with YubiKey/WebAuthn authentication
+- **Authelia** - SSO with YubiKey/WebAuthn hardware authentication
 - **CrowdSec** - Threat intelligence and IP reputation filtering
 
-**Media & Applications:**
+**Applications:**
+- **Nextcloud** - File sync and collaboration (with Collabora, MariaDB, Redis)
 - **Jellyfin** - Media streaming server
-- **Immich** - Photo and video management
+- **Immich** - Photo and video management (with ML, PostgreSQL, Redis)
+- **Vaultwarden** - Password manager
+- **Gathio** - Event management
+- **Homepage** - Dashboard
+
+**Home Automation:**
+- **Home Assistant** - Smart home hub (with Matter Server)
 
 **Monitoring & Observability:**
-- **Prometheus** - Metrics collection and alerting
-- **Grafana** - Visualization dashboards
-- **Loki** - Log aggregation
+- **Prometheus + Grafana + Loki** - Full observability stack
 - **Alertmanager** - Alert routing to Discord
-- **cAdvisor** - Container metrics exporter
-- **Trivy** - Vulnerability scanning (weekly automated scans)
+- **cAdvisor + Node Exporter + UnPoller** - Metrics exporters
 
-**Intelligence & Automation:**
-- **Autonomous Operations** - OODA loop for self-healing infrastructure
-- **Predictive Analytics** - Resource exhaustion forecasting
-- **Natural Language Queries** - Cached system interrogation
-- **Skill Recommendation** - Context-aware automation suggestions
+**Autonomous Operations:**
+- OODA loop for daily automated assessment and remediation
+- Predictive analytics for resource exhaustion forecasting
+- Natural language system queries
+- Drift detection and health scoring
 
 ## Architecture
 
-- **Container Runtime:** Podman (rootless)
-- **Orchestration:** systemd quadlets with pattern-based deployment
+- **Container Runtime:** Podman (rootless, UID 1000, SELinux enforcing)
+- **Orchestration:** Systemd quadlets with 9 pattern-based deployment templates
 - **Authentication:** Authelia SSO with YubiKey/WebAuthn + TOTP fallback
-- **Security:** Layered middleware (CrowdSec → Rate Limiting → Authelia → Security Headers), vulnerability scanning, compliance framework
-- **Storage:** BTRFS with automated snapshots and incremental backups
-- **Networking:** Segmented Podman networks (reverse_proxy, media_services, auth_services, monitoring, photos)
-- **Intelligence:** Autonomous OODA loop, predictive analytics, natural language query system
-- **Automation:** Daily drift detection, resource forecasting, autonomous remediation with safety controls
+- **Security:** 7-layer defense-in-depth (CrowdSec, rate limiting, MFA, headers, network segmentation, container isolation, firewall)
+- **Networking:** 8 segmented Podman networks for trust boundaries
+- **Storage:** BTRFS with automated daily snapshots and incremental backups
+- **Monitoring:** SLO tracking (9 SLOs), burn-rate alerting, monthly compliance
+- **Automation:** 53 systemd timers, 65+ scripts, daily autonomous operations
 
 ## Key Capabilities
 
 **Self-Managing Infrastructure:**
-- **Autonomous Operations** - Daily OODA loop (Observe, Orient, Decide, Act) with confidence-based decision making and circuit breaker safety controls
-- **Predictive Analytics** - Forecasts disk/memory exhaustion 7-14 days in advance with automated capacity planning
-- **Natural Language Queries** - Answer system questions instantly using cached query results (e.g., "what services use the most memory?")
-- **Drift Detection** - Automated daily comparison of running vs. declared state with Discord alerts
+- Daily OODA loop (Observe, Orient, Decide, Act) with confidence-based decision making
+- Predictive analytics forecasting disk/memory exhaustion 7-14 days ahead
+- Automated drift detection with Discord alerts
+- Circuit breaker safety controls and BTRFS snapshots before destructive actions
 
 **Security & Compliance:**
-- **Security Framework** - Automated security audits, ADR compliance checking, and incident response runbooks
-- **Vulnerability Scanning** - Weekly CVE scanning with Trivy, Discord notifications for critical issues
-- **Layered Defense** - CrowdSec IP reputation → Rate limiting → Authelia YubiKey auth → Security headers
-- **Disaster Recovery** - 4 runbooks covering all scenarios; verified external backup restore capability (Level 2 + off-site mirror Level 3)
+- 40+ item automated security audits
+- Weekly CVE scanning with severity-based alerting
+- 10 runbooks (4 disaster recovery, 5 incident response, + procedures)
+- Validated disaster recovery with 6-minute RTO
 
 **Operational Excellence:**
-- **Pattern-Based Deployment** - 9 battle-tested deployment patterns with validation and health checks
-- **Comprehensive Monitoring** - SLO tracking, burn rate alerting, monthly compliance reports
-- **Weekly Intelligence Reports** - Automated Friday summaries with health scores, predictions, and recommendations
-- **Skill-Based Automation** - Context-aware skill recommendations with usage analytics
+- Pattern-based deployment with validation and health checks
+- SLO tracking with error budgets and burn-rate alerting
+- Comprehensive documentation (373 files, 18 ADRs)
+- Weekly intelligence reports with health scores and predictions
 
 ## Documentation Structure
 
-See [CONTRIBUTING.md](docs/CONTRIBUTING.md) and [docs/README.md](docs/README.md) for detailed documentation conventions.
+See [CONTRIBUTING.md](docs/CONTRIBUTING.md) for conventions.
 
-- `00-foundation/` - Core concepts and fundamentals
-- `10-services/` - Service-specific documentation
-- `20-operations/` - Operational guides and procedures (includes DR runbooks)
-- `30-security/` - Security configurations and guides (includes incident response runbooks)
-- `40-monitoring-and-documentation/` - System monitoring and docs
+- `00-foundation/` - Core concepts, fundamentals, ADRs
+- `10-services/` - Service-specific guides (22 services documented)
+- `20-operations/` - Operational guides, DR runbooks, automation reference
+- `30-security/` - Security guides, IR runbooks, CrowdSec field manuals
+- `40-monitoring-and-documentation/` - SLO framework, monitoring stack
 - `90-archive/` - Historical documentation
-- `98-journals/` - Chronological learning log (120+ entries documenting the journey)
+- `97-plans/` - Strategic planning
+- `98-journals/` - Chronological learning log (156 entries)
+- `99-reports/` - Automated reports and snapshots
 
 ## Learning Goals
 
 1. Systems design and architecture
 2. Container orchestration with Podman
 3. Security hardening and best practices
-4. Documentation as a learning tool
+4. Autonomous operations and observability
+5. Documentation as a learning tool
 
 ---
 
-*This is a living documentation project. Each directory contains chronologically-organized markdown files tracking the evolution of the system.*
+*This is a living documentation project. Each directory contains organized markdown files tracking the evolution of a homelab from first container to autonomous infrastructure.*

--- a/docs/10-services/guides/alert-discord-relay.md
+++ b/docs/10-services/guides/alert-discord-relay.md
@@ -1,0 +1,286 @@
+# Alert Discord Relay
+
+**Last Updated:** 2026-02-05
+**Version:** Custom-built (localhost/alert-discord-relay:latest)
+**Status:** Production
+**Networks:** monitoring
+
+---
+
+## Overview
+
+Alert Discord Relay is a **custom-built Python service** that bridges Alertmanager webhooks to Discord, transforming raw alert payloads into formatted rich embeds with color-coded severity, structured fields, and timestamps.
+
+**Key features:**
+- Converts Alertmanager webhook payloads to Discord embed format
+- Color-coded alerts: red (critical), orange (warning), green (resolved)
+- Structured fields for severity, instance, service, job, and timestamps
+- Health check endpoint for container monitoring
+- Lightweight Flask/Gunicorn application (~128MB memory limit)
+
+**Integration:** Receives webhooks from Alertmanager on port 9095, forwards formatted embeds to Discord
+
+---
+
+## Quick Reference
+
+### Service Management
+
+```bash
+# Status
+systemctl --user status alert-discord-relay.service
+podman ps | grep alert-discord-relay
+
+# Control
+systemctl --user restart alert-discord-relay.service
+
+# Logs
+journalctl --user -u alert-discord-relay.service -f
+podman logs -f alert-discord-relay
+```
+
+### Health Checks
+
+```bash
+# Container health check (built-in)
+podman healthcheck run alert-discord-relay
+
+# Manual health check
+podman exec alert-discord-relay python3 -c \
+  "import urllib.request; urllib.request.urlopen('http://localhost:9095/health', timeout=5)"
+
+# From the host (via monitoring network)
+podman exec alertmanager wget -qO- http://alert-discord-relay:9095/health
+```
+
+---
+
+## Architecture
+
+### Data Flow
+
+```
+Prometheus evaluates alert rules (every 15s)
+  |
+  v
+Alertmanager receives firing/resolved alerts
+  |
+  v
+Alertmanager routes to webhook receivers
+  |
+  +--> discord-critical  (send_resolved: true)
+  +--> discord-warnings  (send_resolved: false, waking hours only)
+  +--> discord-default   (send_resolved: true, fallback)
+  +--> discord-info      (send_resolved: false, repeat: 1 week)
+  |
+  v
+alert-discord-relay:9095/webhook
+  |
+  v
+Transforms payload to Discord embed format
+  |  - Color: red=critical, orange=warning, green=resolved
+  |  - Fields: severity, instance, service, job, timestamps
+  |  - Footer: "Homelab Monitoring" + Alertmanager URL
+  |
+  v
+Discord Webhook API --> Discord channel
+```
+
+### Alertmanager Receivers
+
+The relay serves four Alertmanager receivers, all pointing to the same endpoint (`http://alert-discord-relay:9095/webhook`) with different routing behavior:
+
+| Receiver | Severity | Resolved | Timing | Repeat |
+|----------|----------|----------|--------|--------|
+| `discord-critical` | critical | Yes | Always | 1h |
+| `discord-warnings` | warning | No | Waking hours (07:00-23:00) | 4h |
+| `discord-info` | info | No | Always | 168h (1 week) |
+| `discord-default` | fallback | Yes | Always | 4h |
+
+**Configuration:** `~/containers/config/alertmanager/alertmanager.yml`
+
+---
+
+## Custom-Built Image
+
+The relay is a custom container image built locally, not pulled from a registry.
+
+### Source Files
+
+All source files are in `~/containers/config/alert-discord-relay/`:
+
+| File | Purpose |
+|------|---------|
+| `Dockerfile` | Python 3.11-slim base, non-root user (UID 1000) |
+| `relay.py` | Flask application with webhook and health endpoints |
+| `requirements.txt` | Dependencies: Flask 3.0.0, requests 2.31.0, gunicorn 21.2.0 |
+
+### Building the Image
+
+```bash
+# Build the container image
+podman build -t localhost/alert-discord-relay:latest \
+  ~/containers/config/alert-discord-relay/
+
+# Verify the image
+podman images | grep alert-discord-relay
+```
+
+### Runtime Details
+
+- **WSGI server:** Gunicorn with 2 workers, 30s timeout
+- **Listen port:** 9095
+- **Endpoints:**
+  - `POST /webhook` -- receives Alertmanager payloads
+  - `GET /health` -- returns `{"status": "healthy"}`
+- **Runs as:** Non-root user (UID 1000) inside the container
+
+---
+
+## Network Configuration
+
+The relay runs exclusively on the **monitoring** network. It does not need internet access or reverse proxy exposure.
+
+```
+Quadlet: Network=systemd-monitoring
+
+Alertmanager (monitoring network)
+  --> http://alert-discord-relay:9095/webhook
+
+alert-discord-relay (monitoring network)
+  --> Discord Webhook URL (via container networking)
+```
+
+**Note:** The container does require outbound internet access to reach the Discord API. The monitoring network provides this through Podman's default gateway.
+
+---
+
+## Secrets
+
+The Discord webhook URL is injected via Podman secret:
+
+```bash
+# View existing secret
+podman secret ls | grep discord
+
+# Update the webhook URL
+echo "https://discord.com/api/webhooks/..." | podman secret create discord_webhook_url -
+
+# If updating, remove old secret first
+podman secret rm discord_webhook_url
+echo "https://discord.com/api/webhooks/..." | podman secret create discord_webhook_url -
+systemctl --user restart alert-discord-relay.service
+```
+
+**Quadlet directive:** `Secret=discord_webhook_url,type=env,target=DISCORD_WEBHOOK_URL`
+
+---
+
+## Resource Limits
+
+| Resource | Limit | Notes |
+|----------|-------|-------|
+| Memory (max) | 128M | Hard ceiling, container killed if exceeded |
+| Memory (high) | 115M | Pressure applied above this threshold |
+| CPU | Unrestricted | Negligible usage under normal load |
+
+---
+
+## Troubleshooting
+
+### Alerts Not Appearing in Discord
+
+1. **Check relay is running:**
+   ```bash
+   systemctl --user status alert-discord-relay.service
+   podman healthcheck run alert-discord-relay
+   ```
+
+2. **Check relay logs for errors:**
+   ```bash
+   podman logs --tail 50 alert-discord-relay | grep -i error
+   ```
+
+3. **Check Alertmanager can reach the relay:**
+   ```bash
+   podman exec alertmanager wget -qO- http://alert-discord-relay:9095/health
+   ```
+
+4. **Send a test webhook manually:**
+   ```bash
+   podman exec alertmanager wget -qO- --post-data='{"status":"firing","alerts":[{"labels":{"alertname":"TestAlert","severity":"warning"},"annotations":{"summary":"Test alert from manual check"},"startsAt":"2026-01-01T00:00:00Z"}]}' \
+     --header='Content-Type: application/json' \
+     http://alert-discord-relay:9095/webhook
+   ```
+
+5. **Check Discord webhook URL is valid:**
+   ```bash
+   # Verify the secret exists
+   podman secret ls | grep discord_webhook_url
+
+   # Check relay startup logs for the URL validation
+   podman logs alert-discord-relay 2>&1 | head -5
+   ```
+
+### Discord Returns Non-200 Status
+
+**Symptom:** Relay logs show `Discord returned 4xx/5xx`
+
+**Common causes:**
+- **429 (Rate Limited):** Too many alerts firing simultaneously. Alertmanager group_wait (30s) and group_interval (5m) should throttle this.
+- **400 (Bad Request):** Embed format issue, usually from very long alert descriptions exceeding Discord's 6000-character embed limit.
+- **401/403 (Unauthorized):** Webhook URL is invalid or the webhook was deleted from Discord.
+
+**Fix:** Verify the webhook URL is still active in Discord Server Settings > Integrations > Webhooks.
+
+### Container Fails to Start
+
+1. **Check image exists:**
+   ```bash
+   podman images | grep alert-discord-relay
+   ```
+
+2. **Rebuild if missing:**
+   ```bash
+   podman build -t localhost/alert-discord-relay:latest \
+     ~/containers/config/alert-discord-relay/
+   ```
+
+3. **Check secret exists:**
+   ```bash
+   podman secret ls | grep discord_webhook_url
+   ```
+
+4. **Check monitoring network exists:**
+   ```bash
+   podman network ls | grep monitoring
+   ```
+
+### Health Check Failing
+
+**Symptom:** `podman healthcheck run alert-discord-relay` returns unhealthy
+
+The health check uses Python's `urllib` since `wget`/`curl` are not available in the slim image. If the Flask/Gunicorn process has crashed, the health check will fail.
+
+```bash
+# Check if the process is running inside the container
+podman exec alert-discord-relay ps aux
+
+# Check Gunicorn worker status
+podman logs --tail 20 alert-discord-relay
+```
+
+---
+
+## Related Documentation
+
+- **Monitoring stack:** `docs/40-monitoring-and-documentation/guides/monitoring-stack.md`
+- **Alertmanager config:** `config/alertmanager/alertmanager.yml`
+- **Relay source code:** `config/alert-discord-relay/`
+- **Quadlet file:** `quadlets/alert-discord-relay.container`
+
+---
+
+**Maintainer:** patriark
+**Image:** localhost/alert-discord-relay:latest (custom-built)
+**Port:** 9095 (internal only, no external exposure)

--- a/docs/10-services/guides/collabora.md
+++ b/docs/10-services/guides/collabora.md
@@ -1,0 +1,330 @@
+# Collabora Online Service Guide
+
+**Service:** Collabora Online (LibreOffice-based document editing)
+**Image:** `docker.io/collabora/code:latest`
+**Deployment:** Systemd Quadlet (Rootless Podman)
+**Status:** Production
+**Last Updated:** 2026-02-05
+
+---
+
+## Quick Reference
+
+**Access Points:**
+- **WOPI Discovery:** `http://collabora:9980/hosting/discovery` (internal only)
+- **Admin Console:** `http://collabora:9980/browser/dist/admin/admin.html` (internal only)
+
+Collabora has no public Traefik route. It is an internal-only service accessed exclusively by Nextcloud over the shared `systemd-nextcloud` network. This reduces attack surface and follows the least-privilege principle.
+
+**Service Management:**
+```bash
+# Status
+systemctl --user status collabora.service
+
+# Start / Stop / Restart
+systemctl --user start collabora.service
+systemctl --user stop collabora.service
+systemctl --user restart collabora.service
+
+# Logs
+journalctl --user -u collabora.service -f
+podman logs -f collabora
+```
+
+**Health Checks:**
+```bash
+# Container health check
+podman healthcheck run collabora
+
+# Manual WOPI discovery test (from any container on the nextcloud network)
+podman exec nextcloud curl -f http://collabora:9980/hosting/discovery
+# Expected: XML response with <wopi-discovery>
+```
+
+**Critical Files:**
+- Quadlet: `~/containers/quadlets/collabora.container` (symlinked to `~/.config/containers/systemd/`)
+- Secret: `podman secret ls | grep collabora` (`collabora_admin_password`)
+- Traefik: No route -- internal-only service (confirmed in `config/traefik/dynamic/routers.yml`)
+
+---
+
+## Architecture Overview
+
+### Role in the Nextcloud Stack
+
+Collabora Online provides browser-based document editing (Word, Excel, PowerPoint, ODF) for files stored in Nextcloud, via the WOPI protocol. Nextcloud's "Nextcloud Office" app (`richdocuments`) connects to Collabora as a backend.
+
+```
+User Browser
+     |
+     v
+Nextcloud (nextcloud.patriark.org)
+     |  WOPI protocol (internal)
+     v
+Collabora (collabora:9980)
+     |
+     v
+LibreOffice engine
+```
+
+Collabora does not serve end users directly. All document editing sessions are initiated through Nextcloud, which proxies the Collabora iframe to the user's browser.
+
+### Network Topology
+
+```
+systemd-reverse_proxy (10.89.2.0/24) -- listed FIRST for default route
+    +-- Collabora  (10.89.2.74)
+    +-- Nextcloud   (10.89.2.X)
+    +-- Traefik     (10.89.2.40)
+
+systemd-nextcloud (10.89.10.0/24) -- internal communication
+    +-- Collabora       (10.89.10.74)
+    +-- Nextcloud
+    +-- nextcloud-db
+    +-- nextcloud-redis
+```
+
+**Network order matters:** `reverse_proxy` is listed first in the quadlet so that Collabora gets a default route with internet access. The `nextcloud` network provides the internal path for WOPI communication.
+
+### Static IP Assignment
+
+Collabora uses static IPs on both networks (per ADR-018):
+- `10.89.2.74` on `systemd-reverse_proxy`
+- `10.89.10.74` on `systemd-nextcloud`
+
+This avoids Podman's undefined DNS ordering issues for multi-network containers.
+
+---
+
+## Deployment Details
+
+### Quadlet Configuration
+
+Key settings from `~/containers/quadlets/collabora.container`:
+
+| Directive | Value | Purpose |
+|-----------|-------|---------|
+| `Image` | `collabora/code:latest` | Collabora Online Development Edition |
+| `AutoUpdate` | `registry` | Automatic image updates via `podman auto-update` |
+| `aliasgroup1` | `https://nextcloud.patriark.org` | Whitelist Nextcloud as allowed WOPI client |
+| `extra_params` | `--o:ssl.enable=false --o:ssl.termination=true` | SSL terminated at Traefik/Nextcloud, not Collabora |
+| `dictionaries` | `en_US no_NO` | Spellcheck languages |
+| `AddCapability` | `MKNOD` | Required by LibreOffice for device node creation |
+| `MemoryMax` | `2G` | Hard memory ceiling |
+| `MemoryHigh` | `1.8G` | Soft memory pressure threshold |
+| `TimeoutStartSec` | `300` | LibreOffice initialization can be slow |
+
+### Secrets
+
+| Secret Name | Target | Purpose |
+|-------------|--------|---------|
+| `collabora_admin_password` | `password` env var | Admin console credentials |
+
+The admin username is set directly as `admin` in the quadlet environment.
+
+### Resource Usage
+
+```bash
+podman stats --no-stream collabora
+
+# Expected:
+# Idle:    ~80MB RAM
+# Editing: up to ~2GB RAM (one or more documents open)
+```
+
+### Dependencies
+
+```
+collabora.service
+    +-- After: nextcloud.service
+    +-- After: network-online.target
+    +-- Wants: network-online.target
+```
+
+Collabora starts after Nextcloud. It does not have a hard `Requires` dependency -- if Nextcloud is down, Collabora will still run but document editing will be unavailable.
+
+---
+
+## Configuration
+
+### Nextcloud Integration
+
+The Nextcloud Office app (`richdocuments`) must be configured to point at the Collabora server. Since Collabora is internal-only (no public route), Nextcloud reaches it via the internal container hostname.
+
+**Check current WOPI URL:**
+```bash
+podman exec -u www-data nextcloud php occ config:app:get richdocuments wopi_url
+```
+
+**Set WOPI URL (if needed):**
+```bash
+podman exec -u www-data nextcloud php occ config:app:set richdocuments wopi_url --value="http://collabora:9980"
+```
+
+Alternatively, configure via the Nextcloud web UI: Settings -> Administration -> Office -> "Use your own server" and enter the Collabora URL.
+
+**Verify the richdocuments app is enabled:**
+```bash
+podman exec -u www-data nextcloud php occ app:list | grep richdocuments
+```
+
+### Domain Whitelist
+
+The `aliasgroup1` environment variable controls which Nextcloud instances are allowed to use this Collabora server. Currently set to `https://nextcloud.patriark.org`. If additional Nextcloud instances are added, use `aliasgroup2`, `aliasgroup3`, etc.
+
+### SSL Configuration
+
+Collabora runs with SSL disabled internally (`ssl.enable=false`) and SSL termination awareness enabled (`ssl.termination=true`). This means:
+- Nextcloud communicates with Collabora over plain HTTP on the internal network
+- Collabora knows the end-user connection is HTTPS (for correct URL generation)
+- No certificate management needed inside the Collabora container
+
+---
+
+## Common Operations
+
+### Rotate Admin Password
+
+```bash
+# 1. Stop Collabora
+systemctl --user stop collabora.service
+
+# 2. Remove and recreate secret
+podman secret rm collabora_admin_password
+echo -n "NEW_PASSWORD_HERE" | podman secret create collabora_admin_password -
+
+# 3. Restart
+systemctl --user daemon-reload
+systemctl --user start collabora.service
+```
+
+### Check Supported File Formats
+
+```bash
+# Query WOPI discovery for supported MIME types
+podman exec nextcloud curl -s http://collabora:9980/hosting/discovery | grep -o 'ext="[^"]*"' | sort -u
+```
+
+### Force Container Update
+
+```bash
+# Check for new image
+podman auto-update --dry-run | grep collabora
+
+# Pull and restart
+podman pull docker.io/collabora/code:latest
+systemctl --user restart collabora.service
+```
+
+---
+
+## Troubleshooting
+
+### Documents Won't Open in Nextcloud
+
+**Symptoms:** Clicking a document in Nextcloud shows an error or infinite loading spinner.
+
+**Diagnosis:**
+```bash
+# 1. Is Collabora running?
+podman ps | grep collabora
+systemctl --user status collabora.service
+
+# 2. Health check passing?
+podman healthcheck run collabora
+
+# 3. Can Nextcloud reach Collabora?
+podman exec nextcloud curl -f http://collabora:9980/hosting/discovery
+
+# 4. Is the richdocuments app enabled?
+podman exec -u www-data nextcloud php occ app:list | grep richdocuments
+
+# 5. What is the configured WOPI URL?
+podman exec -u www-data nextcloud php occ config:app:get richdocuments wopi_url
+```
+
+**Common Causes:**
+1. **Collabora not running:** `systemctl --user start collabora.service`
+2. **Wrong WOPI URL:** Must be `http://collabora:9980` (internal hostname, not a public URL)
+3. **Domain whitelist mismatch:** `aliasgroup1` must match the Nextcloud domain exactly (`https://nextcloud.patriark.org`)
+4. **Network issue:** Verify both containers are on the `systemd-nextcloud` network
+5. **richdocuments app disabled:** Enable via `podman exec -u www-data nextcloud php occ app:enable richdocuments`
+
+### Collabora Won't Start
+
+**Symptoms:** Service fails or container exits immediately.
+
+**Diagnosis:**
+```bash
+# Check logs for startup errors
+journalctl --user -u collabora.service -n 50
+podman logs collabora --tail 50
+
+# Check if MKNOD capability is applied
+podman inspect collabora | jq '.[0].HostConfig.CapAdd'
+
+# Check networks exist
+podman network ls | grep -E "reverse_proxy|nextcloud"
+```
+
+**Common Causes:**
+1. **Missing MKNOD capability:** Ensure `AddCapability=MKNOD` is in the quadlet
+2. **Network missing:** Create with `podman network create systemd-nextcloud --subnet 10.89.10.0/24`
+3. **Secret missing:** `podman secret ls | grep collabora` -- recreate if absent
+4. **IP conflict:** Another container may hold `10.89.2.74` or `10.89.10.74`
+
+### High Memory Usage
+
+**Symptoms:** Collabora consuming close to or exceeding its 2G limit.
+
+**Diagnosis:**
+```bash
+podman stats --no-stream collabora
+```
+
+**Context:** Memory usage scales with the number of concurrent document editing sessions. Each open document consumes additional memory for the LibreOffice rendering process. Under the `MemoryMax=2G` / `MemoryHigh=1.8G` limits, the system will apply memory pressure at 1.8G and OOM-kill at 2G.
+
+**Solutions:**
+1. **Normal behavior:** Memory drops when editing sessions close. No action needed.
+2. **Persistent high usage:** Restart the service to reclaim memory: `systemctl --user restart collabora.service`
+3. **Frequent OOM kills:** Increase `MemoryMax` in the quadlet if concurrent editing is a regular use case.
+
+### Admin Console Not Accessible
+
+The admin console at `http://collabora:9980/browser/dist/admin/admin.html` is only reachable from within the container network. To access it:
+
+```bash
+# From the host (if port is not published)
+podman exec collabora curl -u admin:PASSWORD http://localhost:9980/browser/dist/admin/admin.html
+```
+
+There is no public route to the admin console by design.
+
+---
+
+## Why Internal-Only?
+
+Collabora was previously configured with a public Traefik route (`collabora.patriark.org`). This was removed because:
+
+1. **No direct user access needed:** Users interact with Collabora exclusively through Nextcloud's web UI. The WOPI protocol handles all communication between Nextcloud and Collabora internally.
+2. **Reduced attack surface:** One fewer public endpoint to defend with CrowdSec, rate limiting, and TLS.
+3. **Simpler architecture:** No need for a separate TLS certificate, Traefik router, or middleware chain.
+4. **Least-privilege principle:** Collabora only needs to be reachable by Nextcloud, not the entire internet.
+
+The `reverse_proxy` network is still assigned (listed first) to provide Collabora with a default route for outbound internet access, which it may need for fetching remote resources or fonts.
+
+---
+
+## Related Documentation
+
+- **Nextcloud Guide:** `docs/10-services/guides/nextcloud.md`
+- **ADR-016:** Configuration Design Principles (routing in dynamic config, not labels)
+- **ADR-018:** Static IP for Multi-Network Services
+- **Stack Definition:** `.claude/skills/homelab-deployment/stacks/nextcloud.yml`
+- **Network Topology:** `docs/AUTO-NETWORK-TOPOLOGY.md`
+
+---
+
+**Guide Version:** 1.0
+**Last Updated:** 2026-02-05
+**Maintained By:** patriark + Claude Code

--- a/docs/10-services/guides/matter-server.md
+++ b/docs/10-services/guides/matter-server.md
@@ -1,0 +1,263 @@
+# Matter Server - Service Guide
+
+**Status:** Production
+**Version:** Stable (auto-update enabled)
+**Image:** `ghcr.io/home-assistant-libs/python-matter-server:stable`
+**Network:** home_automation only (internal service)
+**Quadlet:** `~/containers/quadlets/matter-server.container`
+
+---
+
+## Quick Reference
+
+### Service Management
+
+```bash
+# Status
+systemctl --user status matter-server.service
+podman ps | grep matter-server
+
+# Control
+systemctl --user start matter-server.service
+systemctl --user stop matter-server.service
+systemctl --user restart matter-server.service
+
+# Logs
+journalctl --user -u matter-server.service -f
+podman logs -f matter-server
+```
+
+### Health Checks
+
+```bash
+# Podman health check (runs every 30s automatically)
+podman healthcheck run matter-server
+
+# Manual WebSocket port check
+podman exec matter-server python3 -c \
+  "import socket; s=socket.socket(); s.settimeout(5); s.connect(('localhost', 5580)); s.close()"
+```
+
+### Critical Files
+
+```
+~/containers/quadlets/matter-server.container   # Quadlet definition
+~/containers/data/matter-server/                # Runtime data (certificates, vendor info, node config)
+```
+
+### Resource Usage
+
+- **Memory:** ~99MB typical / 512MB max
+- **CPU:** Minimal (<1% idle)
+
+---
+
+## Architecture
+
+### Role
+
+Matter Server (`python-matter-server`) is a standalone WebSocket server that acts as a protocol bridge between Matter/Thread smart home devices and Home Assistant. It implements the Matter controller stack, handling device commissioning, communication, and state management.
+
+Home Assistant connects to it as a WebSocket client. The server runs independently so it can maintain persistent connections to commissioned devices regardless of Home Assistant restarts.
+
+### Communication Flow
+
+```
+Matter Device (Thread/WiFi)
+  |
+  v
+Matter Server (python-matter-server)
+  Port 5580 (WebSocket)
+  |
+  v
+Home Assistant (Matter integration)
+  ws://matter-server:5580/ws
+```
+
+### Why a Separate Container
+
+- **Independent lifecycle:** Matter Server stays up during Home Assistant restarts, maintaining device connections
+- **Resource isolation:** Dedicated memory limits (512MB) separate from Home Assistant (2GB)
+- **Future flexibility:** Multiple Home Assistant instances could connect to the same Matter Server
+
+---
+
+## Network Configuration
+
+Matter Server runs on the `home_automation` network only (10.89.6.0/24). It does not need internet access -- device commissioning and certificate operations are handled through Home Assistant.
+
+```
+systemd-home_automation (10.89.6.0/24)
+├── Home Assistant  (10.89.6.3)  -- WebSocket client
+└── Matter Server   (internal)   -- WebSocket server on port 5580
+```
+
+No ports are published to the host. All communication happens container-to-container over the home_automation network.
+
+No Traefik routing is configured -- this is a purely internal service with no external access.
+
+---
+
+## Integration with Home Assistant
+
+### Adding the Matter Integration
+
+1. Open https://ha.patriark.org
+2. Navigate to **Settings > Devices & Services**
+3. Click **"+ ADD INTEGRATION"**
+4. Search for **"Matter"** and select **"Matter (BETA)"**
+5. Enter server URL: `ws://matter-server:5580/ws`
+6. Click **Submit**
+
+The integration should connect successfully and show 0 devices initially. Devices appear after commissioning through the Home Assistant UI.
+
+### Commissioning Matter Devices
+
+1. In Home Assistant, go to **Settings > Devices & Services > Matter**
+2. Click **"Add Device"** (or use the Companion App for phone-based commissioning)
+3. Follow the on-screen pairing flow (scan QR code or enter setup code)
+4. The Matter Server handles the CHIP protocol handshake and stores the device credentials in `/data`
+
+### Dependency Chain
+
+```
+home_automation-network.service
+  └── matter-server.service
+        └── home-assistant.service (connects via WebSocket)
+```
+
+The quadlet declares `Requires=home_automation-network.service` so the network is created before the container starts. Home Assistant does not have an explicit systemd dependency on Matter Server -- the Matter integration reconnects automatically if the server restarts.
+
+---
+
+## Data and Storage
+
+All persistent state is stored in `~/containers/data/matter-server/`:
+
+- **Certificates:** CHIP fabric credentials and PAA root certificates (72+ fetched from DCL)
+- **Vendor info:** Cached vendor database (387+ entries)
+- **Node config:** Commissioned device data (node credentials, fabric assignments)
+
+This directory is bind-mounted as `/data` inside the container with the `:Z` SELinux label.
+
+### Backup
+
+```bash
+# Stop service for consistent state
+systemctl --user stop matter-server.service
+
+# Backup data directory
+tar czf matter-server-data-$(date +%Y%m%d).tar.gz \
+  ~/containers/data/matter-server/
+
+# Restart
+systemctl --user start matter-server.service
+```
+
+Losing this data means all commissioned Matter devices must be re-paired.
+
+---
+
+## Troubleshooting
+
+### Matter Server Won't Start
+
+**Check service status:**
+```bash
+systemctl --user status matter-server.service
+journalctl --user -u matter-server.service --no-pager -n 30
+```
+
+**Verify network exists:**
+```bash
+podman network ls | grep home_automation
+```
+
+**Reload and restart:**
+```bash
+systemctl --user daemon-reload
+systemctl --user restart matter-server.service
+```
+
+### Health Check Failing
+
+The health check uses a Python socket connection to port 5580. A 90-second start period is configured to allow for initial certificate fetching.
+
+**Check if the WebSocket port is listening:**
+```bash
+podman exec matter-server python3 -c \
+  "import socket; s=socket.socket(); s.settimeout(5); s.connect(('localhost', 5580)); s.close()"
+```
+
+**Check container logs for errors:**
+```bash
+podman logs matter-server --tail 50
+```
+
+**Common startup messages (normal):**
+```
+INFO [chip.CertificateAuthority] Loading certificate authorities from storage...
+INFO [matter_server.server.stack] CHIP Controller Stack initialized
+INFO [matter_server.server.helpers.paa_certificates] Fetched 72 PAA root certificates from DCL
+INFO [matter_server.server.server] Matter Server successfully initialized
+```
+
+### Home Assistant Cannot Connect
+
+**Verify Matter Server is running and healthy:**
+```bash
+podman healthcheck run matter-server
+```
+
+**Verify both containers are on the same network:**
+```bash
+podman inspect matter-server --format '{{range .NetworkSettings.Networks}}{{.NetworkID}}{{end}}'
+podman inspect home-assistant --format '{{range $k,$v := .NetworkSettings.Networks}}{{$k}} {{end}}'
+```
+
+Both should include the `systemd-home_automation` network.
+
+**Test connectivity from Home Assistant container:**
+```bash
+podman exec home-assistant python3 -c \
+  "import socket; s=socket.socket(); s.settimeout(5); s.connect(('matter-server', 5580)); s.close(); print('OK')"
+```
+
+**Check the Matter integration in Home Assistant:**
+1. **Settings > Devices & Services > Matter**
+2. If showing "Setup Error", click the three-dot menu and select **Reload**
+3. Verify the URL is `ws://matter-server:5580/ws`
+
+### Device Commissioning Fails
+
+**Check Matter Server logs during commissioning:**
+```bash
+podman logs -f matter-server
+```
+
+**Common issues:**
+- Device not in pairing mode (reset the device and try again)
+- Device too far from the network (bring closer during initial commissioning)
+- Thread border router not available (for Thread devices, ensure a border router is on the network)
+
+### Resource Limits Hit
+
+The container is limited to 512MB. If memory pressure triggers, check for runaway processes:
+
+```bash
+podman stats --no-stream matter-server
+```
+
+Normal usage is around 99MB. If significantly higher, restart the service:
+```bash
+systemctl --user restart matter-server.service
+```
+
+---
+
+## Related Documentation
+
+- **Deployment journal:** `docs/98-journals/2026-01-28-matter-hybrid-week2-matter-server-deployment.md`
+- **Implementation plan:** `docs/97-plans/2025-12-30-matter-home-automation-implementation-plan.md`
+- **Home Assistant guide:** `docs/10-services/guides/home-assistant.md`
+- **Network topology:** `docs/AUTO-NETWORK-TOPOLOGY.md`

--- a/docs/20-operations/guides/homelab-architecture.md
+++ b/docs/20-operations/guides/homelab-architecture.md
@@ -1,13 +1,12 @@
 # Homelab Architecture Documentation
 
-**Last Updated:** November 14, 2025 (Pattern-based deployment adoption)
-**Status:** Production Ready ✅
-**Owner:** patriark
-**Domain:** patriark.org
+**Last Updated:** February 5, 2026
+**Status:** Production Ready
+**Health Score:** 100/100 (as of 2026-02-05)
 
 ---
 
-## 📋 Table of Contents
+## Table of Contents
 
 1. [Overview](#overview)
 2. [Network Architecture](#network-architecture)
@@ -17,1344 +16,467 @@
 6. [DNS Configuration](#dns-configuration)
 7. [Storage & Data](#storage--data)
 8. [Backup Strategy](#backup-strategy)
-9. [Service Details](#service-details)
-10. [Expansion Guide](#expansion-guide)
-11. [Maintenance](#maintenance)
-12. [Troubleshooting](#troubleshooting)
+9. [Monitoring & Observability](#monitoring--observability)
+10. [Autonomous Operations](#autonomous-operations)
+11. [Expansion Guide](#expansion-guide)
+12. [Maintenance](#maintenance)
 
 ---
 
-## 🏗️ Overview
+## Overview
 
 ### Current State
 
-**Homelab Type:** Self-hosted infrastructure
-**Primary Use:** Media streaming, secure services, learning platform
-**Accessibility:** Internet-accessible with multi-layer security
-**Infrastructure:** Containerized microservices on Fedora Linux
+**Infrastructure:** 28 rootless Podman containers across 14 service groups on Fedora Linux
+**Orchestration:** Systemd quadlets with pattern-based deployment
+**Accessibility:** Internet-accessible with 7-layer defense-in-depth security
+**Autonomous:** Daily OODA loop, predictive maintenance, drift detection
 
 ### Technology Stack
 
 ```
-Operating System:  Fedora Workstation
-Container Runtime: Podman (rootless)
-Orchestration:     Systemd Quadlets
-Reverse Proxy:     Traefik v3.2
-Authentication:    Authelia (SSO + YubiKey MFA)
-Security:          CrowdSec + WebAuthn/FIDO2
+Operating System:  Fedora Workstation 43
+Container Runtime: Podman (rootless, UID 1000)
+Orchestration:     Systemd Quadlets (~/.config/containers/systemd/)
+Reverse Proxy:     Traefik v3 (dynamic config, no container labels)
+Authentication:    Authelia SSO (YubiKey/WebAuthn + TOTP)
+Security:          CrowdSec IP reputation + layered middleware
 DNS:               Cloudflare (external) + Pi-hole (internal)
-SSL:               Let's Encrypt (automated)
+SSL:               Let's Encrypt (automated, TLS 1.2+)
 Network:           UniFi Dream Machine Pro
+Storage:           BTRFS (SSD + 14.5TB HDD pool, 4 drives)
+Monitoring:        Prometheus + Grafana + Loki + Alertmanager
 ```
-
-### Key Features
-
-- ✅ **Phishing-resistant authentication** - YubiKey/WebAuthn hardware 2FA
-- ✅ **Single Sign-On (SSO)** - Authelia provides unified authentication
-- ✅ **Zero-trust security** - Multi-factor authentication required for all admin services
-- ✅ **Automatic SSL** - Let's Encrypt certificates with auto-renewal
-- ✅ **Threat protection** - CrowdSec with global threat intelligence
-- ✅ **Dynamic DNS** - Automatic IP updates every 30 minutes
-- ✅ **Rootless containers** - Enhanced security with user-space isolation
-- ✅ **High availability** - Automatic container restarts on failure
-- ✅ **Monitoring ready** - Prometheus + Grafana + Loki stack
 
 ---
 
-## 🌐 Network Architecture
+## Network Architecture
 
 ### Physical Network
 
 ```
-Internet (ISP)
+Internet (ISP) → Public IP (dynamic, DDNS every 30min)
     ↓
-[62.249.184.112] Public IP (dynamic)
-    ↓
-UDM Pro (192.168.1.1)
-    ├── Port Forwarding
-    │   ├── 80 → fedora-htpc:80 (HTTP)
-    │   └── 443 → fedora-htpc:443 (HTTPS)
-    ├── DHCP Server
-    ├── Firewall
+UDM Pro (gateway/firewall)
+    ├── Port Forward: 80/443 → fedora-htpc
+    ├── DHCP / Firewall / IDS
     └── Local Network (192.168.1.0/24)
-        ├── fedora-htpc (192.168.1.70) - Main server
-        ├── pi-hole (192.168.1.69) - DNS server
+        ├── fedora-htpc - Container host
+        ├── raspberrypi - Pi-hole DNS
         └── Other devices
 ```
 
-### Logical Service Flow
+### Container Networks (8 custom networks)
+
+Services are segmented across 8 Podman bridge networks based on trust boundaries.
+Key principle: **First `Network=` line in a quadlet gets the default route** (determines internet access).
 
 ```
-Internet Request
-    ↓
-[1] DNS Resolution (Cloudflare)
-    patriark.org → 62.249.184.112
-    ↓
-[2] Port Forwarding (UDM Pro)
-    :80/:443 → 192.168.1.70
-    ↓
-[3] CrowdSec Check
-    ✓ IP not banned → Continue
-    ✗ IP banned → 403 Forbidden
-    ↓
-[4] Traefik (Reverse Proxy)
-    ├── SSL Termination (Let's Encrypt)
-    ├── Rate Limiting
-    ├── Authelia SSO (YubiKey + TOTP)
-    ├── Security Headers
-    └── Route to service or SSO portal
-    ↓
-[5] Authelia (SSO + Multi-Factor Authentication)
-    ✓ Valid session → Service access
-    ✗ No session → SSO portal (sso.patriark.org)
-        ├── Username + Password (Argon2id)
-        ├── YubiKey touch (WebAuthn/FIDO2)
-        └── Session created (Redis-backed, 1h expiration)
-    ↓
-[6] Service (Jellyfin, Grafana, etc.)
-    Render response
-    ↓
-[7] Return to User
+┌─────────────────────────────────────────────────────────────┐
+│  reverse_proxy (10.89.2.0/24) — 15 containers              │
+│  Internet-facing services. Traefik routes to all backends.  │
+│  Has default route (internet access).                       │
+│  Members: traefik, crowdsec, authelia, homepage, jellyfin,  │
+│           immich-server, nextcloud, vaultwarden, grafana,   │
+│           prometheus, loki, alertmanager, gathio,           │
+│           home-assistant, alert-discord-relay                │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│  monitoring (10.89.1.0/24) — 17 containers                 │
+│  Observability stack. Cross-network scraping.               │
+│  Members: prometheus, grafana, loki, promtail, alertmanager,│
+│           cadvisor, node_exporter, unpoller,                │
+│           alert-discord-relay, + most services for scraping │
+└─────────────────────────────────────────────────────────────┘
+
+┌───────────────────────────┐  ┌──────────────────────────────┐
+│  auth_services            │  │  media_services              │
+│  (10.89.3.0/24) — 3      │  │  Jellyfin media isolation    │
+│  authelia, traefik,       │  │  Members: jellyfin           │
+│  redis-authelia           │  │                              │
+└───────────────────────────┘  └──────────────────────────────┘
+
+┌───────────────────────────┐  ┌──────────────────────────────┐
+│  photos                   │  │  nextcloud                   │
+│  Immich stack isolation   │  │  Nextcloud ecosystem         │
+│  Members: immich-server,  │  │  Members: nextcloud,         │
+│  immich-ml, postgresql-   │  │  collabora, nextcloud-db,    │
+│  immich, redis-immich     │  │  nextcloud-redis             │
+└───────────────────────────┘  └──────────────────────────────┘
+
+┌───────────────────────────┐  ┌──────────────────────────────┐
+│  home_automation          │  │  gathio                      │
+│  Smart home stack         │  │  Event management            │
+│  Members: home-assistant, │  │  Members: gathio, gathio-db  │
+│  matter-server            │  │                              │
+└───────────────────────────┘  └──────────────────────────────┘
 ```
 
-### Container Network
+### Logical Request Flow
 
 ```
-Host: fedora-htpc (192.168.1.70)
-    │
-    ├── Podman Network: systemd-reverse_proxy (10.89.2.0/24)
-    │   ├── traefik (10.89.2.x) - Reverse proxy & SSL
-    │   ├── crowdsec (10.89.2.x) - Threat protection
-    │   ├── authelia (10.89.2.x) - SSO portal
-    │   └── jellyfin (10.89.2.x) - Media service
-    │
-    └── Podman Network: systemd-auth_services (10.89.3.0/24)
-        ├── authelia (10.89.3.x) - SSO server
-        └── redis-authelia (10.89.3.x) - Session storage
+Internet Request → DNS (Cloudflare) → Port Forward (UDM Pro :80/:443)
+    ↓
+[1] CrowdSec IP Reputation (cache lookup — fastest, fail-fast)
+    ↓
+[2] Rate Limiting (tiered: 50-400 req/min depending on service)
+    ↓
+[3] Authentication
+    ├── Authelia SSO (YubiKey/WebAuthn + TOTP) for admin services
+    └── Native auth for Jellyfin, Immich, Nextcloud, Vaultwarden, HA
+    ↓
+[4] Security Headers (HSTS, CSP, X-Frame-Options)
+    ↓
+Backend Service
 ```
 
-**Network Type:** Podman bridge network
-**DNS:** Internal DNS resolution between containers
-**Isolation:** Containers can only talk to each other on this network
+### Multi-Network DNS (ADR-018)
+
+Services on multiple networks use static IP assignment + Traefik /etc/hosts override to ensure predictable routing. Without this, Podman's aardvark-dns returns IPs in undefined order, causing untrusted-proxy errors.
+
+**See:** `docs/00-foundation/decisions/2026-02-04-ADR-018-static-ip-multi-network-services.md`
 
 ---
 
-## 🔧 Service Stack
+## Service Stack
 
-### Core Infrastructure
+### Production Services (14 service groups, 28 containers)
 
-| Service | Purpose | Technology | Port(s) | Status |
-|---------|---------|------------|---------|--------|
-| **Traefik** | Reverse proxy & SSL | Traefik v3.2 | 80, 443, 8080 | Running ✅ |
-| **CrowdSec** | Threat protection | CrowdSec latest | 8080 (internal) | Running ✅ |
-| **Authelia** | SSO + YubiKey MFA | Authelia 4.38 | 9091 (internal) | Running ✅ |
-| **Redis** | Session storage | Redis 7 Alpine | 6379 (internal) | Running ✅ |
-| **~~TinyAuth~~** | ~~SSO Authentication~~ | ~~Tinyauth v4~~ | ~~3000 (internal)~~ | **Replaced by Authelia** ⚠️ |
+#### Core Infrastructure
 
-### Application Services
+| Service | Container(s) | Network(s) | Purpose |
+|---------|-------------|------------|---------|
+| **Traefik** | traefik | reverse_proxy, auth_services, monitoring | Reverse proxy, SSL termination, routing |
+| **CrowdSec** | crowdsec | reverse_proxy, monitoring | IP reputation, threat intelligence |
+| **Authelia** | authelia, redis-authelia | reverse_proxy, auth_services, monitoring | SSO + YubiKey MFA |
 
-| Service | Purpose | Technology | Port | Status |
-|---------|---------|------------|------|--------|
-| **Jellyfin** | Media server | Jellyfin latest | 8096 (internal) | Running ✅ |
+#### User Applications
 
-### External Dependencies
+| Service | Container(s) | Network(s) | Auth Method | URL Pattern |
+|---------|-------------|------------|-------------|-------------|
+| **Homepage** | homepage | reverse_proxy, monitoring | Authelia | home.* |
+| **Jellyfin** | jellyfin | reverse_proxy, media_services, monitoring | Native | jellyfin.* |
+| **Immich** | immich-server, immich-ml, postgresql-immich, redis-immich | reverse_proxy, photos, monitoring | Native | photos.* |
+| **Nextcloud** | nextcloud, collabora, nextcloud-db, nextcloud-redis | reverse_proxy, nextcloud, monitoring | Native | nextcloud.* |
+| **Vaultwarden** | vaultwarden | reverse_proxy, monitoring | Native | vault.* |
+| **Gathio** | gathio, gathio-db | reverse_proxy, gathio, monitoring | Authelia | events.* |
+| **Home Assistant** | home-assistant, matter-server | reverse_proxy, home_automation, monitoring | Native | ha.* |
 
-| Service | Purpose | Provider | Configuration |
-|---------|---------|----------|---------------|
-| **Cloudflare DNS** | Public DNS | Cloudflare | Auto-update via API |
-| **Pi-hole** | Local DNS | Self-hosted | 192.168.1.69 |
-| **Let's Encrypt** | SSL Certificates | ACME | Auto-renew every 90 days |
+#### Monitoring & Observability
+
+| Service | Container(s) | Network(s) | Purpose |
+|---------|-------------|------------|---------|
+| **Prometheus** | prometheus | reverse_proxy, monitoring | Metrics collection |
+| **Grafana** | grafana | reverse_proxy, monitoring | Dashboards & visualization |
+| **Loki** | loki | reverse_proxy, monitoring | Log aggregation |
+| **Alertmanager** | alertmanager | monitoring | Alert routing (Discord) |
+| **Promtail** | promtail | monitoring | Log shipping to Loki |
+| **cAdvisor** | cadvisor | monitoring | Container metrics |
+| **Node Exporter** | node_exporter | monitoring | Host system metrics |
+| **UnPoller** | unpoller | monitoring | UniFi network metrics |
+| **Alert Discord Relay** | alert-discord-relay | reverse_proxy, monitoring | Alertmanager → Discord |
+
+### Internal-Only Services (no public route)
+
+- **Collabora** - Document editing server (accessed by Nextcloud internally)
+- **Alertmanager** - Alert routing (access via Grafana or direct container exec)
+- **All databases/Redis instances** - Backend-only, no Traefik routing
+
+### Authentication Model
+
+| Auth Method | Services | Rationale |
+|-------------|----------|-----------|
+| **Authelia SSO** | Homepage, Traefik Dashboard, Grafana, Prometheus, Loki, Gathio | Admin/monitoring tools — centralized auth |
+| **Native auth** | Jellyfin, Immich, Nextcloud, Vaultwarden, Home Assistant | Mobile apps, WebDAV clients need direct auth |
 
 ---
 
-## 📦 Deployment Ecosystem
+## Deployment Ecosystem
 
-**Since:** November 14, 2025 (Session 3)
-**Method:** Pattern-based deployment automation
-**Status:** Production ✅
+### Configuration Philosophy (ADR-016)
 
-### Pattern Library
+**ALL Traefik routing in dynamic config files. NEVER in container labels.**
 
-The homelab uses **deployment patterns** to standardize service deployment. Patterns are reusable YAML templates that encode best practices, network configuration, resource limits, and security settings.
+- **Quadlet files** (`~/.config/containers/systemd/`) = deployment: image, volumes, networks, resources
+- **Traefik dynamic config** (`config/traefik/dynamic/`) = routing: rules, middleware chains, TLS
+- **Never mix** — single source of truth for each concern
 
-**Available Patterns (9 total):**
+### Pattern-Based Deployment
 
-| Pattern | Service Type | Resource Tier | Examples | Use Case |
-|---------|--------------|---------------|----------|----------|
-| **media-server-stack** | Media streaming | High (4GB+) | Jellyfin, Plex, Emby | GPU transcoding, large storage |
-| **web-app-with-database** | Web applications | Medium (2GB) | Wiki.js, Bookstack, Nextcloud | Standard 2-container stacks |
-| **document-management** | Document systems | High (3GB+) | Paperless-ngx | OCR, indexing, multi-service |
-| **authentication-stack** | SSO/Authentication | Low (512MB) | Authelia + Redis | Hardware 2FA, session management |
-| **password-manager** | Password vaults | Low (512MB) | Vaultwarden | Self-contained, own auth |
-| **database-service** | Databases | Medium (2GB) | PostgreSQL, MySQL | BTRFS NOCOW optimized |
-| **cache-service** | Caching | Low (256-512MB) | Redis, Memcached | Sessions, temporary data |
-| **reverse-proxy-backend** | Internal APIs | Low (512MB) | Admin panels, tools | Strict auth required |
-| **monitoring-exporter** | Metrics exporters | Minimal (128MB) | node_exporter, cAdvisor | Prometheus scraping |
+9 battle-tested patterns for consistent deployments:
 
-### Deployment Workflow
+| Pattern | Examples | Resource Tier |
+|---------|----------|---------------|
+| `media-server-stack` | Jellyfin, Plex | High (4GB+, GPU) |
+| `web-app-with-database` | Wiki.js, Bookstack | Medium (2GB) |
+| `document-management` | Paperless-ngx, Nextcloud | High (3GB+, OCR) |
+| `authentication-stack` | Authelia + Redis | Low (512MB) |
+| `password-manager` | Vaultwarden | Low (512MB) |
+| `database-service` | PostgreSQL, MySQL | Medium (2GB, NOCOW) |
+| `cache-service` | Redis, Memcached | Low (256-512MB) |
+| `reverse-proxy-backend` | Internal services | Low (512MB) |
+| `monitoring-exporter` | node_exporter, cAdvisor | Minimal (128MB) |
 
-**Standard deployment process:**
-
-1. **Health Check:** System health scoring (0-100) determines deployment readiness
-2. **Pattern Selection:** Choose appropriate pattern based on service type
-3. **Validation:** Prerequisite checks (image exists, networks exist, ports available)
-4. **Deployment:** Generate systemd quadlet from pattern template
-5. **Verification:** Drift detection confirms quadlet matches running container
-
-**Command example:**
+**Deploy:**
 ```bash
 cd .claude/skills/homelab-deployment
-
-# Deploy with pattern
 ./scripts/deploy-from-pattern.sh \
-  --pattern media-server-stack \
-  --service-name jellyfin \
-  --hostname jellyfin.patriark.org \
-  --memory 4G
-
-# Verify deployment
-./scripts/check-drift.sh jellyfin
+  --pattern web-app-with-database \
+  --service-name wiki \
+  --hostname wiki.example.org \
+  --memory 2G
 ```
 
-### Intelligence Integration
-
-**Health-aware deployment:**
-- Health scores 90-100: Excellent - deploy anything
-- Health scores 75-89: Good - proceed with monitoring
-- Health scores 50-74: Degraded - address warnings first
-- Health scores 0-49: Critical - block deployment
-
-**Drift detection:**
-- **MATCH:** Configuration correct (no action needed)
-- **DRIFT:** Mismatch detected (restart service to reconcile)
-- **WARNING:** Minor differences (informational only)
-
-**Checked categories:** Image version, memory limits, networks, volumes, Traefik labels
-
-### Pattern Benefits
-
-**Consistency:** All services follow the same configuration standards
-
-**Best Practices Built-In:**
-- Network ordering (reverse_proxy first for internet access)
-- SELinux labels (`:Z` on volume mounts)
-- BTRFS NOCOW for databases
-- Traefik middleware chains (CrowdSec → rate limit → auth → headers)
-- Resource limits and systemd dependencies
-
-**Validation:** Pre-deployment checks prevent common mistakes
-
-**Documentation:** Patterns are self-documenting with deployment notes and checklists
-
-**Documentation References:**
-- **Pattern Selection Guide:** `docs/10-services/guides/pattern-selection-guide.md`
-- **Deployment Cookbook:** `.claude/skills/homelab-deployment/COOKBOOK.md`
-- **Skill Integration:** `docs/10-services/guides/skill-integration-guide.md`
-- **ADR-007:** `docs/20-operations/decisions/2025-11-14-decision-007-pattern-based-deployment.md`
+**See:** `docs/10-services/guides/pattern-selection-guide.md`
 
 ---
 
-## 🛡️ Security Layers
+## Security Layers
 
-### Defense in Depth Strategy
+### Defense in Depth (7 layers, fail-fast ordering)
 
 ```
-Layer 7: Multi-Factor Authentication (Authelia: YubiKey + TOTP)
-    ↓
-Layer 6: SSO Session Management (Redis: 1h expiration)
-    ↓
-Layer 5: Rate Limiting (Traefik Middleware: Tiered 100-200 req/min)
-    ↓
-Layer 4: Threat Intelligence (CrowdSec Bouncer: IP reputation)
-    ↓
-Layer 3: TLS Encryption (Let's Encrypt: TLS 1.2+ with modern ciphers)
-    ↓
-Layer 2: Security Headers (Traefik: HSTS, CSP, X-Frame-Options)
-    ↓
-Layer 1: Port Filtering (UDM Pro Firewall: Only 80/443 exposed)
+Layer 7: Container Isolation (rootless, SELinux enforcing, UID 1000)
+Layer 6: Network Segmentation (8 isolated Podman networks)
+Layer 5: Security Headers (HSTS, CSP, X-Frame-Options)
+Layer 4: Authentication (Authelia YubiKey/WebAuthn + TOTP, or native)
+Layer 3: Rate Limiting (tiered: 50-400 req/min by service type)
+Layer 2: Threat Intelligence (CrowdSec IP reputation, behavioral analysis)
+Layer 1: Port Filtering (UDM Pro firewall, only 80/443 exposed)
 ```
 
-### Security Features Implemented
+### Middleware Chains (per-service in routers.yml)
 
-#### 1. **CrowdSec Threat Protection**
-- **Type:** Collaborative security
-- **Coverage:** Global threat intelligence
-- **Detection:** Behavioral analysis + community blocklists
-- **Response:** Automatic IP banning
-- **Scope:** All HTTP/HTTPS traffic through Traefik
+**Authelia-protected services:**
+`crowdsec-bouncer → rate-limit → authelia → security-headers`
 
-**Active Scenarios:**
-- Brute force detection
-- Web scanner detection
-- HTTP exploit attempts
-- Rate abuse detection
+**Native-auth services (Jellyfin, Immich, Nextcloud, Vaultwarden, HA):**
+`crowdsec-bouncer → rate-limit-{service} → [circuit-breaker] → [retry] → security-headers`
 
-#### 2. **Multi-Factor Authentication (Authelia)**
-- **Primary:** YubiKey/WebAuthn (FIDO2 phishing-resistant)
-- **Fallback:** TOTP (Microsoft Authenticator)
-- **Base:** Username + password (Argon2id hashed)
-- **Session:** Redis-backed (1h expiration, 15min inactivity)
-- **SSO:** Single sign-on across all protected services
-- **Scope:** Admin services (Grafana, Prometheus, Traefik), Jellyfin web UI
+### Vulnerability Management
 
-**Protected services:**
-- ✅ Grafana (grafana.patriark.org)
-- ✅ Prometheus (prometheus.patriark.org)
-- ✅ Loki (loki.patriark.org)
-- ✅ Traefik Dashboard (traefik.patriark.org)
-- ✅ Jellyfin Web UI (jellyfin.patriark.org)
-
-**Bypass patterns:**
-- Health check endpoints (all services)
-- Jellyfin API endpoints (mobile app compatibility)
-- Immich (uses native authentication)
-
-#### 3. **Rate Limiting (Tiered)**
-- **Public services:** 200 requests/minute (media, asset-heavy)
-- **Standard services:** 100 requests/minute (admin interfaces)
-- **Auth endpoints:** 10 requests/minute (SSO portal was 10, increased to 100 for SPA assets)
-- **Applied to:** All routes via Traefik middleware
-- **Purpose:** Prevent abuse and DoS
-
-#### 4. **SSL/TLS**
-- **Provider:** Let's Encrypt
-- **Certificates:** Wildcard + domain-specific
-- **Renewal:** Automatic every 90 days
-- **Protocols:** TLS 1.2+ only
-- **Ciphers:** Modern secure ciphers only
-
-#### 5. **Security Headers**
-```yaml
-X-Frame-Options: SAMEORIGIN
-X-Content-Type-Options: nosniff
-X-XSS-Protection: 1; mode=block
-Strict-Transport-Security: max-age=31536000
-```
-
-#### 6. **Container Security**
-- **Rootless:** All containers run as user (UID 1000)
-- **SELinux:** Enforcing mode
-- **Isolation:** Each service in separate container
-- **Networks:** Isolated bridge networks
+- **Weekly:** Automated CVE scanning (Sundays 06:00)
+- **Monthly:** Security audit (`scripts/security-audit.sh`, 40+ checks)
+- **Continuous:** CrowdSec behavioral analysis + global threat intelligence
 
 ---
 
-## 🌐 DNS Configuration
+## DNS Configuration
 
-### Public DNS (Cloudflare)
+### External DNS (Cloudflare)
 
-**Zone:** patriark.org
-**Nameservers:** Cloudflare (cam.ns.cloudflare.com, drew.ns.cloudflare.com)
+- Wildcard A record: `*.example.org` → public IP (dynamic)
+- DDNS updates: Every 30 minutes via `scripts/cloudflare-ddns.sh` + systemd timer
+- Cloudflare API token stored in `secrets/cloudflare_token`
 
-**DNS Records:**
+### Internal DNS (Pi-hole)
 
-| Type | Name | Value | TTL | Proxy |
-|------|------|-------|-----|-------|
-| A | @ | 62.249.184.112 | Auto | DNS only |
-| A | * | 62.249.184.112 | Auto | DNS only |
-
-**Dynamic Updates:**
-- **Script:** `~/containers/scripts/cloudflare-ddns.sh`
-- **Frequency:** Every 30 minutes (systemd timer)
-- **Method:** Cloudflare API in ~/containers/secrets
-
-### Local DNS (Pi-hole)
-
-**Server:** 192.168.1.69
-**Purpose:** Local resolution for LAN clients
-
-**Custom Records:**
-
-| Domain | IP | Purpose |
-|--------|----|---------| 
-| patriark.org | 192.168.1.70 | Local routing |
-| auth.patriark.org | 192.168.1.70 | Auth portal |
-| jellyfin.patriark.org | 192.168.1.70 | Media server |
-| traefik.patriark.org | 192.168.1.70 | Dashboard |
-
-**Benefit:** LAN traffic stays local, doesn't hairpin through WAN
+- Local resolution: `*.example.org` → server LAN IP
+- Benefit: LAN traffic stays local (no hairpin NAT)
 
 ---
 
-## 💾 Storage & Data
+## Storage & Data
 
 ### Directory Structure
 
 ```
-/home/patriark/containers/
-├── config/                      # Service configurations
-│   ├── traefik/
-│   │   ├── traefik.yml         # Static config
-│   │   ├── dynamic/            # Dynamic configs
-│   │   │   ├── routers.yml     # Route definitions
-│   │   │   ├── middleware.yml  # Middleware configs
-│   │   │   └── tls.yml         # TLS settings
-│   │   └── letsencrypt/        # SSL certificates
-│   │       └── acme.json       # Let's Encrypt data
-│   ├── jellyfin/               # Jellyfin config
-│   └── crowdsec/               # CrowdSec config
+~/containers/
+├── config/                 # Service configurations (git-tracked)
+│   ├── traefik/           # Static + dynamic config
+│   │   ├── traefik.yml    # Static config (entry points, providers)
+│   │   └── dynamic/       # Watched by Traefik (auto-reload)
+│   │       ├── routers.yml      # All routes + services
+│   │       ├── middleware.yml   # Security middleware chains
+│   │       ├── tls.yml          # TLS 1.2+ config
+│   │       └── rate-limit.yml   # Tiered rate limits
+│   ├── authelia/          # SSO config
+│   ├── crowdsec/          # Threat detection config
+│   ├── prometheus/        # Scrape targets, recording rules, alerts
+│   ├── grafana/           # Provisioned dashboards & datasources
+│   ├── loki/              # Log aggregation config
+│   └── homepage/          # Dashboard widget config
 │
-├── data/                        # Service data
-│   ├── crowdsec/
-│   │   ├── db/                 # CrowdSec database
-│   │   └── config/             # Runtime config
-│   └── jellyfin/               # Media library metadata
+├── data/                   # Runtime data (gitignored, on BTRFS pool)
+│   ├── crowdsec/          # Threat database
+│   └── backup-logs/       # Backup operation logs
 │
-├── scripts/                     # Automation scripts
-│   ├── cloudflare-ddns.sh     # DNS updater
-│   └── security-audit.sh       # Security checker
+├── quadlets/              # Symlink → ~/.config/containers/systemd/
+│                           # All 28 .container files + .network files
 │
-├── secrets/                     # Sensitive data (chmod 600)
-│   ├── cloudflare_token        # API token
-│   └── cloudflare_zone_id      # Zone ID
-│
-├── backups/                     # Configuration backups
-│   └── phase1-TIMESTAMP/       # Timestamped backups
-│
-└── documentation/               # Documentation
-    └── (this file)
+├── scripts/               # 65+ automation scripts (git-tracked)
+├── secrets/               # API tokens, passwords (gitignored, chmod 600)
+├── docs/                  # Documentation (373 files, git-tracked)
+└── .claude/               # Claude Code skills, agents, hooks
 ```
 
-### Systemd Service Files
+### BTRFS Storage Pool
 
-```
-/home/patriark/.config/containers/systemd/
-├── traefik.container           # Traefik quadlet
-├── authelia.container          # Authelia SSO quadlet
-├── redis-authelia.container    # Redis for Authelia sessions
-├── jellyfin.container          # Jellyfin quadlet
-├── crowdsec.container          # CrowdSec quadlet
-├── cloudflare-ddns.service     # DDNS service - This seems like an error entry as cloudflare-ddns is run as a script in ~/containers/scripts with automations to run at timely intervals
-└── cloudflare-ddns.timer       # DDNS timer - See previous comment
-```
+- **Capacity:** 14.55 TiB (4 drives, single data / RAID1 metadata)
+- **Usage:** ~73% (10.54 TiB used, 4.01 TiB free)
+- **Snapshots:** Daily automated at `/mnt/btrfs-pool/.snapshots/`
+- **NOCOW:** Applied to database directories (Prometheus, Loki, PostgreSQL) to avoid CoW fragmentation
 
-### BTRFS Snapshots
+### System SSD
 
-**Filesystem:** BTRFS on /home
-**Snapshots:** Manual before major changes
-
-```bash
-# List snapshots in / and limit shown results to include text home - should be revised
-sudo btrfs subvolume list / | grep home
-```
+- **Capacity:** 118GB
+- **Usage:** ~64% (normal range)
+- **Thresholds:** Normal <70% | Warning >75% | Critical >85%
 
 ---
 
-## 💾 Backup Strategy
+## Backup Strategy
 
-### What Gets Backed Up
+### Three Pillars
 
-#### Critical (Daily)
-- Service configurations (`~/containers/config/`)
-- Systemd quadlets (`~/.config/containers/systemd/`)
-- Scripts (`~/containers/scripts/`)
-- Secrets (`~/containers/secrets/`)
+1. **Local BTRFS Snapshots**
+   - Daily automated, 14+ day retention
+   - RTO: <10 minutes (validated)
+   - RPO: 24 hours
 
-#### Important (Weekly)
-- CrowdSec database
-- Jellyfin metadata
-- Documentation
+2. **Git Version Control**
+   - Configs, quadlets, docs, scripts tracked on GitHub
+   - Full history, instant config recovery
 
-#### Optional (Monthly)
-- Container images (can be re-pulled)
-- Logs (if needed for forensics)
+3. **External Backup**
+   - WD-18TB drive, validated restore (81,716 files)
+   - Off-site capability for catastrophic recovery
 
-### Backup Methods
+### Disaster Recovery Runbooks
 
-#### 1. **BTRFS Snapshots**
-```bash
-# Before major changes
-sudo btrfs subvolume snapshot /home ~/snapshots/YYYYMMDD-htpc-home
-```
-
-**Pros:** Instant, space-efficient, easy rollback
-**Cons:** Same filesystem (not off-site)
-
-#### 2. **Configuration Tarball**
-```bash
-# Weekly backup
-tar -czf ~/backups/config-$(date +%Y%m%d).tar.gz \
-    ~/containers/config \
-    ~/.config/containers/systemd \
-    ~/containers/scripts
-```
-
-**Pros:** Portable, easy to restore  
-**Cons:** Manual process
-
-#### 3. **Git Repository** (Recommended for configs)
-```bash
-cd ~/containers
-git init
-git add config/ scripts/ .config/containers/systemd/
-git commit -m "Backup $(date)"
-git push # to private repo
-```
-
-**Pros:** Version history, off-site, easy to track changes  
-**Cons:** Secrets need to be gitignored
+| Runbook | Scenario | RTO | Status |
+|---------|----------|-----|--------|
+| DR-001 | System SSD Failure | ~6 min | Validated |
+| DR-002 | BTRFS Pool Corruption | Hours | Tested |
+| DR-003 | Accidental Deletion | ~6 min | Validated 2025-12-31 |
+| DR-004 | Total Catastrophe | Days | Validated 2026-01-03 |
 
 ---
 
-## 🔧 Service Details
+## Monitoring & Observability
 
-### Traefik (Reverse Proxy)
+### Stack
 
-**Container:** `traefik`  
-**Image:** `docker.io/library/traefik:v3.2`  
-**Network:** systemd-reverse_proxy  
-**Ports:** 80 (HTTP), 443 (HTTPS), 8080 (Dashboard)
-
-**Key Features:**
-- Automatic service discovery via Docker provider
-- Let's Encrypt integration with HTTP challenge
-- Dynamic configuration from files
-- Built-in dashboard
-
-**Configuration Files:**
-- Static: `~/containers/config/traefik/traefik.yml`
-- Dynamic: `~/containers/config/traefik/dynamic/*.yml`
-
-**Access:**
-- Dashboard: https://traefik.patriark.org (requires login)
-- API: http://localhost:8080/api (local only)
-
-**Plugins:**
-- crowdsec-bouncer-traefik-plugin v1.4.5
-
----
-
-### CrowdSec (Security)
-
-**Container:** `crowdsec`
-**Image:** `ghcr.io/crowdsecurity/crowdsec:latest`
-**Network:** systemd-reverse_proxy
-**Port:** 8080 (LAPI - internal only)
-
-**Installed Collections:**
-- crowdsecurity/traefik
-- crowdsecurity/http-cve
-
-**Bouncers:**
-- traefik-bouncer (Traefik middleware)
-
-**Key Features:**
-- Real-time threat detection
-- Global IP reputation
-- Behavioral analysis
-- Automatic banning
-
-**Management:**
-```bash
-# View metrics
-podman exec crowdsec cscli metrics
-
-# List active bans
-podman exec crowdsec cscli decisions list
-
-# View alerts
-podman exec crowdsec cscli alerts list
-
-# List bouncers
-podman exec crowdsec cscli bouncers list
+```
+Prometheus (metrics) → Grafana (dashboards) → Alertmanager (Discord)
+                  ↗                                    ↗
+Node Exporter (host)     Loki (logs) ← Promtail (shipping)
+cAdvisor (containers)    UnPoller (UniFi network)
 ```
 
----
+### SLO Framework
 
-### Authelia (SSO + Multi-Factor Authentication)
+9 SLOs across 5 services (Traefik, Authelia, Jellyfin, Immich, Nextcloud):
+- Burn-rate alerting (Tier 1: critical, Tier 2: high)
+- Error budget tracking via Prometheus recording rules
+- Monthly compliance reporting
 
-**Container:** `authelia`
-**Image:** `docker.io/authelia/authelia:4.38`
-**Networks:** systemd-reverse_proxy, systemd-auth_services
-**Port:** 9091 (internal only)
+**Dashboard:** Grafana SLO dashboard
+**Reference:** `docs/40-monitoring-and-documentation/guides/slo-framework.md`
 
-**Configuration:**
-- SSO Portal: https://sso.patriark.org
-- Authentication methods:
-  - Primary: YubiKey/WebAuthn (FIDO2)
-  - Fallback: TOTP (Microsoft Authenticator)
-  - Base: Username + password (Argon2id)
-- Session storage: Redis (redis-authelia)
-- Session expiration: 1 hour (15min inactivity)
-- Database: SQLite (`/data/db.sqlite3`)
+### Alerting
 
-**Users:**
-- patriark (groups: admins, users)
-
-**Enrolled devices:**
-- YubiKey 5 NFC
-- YubiKey 5C Nano
-- Microsoft Authenticator (TOTP)
-
-**Integration:**
-- Traefik ForwardAuth middleware (`authelia@file`)
-- Protects: Admin services, Jellyfin web UI
-- Bypasses: Health checks, Jellyfin API (mobile apps)
-
-**Access:**
-- SSO Portal: https://sso.patriark.org
-- Settings: https://sso.patriark.org/settings
-
-**Management:**
-```bash
-# Service status
-systemctl --user status authelia.service
-
-# View logs
-podman logs -f authelia
-
-# Health check
-curl http://localhost:9091/api/health
-
-# Generate password hash
-podman exec -it authelia authelia crypto hash generate argon2 --random
-```
+- **Route:** Alertmanager → Alert Discord Relay → Discord webhook
+- **Tiers:** Critical (page immediately), High (within 1h), Warning (daily digest)
+- **Daily error digest:** Automated aggregation at 07:00
 
 ---
 
-### Redis (Session Storage)
+## Autonomous Operations
 
-**Container:** `redis-authelia`
-**Image:** `docker.io/library/redis:7-alpine`
-**Network:** systemd-auth_services
-**Port:** 6379 (internal only)
+### OODA Loop
 
-**Configuration:**
-- Persistence: AOF (append-only file)
-- Max memory: 128MB
-- Eviction policy: allkeys-lru
+Daily automated cycle: **Observe → Orient → Decide → Act**
 
-**Purpose:**
-- Store Authelia SSO sessions
-- Session data encrypted by Authelia
+- **Schedule:** 06:00 (predictive maintenance) + 06:30 (OODA assessment)
+- **Safety:** Circuit breaker on failures, BTRFS snapshots before actions
+- **Protected services:** Traefik and Authelia exempt from auto-restart
+- **Decision confidence:** >90% required for execution
 
-**Management:**
-```bash
-# Check health
-podman exec redis-authelia redis-cli ping
+### Capabilities
 
-# View stats
-podman exec redis-authelia redis-cli INFO stats
+| Capability | Schedule | Status |
+|-----------|----------|--------|
+| Health scoring (0-100) | On-demand | Operational |
+| Predictive maintenance | Daily 06:00 | Operational |
+| OODA assessment | Daily 06:30 | Operational |
+| Drift detection | Daily | Operational |
+| Resource forecasting | Daily | Operational |
+| Natural language queries | On-demand (cached) | Operational |
+| Alert-driven remediation | Real-time (webhook) | Operational |
 
-# Session count
-podman exec redis-authelia redis-cli DBSIZE
-```
+### Systemd Timers (53 active)
 
----
-
-### ~~TinyAuth~~ (DEPRECATED - Replaced by Authelia)
-
-**Status:** Decommissioned (replaced 2025-11-11)
-**Superseded by:** Authelia SSO with YubiKey MFA
-**Migration Date:** 2025-11-11
-**Rationale:** Authelia provides superior security with hardware 2FA (YubiKey/WebAuthn), TOTP fallback, and better SSO capabilities
-
-**See:**
-- [Authelia Guide](../../10-services/guides/authelia.md) - Current SSO documentation
-- [ADR-006](../../30-security/decisions/2025-11-11-ADR-006-authelia-sso-yubikey-deployment.md) - Migration decision rationale
+Key scheduled operations:
+- Every 5 min: Nextcloud cron, dependency metrics
+- Every 30 min: Cloudflare DDNS
+- Hourly: Journal log rotation
+- Daily: BTRFS backup, SLO snapshot, drift check, resource forecast, error digest, auto-doc
+- Weekly: Intelligence report, vulnerability scan, podman auto-update, database maintenance
+- Monthly: SLO report, remediation report, skill usage report
+- Biweekly: Backup restore test
 
 ---
 
-### Jellyfin (Media Server)
+## Expansion Guide
 
-**Container:** `jellyfin`
-**Image:** `docker.io/jellyfin/jellyfin:latest`
-**Network:** systemd-reverse_proxy
-**Port:** 8096 (internal only)
+### Adding a New Service
 
-**Features:**
-- Media streaming (movies, TV, music)
-- Hardware transcoding
-- User management
-- Mobile apps available
+1. **Design:** Consult `infrastructure-architect` subagent for network topology and pattern selection
+2. **Deploy:** Use pattern-based deployment or manual quadlet creation
+3. **Route:** Add to `config/traefik/dynamic/routers.yml` (never use container labels)
+4. **Verify:** Run `service-validator` subagent for 7-level verification
+5. **Clean:** Use `code-simplifier` subagent for post-deployment refactoring
+6. **Commit:** Use `/commit-push-pr` for git workflow
 
-**Access:**
-- Web: https://jellyfin.patriark.org (requires Authelia SSO login first)
-- SSO Portal: https://sso.patriark.org (YubiKey + TOTP authentication)
-- Internal login: Separate Jellyfin user account (after SSO)
+### Network Ordering Rule
 
-**Storage:**
-- Config: `~/containers/config/jellyfin/`
-- Media: (configure media library paths)
+When a container needs multiple networks, **the first `Network=` line gets the default route**:
 
----
-
-## 🚀 Expansion Guide
-
-### How to Add New Services
-
-#### Standard Service Addition Process
-
-**Step 1: Plan the Service**
-- Choose service (e.g., Nextcloud, Vaultwarden)
-- Check Docker image availability
-- Identify required ports
-- Review dependencies
-
-**Step 2: Create Quadlet**
-```bash
-nano ~/.config/containers/systemd/SERVICE_NAME.container
-```
-
-**Template:**
 ```ini
-[Unit]
-Description=SERVICE_NAME
-After=network-online.target traefik.service
-Wants=network-online.target
+# Correct: reverse_proxy first (has internet access)
+Network=systemd-reverse_proxy.network
+Network=systemd-monitoring.network
 
-[Container]
-Image=docker.io/SERVICE_IMAGE:TAG
-ContainerName=SERVICE_NAME
-AutoUpdate=registry
-Network=systemd-reverse_proxy
-
-# Volumes
-Volume=%h/containers/config/SERVICE_NAME:/config:Z
-Volume=%h/containers/data/SERVICE_NAME:/data:Z
-
-# Environment variables
-Environment=KEY=VALUE
-
-[Service]
-Restart=always
-TimeoutStartSec=900
-
-[Install]
-WantedBy=default.target
-```
-
-**Step 3: Add Traefik Route**
-```bash
-nano ~/containers/config/traefik/dynamic/routers.yml
-```
-
-**Add:**
-```yaml
-http:
-  routers:
-    SERVICE_NAME:
-      rule: "Host(`SERVICE_NAME.patriark.org`)"
-      service: "SERVICE_NAME"
-      entryPoints:
-        - websecure
-      middlewares:
-        - crowdsec-bouncer
-        - rate-limit
-        - authelia@file  # SSO authentication
-      tls:
-        certResolver: letsencrypt
-  
-  services:
-    SERVICE_NAME:
-      loadBalancer:
-        servers:
-          - url: "http://SERVICE_NAME:PORT"
-```
-
-**Step 4: Start Service**
-```bash
-systemctl --user daemon-reload
-systemctl --user start SERVICE_NAME.service
-systemctl --user enable SERVICE_NAME.service
-```
-
-**Step 5: Test**
-```bash
-# Check running
-podman ps | grep SERVICE_NAME
-
-# Check logs
-podman logs SERVICE_NAME --tail 20
-
-# Test access
-curl -I https://SERVICE_NAME.patriark.org
+# Wrong: monitoring first (no internet, breaks outbound connectivity)
+Network=systemd-monitoring.network
+Network=systemd-reverse_proxy.network
 ```
 
 ---
 
-### Service Categories
+## Maintenance
 
-#### **Media Services**
-- **Sonarr** - TV show management
-- **Radarr** - Movie management
-- **Prowlarr** - Indexer management
-- **Bazarr** - Subtitle management
-- **Overseerr** - Media requests
+### Automated (no manual action needed)
 
-#### **Productivity**
-- **Nextcloud** - File sync & collaboration
-- **Vaultwarden** - Password manager
-- **Paperless-ngx** - Document management
-- **Bookstack** - Documentation wiki
+- DDNS updates (every 30 min)
+- CrowdSec threat updates (continuous)
+- Container health checks (every 10-30s)
+- SSL certificate renewal (Let's Encrypt)
+- BTRFS snapshots (daily)
+- Log rotation (hourly)
+- Documentation regeneration (daily 07:00)
 
-#### **Monitoring**
-- **Uptime Kuma** - Service monitoring
-- **Grafana** - Metrics visualization
-- **Prometheus** - Metrics collection
-- **Loki** - Log aggregation
-
-#### **Smart Home**
-- **Home Assistant** - Smart home hub
-- **Node-RED** - Automation flows
-- **Zigbee2MQTT** - Zigbee device bridge
-
-#### **Development**
-- **Gitea** - Git hosting
-- **Drone CI** - CI/CD pipeline
-- **Code Server** - VS Code in browser
-
----
-
-### Network Expansion Options
-
-#### **Option 1: Add More Services (Current Setup)**
-```
-systemd-reverse_proxy network
-├── traefik
-├── crowdsec
-├── authelia
-├── jellyfin
-├── nextcloud      ← Add here
-├── vaultwarden    ← Add here
-└── uptime-kuma    ← Add here
-```
-
-**Pros:** Simple, everything on one network
-**Cons:** All services can talk to each other
-
----
-
-#### **Option 2: Multiple Networks (Better Isolation)**
-```
-systemd-reverse_proxy (frontend)
-├── traefik
-├── crowdsec
-└── authelia
-
-systemd-services (backend)
-├── jellyfin
-├── nextcloud
-└── vaultwarden
-
-systemd-databases (data)
-├── postgres
-├── redis
-└── mariadb
-```
-
-**Pros:** Better security isolation  
-**Cons:** More complex configuration
-
----
-
-#### **Option 3: Service-Specific Networks**
-```
-Each service gets its own network + reverse_proxy
-
-traefik → reverse_proxy + jellyfin_net + nextcloud_net
-jellyfin → jellyfin_net only
-nextcloud → nextcloud_net only
-```
-
-**Pros:** Maximum isolation
-**Cons:** Most complex
-
----
-
-### Recommended Expansion Path
-
-**Phase 1: Core Services** (Current)
-- ✅ Traefik
-- ✅ CrowdSec
-- ✅ Authelia (SSO + YubiKey MFA)
-- ✅ Jellyfin
-
-**Phase 2: Add Utilities**
-- Nextcloud (file storage)
-- Vaultwarden (passwords)
-- Homepage (dashboard)
-
-**Phase 3: Add Monitoring**
-- Uptime Kuma (service monitoring)
-- Grafana + Prometheus (metrics)
-- Loki (Logs aggregation)
-
-**Phase 4: Advanced**
-- WireGuard VPN
-- Home Assistant
-- Media *arr stack
-
----
-
-## 🔧 Maintenance
-
-### Daily
-
-**Automatic:**
-- DDNS updates (every 30 minutes)
-- CrowdSec threat updates
-- Container health checks
-- SSL certificate renewal checks
-
-**Manual:**
-None required! Everything is automated.
-
----
-
-### Weekly
+### Weekly Review
 
 ```bash
-# Check service health
-podman ps -a
-
-# Review CrowdSec alerts
-podman exec crowdsec cscli alerts list
-
-# Check for container updates
-podman auto-update --dry-run
-
-# Review logs for errors
-journalctl --user -u traefik.service --since "1 week ago" | grep -i error
+./scripts/homelab-intel.sh              # Health score + recommendations
+./scripts/check-drift.sh                # Config drift detection
+./scripts/security-audit.sh             # Security baseline
 ```
 
----
-
-### Monthly
+### Update Workflow
 
 ```bash
-# Update containers
-podman auto-update
-
-# Restart services after updates
-systemctl --user restart traefik.service
-systemctl --user restart crowdsec.service
-systemctl --user restart authelia.service redis-authelia.service
-systemctl --user restart jellyfin.service
-
-# Create config backup
-tar -czf ~/backups/config-$(date +%Y%m%d).tar.gz \
-    ~/containers/config \
-    ~/.config/containers/systemd
-
-# Create BTRFS snapshot
-sudo btrfs subvolume snapshot /home /home-monthly-$(date +%Y%m%d)
-
-# Clean old snapshots (keep 3 months)
-sudo btrfs subvolume list / | grep home-monthly | head -n -3 | \
-    awk '{print $NF}' | xargs -I {} sudo btrfs subvolume delete {}
-
-# Review CrowdSec statistics
-podman exec crowdsec cscli metrics
+~/containers/scripts/update-before-reboot.sh  # Before DNF updates
+# Uses :latest tags for most services
+# Databases pinned to major version
+# Immich pinned to specific version
+# Rollback via BTRFS snapshots
 ```
 
 ---
 
-### Quarterly
-
-```bash
-# Full security audit
-~/containers/scripts/security-audit.sh
-
-# Review and update documentation
-nano ~/containers/documentation/HOMELAB-ARCHITECTURE-DOCUMENTATION.md
-
-# Test disaster recovery
-# (restore from backup to test machine)
-
-# Review SSL certificate health
-ls -la ~/containers/config/traefik/letsencrypt/
-
-# Update passwords/secrets
-# (rotate API keys, update passwords)
-```
-
----
-
-## 🔍 Troubleshooting
-
-### Common Issues
-
-#### Service Won't Start
-
-```bash
-# Check service status
-systemctl --user status SERVICE.service
-
-# Check logs
-journalctl --user -u SERVICE.service -n 50
-
-# Check container logs
-podman logs SERVICE --tail 50
-
-# Common fixes:
-systemctl --user daemon-reload
-systemctl --user restart SERVICE.service
-```
-
----
-
-#### Can't Access Service from Internet
-
-```bash
-# Check DNS
-dig SERVICE.patriark.org +short
-# Should show your public IP
-
-# Check port forwarding
-# UDM Pro → Settings → Port Forwarding
-# Verify 80 and 443 → 192.168.1.70
-
-# Check Traefik routing
-podman logs traefik | grep SERVICE
-
-# Check if service is running
-podman ps | grep SERVICE
-```
-
----
-
-#### SSL Certificate Issues
-
-```bash
-# Check certificate file
-ls -la ~/containers/config/traefik/letsencrypt/acme.json
-
-# Force renewal
-# Delete cert from acme.json, restart Traefik
-
-# Check Let's Encrypt logs
-podman logs traefik | grep -i acme
-podman logs traefik | grep -i certificate
-```
-
----
-
-#### CrowdSec Not Blocking
-
-```bash
-# Check CrowdSec is running
-podman ps | grep crowdsec
-
-# Check bouncer is connected
-podman exec crowdsec cscli bouncers list
-
-# Check decisions
-podman exec crowdsec cscli decisions list
-
-# Test blocking manually
-MY_IP=$(curl -s ifconfig.me)
-podman exec crowdsec cscli decisions add --ip $MY_IP --duration 5m
-curl -I https://jellyfin.patriark.org
-# Should return 403
-```
-
----
-
-#### Authentication Loop
-
-```bash
-# Check Authelia is running
-podman ps | grep authelia
-
-# Check Authelia logs
-podman logs authelia --tail 50
-
-# Check Redis (session storage)
-podman logs redis-authelia --tail 50
-
-# Check Authelia health endpoint
-curl http://localhost:9091/api/health
-
-# Clear browser cookies and try again
-```
-
----
-
-### Emergency Procedures
-
-#### Complete System Restore
-
-```bash
-# 1. Stop all services
-systemctl --user stop traefik.service
-systemctl --user stop crowdsec.service
-systemctl --user stop authelia.service redis-authelia.service
-systemctl --user stop jellyfin.service
-
-# 2. Restore from BTRFS snapshot
-sudo btrfs subvolume snapshot /home-backup-DATE /home
-
-# 3. Reboot
-sudo reboot
-
-# 4. Verify services start
-podman ps
-```
-
----
-
-#### Remove All Containers (Nuclear Option)
-
-```bash
-# Stop all user services
-systemctl --user stop traefik.service crowdsec.service authelia.service redis-authelia.service jellyfin.service
-
-# Remove all containers
-podman rm -af
-
-# Remove all images
-podman rmi -af
-
-# Reload and restart
-systemctl --user daemon-reload
-systemctl --user start traefik.service
-systemctl --user start crowdsec.service
-systemctl --user start authelia.service redis-authelia.service
-systemctl --user start jellyfin.service
-
-# Containers will be re-pulled
-```
-
----
-
-### Health Check Script
-
-```bash
-#!/bin/bash
-# ~/containers/scripts/health-check.sh
-
-echo "=== Homelab Health Check ==="
-echo ""
-
-echo "Services:"
-systemctl --user is-active traefik.service crowdsec.service authelia.service redis-authelia.service jellyfin.service
-
-echo ""
-echo "Containers:"
-podman ps --format "table {{.Names}}\t{{.Status}}"
-
-echo ""
-echo "Public IP:"
-curl -s ifconfig.me
-
-echo ""
-echo "DNS:"
-dig +short patriark.org
-
-echo ""
-echo "SSL Expiry:"
-echo | openssl s_client -servername jellyfin.patriark.org -connect jellyfin.patriark.org:443 2>/dev/null | \
-    openssl x509 -noout -dates | grep notAfter
-
-echo ""
-echo "CrowdSec Status:"
-podman exec crowdsec cscli bouncers list 2>/dev/null || echo "CrowdSec not responding"
-
-echo ""
-echo "=== Health Check Complete ==="
-```
-
----
-
-## 📊 Monitoring & Observability
-
-### Current Monitoring Capabilities
-
-**Service Health:**
-- Systemd status (`systemctl --user status`)
-- Container health checks (Podman)
-- Process monitoring (automatic restarts)
-
-**Logs:**
-- Systemd journal (`journalctl`)
-- Container logs (`podman logs`)
-- Traefik access logs (to be configured)
-
-**Security:**
-- CrowdSec alerts and decisions
-- Traefik error logs
-- Failed authentication attempts (Authelia logs)
-
-**Metrics:**
-- CrowdSec metrics (`cscli metrics`)
-- Traefik internal metrics (API)
-- System resources (htop, podman stats)
-
----
-
-### Future Monitoring Stack (Recommended)
-
-```
-Grafana (Visualization)
-    ↓
-Prometheus (Metrics)
-    ↓
-├── Node Exporter (System metrics)
-├── cAdvisor (Container metrics)
-└── Traefik metrics (HTTP metrics)
-    ↓
-Loki (Log aggregation)
-    ↓
-├── Traefik logs
-├── CrowdSec logs
-└── Application logs
-```
-
----
-
-## 🎓 Learning Resources
-
-### Understanding the Stack
-
-**Traefik:**
-- Official docs: https://doc.traefik.io/traefik/
-- Getting started: https://doc.traefik.io/traefik/getting-started/quick-start/
-
-**Podman:**
-- Official docs: https://docs.podman.io/
-- Quadlets guide: https://docs.podman.io/en/latest/markdown/podman-systemd.unit.5.html
-
-**CrowdSec:**
-- Official docs: https://docs.crowdsec.net/
-- Traefik bouncer: https://github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin
-
-**Let's Encrypt:**
-- How it works: https://letsencrypt.org/how-it-works/
-- ACME protocol: https://letsencrypt.org/docs/client-options/
-
----
-
-## 📝 Change Log
-
-### 2025-11-11 - Authelia SSO Migration
-- Migrated from TinyAuth to Authelia
-- Implemented YubiKey/WebAuthn hardware 2FA
-- Added TOTP fallback (Microsoft Authenticator)
-- Deployed Redis for session storage
-
-### 2025-10-23 - Initial Production Setup
-- Initial SSO deployment (TinyAuth - later replaced)
-- Configured Cloudflare DDNS
-- Implemented Let's Encrypt SSL
-- Added CrowdSec security
-- Documented complete architecture
-
-### Future Changes
-- [Date] - [Change description]
-
----
-
-## 🎯 Success Metrics
-
-**Security:**
-- ✅ Zero unauthorized access attempts succeeded
-- ✅ All traffic encrypted (SSL/TLS)
-- ✅ Rate limiting active on all endpoints
-- ✅ CrowdSec blocking malicious IPs
-- ✅ Multi-factor authentication ready (can add)
-
-**Reliability:**
-- ✅ 99%+ uptime (container auto-restart)
-- ✅ Automatic SSL renewal
-- ✅ Automatic DNS updates
-- ✅ Self-healing infrastructure
-
-**Maintainability:**
-- ✅ Declarative configuration (Infrastructure as Code)
-- ✅ Version controlled (can be)
-- ✅ Well documented
-- ✅ Easy to restore from backup
-- ✅ Systemd integration (starts on boot)
-
----
-
-## 🏆 Best Practices Implemented
-
-1. ✅ **Least Privilege** - Rootless containers, minimal permissions
-2. ✅ **Defense in Depth** - Multiple security layers
-3. ✅ **Automation** - DDNS, SSL renewal, restarts
-4. ✅ **Declarative Config** - Quadlets, YAML files
-5. ✅ **Immutable Infrastructure** - Containers, not processes
-6. ✅ **Observability** - Structured logs, metrics available
-7. ✅ **Documentation** - Architecture documented
-8. ✅ **Backups** - BTRFS snapshots, config backups
-9. ✅ **Secrets Management** - Separated, protected files
-10. ✅ **Network Segmentation** - Isolated container networks
-
----
-
-## 📞 Quick Reference
-
-### Important URLs
-
-| Service | URL | Authentication |
-|---------|-----|----------------|
-| Jellyfin | https://jellyfin.patriark.org | Authelia SSO → Jellyfin |
-| Traefik Dashboard | https://traefik.patriark.org | Authelia SSO |
-| Authelia SSO Portal | https://sso.patriark.org | YubiKey + TOTP |
-
-### Important Commands
-
-```bash
-# Restart all services
-systemctl --user restart traefik.service crowdsec.service authelia.service redis-authelia.service jellyfin.service
-
-# View all logs
-journalctl --user -u traefik.service -f
-
-# Update containers
-podman auto-update
-
-# Create backup
-tar -czf ~/backup-$(date +%Y%m%d).tar.gz ~/containers/config ~/.config/containers/systemd
-
-# Check CrowdSec status
-podman exec crowdsec cscli metrics
-
-# Manual DDNS update
-~/containers/scripts/cloudflare-ddns.sh
-
-# Health check
-~/containers/scripts/health-check.sh
-```
-
-### Important Files
-
-```bash
-# Traefik
-~/containers/config/traefik/traefik.yml
-~/containers/config/traefik/dynamic/routers.yml
-~/containers/config/traefik/dynamic/middleware.yml
-
-# Systemd
-~/.config/containers/systemd/*.container
-
-# Secrets
-~/containers/secrets/cloudflare_token
-~/containers/secrets/cloudflare_zone_id
-
-# Scripts
-~/containers/scripts/cloudflare-ddns.sh
-~/containers/scripts/security-audit.sh
-```
-
----
-
-## 🎊 Conclusion
-
-This homelab represents a **production-grade, secure, self-hosted infrastructure** using modern DevOps practices and enterprise-grade tools. The architecture is:
-
-- **Secure** - Multiple layers of protection
-- **Reliable** - Self-healing, automatic recovery
-- **Maintainable** - Well-documented, easy to understand
-- **Scalable** - Easy to add new services
-- **Professional** - Industry-standard tools and practices
-
-**You've built something impressive!** 🌟
-
----
-
-**Document Version:** 1.0
-**Last Review:** October 23, 2025
-**Next Review:** January 23, 2026
+**Document Version:** 3.0
+**Previous versions:** [v1.0 archived from Nov 2025](../../90-archive/)

--- a/docs/90-archive/STATE-OF-HOMELAB-2025-12-31-baseline.md
+++ b/docs/90-archive/STATE-OF-HOMELAB-2025-12-31-baseline.md
@@ -1,0 +1,525 @@
+# State of the Homelab - New Year 2026 Baseline
+
+**Snapshot Date:** December 31, 2025, 21:00 CET
+**Health Score:** 95/100
+**Status:** Production-Ready, Mature Infrastructure
+**Purpose:** Baseline documentation for measuring progress throughout 2026
+
+---
+
+## Executive Summary
+
+The homelab enters 2026 in **exceptional operational condition**. After a year of building, hardening, and optimizing, the infrastructure demonstrates production-grade capabilities with autonomous operations, comprehensive monitoring, security hardening, and validated disaster recovery.
+
+**Key Achievements:**
+- ✅ 95/100 health score (excellent)
+- ✅ 23 services running smoothly
+- ✅ Autonomous OODA loop operations functional
+- ✅ Disaster recovery validated (6-minute RTO)
+- ✅ Zero critical issues outstanding
+- ✅ Comprehensive monitoring with 9 SLOs
+- ✅ Security hardened (CrowdSec, Authelia, YubiKey MFA)
+
+**2025 in Numbers:**
+- **Services Deployed:** 9 production services
+- **Uptime:** 3 days (post-maintenance)
+- **Containers Running:** 23
+- **Memory Usage:** 13GB / 30GB (43%)
+- **Storage:** Root 69%, BTRFS pool 71%
+- **SLO Compliance:** To be measured in January 2026 report
+- **Security Audit:** 7 passes, 3 minor warnings, 0 failures
+
+---
+
+## Infrastructure Capabilities Matrix
+
+### Core Services (Production)
+
+| Service | Purpose | Status | Health | Uptime Target |
+|---------|---------|--------|--------|---------------|
+| **Traefik** | Reverse proxy + routing | ✅ Running | Healthy | 99.95% |
+| **Authelia** | SSO + YubiKey MFA | ✅ Running | Healthy | 99.90% |
+| **CrowdSec** | IP reputation + threat intel | ✅ Running | Healthy | 99.50% |
+| **Jellyfin** | Media streaming | ✅ Running | Healthy | 99.50% |
+| **Immich** | Photo management | ✅ Running | Healthy | 99.90% |
+| **Nextcloud** | File sync + collaboration | ✅ Running | Healthy | 99.50% |
+| **Vaultwarden** | Password manager | ✅ Running | Healthy | 99.90% |
+| **Prometheus** | Metrics collection | ✅ Running | Healthy | 99.50% |
+| **Grafana** | Monitoring dashboards | ✅ Running | Healthy | 99.50% |
+
+**Total Services:** 9 production services + 14 supporting containers (Redis, databases, exporters, etc.)
+
+### Monitoring & Observability Stack
+
+| Component | Purpose | Status | Coverage |
+|-----------|---------|--------|----------|
+| **Prometheus** | Metrics collection | ✅ Active | 23 containers monitored |
+| **Grafana** | Visualization | ✅ Active | 15+ dashboards |
+| **Loki** | Log aggregation | ⚠️ Intermittent | Traefik + remediation logs |
+| **Alertmanager** | Alert routing | ✅ Active | Discord webhook integration |
+| **cAdvisor** | Container metrics | ✅ Active | Resource monitoring |
+| **Node Exporter** | System metrics | ✅ Active | Host-level metrics |
+
+**SLO Framework:**
+- **Services Covered:** 5 (Traefik, Authelia, Jellyfin, Immich, Nextcloud)
+- **SLOs Defined:** 9 total
+- **Alerting:** Tier 1 (critical) and Tier 2 (high) burn rate alerts configured
+- **Error Budget Tracking:** Active via Prometheus rules
+
+### Autonomous Operations Capabilities
+
+| Capability | Status | Confidence | Automation Level |
+|------------|--------|------------|------------------|
+| **OODA Loop** | ✅ Operational | High | Daily autonomous assessment |
+| **Predictive Maintenance** | ✅ Operational | Medium | 7-14 day forecasting |
+| **Alert-Driven Remediation** | ✅ Operational | Medium | Conservative actions only |
+| **Drift Detection** | ✅ Operational | High | Configuration monitoring |
+| **Health Scoring** | ✅ Operational | High | 0-100 automated scoring |
+| **Natural Language Queries** | ✅ Operational | High | homelab-intel.sh |
+| **Resource Forecasting** | ✅ Operational | Low | Disk exhaustion prediction |
+
+**Autonomous Execution:**
+- **Schedule:** Daily at 06:00 (predictive) and 06:30 (OODA)
+- **Circuit Breaker:** Active (pauses after failures)
+- **Service Overrides:** Traefik, Authelia protected from auto-restart
+- **Safety Controls:** BTRFS snapshots before destructive actions
+- **Decision Confidence:** >90% required for execution
+
+### Security Posture
+
+**Security Layers (Defense in Depth):**
+
+1. **Network Segmentation** ✅
+   - 5 isolated networks (reverse_proxy, database, monitoring, backend, internal)
+   - Trust boundaries enforced via network policies
+
+2. **IP Reputation** ✅
+   - CrowdSec with CAPI integration
+   - Real-time threat intelligence
+   - Current status: No active threats detected
+
+3. **Rate Limiting** ✅
+   - Tiered limits (global: 50/min, auth: 10/min, API: 30/min)
+   - Fail-fast middleware ordering
+
+4. **Authentication** ✅
+   - Authelia SSO for all public services
+   - YubiKey WebAuthn (phishing-resistant)
+   - TOTP backup authentication
+
+5. **TLS Encryption** ✅
+   - Let's Encrypt certificates (81 days valid)
+   - TLS 1.2+ with modern ciphers
+   - HSTS enabled (31536000s)
+
+6. **Security Headers** ✅
+   - CSP, X-Frame-Options, X-Content-Type-Options
+   - Browser-level protection
+
+7. **Container Isolation** ✅
+   - Rootless containers (UID 1000)
+   - SELinux enforcing mode
+   - Read-only volumes where possible
+
+**Security Audit Results (2025-12-31):**
+- ✅ Passes: 7
+- ⚠️ Warnings: 3 (minor - homepage as root, expected ports, no memory limits on some containers)
+- ❌ Failures: 0
+
+**Vulnerability Scanning:**
+- **Schedule:** Weekly (Sundays 06:00)
+- **Tool:** Trivy
+- **Action:** Automated critical/high severity alerts
+
+### Disaster Recovery & Backup
+
+**Validated Capabilities (DR-003 Test, 2025-12-31):**
+- ✅ BTRFS snapshot restoration (6-minute RTO for 939MB)
+- ✅ Git-based configuration recovery
+- ✅ Multi-source restoration strategy
+- ✅ `podman unshare` permission handling
+
+**Backup Strategy (Three Pillars):**
+
+1. **Local BTRFS Snapshots**
+   - **Location:** `/mnt/btrfs-pool/.snapshots/`
+   - **Frequency:** Daily (automated)
+   - **Retention:** 14+ days visible
+   - **RTO:** <10 minutes (validated)
+   - **RPO:** 24 hours
+
+2. **Git Version Control**
+   - **Repository:** GitHub (vonrobak/fedora-homelab-containers)
+   - **Coverage:** Quadlets, configs, documentation, scripts
+   - **Retention:** Full history
+   - **RTO:** <5 minutes for config
+
+3. **External Backups**
+   - **Status:** Exists (not tested in DR-003)
+   - **Purpose:** Off-site catastrophic recovery
+   - **RTO:** Unknown (estimate: hours)
+
+**Runbooks Available:**
+- DR-001: System SSD Failure
+- DR-002: BTRFS Pool Corruption
+- DR-003: Accidental Deletion (validated 2025-12-31)
+- DR-004: Total Catastrophe
+- IR-001: Brute Force Attack
+- IR-002: Unauthorized Port
+- IR-003: Critical CVE
+- IR-004: Compliance Failure
+
+---
+
+## Performance Baselines
+
+### Resource Utilization (December 31, 2025)
+
+**Memory:**
+- **Total:** 30GB
+- **Used:** 13GB (43%)
+- **Available:** 17GB (57%)
+- **Swap:** 2.7GB used (normal for long-running services)
+- **Top Consumers:** Jellyfin (752MB), Immich-server (343MB), cAdvisor (246MB)
+
+**CPU:**
+- **Load Average:** 0.00 (idle)
+- **Normal Usage:** 2-5%
+- **Top Consumers:** Jellyfin (4.86%), cAdvisor (4.68%), Traefik (0.83%)
+- **Transcoding Spikes:** 50-80% (expected during media encoding)
+
+**Disk (Root SSD):**
+- **Total:** 118GB
+- **Used:** 80GB (69%)
+- **Available:** 37GB (31%)
+- **Threshold:** ⚠️ >70%, 🚨 >80%
+- **Status:** Comfortable
+
+**Disk (BTRFS Pool):**
+- **Total:** 15TB
+- **Used:** 11TB (71%)
+- **Available:** 4.3TB (29%)
+- **Growth Rate:** -0.30 GB/day (declining due to log rotation)
+- **Days to 90%:** 80+ days
+
+**Network:**
+- **Containers:** 23 running
+- **Networks:** 5 (reverse_proxy, database, monitoring, backend, internal)
+- **Internet:** ✅ Operational
+- **External Access:** Ports 80/443 forwarded
+
+### Service Response Times (Typical)
+
+| Service | Endpoint | Response Time | Notes |
+|---------|----------|---------------|-------|
+| Traefik | Dashboard | <100ms | Local network |
+| Authelia | SSO auth | 200-500ms | Includes 2FA |
+| Jellyfin | Web UI | <200ms | No transcoding |
+| Immich | Photo library | 300-600ms | Thumbnails cached |
+| Nextcloud | Files | 200-400ms | With Redis cache |
+| Grafana | Dashboards | <300ms | Prometheus data source |
+| Prometheus | Queries | 50-200ms | Depends on query complexity |
+
+**Note:** Response times vary based on query complexity, cache hits, and user load
+
+---
+
+## Architecture Highlights
+
+### Pattern-Based Deployment System
+
+**9 Battle-Tested Patterns:**
+1. `media-server-stack` - Jellyfin, Plex (GPU transcoding)
+2. `web-app-with-database` - Wiki.js, Bookstack
+3. `document-management` - Paperless-ngx, Nextcloud
+4. `authentication-stack` - Authelia + Redis
+5. `password-manager` - Vaultwarden
+6. `database-service` - PostgreSQL, MySQL (NOCOW optimized)
+7. `cache-service` - Redis, Memcached
+8. `reverse-proxy-backend` - Internal services
+9. `monitoring-exporter` - Node exporter, cAdvisor
+
+**Deployment Features:**
+- Automated routing generation (Traefik dynamic config)
+- Health-aware deployment (wait for service readiness)
+- Validation scripts (configuration correctness)
+- ADR-016 compliance (separation of concerns)
+
+### Configuration Philosophy (ADR-016)
+
+**Key Principle:** Separation of Concerns
+- **Quadlets:** Deployment configuration (systemd units)
+- **Traefik Dynamic Config:** Routing configuration (centralized)
+- **Never Mix:** No Traefik labels in quadlets (248-line routers.yml is source of truth)
+
+**Benefits:**
+- Single source of truth for routing
+- Centralized security policy enforcement
+- Git-friendly (routing changes isolated)
+- Auditable (all routes in one file)
+
+### Network Topology
+
+**5-Network Design:**
+
+```
+┌─────────────────────────────────────────────────┐
+│  reverse_proxy (10.89.0.0/24)                   │
+│  - Traefik, all user-facing services            │
+│  - Default route (internet access)              │
+└─────────────────────────────────────────────────┘
+          ↓
+┌─────────────────────────────────────────────────┐
+│  database (10.89.3.0/24)                        │
+│  - PostgreSQL, MySQL, Redis                     │
+│  - No internet access (internal only)           │
+└─────────────────────────────────────────────────┘
+          ↓
+┌─────────────────────────────────────────────────┐
+│  monitoring (10.89.1.0/24)                      │
+│  - Prometheus, Grafana, Loki                    │
+│  - Cross-network scraping                       │
+└─────────────────────────────────────────────────┘
+          ↓
+┌─────────────────────────────────────────────────┐
+│  backend (10.89.2.0/24)                         │
+│  - Internal services, not internet-facing       │
+└─────────────────────────────────────────────────┘
+          ↓
+┌─────────────────────────────────────────────────┐
+│  internal (10.89.4.0/24)                        │
+│  - Fully isolated services                      │
+└─────────────────────────────────────────────────┘
+```
+
+**Design Rationale:** Trust boundaries, defense in depth, least privilege
+
+---
+
+## Documentation & Knowledge Management
+
+### Documentation Structure (298 Total Files)
+
+**Topical Reference:**
+- `00-foundation/` - Core architecture, ADRs, guides
+- `10-services/` - Service-specific guides, patterns
+- `20-operations/` - Runbooks, automation, operations
+- `30-security/` - Security guides, runbooks, policies
+- `40-monitoring-and-documentation/` - SLO framework, monitoring
+
+**Chronological Learning:**
+- `98-journals/` - Complete project timeline (append-only)
+- `97-plans/` - Strategic planning (forward-looking)
+- `99-reports/` - Automated reports + snapshots
+
+**Auto-Generated (Daily 07:00):**
+- `AUTO-SERVICE-CATALOG.md` - Service inventory
+- `AUTO-NETWORK-TOPOLOGY.md` - Network diagrams
+- `AUTO-DEPENDENCY-GRAPH.md` - 4-tier dependency graph
+- `AUTO-DOCUMENTATION-INDEX.md` - Complete catalog
+
+**Architecture Decision Records:** 15 ADRs documenting key decisions
+
+**Regeneration:** `~/containers/scripts/auto-doc-orchestrator.sh` (~2 seconds)
+
+### Automation & Scripts
+
+**65 Scripts Across 8 Categories:**
+1. **Health & Diagnostics** (11 scripts)
+2. **Monitoring & Alerting** (9 scripts)
+3. **Backup & Disaster Recovery** (7 scripts)
+4. **Security & Compliance** (8 scripts)
+5. **Deployment & Configuration** (12 scripts)
+6. **Autonomous Operations** (6 scripts)
+7. **Documentation Generation** (7 scripts)
+8. **Utility & Maintenance** (5 scripts)
+
+**Full catalog:** `docs/20-operations/guides/automation-reference.md`
+
+---
+
+## Lessons Learned (2025 Highlights)
+
+### What Worked Exceptionally Well
+
+1. **Pattern-Based Deployment**
+   - Reduced deployment time from hours to minutes
+   - Consistent configuration across services
+   - Lower error rate for new services
+
+2. **Autonomous Operations**
+   - Predictive maintenance caught resource issues before alerts
+   - OODA loop reduced manual monitoring burden
+   - Confidence-based decision making prevented over-automation
+
+3. **Documentation-First Approach**
+   - ADRs prevented repeated architectural debates
+   - Auto-generated docs stayed current
+   - Journals provided institutional memory
+
+4. **Security Hardening**
+   - YubiKey MFA eliminated password fatigue
+   - CrowdSec provided peace of mind
+   - Layered security caught multiple threat vectors
+
+5. **BTRFS Snapshots**
+   - Zero-cost daily snapshots
+   - Fast restoration (6-minute RTO validated)
+   - No backup-specific tooling needed
+
+### Challenges Overcome
+
+1. **SELinux Permission Conflicts**
+   - **Issue:** Nested mounts, container permissions
+   - **Solution:** Proper `:Z` labeling, `podman unshare`
+   - **Learning:** Rootless containers require discipline
+
+2. **OCIS → Nextcloud Migration**
+   - **Issue:** Feature gaps, performance differences
+   - **Solution:** Comprehensive testing, gradual migration
+   - **Learning:** Evaluate production-readiness thoroughly
+
+3. **Alert Noise**
+   - **Issue:** Frequent low-priority alerts (LowSnapshotCount)
+   - **Solution:** Inhibition rules, threshold tuning
+   - **Learning:** SLO-based alerting > symptom-based
+
+4. **Configuration Drift**
+   - **Issue:** Quadlets vs. Traefik config sync
+   - **Solution:** ADR-016 (separation of concerns)
+   - **Learning:** Centralized configuration reduces drift
+
+### Technical Debt Addressed
+
+1. ✅ OCIS fully decommissioned (2025-12-20)
+2. ✅ Vaultwarden secrets migrated to Pattern 2 (2025-12-31)
+3. ✅ Traefik routing centralized (all labels removed)
+4. ✅ SLO framework operational (9 SLOs defined)
+5. ✅ Autonomous operations circuit breaker implemented
+
+### Technical Debt Remaining
+
+1. **Loki Health Check Intermittent**
+   - **Priority:** Low
+   - **Impact:** Minor (service runs, query works)
+   - **Plan:** Investigate startup timing in Q1 2026
+
+2. **No Memory Limits on Some Containers**
+   - **Priority:** Low
+   - **Impact:** System stable, no OOM events
+   - **Plan:** Add limits during Q1 resource optimization
+
+3. **External Backup Not Tested**
+   - **Priority:** Medium
+   - **Impact:** Unknown restoration capability
+   - **Plan:** Test external backup in Q1 2026
+
+---
+
+## Looking Ahead: 2026 Roadmap
+
+### Q1 2026: Optimization & Validation
+
+- [ ] Test external backup restoration
+- [ ] Quarterly DR drill (rotate through DR-001 to DR-004)
+- [ ] Resource right-sizing based on trends
+- [ ] Loki health check investigation
+- [ ] SLO target calibration (based on December baseline)
+
+### Q2 2026: Expansion (If Needed)
+
+- [ ] Evaluate new service candidates
+- [ ] Home automation integration exploration (Matter-first)
+- [ ] Additional monitoring dashboards (if gaps identified)
+- [ ] Security audit automation enhancements
+
+### Q3 2026: Maintenance & Polish
+
+- [ ] Major dependency updates (Immich, Nextcloud, etc.)
+- [ ] Pattern deployment refinements
+- [ ] Documentation cleanup/reorganization
+- [ ] Second quarterly DR drill
+
+### Q4 2026: Year-End Review
+
+- [ ] Annual SLO report
+- [ ] Security posture review
+- [ ] Architecture decision review
+- [ ] State of Homelab 2027 baseline
+
+### Continuous Improvements
+
+- **Weekly:** Vulnerability scanning (Sundays 06:00)
+- **Daily:** Autonomous OODA loop assessment
+- **Daily:** Auto-documentation regeneration
+- **Monthly:** SLO compliance reporting
+- **Quarterly:** DR drills
+
+---
+
+## Success Metrics for 2026
+
+### Reliability Targets
+
+| Metric | 2025 Baseline | 2026 Target | Measurement |
+|--------|---------------|-------------|-------------|
+| Health Score | 95/100 | ≥95/100 | Daily via homelab-intel.sh |
+| SLO Compliance | TBD | 100% (all SLOs met) | Monthly SLO report |
+| Unplanned Downtime | Unknown | <0.5% per service | Prometheus uptime metrics |
+| DR RTO | 6 min (tested) | <10 min | Quarterly DR drills |
+
+### Operational Targets
+
+| Metric | 2025 Baseline | 2026 Target | Measurement |
+|--------|---------------|-------------|-------------|
+| Autonomous Actions | Active | >80% success rate | Decision audit logs |
+| Alert Noise | Reduced | <5 alerts/week | Alertmanager metrics |
+| Config Drift | 0 detected | 0 detected | Daily drift detection |
+| Security Audit | 7 pass / 3 warn / 0 fail | 10 pass / 0 warn / 0 fail | Monthly audits |
+
+### Personal Learning Targets
+
+- [ ] Complete 4 quarterly DR drills (one per quarter)
+- [ ] Write 4 new ADRs documenting architectural decisions
+- [ ] Contribute to 1 open-source project used in homelab
+- [ ] Achieve 99.9% uptime for critical services (Traefik, Authelia)
+
+---
+
+## Closing Thoughts
+
+This homelab has evolved from a collection of services into a **production-grade infrastructure** with autonomous operations, comprehensive monitoring, validated disaster recovery, and security hardening. The health score of 95/100 reflects not just uptime, but operational maturity.
+
+### What Makes This Homelab Special
+
+1. **Autonomous Intelligence** - OODA loop, predictive maintenance, natural language queries
+2. **Battle-Tested DR** - Validated 6-minute RTO, multi-source recovery strategy
+3. **Production Practices** - SLOs, error budgets, runbooks, ADRs, circuit breakers
+4. **Security Layers** - 7 independent security controls (defense in depth)
+5. **Documentation Excellence** - 298 files, auto-generated docs, institutional memory
+
+### The Path Forward
+
+2026 will focus on **validation, optimization, and confidence-building** rather than expansion. The foundation is solid. Now it's about:
+- Proving it works under pressure (quarterly DR drills)
+- Optimizing what exists (resource tuning, alert refinement)
+- Building operational muscle memory (practicing runbooks)
+- Measuring and improving (SLO compliance, health scores)
+
+### New Year Message
+
+Welcome to 2026 with a homelab that's ready for anything. The monitoring will tell you when something's wrong. The automation will often fix it before you notice. The runbooks will guide you when manual intervention is needed. And the snapshots will save you when all else fails.
+
+**Health Score: 95/100**
+**Status: Supreme**
+**Confidence: High**
+**Ready for: 2026 and Beyond**
+
+---
+
+**Baseline Established:** December 31, 2025, 21:00 CET
+**Next Review:** March 31, 2026 (Q1 2026)
+**Document Version:** 1.0
+**Author:** Claude Sonnet 4.5 + User (patriark)
+
+*"The best time to test your backups is before you need them."* — Validated December 31, 2025

--- a/docs/98-journals/2026-02-05-documentation-accuracy-audit-and-strategic-assessment.md
+++ b/docs/98-journals/2026-02-05-documentation-accuracy-audit-and-strategic-assessment.md
@@ -1,0 +1,185 @@
+# Documentation Accuracy Audit and Strategic Assessment
+
+**Date:** 2026-02-05
+**Author:** Claude Opus 4.6 (first session with this project)
+**Status:** Documentation phase complete, strategic recommendations below
+**Health Score at Time of Audit:** 100/100
+
+---
+
+## Context
+
+This journal entry documents the findings of a comprehensive documentation accuracy audit performed by cross-referencing 373 documentation files against the live system state (28 running containers, 8 networks, 53 systemd timers). The audit was prompted by the user's goal of reaching operational excellence through documentation polish before pursuing new capabilities.
+
+## Audit Findings Summary
+
+### What Was Fixed
+
+**CLAUDE.md (master reference):**
+- Current Services: Updated from 6 groups to 14 service groups (28 containers)
+- Network count: Corrected from "5 networks" to 8, with all networks named and described
+- Memory estimates: Corrected from "2-3GB total" to "4-5GB total" with updated per-service figures (Prometheus 300MB not 80MB, Loki 200MB not 60MB)
+- Fedora version: 42 → 43
+- ADR count: 16 → 18
+- IR runbook count: 4 → 5
+- Subagent status: Removed "Coming in Phase 2/3" labels (all agents exist)
+- System SSD threshold: Adjusted to reflect current 64% usage reality
+
+**homelab-architecture.md:**
+- Complete rewrite from v1.0 (Nov 2025, 1360 lines) to v3.0 (Feb 2026, 483 lines)
+- Previous version only documented Traefik, CrowdSec, Authelia, Jellyfin
+- New version covers all 14 service groups, 8 networks, ADR-018, autonomous operations
+- Removed obsolete content (TinyAuth references, "Future Monitoring Stack" section that's been production for months, Phase 1-4 expansion roadmap that's been completed)
+- Trimmed from 1360 lines to 483 -- denser, more accurate, less cruft
+
+**STATE-OF-HOMELAB-2026.md:**
+- December 31 baseline archived to `docs/90-archive/STATE-OF-HOMELAB-2025-12-31-baseline.md`
+- New February 2026 snapshot with current 28-container, 8-network, 100/100 health reality
+- Tracks delta from December baseline (23→28 containers, 5→8 networks, 95→100 health)
+
+**README.md:**
+- Updated for public consumption -- removed specific domain names, IPs, hostnames
+- Reflects current 14 service groups, 8 networks, 53 timers, 18 ADRs
+- Added home automation section
+
+**New files created:**
+- `secrets/identity/homelab-identity.yml` -- YAML-structured private reference (domains, IPs, hosts, auth details) for programmatic access
+- `docs/10-services/guides/collabora.md` -- Service guide for Collabora Online
+- `docs/10-services/guides/matter-server.md` -- Service guide for Matter Server
+- `docs/10-services/guides/alert-discord-relay.md` -- Service guide for Alert Discord Relay
+
+### What Was Already Excellent
+
+The documentation audit revealed that the vast majority of this project's documentation is in outstanding condition:
+
+- **Auto-generated docs** regenerate daily and are accurate
+- **ADRs** are well-maintained with clear supersession chains
+- **Journal entries** (156) provide complete institutional memory
+- **DR runbooks** are validated and current
+- **Security guides** including CrowdSec field manuals (4 phases) are comprehensive
+- **SLO framework** is mature with burn-rate alerting
+- **Automation reference** catalogs 65 scripts with schedules
+
+The documentation problems were concentrated in the "headline" files (CLAUDE.md, architecture doc, README) that hadn't been refreshed since major service expansions in December-January. The deep reference material was already correct.
+
+---
+
+## Strategic Assessment: High-Impact Development Recommendations
+
+Having audited the full system state and read the recent journal history, here are my recommendations ordered by impact-to-effort ratio.
+
+### 1. Nextcloud Client Sync Stability Testing (HIGH IMPACT)
+
+**Why:** Nextcloud is one of only 4 user-facing applications with native auth, serving as the primary file sync and collaboration platform. The user has explicitly called this out as a priority. Journal entries show Nextcloud has received significant optimization (Dec 2025 project completion report) but client sync reliability across all connected devices hasn't been systematically tested.
+
+**What to do:**
+- Establish a sync test protocol: create/modify/delete files on each client, verify propagation timing and consistency
+- Test CalDAV/CardDAV sync (calendar/contacts) across iOS, macOS, and web clients
+- Test Collabora document editing concurrent access
+- Document any conflict resolution behavior
+- Verify the circuit-breaker and retry middleware in Traefik is actually helping during transient failures
+- Consider adding Nextcloud-specific SLOs (sync latency, conflict rate)
+
+**Effort:** Medium (1-2 sessions of systematic testing and documentation)
+
+### 2. Add Healthchecks for Loki and Promtail (LOW EFFORT, REAL VALUE)
+
+**Why:** These are the only 2 of 28 containers without healthchecks. Loki is a critical observability component -- if it goes down silently, log aggregation stops and you lose visibility. The healthcheck endpoints already exist (`localhost:3100/ready` for Loki, `localhost:9080/ready` for Promtail).
+
+**What to do:**
+- Add `HealthCmd` directives to `loki.container` and `promtail.container` quadlets
+- Use `curl -f http://localhost:3100/ready` and `curl -f http://localhost:9080/ready`
+- Note: May need to verify that curl or wget is available in these minimal images, otherwise use a wget-based or shell-based check
+
+**Effort:** Low (15 minutes)
+
+### 3. System SSD Space Management (PREVENTIVE)
+
+**Why:** System SSD is at 64%, approaching the documented warning threshold. The December baseline was 69%, and it's improved to 64% (likely from cleanup efforts), but with 28 containers and growing, proactive management prevents future pressure.
+
+**What to do:**
+- Review `podman system df` output for unused images and build cache
+- Check journal log size (`journalctl --user --disk-usage`)
+- Verify the weekly maintenance-cleanup timer is effective
+- Consider whether any container data on the SSD could be moved to the BTRFS pool
+- Document the current space consumers in a brief report
+
+**Effort:** Low (30 minutes)
+
+### 4. UDM Pro Security Visibility Gap (MEDIUM IMPACT)
+
+**Why:** The February security evaluation identifies this as the single largest gap -- the UDM Pro blocks 20-30 intrusion attempts daily but this data isn't in Prometheus/Grafana. UnPoller is running and healthy (609 metrics exported), but firewall block metrics, DPI, and IDS/IPS data aren't exposed.
+
+**What to do:**
+- Investigate what the UDM Pro API actually exposes for security events
+- Check if UnPoller can be configured to export firewall/IDS metrics (recent versions may support this)
+- If not available via UnPoller, explore the UniFi syslog forwarding → Promtail → Loki pipeline
+- Would push security score from 8.5/10 toward 9.5/10
+
+**Effort:** Medium (requires research into UniFi API capabilities)
+
+### 5. ESP32 Bluetooth Proxy Deployment (AWAITING HARDWARE)
+
+**Why:** This is the planned next physical expansion -- bridging Plejd smart lighting into Home Assistant via an ESP32 D1 Mini running ESPHome. The planning journal (Feb 4) is comprehensive. The hardware is ordered.
+
+**What to do when hardware arrives:**
+- Follow the existing plan in `docs/98-journals/2026-02-04-esp32-bluetooth-proxy-for-plejd-integration.md`
+- Flash ESPHome, configure WiFi and Bluetooth proxy
+- Verify Plejd devices appear in Home Assistant
+- Create automations for the 4 Plejd devices (2 dimmers, 2 controllers)
+- Document the integration as a service guide
+
+**Effort:** Low once hardware arrives (~15 min setup per the plan)
+
+### 6. Quarterly DR Drill (DUE)
+
+**Why:** Q1 2026 is approaching mid-quarter. The DR-001 through DR-004 runbooks are validated but the State of Homelab 2026 baseline lists quarterly DR drills as a 2026 target. Muscle memory fades.
+
+**What to do:**
+- Pick one DR scenario (suggest DR-002: BTRFS Pool Corruption as it hasn't been re-validated since the pool grew to 73% usage)
+- Execute the drill
+- Document results in a journal entry
+- Update the runbook if any steps have changed
+
+**Effort:** Medium (2-4 hours depending on scenario)
+
+### 7. Mill Air Purifier Integration Fix (DEFERRED, WATCHING)
+
+**Why:** The Jan 31 journal documents that the Mill integration receives full sensor data from 2 air purifiers (temperature, humidity, PM2.5, PM10) but filters them out as "Unsupported device". This is an upstream issue in the Mill integration.
+
+**What to do:**
+- Monitor the Home Assistant Mill integration repository for updates
+- The sensor data IS available in the API response -- a PR or custom component could unlock it
+- If the upstream fix doesn't come, consider contributing a PR or using a custom integration
+- Would add 2 more air quality sensors to the 37-automation Home Assistant setup
+
+**Effort:** Low to check, Medium if contributing a fix
+
+---
+
+## Observations from a Fresh Perspective
+
+Having entered this project with zero prior context and systematically audited every layer, a few patterns stand out:
+
+**What's genuinely impressive:**
+- The layered security architecture is production-grade. The fail-fast middleware ordering, the careful separation of Authelia-protected vs native-auth services, and the 8-network segmentation are all well-reasoned.
+- The autonomous operations (OODA loop, predictive maintenance, 53 timers) give this homelab capabilities most production environments don't have.
+- The documentation-as-learning approach has created genuine institutional memory. The 156 journal entries mean that decisions can always be traced back to their context.
+- ADR-016 (routing in config, not labels) is a particularly clean architectural decision that prevents the configuration drift that plagues most container setups.
+
+**Where to be cautious:**
+- The documentation volume (373 files) is approaching the point where navigation becomes harder than searching. The auto-generated index helps, but consider whether some older guides could be consolidated.
+- The 65 scripts + 53 timers represent significant automation surface area. Each timer is a potential failure mode. The weekly maintenance-cleanup timer is important -- make sure it's actually cleaning up.
+- With 28 containers, the blast radius of a Podman or systemd update grows. The update-before-reboot script is critical infrastructure.
+
+**The right next phase:**
+The user's instinct is correct -- this system needs polish and testing more than new services. The foundation is strong, the automation is mature, and the documentation is now accurate. The highest-leverage activities are: verifying Nextcloud sync reliability across all clients, closing the 2 healthcheck gaps, and building confidence through the quarterly DR drill. These are all "proving the system works under pressure" activities, which is exactly what operational excellence demands.
+
+---
+
+**Session Summary:**
+- 7 files created or rewritten
+- 1 file archived
+- ~15 factual errors corrected across documentation
+- 3 new service guides created
+- Strategic assessment with 7 prioritized recommendations delivered

--- a/docs/AUTO-DEPENDENCY-GRAPH.md
+++ b/docs/AUTO-DEPENDENCY-GRAPH.md
@@ -1,6 +1,6 @@
 # Service Dependency Graph (Auto-Generated)
 
-**Generated:** 2026-02-04 06:02:59 UTC
+**Generated:** 2026-02-05 06:01:15 UTC
 **System:** fedora-htpc
 
 This document visualizes service dependencies and critical paths in the homelab infrastructure.
@@ -178,11 +178,11 @@ Services on the same network can communicate:
 
 **gathio:** gathio,gathio-db
 
-**home_automation:** home-assistant,matter-server,mosquitto
+**home_automation:** home-assistant,matter-server
 
 **media_services:** jellyfin
 
-**monitoring:** alert-discord-relay,alertmanager,cadvisor,gathio,grafana,home-assistant,immich-server,jellyfin,loki,mosquitto,nextcloud,nextcloud-db,nextcloud-redis,node_exporter,prometheus,promtail,traefik,unpoller
+**monitoring:** alert-discord-relay,alertmanager,cadvisor,gathio,grafana,home-assistant,immich-server,jellyfin,loki,nextcloud,nextcloud-db,nextcloud-redis,node_exporter,prometheus,promtail,traefik,unpoller
 
 **nextcloud:** collabora,nextcloud,nextcloud-db,nextcloud-redis
 

--- a/docs/AUTO-DOCUMENTATION-INDEX.md
+++ b/docs/AUTO-DOCUMENTATION-INDEX.md
@@ -1,7 +1,7 @@
 # Documentation Index (Auto-Generated)
 
-**Generated:** 2026-02-04 06:02:59 UTC
-**Total Documents:** 370
+**Generated:** 2026-02-05 06:01:15 UTC
+**Total Documents:** 373
 
 ---
 
@@ -40,11 +40,11 @@
 - ADR-015: [2025-12-22-ADR-015-container-update-strategy](00-foundation/decisions/2025-12-22-ADR-015-container-update-strategy.md)
 - ADR-016: [2025-12-31-ADR-016-configuration-design-principles](00-foundation/decisions/2025-12-31-ADR-016-configuration-design-principles.md)
 - ADR-017: [2026-01-05-ADR-017-slash-commands-and-subagents](00-foundation/decisions/2026-01-05-ADR-017-slash-commands-and-subagents.md)
-- ADR-017: [2026-02-04-ADR-017-static-ip-multi-network-services](00-foundation/decisions/2026-02-04-ADR-017-static-ip-multi-network-services.md)
+- ADR-018: [2026-02-04-ADR-018-static-ip-multi-network-services](00-foundation/decisions/2026-02-04-ADR-018-static-ip-multi-network-services.md)
 
 ---
 
-### 10-services/ (25 documents)
+### 10-services/ (26 documents)
 
 **Service-specific documentation and deployment guides**
 
@@ -52,6 +52,7 @@
 - [apple-ecosystem-quick-reference.md](10-services/guides/apple-ecosystem-quick-reference.md)
 - [authelia.md](10-services/guides/authelia.md)
 - [crowdsec.md](10-services/guides/crowdsec.md)
+- [esp32-plejd-quick-start.md](10-services/guides/esp32-plejd-quick-start.md)
 - [gathio-email-setup.md](10-services/guides/gathio-email-setup.md)
 - [home-assistant.md](10-services/guides/home-assistant.md)
 - [homepage-widget-configuration.md](10-services/guides/homepage-widget-configuration.md)
@@ -112,7 +113,7 @@
 
 ---
 
-### 30-security/ (16 documents)
+### 30-security/ (17 documents)
 
 **Security architecture, configurations, and incident response**
 
@@ -121,6 +122,7 @@
 - [crowdsec-phase2-and-5-advanced-features.md](30-security/guides/crowdsec-phase2-and-5-advanced-features.md)
 - [crowdsec-phase3-threat-intelligence.md](30-security/guides/crowdsec-phase3-threat-intelligence.md)
 - [crowdsec-phase4-configuration-management.md](30-security/guides/crowdsec-phase4-configuration-management.md)
+- [esp32-vlan2-firewall-rule.md](30-security/guides/esp32-vlan2-firewall-rule.md)
 - [secrets-management.md](30-security/guides/secrets-management.md)
 - [security-audit.md](30-security/guides/security-audit.md)
 - [sshd-deployment-procedure.md](30-security/guides/sshd-deployment-procedure.md)
@@ -194,7 +196,7 @@
 
 ---
 
-### 98-journals/ (155 documents)
+### 98-journals/ (156 documents)
 
 **Chronological project history (append-only log)**
 
@@ -212,16 +214,14 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 
 ## Recently Updated (Last 7 Days)
 
-- 2026-02-04: [2026-02-04-ADR-017-static-ip-multi-network-services.md](00-foundation/decisions/2026-02-04-ADR-017-static-ip-multi-network-services.md)
+- 2026-02-04: [2026-02-04-ADR-018-static-ip-multi-network-services.md](00-foundation/decisions/2026-02-04-ADR-018-static-ip-multi-network-services.md)
 - 2026-01-30: [apple-ecosystem-quick-reference.md](10-services/guides/apple-ecosystem-quick-reference.md)
+- 2026-02-04: [esp32-plejd-quick-start.md](10-services/guides/esp32-plejd-quick-start.md)
 - 2026-02-01: [home-assistant.md](10-services/guides/home-assistant.md)
 - 2026-01-31: [ios-shortcuts-quick-reference.md](10-services/guides/ios-shortcuts-quick-reference.md)
 - 2026-01-31: [roborock-room-cleaning-setup.md](10-services/guides/roborock-room-cleaning-setup.md)
-- 2026-01-28: [unpoller-metrics-guide.md](20-operations/guides/unpoller-metrics-guide.md)
+- 2026-02-04: [esp32-vlan2-firewall-rule.md](30-security/guides/esp32-vlan2-firewall-rule.md)
 - 2026-01-31: [2025-12-30-home-automation-hub-exploration.md](98-journals/2025-12-30-home-automation-hub-exploration.md)
-- 2026-01-28: [2026-01-28-matter-hybrid-week1-home-assistant-deployment.md](98-journals/2026-01-28-matter-hybrid-week1-home-assistant-deployment.md)
-- 2026-01-28: [2026-01-28-matter-hybrid-week2-matter-server-deployment.md](98-journals/2026-01-28-matter-hybrid-week2-matter-server-deployment.md)
-- 2026-01-28: [2026-01-28-quadlet-tracking-migration.md](98-journals/2026-01-28-quadlet-tracking-migration.md)
 - 2026-01-29: [2026-01-29-home-assistant-learning-journey-start.md](98-journals/2026-01-29-home-assistant-learning-journey-start.md)
 - 2026-01-30: [2026-01-30-phase2-dashboards-and-apple-integration.md](98-journals/2026-01-30-phase2-dashboards-and-apple-integration.md)
 - 2026-01-31: [2026-01-31-learning-journey-completion.md](98-journals/2026-01-31-learning-journey-completion.md)
@@ -232,6 +232,8 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 - 2026-02-03: [2026-02-02-catastrophic-network-failure-investigation.md](98-journals/2026-02-02-catastrophic-network-failure-investigation.md)
 - 2026-02-03: [2026-02-02-kernel-rollback-test-procedure.md](98-journals/2026-02-02-kernel-rollback-test-procedure.md)
 - 2026-02-03: [2026-02-02-post-reboot-analysis-symlink-test-failed.md](98-journals/2026-02-02-post-reboot-analysis-symlink-test-failed.md)
+- 2026-02-03: [2026-02-02-ROOT-CAUSE-CONFIRMED-dns-resolution-order.md](98-journals/2026-02-02-ROOT-CAUSE-CONFIRMED-dns-resolution-order.md)
+- 2026-02-03: [2026-02-02-solution-implemented-pending-reboot-verification.md](98-journals/2026-02-02-solution-implemented-pending-reboot-verification.md)
 
 ---
 

--- a/docs/AUTO-NETWORK-TOPOLOGY.md
+++ b/docs/AUTO-NETWORK-TOPOLOGY.md
@@ -1,6 +1,6 @@
 # Network Topology (Auto-Generated)
 
-**Generated:** 2026-02-04 06:02:57 UTC
+**Generated:** 2026-02-05 06:01:13 UTC
 **System:** fedora-htpc
 
 This document provides comprehensive visualizations of the homelab network architecture, combining traffic flow analysis with network-centric topology views.
@@ -73,7 +73,6 @@ graph TB
         direction LR
         home_automation_home_assistant[home-assistant]
         home_automation_matter_server[matter-server]
-        home_automation_mosquitto[mosquitto]
     end
 
     subgraph media_services["media_services<br/>10.89.1.0/24"]
@@ -92,7 +91,6 @@ graph TB
         monitoring_immich_server[immich-server]
         monitoring_jellyfin[jellyfin]
         monitoring_loki[loki]
-        monitoring_mosquitto[mosquitto]
         monitoring_nextcloud[nextcloud]
         monitoring_nextcloud_db[nextcloud-db]
         monitoring_nextcloud_redis[nextcloud-redis]
@@ -278,12 +276,11 @@ sequenceDiagram
 
 - **Full Name:** `systemd-home_automation`
 - **Subnet:** 10.89.6.0/24
-- **Services:** 3
+- **Services:** 2
 
 **Members:**
 - home-assistant
 - matter-server
-- mosquitto
 
 
 ### media_services
@@ -300,7 +297,7 @@ sequenceDiagram
 
 - **Full Name:** `systemd-monitoring`
 - **Subnet:** 10.89.4.0/24
-- **Services:** 18
+- **Services:** 17
 
 **Members:**
 - alert-discord-relay
@@ -312,7 +309,6 @@ sequenceDiagram
 - immich-server
 - jellyfin
 - loki
-- mosquitto
 - nextcloud
 - nextcloud-db
 - nextcloud-redis

--- a/docs/AUTO-SERVICE-CATALOG.md
+++ b/docs/AUTO-SERVICE-CATALOG.md
@@ -1,6 +1,6 @@
 # Service Catalog (Auto-Generated)
 
-**Generated:** 2026-02-04 06:02:57 UTC
+**Generated:** 2026-02-05 06:01:13 UTC
 **System:** fedora-htpc
 
 ---
@@ -12,7 +12,7 @@
 | node_exporter | quay.io/prometheus/node-exporter:latest | ✅ Up | monitoring |
 | redis-authelia | redis:7-alpine | ✅ Up | auth_services |
 | alertmanager | quay.io/prometheus/alertmanager:latest | ✅ Up | monitoring,reverse_proxy |
-| traefik | traefik:latest | ✅ Up | monitoring,reverse_proxy,auth_services |
+| traefik | traefik:latest | ✅ Up | auth_services,monitoring,reverse_proxy |
 | grafana | grafana/grafana:latest | ✅ Up | monitoring,reverse_proxy |
 | nextcloud-db | mariadb:11 | ✅ Up | monitoring,nextcloud |
 | nextcloud-redis | redis:7-alpine | ✅ Up | monitoring,nextcloud |
@@ -28,24 +28,23 @@
 | crowdsec | crowdsecurity/crowdsec:latest | ✅ Up | reverse_proxy |
 | jellyfin | jellyfin/jellyfin:latest | ✅ Up | media_services,monitoring,reverse_proxy |
 | prometheus | quay.io/prometheus/prometheus:latest | ✅ Up | monitoring,reverse_proxy |
-| authelia | authelia/authelia:latest | ✅ Up | reverse_proxy,auth_services |
+| authelia | authelia/authelia:latest | ✅ Up | auth_services,reverse_proxy |
 | vaultwarden | vaultwarden/server:latest | ✅ Up | reverse_proxy |
 | nextcloud | nextcloud:31 | ✅ Up | monitoring,nextcloud,reverse_proxy |
 | unpoller | unpoller/unpoller:latest | ✅ Up | monitoring |
 | immich-server | immich-app/immich-server:v2.5.2 | ✅ Up | reverse_proxy,monitoring,photos |
 | promtail | grafana/promtail:latest | ✅ Up | monitoring |
 | gathio | lowercasename/gathio:latest | ✅ Up | gathio,monitoring,reverse_proxy |
-| collabora | collabora/code:latest | ✅ Up | reverse_proxy,nextcloud |
-| mosquitto | eclipse-mosquitto:2 | ✅ Up | home_automation,monitoring |
+| collabora | collabora/code:latest | ✅ Up | nextcloud,reverse_proxy |
 | home-assistant | home-assistant/home-assistant:stable | ✅ Up | home_automation,monitoring,reverse_proxy |
 
 ---
 
 ## Statistics
 
-- **Total Running:** 29
-- **Total Defined:** 29
-- **System Load:**  0,64, 0,48, 0,47
+- **Total Running:** 28
+- **Total Defined:** 28
+- **System Load:**  0,29, 0,39, 0,41
 
 ---
 


### PR DESCRIPTION
## Summary

- Cross-referenced 373 documentation files against live system state (28 containers, 8 networks, 53 timers) and corrected ~15 factual errors in headline files
- **CLAUDE.md**: Updated service count (6→14 groups), networks (5→8), memory estimates (2-3GB→4-5GB), Fedora 42→43, ADR count 16→18
- **homelab-architecture.md**: Complete rewrite from v1.0 (Nov 2025, 1360 lines) to v3.0 (Feb 2026, 483 lines) covering all services and networks
- **README.md**: Updated for public GitHub consumption, removed specific domains/IPs/hostnames
- **3 new service guides**: Collabora (WOPI architecture), Matter Server (WebSocket bridge), Alert Discord Relay (custom image)
- **Archived** Dec 31 baseline to `docs/90-archive/`, STATE-OF-HOMELAB-2026 already reflects Feb 2026 snapshot
- **Journal entry** with 7 prioritized strategic recommendations for Q1 2026

## Files Changed (12)

| File | Change |
|------|--------|
| `CLAUDE.md` | ~15 factual corrections (services, networks, memory, versions) |
| `README.md` | Updated for public repo, removed private details |
| `homelab-architecture.md` | Complete rewrite v1.0→v3.0 (1360→483 lines) |
| `collabora.md` | New service guide |
| `matter-server.md` | New service guide |
| `alert-discord-relay.md` | New service guide |
| `STATE-OF-HOMELAB-2025-12-31-baseline.md` | Archived from 99-reports to 90-archive |
| `2026-02-05-...audit...md` | New journal entry with strategic assessment |
| `AUTO-*.md` (4 files) | Daily auto-regeneration updates |

## Test plan

- [ ] Verify no broken internal links in documentation
- [ ] Confirm auto-generated docs still regenerate correctly (`scripts/auto-doc-orchestrator.sh`)
- [ ] Spot-check CLAUDE.md figures against `podman ps`, `podman network ls`, `df -h`
- [ ] Verify README contains no private domain names or IPs

🤖 Generated with [Claude Code](https://claude.com/claude-code)