### PR TITLE
fix: Nextcloud v32 upgrade, rate limit tuning, and Collabora WOPI configuration

### DIFF
--- a/config/traefik/dynamic/middleware.yml
+++ b/config/traefik/dynamic/middleware.yml
@@ -107,10 +107,11 @@ http:
             depth: 1
 
     # Nextcloud (authenticated users - high capacity for WebDAV sync, bulk imports)
+    # Burst sized for Music library tree walk (2,080+ directories via PROPFIND)
     rate-limit-nextcloud:
       rateLimit:
-        average: 400      # Higher sustained rate for file/calendar/contact sync
-        burst: 1400       # Support bulk operations (1300+ contact CSV imports)
+        average: 600      # Higher sustained rate for file/calendar/contact sync
+        burst: 3000       # Support full directory tree PROPFIND + bulk operations
         period: 1m
         sourceCriterion:
           ipStrategy:

--- a/config/traefik/dynamic/routers.yml
+++ b/config/traefik/dynamic/routers.yml
@@ -108,7 +108,7 @@ http:
         - websecure
       middlewares:
         - crowdsec-bouncer@file
-        - rate-limit-nextcloud@file     # High capacity for WebDAV sync, bulk imports (400/min, 1400 burst)
+        - rate-limit-nextcloud@file     # High capacity for WebDAV sync (600/min, 3000 burst for PROPFIND tree walks)
         - circuit-breaker@file          # Prevent cascade failures
         - retry@file                    # Retry transient errors
         - nextcloud-caldav              # CalDAV/.well-known redirects
@@ -116,10 +116,20 @@ http:
       tls:
         certResolver: letsencrypt
 
-    # Collabora Online - INTERNAL ONLY (accessed by Nextcloud via http://collabora:9980)
-    # Removed public router - Collabora does not need Internet access
-    # Nextcloud communicates with it directly on the nextcloud network
-    # This reduces attack surface and follows least-privilege principle
+    # Collabora Online - Browser needs direct access to load editor iframe
+    # Server-to-server WOPI calls go via internal network (http://collabora:9980)
+    # But browser must load cool.html from Collabora directly
+    collabora-secure:
+      rule: "Host(`collabora.patriark.org`)"
+      service: "collabora"
+      entryPoints:
+        - websecure
+      middlewares:
+        - crowdsec-bouncer@file
+        - rate-limit@file
+        - hsts-only@file                # Collabora sets own CSP/frame-ancestors - just add HSTS
+      tls:
+        certResolver: letsencrypt
 
     # Grafana Monitoring Dashboard
     grafana-secure:
@@ -242,7 +252,10 @@ http:
         servers:
           - url: "http://nextcloud:80"
 
-    # collabora: (removed - internal-only service, no public router needed)
+    collabora:
+      loadBalancer:
+        servers:
+          - url: "http://collabora:9980"
 
     gathio:
       loadBalancer:

--- a/docs/98-journals/2026-02-05-nextcloud-upgrade-testing-and-collabora-debugging.md
+++ b/docs/98-journals/2026-02-05-nextcloud-upgrade-testing-and-collabora-debugging.md
@@ -1,0 +1,142 @@
+# Nextcloud Upgrade, Device Testing, and Collabora Debugging
+
+**Date:** 2026-02-05 (evening session)
+**Author:** Claude Opus 4.6
+**Status:** Partially complete - Collabora integration unresolved, testing paused
+
+---
+
+## Context
+
+Systematic Nextcloud verification session following the 6-phase plan: server-side health checks, multi-device testing, sharing, on-demand file access, rate limiting, and documentation. The session expanded to include a Nextcloud major version upgrade (v31 → v32.0.5) and extensive Collabora debugging.
+
+## What Was Achieved
+
+### Phase 1: Server-Side Verification (Complete)
+
+All 4 containers healthy (nextcloud, nextcloud-db, nextcloud-redis, collabora). Key findings:
+
+- **Missing database index auto-fixed:** `systag_objecttype` index added by `occ db:add-missing-indices`
+- **All endpoints verified:** HTTPS, status.php, CalDAV redirect, CardDAV redirect, WebDAV, TLS cert
+- **MariaDB NOCOW:** Correctly configured
+- **Redis:** 104 keys, 1.46MB, healthy
+- **Loki analysis:** 94,260 requests/7d, 0.16% error rate, zero CrowdSec blocks, zero auth failures
+
+### Nextcloud Upgrade: v31 → v32.0.5
+
+- Updated quadlet image tag to `:latest` (resolves to 32.0.5)
+- Migration ran automatically, added 2 new DB indices (`properties_name_path_user`, `calobjects_by_uid_index`)
+- Full `maintenance:repair --include-expensive` ran clean
+- richdocuments updated to 9.0.2
+
+### Rate Limit Fix
+
+**Problem:** 2,079 PROPFIND 429 responses from desktop sync client. The Nextcloud desktop client (mirall/4.0.6) performs aggressive tree-walking on large directories (Music library: 2,080+ directories) that exceeded the 1,400 burst limit in ~30 seconds.
+
+**Fix:** Increased Nextcloud-specific rate limits in `config/traefik/dynamic/middleware.yml`:
+- Average: 400 → 600 requests/min
+- Burst: 1,400 → 3,000
+
+**Result:** Zero 429s after the fix. Sync completes cleanly.
+
+### Multi-Device Testing (Partial)
+
+All devices tested successfully for basic sync:
+- **File sync:** Upload/download works across iPhone, iPad Pro, MacBook Air, Gaming PC, Fedora HTPC
+- **Special characters:** `test-æøå-spesial.txt` syncs correctly
+- **Folder sync:** Nested directories propagate to all clients
+- **CalDAV/CardDAV:** App password configured and stored in Bitwarden
+
+### External Storage Permission Fix
+
+**Problem:** Multimedia, Music, and Opptak external storage mounts were configured as read-write in Nextcloud admin settings but mounted read-only at the container level (`:ro`).
+
+**Fix:** Set `readonly=true` in Nextcloud external storage config via `occ files_external:option <id> readonly true` for all three mounts. Container-level and Nextcloud-level permissions now aligned.
+
+### WebAuthn/FIDO2 Dual Registration
+
+After the NC32 upgrade, the user noticed empty WebAuthn 2FA entries and re-registered YubiKeys. They had existing FIDO2 passwordless registrations. Analysis: dual registration is harmless - WebAuthn 2FA and FIDO2 passwordless are separate ceremonies using different Nextcloud API endpoints.
+
+### Documentation Update
+
+Updated `docs/10-services/guides/nextcloud.md` (v1.0 → v2.0):
+- Corrected version: 32.0.5 (Hub 11)
+- Rate limits: 600/min, 3,000 burst
+- Added Client Setup section (desktop VFS, mobile, CalDAV/CardDAV)
+- Added Sharing Best Practices section
+- Fixed Collabora admin URL references
+- Added ADR-013/014/016/018 cross-references
+
+## What Remains Unresolved: Collabora Integration
+
+### Symptom
+"Document loading failed - failed to load Nextcloud Office" when opening any .docx file from any browser (tested on Fedora HTPC Firefox and MacBook Air).
+
+### Root Cause Analysis
+
+The WOPI flow for Collabora document editing:
+1. Browser requests token from Nextcloud (`/apps/richdocuments/token`)
+2. Nextcloud generates WOPI token and returns iframe URL (from discovery cache)
+3. Browser loads Collabora iframe using the URL
+4. Collabora fetches document from Nextcloud via WOPI callback
+
+**The problem is in step 2-3:** The discovery XML from Collabora returns internal URLs (`http://collabora:9980/browser/.../cool.html?`). The richdocuments app is supposed to replace these with the public URL (`https://collabora.patriark.org/...`) using the `public_wopi_url` config. However:
+
+1. **`activate-config` resets `public_wopi_url`:** The `autoConfigurePublicUrl()` method in `ConnectivityService.php` extracts the domain from discovery URLs and overwrites the `public_wopi_url` database setting. Any manual setting gets destroyed.
+
+2. **Collabora's `server_name` was not configured:** Without `server_name`, Collabora uses its container hostname in discovery URLs. The internal fetch (`http://collabora:9980`) produces `http://collabora:9980/browser/...` URLs.
+
+3. **Protocol mismatch:** Even after adding `server_name=collabora.patriark.org`, the discovery returns `http://collabora.patriark.org/...` (correct hostname, wrong protocol). The `ssl.termination=true` setting doesn't affect the scheme for internally-fetched discovery.
+
+### What Was Tried (in order)
+
+1. Set `public_wopi_url` to `https://collabora.patriark.org` via `occ config:app:set` → Worked until `activate-config` reset it
+2. Removed `public_wopi_url` for proxy mode → richdocuments 9.0.2 proxy mode doesn't work (requests never reach Collabora)
+3. Added public Traefik route for `collabora.patriark.org` with `hsts-only@file` middleware → Route works (200 on capabilities), but didn't solve the document loading
+4. Found `security-headers@file` middleware was blocking iframe with `frame-ancestors 'self'` → Switched to `hsts-only@file`
+5. Discovered `activate-config` resets `public_wopi_url` → Stopped using activate-config for URL configuration
+6. Added `server_name=collabora.patriark.org` to Collabora quadlet → Discovery now returns correct hostname but `http://` instead of `https://`
+7. Manually set `public_wopi_url` to `https://collabora.patriark.org` after activate-config → Currently set correctly, untested
+
+### Current State (as of session end)
+
+- `server_name=collabora.patriark.org` added to `collabora.container` quadlet
+- `public_wopi_url` set to `https://collabora.patriark.org` in database
+- Discovery returns `http://collabora.patriark.org/browser/...` (correct hostname, http protocol)
+- Collabora public route exists and works via Traefik
+- All infrastructure connectivity verified (Nextcloud ↔ Collabora bidirectional)
+
+### Likely Remaining Fix
+
+The JavaScript in richdocuments should use `public_wopi_url` from the Capabilities API to replace the internal URL in `urlsrc`. With the current config (`public_wopi_url=https://collabora.patriark.org`), this *should* work. The user has not tested after the final `server_name` + `activate-config` + manual `public_wopi_url` fix sequence.
+
+If it still fails after testing:
+- Check browser developer console for mixed-content or CSP errors
+- Verify the Capabilities API returns `https://collabora.patriark.org` for `public_wopi_url`
+- Consider making Collabora advertise `https://` by adjusting `extra_params` (e.g., `--o:net.proto=https`)
+- As a last resort, use a reverse proxy configuration that sets `X-Forwarded-Proto: https` for the internal discovery fetch
+
+## Files Modified
+
+| File | Change |
+|------|--------|
+| `quadlets/nextcloud.container` | Image tag → `:latest` (NC 32.0.5) |
+| `quadlets/collabora.container` | Added `server_name=collabora.patriark.org` |
+| `config/traefik/dynamic/middleware.yml` | Nextcloud rate limit: 600/min, 3000 burst |
+| `config/traefik/dynamic/routers.yml` | Added Collabora public route, `hsts-only@file` middleware |
+| `docs/10-services/guides/nextcloud.md` | Version, rate limits, client setup, sharing sections |
+
+## Remaining Plan Phases
+
+- **Phase 2 (partial):** Conflict test, delete, rename, large file, offline edit untested
+- **Phase 3:** Sharing & external access testing not started
+- **Phase 4:** VFS/On-Demand configuration not started
+- **Phase 5:** Rate limit remediation done (600/min, 3000 burst)
+- **Phase 6 (partial):** Documentation updated, journal written
+
+## Lessons Learned
+
+1. **`richdocuments:activate-config` is destructive** - it resets `public_wopi_url` by auto-detecting from discovery URLs. Never use it to "fix" a manually configured public URL.
+2. **Collabora `server_name` is essential** for reverse proxy setups where the public hostname differs from the container hostname. Without it, WOPI discovery advertises internal URLs.
+3. **Traefik access logs only capture 400-599** - this is by design for storage efficiency, but makes debugging 200-response-with-error-body issues invisible from the proxy layer.
+4. **Rate limit burst capacity matters for WebDAV** - desktop sync clients perform aggressive tree-walking (PROPFIND) that can exhaust burst limits in seconds for large directory trees.

--- a/docs/AUTO-DEPENDENCY-GRAPH.md
+++ b/docs/AUTO-DEPENDENCY-GRAPH.md
@@ -1,6 +1,6 @@
 # Service Dependency Graph (Auto-Generated)
 
-**Generated:** 2026-02-05 06:01:15 UTC
+**Generated:** 2026-02-05 23:04:03 UTC
 **System:** fedora-htpc
 
 This document visualizes service dependencies and critical paths in the homelab infrastructure.

--- a/docs/AUTO-DOCUMENTATION-INDEX.md
+++ b/docs/AUTO-DOCUMENTATION-INDEX.md
@@ -1,7 +1,7 @@
 # Documentation Index (Auto-Generated)
 
-**Generated:** 2026-02-05 06:01:15 UTC
-**Total Documents:** 373
+**Generated:** 2026-02-05 23:04:03 UTC
+**Total Documents:** 378
 
 ---
 
@@ -44,13 +44,15 @@
 
 ---
 
-### 10-services/ (26 documents)
+### 10-services/ (29 documents)
 
 **Service-specific documentation and deployment guides**
 
 **Service Guides:**
+- [alert-discord-relay.md](10-services/guides/alert-discord-relay.md)
 - [apple-ecosystem-quick-reference.md](10-services/guides/apple-ecosystem-quick-reference.md)
 - [authelia.md](10-services/guides/authelia.md)
+- [collabora.md](10-services/guides/collabora.md)
 - [crowdsec.md](10-services/guides/crowdsec.md)
 - [esp32-plejd-quick-start.md](10-services/guides/esp32-plejd-quick-start.md)
 - [gathio-email-setup.md](10-services/guides/gathio-email-setup.md)
@@ -63,6 +65,7 @@
 - [ios-shortcuts-quick-reference.md](10-services/guides/ios-shortcuts-quick-reference.md)
 - [jellyfin-gpu-acceleration-troubleshooting.md](10-services/guides/jellyfin-gpu-acceleration-troubleshooting.md)
 - [jellyfin.md](10-services/guides/jellyfin.md)
+- [matter-server.md](10-services/guides/matter-server.md)
 - [nextcloud.md](10-services/guides/nextcloud.md)
 - [pattern-customization-guide.md](10-services/guides/pattern-customization-guide.md)
 - [pattern-selection-guide.md](10-services/guides/pattern-selection-guide.md)
@@ -196,7 +199,7 @@
 
 ---
 
-### 98-journals/ (156 documents)
+### 98-journals/ (157 documents)
 
 **Chronological project history (append-only log)**
 
@@ -215,25 +218,25 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 ## Recently Updated (Last 7 Days)
 
 - 2026-02-04: [2026-02-04-ADR-018-static-ip-multi-network-services.md](00-foundation/decisions/2026-02-04-ADR-018-static-ip-multi-network-services.md)
+- 2026-02-05: [alert-discord-relay.md](10-services/guides/alert-discord-relay.md)
 - 2026-01-30: [apple-ecosystem-quick-reference.md](10-services/guides/apple-ecosystem-quick-reference.md)
+- 2026-02-05: [collabora.md](10-services/guides/collabora.md)
 - 2026-02-04: [esp32-plejd-quick-start.md](10-services/guides/esp32-plejd-quick-start.md)
 - 2026-02-01: [home-assistant.md](10-services/guides/home-assistant.md)
 - 2026-01-31: [ios-shortcuts-quick-reference.md](10-services/guides/ios-shortcuts-quick-reference.md)
+- 2026-02-05: [matter-server.md](10-services/guides/matter-server.md)
+- 2026-02-05: [nextcloud.md](10-services/guides/nextcloud.md)
 - 2026-01-31: [roborock-room-cleaning-setup.md](10-services/guides/roborock-room-cleaning-setup.md)
+- 2026-02-05: [homelab-architecture.md](20-operations/guides/homelab-architecture.md)
 - 2026-02-04: [esp32-vlan2-firewall-rule.md](30-security/guides/esp32-vlan2-firewall-rule.md)
+- 2026-02-05: [STATE-OF-HOMELAB-2025-12-31-baseline.md](90-archive/STATE-OF-HOMELAB-2025-12-31-baseline.md)
 - 2026-01-31: [2025-12-30-home-automation-hub-exploration.md](98-journals/2025-12-30-home-automation-hub-exploration.md)
-- 2026-01-29: [2026-01-29-home-assistant-learning-journey-start.md](98-journals/2026-01-29-home-assistant-learning-journey-start.md)
 - 2026-01-30: [2026-01-30-phase2-dashboards-and-apple-integration.md](98-journals/2026-01-30-phase2-dashboards-and-apple-integration.md)
 - 2026-01-31: [2026-01-31-learning-journey-completion.md](98-journals/2026-01-31-learning-journey-completion.md)
 - 2026-01-31: [2026-01-31-mill-air-purifier-feature-request.md](98-journals/2026-01-31-mill-air-purifier-feature-request.md)
 - 2026-02-01: [2026-01-31-roborock-automation-optimization.md](98-journals/2026-01-31-roborock-automation-optimization.md)
 - 2026-02-01: [2026-02-01-february-security-posture-evaluation.md](98-journals/2026-02-01-february-security-posture-evaluation.md)
 - 2026-02-02: [2026-02-02-backup-compression-strategy-evaluation.md](98-journals/2026-02-02-backup-compression-strategy-evaluation.md)
-- 2026-02-03: [2026-02-02-catastrophic-network-failure-investigation.md](98-journals/2026-02-02-catastrophic-network-failure-investigation.md)
-- 2026-02-03: [2026-02-02-kernel-rollback-test-procedure.md](98-journals/2026-02-02-kernel-rollback-test-procedure.md)
-- 2026-02-03: [2026-02-02-post-reboot-analysis-symlink-test-failed.md](98-journals/2026-02-02-post-reboot-analysis-symlink-test-failed.md)
-- 2026-02-03: [2026-02-02-ROOT-CAUSE-CONFIRMED-dns-resolution-order.md](98-journals/2026-02-02-ROOT-CAUSE-CONFIRMED-dns-resolution-order.md)
-- 2026-02-03: [2026-02-02-solution-implemented-pending-reboot-verification.md](98-journals/2026-02-02-solution-implemented-pending-reboot-verification.md)
 
 ---
 

--- a/docs/AUTO-NETWORK-TOPOLOGY.md
+++ b/docs/AUTO-NETWORK-TOPOLOGY.md
@@ -1,6 +1,6 @@
 # Network Topology (Auto-Generated)
 
-**Generated:** 2026-02-05 06:01:13 UTC
+**Generated:** 2026-02-05 23:04:01 UTC
 **System:** fedora-htpc
 
 This document provides comprehensive visualizations of the homelab network architecture, combining traffic flow analysis with network-centric topology views.

--- a/docs/AUTO-SERVICE-CATALOG.md
+++ b/docs/AUTO-SERVICE-CATALOG.md
@@ -1,6 +1,6 @@
 # Service Catalog (Auto-Generated)
 
-**Generated:** 2026-02-05 06:01:13 UTC
+**Generated:** 2026-02-05 23:04:01 UTC
 **System:** fedora-htpc
 
 ---
@@ -26,17 +26,17 @@
 | cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ Up | monitoring |
 | redis-immich | valkey/valkey:latest | ✅ Up | photos |
 | crowdsec | crowdsecurity/crowdsec:latest | ✅ Up | reverse_proxy |
-| jellyfin | jellyfin/jellyfin:latest | ✅ Up | media_services,monitoring,reverse_proxy |
+| jellyfin | jellyfin/jellyfin:latest | ✅ Up | monitoring,reverse_proxy,media_services |
 | prometheus | quay.io/prometheus/prometheus:latest | ✅ Up | monitoring,reverse_proxy |
 | authelia | authelia/authelia:latest | ✅ Up | auth_services,reverse_proxy |
 | vaultwarden | vaultwarden/server:latest | ✅ Up | reverse_proxy |
-| nextcloud | nextcloud:31 | ✅ Up | monitoring,nextcloud,reverse_proxy |
 | unpoller | unpoller/unpoller:latest | ✅ Up | monitoring |
-| immich-server | immich-app/immich-server:v2.5.2 | ✅ Up | reverse_proxy,monitoring,photos |
+| immich-server | immich-app/immich-server:v2.5.2 | ✅ Up | photos,reverse_proxy,monitoring |
 | promtail | grafana/promtail:latest | ✅ Up | monitoring |
 | gathio | lowercasename/gathio:latest | ✅ Up | gathio,monitoring,reverse_proxy |
-| collabora | collabora/code:latest | ✅ Up | nextcloud,reverse_proxy |
 | home-assistant | home-assistant/home-assistant:stable | ✅ Up | home_automation,monitoring,reverse_proxy |
+| nextcloud | nextcloud:latest | ✅ Up | monitoring,nextcloud,reverse_proxy |
+| collabora | collabora/code:latest | ✅ Up | reverse_proxy,nextcloud |
 
 ---
 
@@ -44,7 +44,7 @@
 
 - **Total Running:** 28
 - **Total Defined:** 28
-- **System Load:**  0,29, 0,39, 0,41
+- **System Load:**  1,31, 1,19, 1,02
 
 ---
 

--- a/quadlets/collabora.container
+++ b/quadlets/collabora.container
@@ -13,6 +13,9 @@ AutoUpdate=registry
 Environment=aliasgroup1=https://nextcloud.patriark.org
 
 # Collabora configuration
+# server_name tells Collabora its public hostname for correct WOPI discovery URLs
+# Without this, discovery returns http://collabora:9980 (internal) instead of public URL
+Environment=server_name=collabora.patriark.org
 Environment=extra_params=--o:ssl.enable=false --o:ssl.termination=true
 
 # Locale

--- a/quadlets/nextcloud.container
+++ b/quadlets/nextcloud.container
@@ -5,7 +5,7 @@ Wants=network-online.target
 
 
 [Container]
-Image=docker.io/library/nextcloud:30
+Image=docker.io/library/nextcloud:latest
 ContainerName=nextcloud
 AutoUpdate=registry
 


### PR DESCRIPTION
## Summary

- **Nextcloud v31 → v32.0.5:** Updated image tag to `:latest`, migration ran clean with 2 new DB indices
- **Rate limit fix:** Increased from 400/min, 1400 burst → 600/min, 3000 burst to eliminate 2,079 PROPFIND 429s during desktop sync Music library tree-walking
- **Collabora WOPI configuration:** Added `server_name=collabora.patriark.org` and public Traefik route for browser iframe access
- **Documentation:** Updated nextcloud.md to v2.0 with client setup, sharing sections, and correct version/rate limit info
- **Journal:** Comprehensive session log documenting all changes, debugging steps, and unresolved Collabora issue

## Deployment Context

Changes already deployed and running:
- Nextcloud 32.0.5 healthy, sync verified on all 5 devices
- Collabora restarted with `server_name`, WOPI discovery now shows correct hostname
- Rate limits applied, zero 429s post-fix

## Test Plan

- [x] Nextcloud container healthy after upgrade
- [x] File sync working across all devices (iPhone, iPad Pro, MacBook Air, Gaming PC, Fedora HTPC)
- [x] Rate limits: zero 429 responses post-fix
- [x] Traefik config validation passed (pre-commit hook)
- [ ] Collabora document editing (pending - `public_wopi_url` fix needs retest)
- [ ] CalDAV/CardDAV sync verification
- [ ] Sharing & external access testing

🤖 Generated with [Claude Code](https://claude.com/claude-code)