### PR TITLE
fix: Rewrite auto-documentation generators for accuracy and dynamic content

### DIFF
--- a/docs/AUTO-DOCUMENTATION-INDEX.md
+++ b/docs/AUTO-DOCUMENTATION-INDEX.md
@@ -1,6 +1,6 @@
 # Documentation Index (Auto-Generated)
 
-**Generated:** 2026-02-13 23:00:14 UTC
+**Generated:** 2026-02-14 12:54:02 UTC
 **Total Documents:** 388
 
 ---
@@ -216,14 +216,13 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 
 ## Recently Updated (Last 7 Days)
 
-- 2026-02-13: [HOMELAB-FIELD-GUIDE.md](00-foundation/guides/HOMELAB-FIELD-GUIDE.md)
+- 2026-02-14: [HOMELAB-FIELD-GUIDE.md](00-foundation/guides/HOMELAB-FIELD-GUIDE.md)
 - 2026-02-08: [immich.md](10-services/guides/immich.md)
 - 2026-02-07: [slo-based-alerting.md](40-monitoring-and-documentation/guides/slo-based-alerting.md)
 - 2026-02-07: [slo-calibration-process.md](40-monitoring-and-documentation/guides/slo-calibration-process.md)
 - 2026-02-07: [slo-framework.md](40-monitoring-and-documentation/guides/slo-framework.md)
 - 2026-02-07: [2026-02-07-five-trajectories-for-digital-sovereignty.md](98-journals/2026-02-07-five-trajectories-for-digital-sovereignty.md)
 - 2026-02-08: [2026-02-07-immich-operational-excellence-phase1.md](98-journals/2026-02-07-immich-operational-excellence-phase1.md)
-- 2026-02-07: [2026-02-07-skill-stack-alignment-with-production.md](98-journals/2026-02-07-skill-stack-alignment-with-production.md)
 - 2026-02-08: [2026-02-08-ambilight-hue-research-and-alternatives.md](98-journals/2026-02-08-ambilight-hue-research-and-alternatives.md)
 - 2026-02-08: [2026-02-08-immich-bulk-upload-stress-test.md](98-journals/2026-02-08-immich-bulk-upload-stress-test.md)
 - 2026-02-09: [2026-02-09-ha-presence-detection-fix.md](98-journals/2026-02-09-ha-presence-detection-fix.md)
@@ -233,6 +232,92 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 - 2026-02-14: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
 - 2026-02-14: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
 - 2026-02-14: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
+
+---
+
+## Quick Search by Service
+
+**Traefik:**
+- Guide: [traefik.md](10-services/guides/traefik.md)
+- Config: `~/containers/config/traefik/`
+- Quadlet: `~/.config/containers/systemd/traefik.container`
+
+**Authelia:**
+- Guide: [authelia.md](10-services/guides/authelia.md)
+- ADR: [ADR-005](30-security/decisions/2025-11-10-ADR-005-authelia-sso-mfa-architecture.md)
+- ADR: [ADR-006](30-security/decisions/2025-11-11-ADR-006-authelia-sso-yubikey-deployment.md)
+- Config: `~/containers/config/authelia/`
+- Quadlet: `~/.config/containers/systemd/authelia.container`
+
+**Crowdsec:**
+- Guide: [crowdsec.md](10-services/guides/crowdsec.md)
+- ADR: [ADR-008](30-security/decisions/2025-11-12-ADR-008-crowdsec-security-architecture.md)
+- Quadlet: `~/.config/containers/systemd/crowdsec.container`
+
+**Jellyfin:**
+- Guide: [jellyfin.md](10-services/guides/jellyfin.md)
+- Related: [jellyfin-gpu-acceleration-troubleshooting.md](10-services/guides/jellyfin-gpu-acceleration-troubleshooting.md)
+- Quadlet: `~/.config/containers/systemd/jellyfin.container`
+
+**Immich Server:**
+- Guide: [immich.md](10-services/guides/immich.md)
+- Related: [immich-configuration-review.md](10-services/guides/immich-configuration-review.md)
+- Related: [immich-deployment-checklist.md](10-services/guides/immich-deployment-checklist.md)
+- Related: [immich-ml-troubleshooting.md](10-services/guides/immich-ml-troubleshooting.md)
+- Quadlet: `~/.config/containers/systemd/immich-server.container`
+
+**Nextcloud:**
+- Guide: [nextcloud.md](10-services/guides/nextcloud.md)
+- ADR: [ADR-013](10-services/decisions/2025-12-20-ADR-013-nextcloud-native-authentication.md)
+- ADR: [ADR-014](10-services/decisions/2025-12-20-ADR-014-nextcloud-passwordless-authentication.md)
+- Config: `~/containers/config/nextcloud/`
+- Quadlet: `~/.config/containers/systemd/nextcloud.container`
+
+**Vaultwarden:**
+- Related: [vaultwarden-deployment.md](10-services/guides/vaultwarden-deployment.md)
+- ADR: [ADR-007](10-services/decisions/2025-11-12-ADR-007-vaultwarden-architecture.md)
+- Config: `~/containers/config/vaultwarden/`
+- Quadlet: `~/.config/containers/systemd/vaultwarden.container`
+
+**Home Assistant:**
+- Guide: [home-assistant.md](10-services/guides/home-assistant.md)
+- Related: [home-assistant.md](10-services/guides/home-assistant.md)
+- Config: `~/containers/config/home-assistant/`
+- Quadlet: `~/.config/containers/systemd/home-assistant.container`
+
+**Homepage:**
+- Related: [homepage-widget-configuration.md](10-services/guides/homepage-widget-configuration.md)
+- Config: `~/containers/config/homepage/`
+- Quadlet: `~/.config/containers/systemd/homepage.container`
+
+**Gathio:**
+- Related: [gathio-email-setup.md](10-services/guides/gathio-email-setup.md)
+- Config: `~/containers/config/gathio/`
+- Quadlet: `~/.config/containers/systemd/gathio.container`
+
+**Prometheus:**
+- Config: `~/containers/config/prometheus/`
+- Quadlet: `~/.config/containers/systemd/prometheus.container`
+- Stack Guide: [monitoring-stack.md](40-monitoring-and-documentation/guides/monitoring-stack.md)
+- SLO Framework: [slo-framework.md](40-monitoring-and-documentation/guides/slo-framework.md)
+
+**Grafana:**
+- Config: `~/containers/config/grafana/`
+- Quadlet: `~/.config/containers/systemd/grafana.container`
+- Stack Guide: [monitoring-stack.md](40-monitoring-and-documentation/guides/monitoring-stack.md)
+- SLO Framework: [slo-framework.md](40-monitoring-and-documentation/guides/slo-framework.md)
+
+**Loki:**
+- Config: `~/containers/config/loki/`
+- Quadlet: `~/.config/containers/systemd/loki.container`
+- Stack Guide: [monitoring-stack.md](40-monitoring-and-documentation/guides/monitoring-stack.md)
+- SLO Framework: [slo-framework.md](40-monitoring-and-documentation/guides/slo-framework.md)
+
+**Alertmanager:**
+- Config: `~/containers/config/alertmanager/`
+- Quadlet: `~/.config/containers/systemd/alertmanager.container`
+- Stack Guide: [monitoring-stack.md](40-monitoring-and-documentation/guides/monitoring-stack.md)
+- SLO Framework: [slo-framework.md](40-monitoring-and-documentation/guides/slo-framework.md)
 
 ---
 
@@ -253,32 +338,6 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 - **Reports:** `TYPE-YYYYMMDD-HHMMSS.json` or `.md`
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for full documentation guidelines.
-
----
-
-## Quick Search by Service
-
-**Traefik:**
-- Guide: [traefik.md](10-services/guides/traefik.md)
-- Config: `~/containers/config/traefik/`
-- Quadlet: `~/.config/containers/systemd/traefik.container`
-
-**Authelia:**
-- Guide: [authelia.md](10-services/guides/authelia.md)
-- ADR: [ADR-006](30-security/decisions/2025-11-11-ADR-006-authelia-sso-yubikey-deployment.md)
-- Config: `~/containers/config/authelia/`
-
-**Jellyfin:**
-- Guide: [jellyfin.md](10-services/guides/jellyfin.md)
-- Management: `~/containers/scripts/jellyfin-manage.sh`
-
-**Immich:**
-- Guide: [immich.md](10-services/guides/immich.md)
-- ADR: [ADR-004](10-services/decisions/2025-11-08-ADR-004-immich-deployment-architecture.md)
-
-**Prometheus/Grafana:**
-- Guides: [prometheus.md](10-services/guides/prometheus.md), [grafana.md](10-services/guides/grafana.md)
-- SLO Framework: [slo-framework.md](40-monitoring-and-documentation/guides/slo-framework.md)
 
 ---
 

--- a/docs/AUTO-NETWORK-TOPOLOGY.md
+++ b/docs/AUTO-NETWORK-TOPOLOGY.md
@@ -1,9 +1,7 @@
 # Network Topology (Auto-Generated)
 
-**Generated:** 2026-02-13 23:00:12 UTC
-**System:** fedora-htpc
-
-This document provides comprehensive visualizations of the homelab network architecture, combining traffic flow analysis with network-centric topology views.
+**Generated:** 2026-02-14 12:53:56 UTC
+**System:** fedora-htpc | **Networks:** 8 | **Containers:** 27
 
 ---
 
@@ -44,7 +42,7 @@ graph TB
 **Key Insights:**
 - **CrowdSec** checks ALL traffic (fail-fast: reject banned IPs immediately)
 - **Authelia** protects administrative/monitoring services (SSO with YubiKey)
-- **Native auth** services handle their own authentication (Jellyfin, Immich, Nextcloud, Vaultwarden)
+- **Native auth** services handle their own authentication (bypass Authelia)
 
 ---
 
@@ -140,60 +138,48 @@ graph TB
 
     class reverse_proxy gatewayNet
     class monitoring observeNet
-    class auth_services,photos,nextcloud,media_services backendNet
+    class auth_services,photos,nextcloud,media_services,gathio,home_automation backendNet
 ```
-
-**Network Functions:**
-- **reverse_proxy** (10.89.2.0/24) - Gateway for Internet-accessible services
-- **monitoring** (10.89.4.0/24) - Observability network (scrapes metrics from all services)
-- **auth_services** (10.89.3.0/24) - Authentication and session management
-- **photos** (10.89.5.0/24) - Immich stack isolation
-- **nextcloud** (10.89.10.0/24) - Nextcloud stack isolation
-- **media_services** (10.89.1.0/24) - Jellyfin media processing
-
-**Note:** Services appear in multiple network boxes if they belong to multiple networks. This accurately represents Podman network membership.
 
 ---
 
 ## Network Membership Matrix
 
-Shows which services belong to which networks. Many services are members of multiple networks.
+Shows which services belong to which networks. Dynamically generated from running container state.
 
-| Service | reverse_proxy | monitoring | auth_services | photos | nextcloud | media_services |
-|---------|:-------------:|:----------:|:-------------:|:------:|:---------:|:--------------:|
+| Service | auth_services | gathio | home_automation | media_services | monitoring | nextcloud | photos | reverse_proxy |
+|---------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **Gateway & Security** |
-| traefik | ✅ | ✅ | ✅ | - | - | - |
-| crowdsec | ✅ | - | - | - | - | - |
-| authelia | ✅ | - | ✅ | - | - | - |
-| redis-authelia | - | - | ✅ | - | - | - |
+| authelia | ✅ | - | - | - | - | - | - | ✅ |
+| crowdsec | - | - | - | - | - | - | - | ✅ |
+| redis-authelia | ✅ | - | - | - | - | - | - | - |
+| traefik | ✅ | - | - | - | ✅ | - | - | ✅ |
 | **Public Services** |
-| jellyfin | ✅ | ✅ | - | - | - | ✅ |
-| immich-server | ✅ | ✅ | - | ✅ | - | - |
-| nextcloud | ✅ | ✅ | - | - | ✅ | - |
-| vaultwarden | ✅ | - | - | - | - | - |
-| collabora | ✅ | - | - | - | ✅ | - |
-| homepage | ✅ | - | - | - | - | - |
+| gathio | - | ✅ | - | - | ✅ | - | - | ✅ |
+| home-assistant | - | - | ✅ | - | ✅ | - | - | ✅ |
+| homepage | - | - | - | - | - | - | - | ✅ |
+| immich-server | - | - | - | - | ✅ | - | ✅ | ✅ |
+| jellyfin | - | - | - | ✅ | ✅ | - | - | ✅ |
+| nextcloud | - | - | - | - | ✅ | ✅ | - | ✅ |
+| vaultwarden | - | - | - | - | - | - | - | ✅ |
 | **Monitoring** |
-| prometheus | ✅ | ✅ | - | - | - | - |
-| grafana | ✅ | ✅ | - | - | - | - |
-| loki | ✅ | ✅ | - | - | - | - |
-| alertmanager | ✅ | ✅ | - | - | - | - |
-| node_exporter | - | ✅ | - | - | - | - |
-| cadvisor | - | ✅ | - | - | - | - |
-| promtail | - | ✅ | - | - | - | - |
-| alert-discord-relay | - | ✅ | - | - | - | - |
+| alert-discord-relay | - | - | - | - | ✅ | - | - | - |
+| alertmanager | - | - | - | - | ✅ | - | - | ✅ |
+| cadvisor | - | - | - | - | ✅ | - | - | - |
+| grafana | - | - | - | - | ✅ | - | - | ✅ |
+| loki | - | - | - | - | ✅ | - | - | ✅ |
+| node_exporter | - | - | - | - | ✅ | - | - | - |
+| prometheus | - | - | - | - | ✅ | - | - | ✅ |
+| promtail | - | - | - | - | ✅ | - | - | - |
+| unpoller | - | - | - | - | ✅ | - | - | - |
 | **Backend Services** |
-| postgresql-immich | - | - | - | ✅ | - | - |
-| redis-immich | - | - | - | ✅ | - | - |
-| immich-ml | - | - | - | ✅ | - | - |
-| nextcloud-db | - | ✅ | - | - | ✅ | - |
-| nextcloud-redis | - | ✅ | - | - | ✅ | - |
-
-**Key Insights:**
-- **Traefik** is in 3 networks (gateway, monitoring, auth) to route traffic and be monitored
-- **Internet-facing services** are all in `reverse_proxy` (primary) + their functional network
-- **Monitoring network** has the most members (14 services) - observability across all tiers
-- **Backend databases/caches** are isolated to their functional networks only
+| gathio-db | - | ✅ | - | - | - | - | - | - |
+| immich-ml | - | - | - | - | - | - | ✅ | - |
+| matter-server | - | - | ✅ | - | - | - | - | - |
+| nextcloud-db | - | - | - | - | ✅ | ✅ | - | - |
+| nextcloud-redis | - | - | - | - | ✅ | ✅ | - | - |
+| postgresql-immich | - | - | - | - | - | - | ✅ | - |
+| redis-immich | - | - | - | - | - | - | ✅ | - |
 
 ---
 
@@ -366,89 +352,15 @@ sequenceDiagram
 
 ---
 
-## Architecture Principles
+## Related Documentation
 
-### Network Segmentation Strategy
+For architecture principles, network ordering rules, and troubleshooting:
 
-Services are organized into isolated networks based on function and trust level:
-
-1. **reverse_proxy** (10.89.2.0/24) - **Gateway Network**
-   - Contains Traefik and all internet-accessible services
-   - **Critical:** First network in quadlets (gets default route for internet access)
-   - 13 members including all public-facing services
-
-2. **monitoring** (10.89.4.0/24) - **Observability Network**
-   - Prometheus, Grafana, Loki, exporters, and relay services
-   - Scrapes metrics from services across all other networks
-   - 14 members (most connected network)
-
-3. **auth_services** (10.89.3.0/24) - **Authentication Network**
-   - Authelia SSO, Redis session storage, and Traefik
-   - Isolated from direct internet except through reverse proxy
-   - 3 members (tightly controlled)
-
-4. **photos** (10.89.5.0/24) - **Photo Management Network**
-   - Immich application stack with PostgreSQL, Redis, and ML
-   - Backend services isolated from internet
-   - 4 members
-
-5. **nextcloud** (10.89.10.0/24) - **File Sync Network**
-   - Nextcloud application with MariaDB, Redis, and Collabora
-   - Backend databases accessible only within this network
-   - 4 members
-
-6. **media_services** (10.89.1.0/24) - **Media Processing Network**
-   - Jellyfin and media-related services
-   - 1 member (Jellyfin also in reverse_proxy and monitoring)
-
-### Multi-Network Services
-
-**Why multiple networks?**
-- **reverse_proxy** = Internet accessibility
-- **monitoring** = Metrics scraping
-- **Functional network** = Backend communication (databases, caches)
-
-**Examples:**
-- **Traefik (3 networks):** reverse_proxy (gateway), auth_services (Authelia access), monitoring (metrics)
-- **Jellyfin (3 networks):** reverse_proxy (internet), monitoring (metrics), media_services (function)
-- **Immich (3 networks):** reverse_proxy (internet), monitoring (metrics), photos (backend DB/cache)
-- **Nextcloud (3 networks):** reverse_proxy (internet), monitoring (metrics), nextcloud (backend DB/cache)
-
-### Network Ordering in Quadlets
-
-**Critical:** First `Network=` line in quadlet gets the default route (internet access).
-
-```ini
-# ✅ Correct - can reach internet AND internal services
-Network=systemd-reverse_proxy.network
-Network=systemd-monitoring.network
-Network=systemd-photos.network
-
-# ❌ Wrong - cannot reach internet (monitoring is internal-only)
-Network=systemd-monitoring.network
-Network=systemd-reverse_proxy.network
-```
-
-**Rule of thumb:**
-- Internet-facing services: `reverse_proxy` first
-- Internal services: Functional network first (photos, nextcloud, etc.)
-- Monitoring-only: `monitoring` network only (no internet needed)
-
-### Service Discovery (Podman DNS)
-
-Services on the same network can communicate using container names as hostnames:
-- `http://authelia:9091` - Traefik reaches Authelia (both in auth_services)
-- `http://redis-authelia:6379` - Authelia reaches Redis (both in auth_services)
-- `http://postgresql-immich:5432` - Immich reaches database (both in photos)
-- `http://prometheus:9090` - Grafana reaches Prometheus (both in monitoring)
-
----
-
-## Quick Links
-
+- [CLAUDE.md](../CLAUDE.md) - Network ordering, gotchas, and deployment patterns
+- [Homelab Architecture](20-operations/guides/homelab-architecture.md) - Full architecture overview
+- [ADR-018: Static IP Multi-Network Services](00-foundation/decisions/2026-02-04-ADR-018-static-ip-multi-network-services.md) - Static IPs and Traefik /etc/hosts override
 - [Service Catalog](AUTO-SERVICE-CATALOG.md) - Complete service inventory
 - [Dependency Graph](AUTO-DEPENDENCY-GRAPH.md) - Service dependencies
-- [Homelab Architecture](20-operations/guides/homelab-architecture.md) - Full documentation
 
 ---
 

--- a/docs/AUTO-SERVICE-CATALOG.md
+++ b/docs/AUTO-SERVICE-CATALOG.md
@@ -1,41 +1,81 @@
 # Service Catalog (Auto-Generated)
 
-**Generated:** 2026-02-13 23:00:12 UTC
-**System:** fedora-htpc
+**Generated:** 2026-02-14 12:53:55 UTC
+**System:** fedora-htpc | **Services:** 27/27 running | **Health:** 26/26 healthy (1 without healthcheck)
 
 ---
 
-## Running Services
+## Core Infrastructure (4)
 
-| Service | Image | Status | Networks |
-|---------|-------|--------|----------|
-| node_exporter | quay.io/prometheus/node-exporter:latest | ✅ Up | monitoring |
-| redis-authelia | redis:7-alpine | ✅ Up | auth_services |
-| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ Up | monitoring,reverse_proxy |
-| grafana | grafana/grafana:latest | ✅ Up | monitoring,reverse_proxy |
-| nextcloud-db | mariadb:11 | ✅ Up | nextcloud,monitoring |
-| nextcloud-redis | redis:7-alpine | ✅ Up | monitoring,nextcloud |
-| alert-discord-relay | localhost/alert-discord-relay:latest | ✅ Up | monitoring |
-| matter-server | home-assistant-libs/python-matter-server | ✅ Up | home_automation |
-| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3- | ✅ Up | photos |
-| gathio-db | mongo:7 | ✅ Up | gathio |
-| cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ Up | monitoring |
-| redis-immich | valkey/valkey:latest | ✅ Up | photos |
-| crowdsec | crowdsecurity/crowdsec:latest | ✅ Up | reverse_proxy |
-| jellyfin | jellyfin/jellyfin:latest | ✅ Up | media_services,monitoring,reverse_proxy |
-| prometheus | quay.io/prometheus/prometheus:latest | ✅ Up | reverse_proxy,monitoring |
-| authelia | authelia/authelia:latest | ✅ Up | auth_services,reverse_proxy |
-| gathio | lowercasename/gathio:latest | ✅ Up | gathio,monitoring,reverse_proxy |
-| nextcloud | nextcloud:latest | ✅ Up | monitoring,nextcloud,reverse_proxy |
-| immich-ml | immich-app/immich-machine-learning:v2.5. | ✅ Up | photos |
-| promtail | grafana/promtail:latest | ✅ Up | monitoring |
-| homepage | gethomepage/homepage:latest | ✅ Up | reverse_proxy |
-| loki | grafana/loki:latest | ✅ Up | monitoring,reverse_proxy |
-| unpoller | unpoller/unpoller:latest | ✅ Up | monitoring |
-| traefik | traefik:latest | ✅ Up | auth_services,monitoring,reverse_proxy |
-| vaultwarden | vaultwarden/server:latest | ✅ Up | reverse_proxy |
-| immich-server | immich-app/immich-server:v2.5.5 | ✅ Up | monitoring,photos,reverse_proxy |
-| home-assistant | home-assistant/home-assistant:stable | ✅ Up | home_automation,monitoring,reverse_proxy |
+| Service | Image | Health | Uptime | URL | Docs |
+|---------|-------|--------|--------|-----|------|
+| authelia | authelia/authelia:latest | ✅ healthy | 10d | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
+| crowdsec | crowdsecurity/crowdsec:latest | ✅ healthy | 10d | — | [guide](10-services/guides/crowdsec.md) |
+| redis-authelia | redis:7-alpine | ✅ healthy | 10d | — | — |
+| traefik | traefik:latest | ✅ healthy | 6d | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
+
+## Nextcloud (3)
+
+| Service | Image | Health | Uptime | URL | Docs |
+|---------|-------|--------|--------|-----|------|
+| nextcloud-db | mariadb:11 | ✅ healthy | 10d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud | nextcloud:latest | ✅ healthy | 8d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-redis | redis:7-alpine | ✅ healthy | 10d | — | [guide](10-services/guides/nextcloud.md) |
+
+## Immich (4)
+
+| Service | Image | Health | Uptime | URL | Docs |
+|---------|-------|--------|--------|-----|------|
+| immich-ml | immich-app/immich-machine-learning:v2.5.5 | ✅ healthy | 6d | — | [guide](10-services/guides/immich.md) |
+| immich-server | immich-app/immich-server:v2.5.5 | ✅ healthy | 6d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
+| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3-pgvec | ✅ healthy | 10d | — | — |
+| redis-immich | valkey/valkey:latest | ✅ healthy | 10d | — | — |
+
+## Jellyfin (1)
+
+| Service | Image | Health | Uptime | URL | Docs |
+|---------|-------|--------|--------|-----|------|
+| jellyfin | jellyfin/jellyfin:latest | ✅ healthy | 10d | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
+
+## Vaultwarden (1)
+
+| Service | Image | Health | Uptime | URL | Docs |
+|---------|-------|--------|--------|-----|------|
+| vaultwarden | vaultwarden/server:latest | ✅ healthy | 6d | [vault.patriark.org](https://vault.patriark.org) | — |
+
+## Home Automation (2)
+
+| Service | Image | Health | Uptime | URL | Docs |
+|---------|-------|--------|--------|-----|------|
+| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 4d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
+| matter-server | home-assistant-libs/python-matter-server:stab | ✅ healthy | 10d | — | [guide](10-services/guides/matter-server.md) |
+
+## Gathio (2)
+
+| Service | Image | Health | Uptime | URL | Docs |
+|---------|-------|--------|--------|-----|------|
+| gathio-db | mongo:7 | ✅ healthy | 10d | — | — |
+| gathio | lowercasename/gathio:latest | ✅ healthy | 10d | [events.patriark.org](https://events.patriark.org) | — |
+
+## Homepage (1)
+
+| Service | Image | Health | Uptime | URL | Docs |
+|---------|-------|--------|--------|-----|------|
+| homepage | gethomepage/homepage:latest | ✅ healthy | 6d | [patriark.org](https://patriark.org) | — |
+
+## Monitoring (9)
+
+| Service | Image | Health | Uptime | URL | Docs |
+|---------|-------|--------|--------|-----|------|
+| alert-discord-relay | localhost/alert-discord-relay:latest | ✅ healthy | 10d | — | [guide](10-services/guides/alert-discord-relay.md) |
+| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ healthy | 10d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ healthy | 10d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| grafana | grafana/grafana:latest | ✅ healthy | 10d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| loki | grafana/loki:latest | — no check | 6d | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| node_exporter | quay.io/prometheus/node-exporter:latest | ✅ healthy | 10d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 10d | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| promtail | grafana/promtail:latest | ✅ healthy | 12h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| unpoller | unpoller/unpoller:latest | ✅ healthy | 6d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
 
 ---
 
@@ -43,15 +83,15 @@
 
 - **Total Running:** 27
 - **Total Defined:** 27
-- **System Load:**  0,72, 0,38, 0,45
+- **System Load:** 2,02, 1,84, 1,80
 
 ---
 
 ## Quick Links
 
+- [Network Topology](AUTO-NETWORK-TOPOLOGY.md)
+- [Dependency Graph](AUTO-DEPENDENCY-GRAPH.md)
 - [Homelab Architecture](20-operations/guides/homelab-architecture.md)
-- [Network Topology](AUTO-NETWORK-TOPOLOGY.md) (when generated)
-- [Dependency Graph](AUTO-DEPENDENCY-GRAPH.md) (when generated)
 
 ---
 

--- a/scripts/generate-dependency-graph.sh
+++ b/scripts/generate-dependency-graph.sh
@@ -1,131 +1,215 @@
 #!/bin/bash
 # Dependency Graph Generator
-# Analyzes service dependencies and generates visualization
+# Dynamically analyzes service dependencies from quadlet files and network membership
 
 set -euo pipefail
 
 OUTPUT_FILE="${HOME}/containers/docs/AUTO-DEPENDENCY-GRAPH.md"
-QUADLET_DIR="${HOME}/.config/containers/systemd"
+QUADLET_DIR="${HOME}/containers/quadlets"
 
 log() {
     echo "[$(date +'%H:%M:%S')] $*" >&2
 }
 
-# Parse systemd dependencies from quadlet files
-get_systemd_deps() {
+# Parse hard dependencies (Requires=) from quadlet files, filtering networks/targets
+get_hard_deps() {
     local service=$1
     local quadlet="${QUADLET_DIR}/${service}.container"
 
-    if [[ -f "$quadlet" ]]; then
-        grep -E "^(After|Requires|Wants)=" "$quadlet" 2>/dev/null | \
-            sed 's/.*=//' | tr ' ' '\n' | \
-            grep -v "network" | grep -v "target" | \
-            sed 's/.service$//' | sed 's/.container$//' || true
-    fi
+    [[ -f "$quadlet" ]] || return
+    grep -E "^Requires=" "$quadlet" 2>/dev/null | \
+        sed 's/Requires=//' | tr ' ' '\n' | \
+        grep -v "network" | grep -v "target" | \
+        sed 's/\.service$//; s/\.container$//' | sort -u || true
 }
 
-# Determine service tier based on role
-get_service_tier() {
+# Parse ordering dependencies (After=) excluding networks/targets
+get_after_deps() {
     local service=$1
+    local quadlet="${QUADLET_DIR}/${service}.container"
 
-    case "$service" in
-        traefik|authelia|redis-authelia)
-            echo "Critical"
-            ;;
-        prometheus|grafana|loki|alertmanager|crowdsec)
-            echo "Infrastructure"
-            ;;
-        jellyfin|immich*|nextcloud|vaultwarden)
-            echo "Applications"
-            ;;
-        *-db|*-postgres|*-redis|postgresql*)
-            echo "Data"
-            ;;
-        *)
-            echo "Supporting"
-            ;;
+    [[ -f "$quadlet" ]] || return
+    grep -E "^After=" "$quadlet" 2>/dev/null | \
+        sed 's/After=//' | tr ' ' '\n' | \
+        grep -v "network" | grep -v "target" | \
+        sed 's/\.service$//; s/\.container$//' | sort -u || true
+}
+
+# Determine service tier
+get_tier() {
+    case "$1" in
+        traefik|authelia|redis-authelia)                         echo "1:Critical" ;;
+        prometheus|grafana|loki|alertmanager|crowdsec)           echo "2:Infrastructure" ;;
+        jellyfin|immich-server|nextcloud|vaultwarden|home-assistant|homepage|gathio)
+                                                                 echo "3:Applications" ;;
+        nextcloud-db|nextcloud-redis|postgresql-immich|redis-immich|gathio-db)
+                                                                 echo "4:Data" ;;
+        *)                                                       echo "5:Supporting" ;;
     esac
 }
 
-# Generate dependency graph
+# Get display label for Mermaid node
+get_label() {
+    case "$1" in
+        traefik)           echo "Traefik<br/>Gateway" ;;
+        authelia)          echo "Authelia<br/>SSO + MFA" ;;
+        redis-authelia)    echo "Redis<br/>Auth Sessions" ;;
+        crowdsec)          echo "CrowdSec<br/>Security" ;;
+        prometheus)        echo "Prometheus<br/>Metrics" ;;
+        grafana)           echo "Grafana<br/>Dashboards" ;;
+        loki)              echo "Loki<br/>Logs" ;;
+        alertmanager)      echo "Alertmanager<br/>Alerts" ;;
+        jellyfin)          echo "Jellyfin<br/>Media" ;;
+        immich-server)     echo "Immich<br/>Photos" ;;
+        nextcloud)         echo "Nextcloud<br/>Files" ;;
+        vaultwarden)       echo "Vaultwarden<br/>Passwords" ;;
+        home-assistant)    echo "Home Assistant<br/>Automation" ;;
+        homepage)          echo "Homepage<br/>Dashboard" ;;
+        gathio)            echo "Gathio<br/>Events" ;;
+        nextcloud-db)      echo "MariaDB<br/>Nextcloud DB" ;;
+        nextcloud-redis)   echo "Redis<br/>Nextcloud Cache" ;;
+        postgresql-immich) echo "PostgreSQL<br/>Immich DB" ;;
+        redis-immich)      echo "Redis<br/>Immich Cache" ;;
+        gathio-db)         echo "MongoDB<br/>Gathio DB" ;;
+        *)                 echo "$1" ;;
+    esac
+}
+
+# Get impact severity for a service going down
+get_impact() {
+    case "$1" in
+        traefik)           echo "🔴 Total outage — no external access to any service" ;;
+        authelia)          echo "🟡 Cannot access Authelia-protected services (monitoring, dashboard)" ;;
+        redis-authelia)    echo "🟡 All SSO sessions lost, users must re-authenticate" ;;
+        crowdsec)          echo "🟡 Reduced security — no IP reputation filtering" ;;
+        prometheus)        echo "🟡 No metrics collection, blind operation" ;;
+        grafana)           echo "🟢 Dashboards unavailable, metrics still collected" ;;
+        loki)              echo "🟢 Log queries unavailable, logs still forwarded" ;;
+        alertmanager)      echo "🟢 Alerts not routed, monitoring continues" ;;
+        jellyfin)          echo "🟢 Media streaming unavailable" ;;
+        immich-server)     echo "🟢 Photo management unavailable" ;;
+        nextcloud)         echo "🟢 File sync unavailable" ;;
+        vaultwarden)       echo "🟡 Password vault inaccessible (keep local cache)" ;;
+        home-assistant)    echo "🟡 Automations stop, smart home degraded" ;;
+        homepage)          echo "🟢 Dashboard unavailable" ;;
+        gathio)            echo "🟢 Event management unavailable" ;;
+        postgresql-immich) echo "🔴 Immich completely non-functional" ;;
+        nextcloud-db)      echo "🔴 Nextcloud completely non-functional" ;;
+        redis-immich)      echo "🟡 Immich degraded (queue processing affected)" ;;
+        nextcloud-redis)   echo "🟡 Nextcloud degraded performance" ;;
+        gathio-db)         echo "🔴 Gathio completely non-functional" ;;
+        *)                 echo "🟢 Service-specific impact" ;;
+    esac
+}
+
 generate_graph() {
-    local timestamp=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+    local timestamp
+    timestamp=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
 
     log "Generating dependency graph..."
 
-    cat > "$OUTPUT_FILE" <<'EOF'
+    # Collect all containers and their tiers
+    local all_containers
+    all_containers=$(podman ps --format '{{.Names}}' | sort)
+
+    # Build tier lists
+    local -A tier_members
+    for container in $all_containers; do
+        local tier
+        tier=$(get_tier "$container")
+        local tier_key="${tier%%:*}"
+        tier_members[$tier_key]="${tier_members[$tier_key]:-} $container"
+    done
+
+    # Start output
+    cat > "$OUTPUT_FILE" <<EOF
 # Service Dependency Graph (Auto-Generated)
 
-**Generated:** TIMESTAMP
-**System:** fedora-htpc
-
-This document visualizes service dependencies and critical paths in the homelab infrastructure.
+**Generated:** ${timestamp}
+**System:** $(hostname)
 
 ---
 
 ## Dependency Overview
 
-Shows how services depend on each other, organized by tier.
+Shows how services depend on each other, organized by tier. Edges are derived from quadlet \`Requires=\` and \`After=\` directives.
 
-```mermaid
+\`\`\`mermaid
 graph TB
-    subgraph Critical[Critical Path - Tier 1]
-        traefik[Traefik<br/>Gateway]
-        authelia[Authelia<br/>SSO + MFA]
-        redis_authelia[Redis<br/>Sessions]
-    end
+EOF
 
-    subgraph Infrastructure[Infrastructure - Tier 2]
-        prometheus[Prometheus<br/>Metrics]
-        grafana[Grafana<br/>Dashboards]
-        loki[Loki<br/>Logs]
-        crowdsec[CrowdSec<br/>Security]
-        alertmanager[Alertmanager<br/>Alerts]
-    end
+    # Generate tier subgraphs dynamically
+    local tier_names=("Critical" "Infrastructure" "Applications" "Data" "Supporting")
+    local tier_nums=(1 2 3 4 5)
 
-    subgraph Applications[Applications - Tier 3]
-        jellyfin[Jellyfin<br/>Media]
-        immich[Immich<br/>Photos]
-        nextcloud[Nextcloud<br/>Files]
-        vaultwarden[Vaultwarden<br/>Passwords]
-    end
+    for i in "${!tier_nums[@]}"; do
+        local tier_num="${tier_nums[$i]}"
+        local tier_name="${tier_names[$i]}"
+        local members="${tier_members[$tier_num]:-}"
 
-    subgraph Data[Data Layer - Tier 4]
-        nextcloud_db[Nextcloud DB<br/>MariaDB]
-        immich_db[Immich DB<br/>PostgreSQL]
-        immich_redis[Immich Redis]
-        nextcloud_redis[Nextcloud Redis]
-    end
+        [[ -z "$members" ]] && continue
 
-    %% Critical path dependencies
-    traefik --> crowdsec
-    traefik --> authelia
-    authelia --> redis_authelia
+        echo "    subgraph ${tier_name}[${tier_name} — Tier ${tier_num}]" >> "$OUTPUT_FILE"
 
-    %% Application → Gateway dependencies
-    traefik --> jellyfin
-    traefik --> immich
-    traefik --> nextcloud
-    traefik --> vaultwarden
-    traefik --> prometheus
-    traefik --> grafana
+        for container in $members; do
+            local node_id="${container//-/_}"
+            local label
+            label=$(get_label "$container")
+            echo "        ${node_id}[${label}]" >> "$OUTPUT_FILE"
+        done
 
-    %% Application → Data dependencies
-    nextcloud --> nextcloud_db
-    nextcloud --> nextcloud_redis
-    immich --> immich_db
-    immich --> immich_redis
+        echo "    end" >> "$OUTPUT_FILE"
+        echo "" >> "$OUTPUT_FILE"
+    done
 
-    %% Monitoring dependencies
-    grafana --> prometheus
-    grafana --> loki
-    alertmanager --> prometheus
+    # Generate edges from quadlet dependencies
+    echo "    %% Hard dependencies (from Requires= directives)" >> "$OUTPUT_FILE"
+    for container in $all_containers; do
+        local node_id="${container//-/_}"
+        for dep in $(get_hard_deps "$container"); do
+            local dep_id="${dep//-/_}"
+            # Verify the dependency is a running container
+            if echo "$all_containers" | grep -qx "$dep"; then
+                echo "    ${node_id} --> ${dep_id}" >> "$OUTPUT_FILE"
+            fi
+        done
+    done
 
-    %% Prometheus scrapes (dotted = soft dependency)
-    prometheus -.->|scrapes| traefik
-    prometheus -.->|scrapes| jellyfin
-    prometheus -.->|scrapes| immich
-    prometheus -.->|scrapes| nextcloud
+    echo "" >> "$OUTPUT_FILE"
+    echo "    %% Routing dependencies (services in reverse_proxy depend on Traefik)" >> "$OUTPUT_FILE"
+
+    # Add Traefik routing edges for services in reverse_proxy network
+    local rp_members
+    rp_members=$(podman network inspect systemd-reverse_proxy 2>/dev/null | \
+        jq -r '.[0].containers // {} | to_entries[] | .value.name' | sort || true)
+
+    for container in $rp_members; do
+        [[ "$container" == "traefik" || "$container" == "crowdsec" ]] && continue
+        local node_id="${container//-/_}"
+        # Only add if not already covered by a hard dep
+        if ! get_hard_deps "$container" | grep -qx "traefik"; then
+            echo "    traefik -.-> ${node_id}" >> "$OUTPUT_FILE"
+        fi
+    done
+
+    echo "" >> "$OUTPUT_FILE"
+    echo "    %% Monitoring (Prometheus scrapes via monitoring network)" >> "$OUTPUT_FILE"
+
+    # Add Prometheus scraping edges for key services
+    local mon_members
+    mon_members=$(podman network inspect systemd-monitoring 2>/dev/null | \
+        jq -r '.[0].containers // {} | to_entries[] | .value.name' | sort || true)
+
+    for container in $mon_members; do
+        case "$container" in
+            prometheus|promtail|cadvisor|node_exporter|alert-discord-relay|loki|alertmanager|grafana|unpoller) continue ;;
+        esac
+        local node_id="${container//-/_}"
+        echo "    prometheus -.->|scrapes| ${node_id}" >> "$OUTPUT_FILE"
+    done
+
+    # Styling
+    cat >> "$OUTPUT_FILE" <<'EOF'
 
     %% Styling
     style traefik fill:#f9f,stroke:#333,stroke-width:4px
@@ -138,90 +222,56 @@ graph TB
 
 ## Critical Path Analysis
 
-### Tier 1: Critical Services
+EOF
 
-These services must be running for the homelab to function:
+    # Generate tier tables dynamically
+    for i in "${!tier_nums[@]}"; do
+        local tier_num="${tier_nums[$i]}"
+        local tier_name="${tier_names[$i]}"
+        local members="${tier_members[$tier_num]:-}"
 
-| Service | Role | Dependent Services | Impact if Down |
-|---------|------|-------------------|----------------|
-| **Traefik** | Gateway | All public services | 🔴 Total outage - no external access |
-| **Authelia** | Authentication | Protected services | 🟡 Cannot access protected services |
-| **Redis (Authelia)** | Session storage | Authelia | 🟡 All users logged out, must re-auth |
+        [[ -z "$members" ]] && continue
 
-**Critical path:** Internet → Traefik → Authelia → Redis
+        echo "### Tier ${tier_num}: ${tier_name}" >> "$OUTPUT_FILE"
+        echo "" >> "$OUTPUT_FILE"
 
-### Tier 2: Infrastructure Services
+        echo "| Service | Hard Dependencies | Impact if Down |" >> "$OUTPUT_FILE"
+        echo "|---------|-------------------|----------------|" >> "$OUTPUT_FILE"
 
-Supporting services for operations:
+        for container in $members; do
+            local deps
+            deps=$(get_hard_deps "$container" | tr '\n' ', ' | sed 's/,$//')
+            [[ -z "$deps" ]] && deps="—"
+            local impact
+            impact=$(get_impact "$container")
+            echo "| **${container}** | ${deps} | ${impact} |" >> "$OUTPUT_FILE"
+        done
 
-| Service | Role | Dependent Services | Impact if Down |
-|---------|------|-------------------|----------------|
-| **Prometheus** | Metrics collection | Grafana, Alertmanager | 🟡 No metrics, blind operation |
-| **Grafana** | Visualization | Users (dashboards) | 🟢 Dashboards unavailable, metrics still collected |
-| **Loki** | Log aggregation | Grafana (logs view) | 🟢 Log queries unavailable |
-| **CrowdSec** | Security | Traefik (IP blocking) | 🟡 Reduced security posture |
-| **Alertmanager** | Alerting | Prometheus | 🟢 Alerts not sent, monitoring continues |
+        echo "" >> "$OUTPUT_FILE"
+    done
 
-### Tier 3: Application Services
-
-End-user applications:
-
-| Service | Role | Dependencies | Impact if Down |
-|---------|------|--------------|----------------|
-| **Jellyfin** | Media streaming | Traefik | 🟢 Media unavailable, other services OK |
-| **Immich** | Photo management | Traefik, PostgreSQL, Redis | 🟢 Photos unavailable |
-| **Nextcloud** | File sync | Traefik, MariaDB, Redis | 🟢 Files unavailable |
-| **Vaultwarden** | Password manager | Traefik | 🟡 Passwords inaccessible (keep local vault) |
-
-### Tier 4: Data Layer
-
-Backend data services:
-
-| Service | Role | Used By | Impact if Down |
-|---------|------|---------|----------------|
-| **PostgreSQL (Immich)** | Database | Immich | 🔴 Immich completely non-functional |
-| **MariaDB (Nextcloud)** | Database | Nextcloud | 🔴 Nextcloud completely non-functional |
-| **Redis (Immich)** | Cache/Queue | Immich | 🟡 Immich degraded performance |
-| **Redis (Nextcloud)** | Cache | Nextcloud | 🟡 Nextcloud degraded performance |
-
+    # Startup order from After= directives
+    cat >> "$OUTPUT_FILE" <<'EOF'
 ---
 
-## Startup Order Recommendations
+## Startup Order
 
-Based on dependencies, services should start in this order:
+Derived from `After=` directives in quadlet files. systemd handles this automatically.
 
-1. **Data Layer** (databases and caches)
-   - redis-authelia
-   - postgresql-immich
-   - nextcloud-db
-   - redis-immich
-   - nextcloud-redis
+EOF
 
-2. **Critical Services**
-   - traefik
-   - crowdsec
-   - authelia
+    echo "| Service | Starts After |" >> "$OUTPUT_FILE"
+    echo "|---------|-------------|" >> "$OUTPUT_FILE"
 
-3. **Infrastructure**
-   - prometheus
-   - loki
-   - alertmanager
+    for container in $all_containers; do
+        local after_deps
+        after_deps=$(get_after_deps "$container" | tr '\n' ', ' | sed 's/,$//')
+        [[ -z "$after_deps" ]] && after_deps="(no ordering constraints)"
+        echo "| ${container} | ${after_deps} |" >> "$OUTPUT_FILE"
+    done
 
-4. **Visualization**
-   - grafana
-
-5. **Applications** (can start in parallel)
-   - jellyfin
-   - immich-server, immich-ml, immich-microservices
-   - nextcloud
-   - vaultwarden
-
-6. **Monitoring Exporters**
-   - node-exporter
-   - cadvisor
-   - promtail
-
-**Note:** systemd handles this automatically via `After=` directives in quadlet files.
+    # Network-based dependencies
+    cat >> "$OUTPUT_FILE" <<'EOF'
 
 ---
 
@@ -231,58 +281,48 @@ Services on the same network can communicate:
 
 EOF
 
-    # Add network-based dependencies
-    for network in $(podman network ls --format '{{.Name}}' | grep '^systemd-'); do
-        local network_short=$(echo "$network" | sed 's/systemd-//')
-        local members=$(podman network inspect "$network" 2>/dev/null | \
+    for network in $(podman network ls --format '{{.Name}}' | grep '^systemd-' | sort); do
+        local network_short="${network#systemd-}"
+        local members
+        members=$(podman network inspect "$network" 2>/dev/null | \
             jq -r '.[0].containers // {} | to_entries[] | .value.name' | sort | tr '\n' ', ' | sed 's/,$//')
 
-        if [[ -n "$members" ]]; then
-            cat >> "$OUTPUT_FILE" <<EOF
-
-**${network_short}:** ${members}
-EOF
-        fi
+        [[ -n "$members" ]] && echo "**${network_short}:** ${members}" >> "$OUTPUT_FILE"
+        echo "" >> "$OUTPUT_FILE"
     done
 
+    # Service overrides and links
     cat >> "$OUTPUT_FILE" <<'EOF'
-
-
 ---
 
 ## Service Overrides
 
-Some services have special handling in autonomous operations:
+Services with restricted auto-restart in autonomous operations:
 
 | Service | Auto-Restart | Rationale |
 |---------|--------------|-----------|
-| traefik | ❌ No | Gateway service - manual intervention required |
-| authelia | ❌ No | Authentication service - manual intervention required |
+| traefik | ❌ No | Gateway — manual intervention required |
+| authelia | ❌ No | Authentication — manual intervention required |
 | Others | ✅ Yes | Can be automatically restarted if unhealthy |
-
-See `~/containers/.claude/context/preferences.yml` for configuration.
 
 ---
 
-## Quick Links
+## Related Documentation
 
 - [Service Catalog](AUTO-SERVICE-CATALOG.md) - What's running
 - [Network Topology](AUTO-NETWORK-TOPOLOGY.md) - Network architecture
 - [Homelab Architecture](20-operations/guides/homelab-architecture.md) - Full documentation
 - [Autonomous Operations](20-operations/guides/autonomous-operations.md) - OODA loop
+- [ADR-011: Service Dependency Mapping](10-services/decisions/2025-11-15-ADR-011-service-dependency-mapping.md) - Dependency design decisions
 
 ---
 
 *Auto-generated by `scripts/generate-dependency-graph.sh`*
 EOF
 
-    # Replace timestamp
-    sed -i "s/TIMESTAMP/$timestamp/" "$OUTPUT_FILE"
-
     log "✓ Dependency graph generated: $OUTPUT_FILE"
 }
 
-# Main
 main() {
     log "Starting dependency graph generation..."
 

--- a/scripts/generate-network-topology.sh
+++ b/scripts/generate-network-topology.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 # Network Topology Generator
 # Generates Mermaid diagrams showing network architecture
+# All sections are dynamically generated from live Podman state
 
 set -euo pipefail
 
 OUTPUT_FILE="${HOME}/containers/docs/AUTO-NETWORK-TOPOLOGY.md"
+ROUTERS_FILE="${HOME}/containers/config/traefik/dynamic/routers.yml"
 
 log() {
     echo "[$(date +'%H:%M:%S')] $*" >&2
@@ -12,7 +14,7 @@ log() {
 
 # Get network information
 get_networks() {
-    podman network ls --format '{{.Name}}' | grep '^systemd-' || true
+    podman network ls --format '{{.Name}}' | grep '^systemd-' | sort || true
 }
 
 # Get containers on a network
@@ -37,103 +39,85 @@ get_container_networks() {
         sed 's/systemd-//' | sort | tr '\n' ',' | sed 's/,$//'
 }
 
-# Get all running containers
-get_all_containers() {
-    podman ps --format '{{.Names}}' | sort
-}
-
 # Check if service uses Authelia middleware (parse routers.yml)
 uses_authelia() {
     local service=$1
-    local routers_file="${HOME}/containers/config/traefik/dynamic/routers.yml"
 
-    if [[ ! -f "$routers_file" ]]; then
-        return 1
-    fi
-
-    # Strategy: Extract router blocks that have "service: \"$service\""
-    # Then check if that block contains "authelia@file"
-    # Router blocks start with 4-space indent + name + colon (e.g., "    router-name:")
-    # and continue until the next router or section
+    [[ ! -f "$ROUTERS_FILE" ]] && return 1
 
     awk -v service="$service" '
-        # Start of a new router (4 spaces + word + colon, not a list item)
         /^    [a-z][a-z0-9_-]*:$/ {
-            # Process previous router if it matched
-            if (found_service && found_authelia) {
-                exit 0
-            }
-            # Reset for new router
-            found_service = 0
-            found_authelia = 0
-            in_router = 1
-            next
+            if (found_service && found_authelia) exit 0
+            found_service = 0; found_authelia = 0; in_router = 1; next
         }
-
-        # Check if this line has our service
-        in_router && $0 ~ "service: \"" service "\"" {
-            found_service = 1
-        }
-
-        # Check if this line has authelia middleware
-        in_router && /authelia@file/ {
-            found_authelia = 1
-        }
-
-        # End of routers section or file
+        in_router && $0 ~ "service: \"" service "\"" { found_service = 1 }
+        in_router && /authelia@file/ { found_authelia = 1 }
         /^  [a-z]+:/ && !/^    / {
-            if (found_service && found_authelia) {
-                exit 0
-            }
+            if (found_service && found_authelia) exit 0
             in_router = 0
         }
-
-        END {
-            if (found_service && found_authelia) {
-                exit 0
-            }
-            exit 1
-        }
-    ' "$routers_file" && return 0
+        END { if (found_service && found_authelia) exit 0; exit 1 }
+    ' "$ROUTERS_FILE" && return 0
 
     return 1
 }
 
-# Determine if container is internet-accessible (in reverse_proxy network)
-is_public_service() {
+# Determine service role for matrix grouping
+get_role() {
     local container=$1
-    get_container_networks "$container" | grep -q "reverse_proxy"
+    local networks
+    networks=$(get_container_networks "$container")
+
+    case "$container" in
+        traefik|crowdsec|authelia|redis-authelia) echo "1-Gateway & Security" ;;
+        *)
+            if echo "$networks" | grep -q "reverse_proxy"; then
+                # Check if it's a monitoring service
+                case "$container" in
+                    prometheus|grafana|loki|alertmanager) echo "3-Monitoring" ;;
+                    *) echo "2-Public Services" ;;
+                esac
+            else
+                case "$container" in
+                    prometheus|grafana|loki|alertmanager|node_exporter|cadvisor|promtail|unpoller|alert-discord-relay)
+                        echo "3-Monitoring" ;;
+                    *) echo "4-Backend Services" ;;
+                esac
+            fi
+            ;;
+    esac
 }
 
-# Get primary network for a container (first network = default route)
-get_primary_network() {
-    local container=$1
-    podman inspect "$container" 2>/dev/null | \
-        jq -r '.[0].NetworkSettings.Networks // {} | keys[0]' | \
-        sed 's/systemd-//'
-}
-
-# Generate the topology document
 generate_topology() {
-    local timestamp=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+    local timestamp
+    timestamp=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
 
     log "Generating network topology..."
 
-    cat > "$OUTPUT_FILE" <<'EOF'
+    # Collect all network names (short form) for the matrix header
+    local network_names=()
+    for network in $(get_networks); do
+        network_names+=("$(echo "$network" | sed 's/systemd-//')")
+    done
+
+    # Collect all containers and their network memberships
+    local all_containers
+    all_containers=$(podman ps --format '{{.Names}}' | sort)
+
+    # Start writing output
+    cat > "$OUTPUT_FILE" <<EOF
 # Network Topology (Auto-Generated)
 
-**Generated:** TIMESTAMP
-**System:** fedora-htpc
-
-This document provides comprehensive visualizations of the homelab network architecture, combining traffic flow analysis with network-centric topology views.
+**Generated:** ${timestamp}
+**System:** $(hostname) | **Networks:** ${#network_names[@]} | **Containers:** $(echo "$all_containers" | wc -l)
 
 ---
 
 ## 1. Traffic Flow & Middleware Routing
 
-Shows how requests flow from Internet through Traefik with middleware routing based on actual configuration in `config/traefik/dynamic/routers.yml`.
+Shows how requests flow from Internet through Traefik with middleware routing based on actual configuration in \`config/traefik/dynamic/routers.yml\`.
 
-```mermaid
+\`\`\`mermaid
 graph TB
     Internet[🌐 Internet<br/>Port 80/443]
     Internet -->|Port Forward| Traefik[Traefik<br/>Reverse Proxy]
@@ -141,17 +125,11 @@ graph TB
     %% All traffic goes through CrowdSec first
     Traefik -->|All Traffic| CrowdSec[CrowdSec<br/>IP Reputation]
 
-EOF
-
-    # Parse routers.yml to determine routing (data-driven)
-    log "Parsing routing configuration..."
-
-    # Services with Authelia
-    cat >> "$OUTPUT_FILE" <<'EOF'
     %% Services requiring Authelia SSO
     CrowdSec -->|Rate Limit| Authelia[Authelia<br/>SSO + YubiKey]
 EOF
 
+    # Dynamically determine which services use Authelia vs native auth
     local authelia_services=""
     local native_auth_services=""
 
@@ -163,24 +141,21 @@ EOF
         fi
     done
 
-    # Add Authelia-protected services
     for service in $authelia_services; do
-        local node_name=$(echo "$service" | sed 's/-/_/g')
+        local node_name="${service//-/_}"
         echo "    Authelia -->|Proxy| ${node_name}[${service}]" >> "$OUTPUT_FILE"
     done
 
-    # Add services with native auth (bypass Authelia)
     cat >> "$OUTPUT_FILE" <<EOF
 
     %% Services with native authentication (bypass Authelia)
 EOF
 
     for service in $native_auth_services; do
-        local node_name=$(echo "$service" | sed 's/-/_/g')
+        local node_name="${service//-/_}"
         echo "    CrowdSec -->|Rate Limit| ${node_name}[${service}]" >> "$OUTPUT_FILE"
     done
 
-    # Styling
     cat >> "$OUTPUT_FILE" <<'EOF'
 
     %% Styling
@@ -192,7 +167,7 @@ EOF
 **Key Insights:**
 - **CrowdSec** checks ALL traffic (fail-fast: reject banned IPs immediately)
 - **Authelia** protects administrative/monitoring services (SSO with YubiKey)
-- **Native auth** services handle their own authentication (Jellyfin, Immich, Nextcloud, Vaultwarden)
+- **Native auth** services handle their own authentication (bypass Authelia)
 
 ---
 
@@ -204,13 +179,13 @@ Shows actual Podman network membership. Services appear in EVERY network they be
 graph TB
 EOF
 
-    # Build accurate network topology - services appear in ALL networks they're in
+    # Build dynamic network topology diagram
     log "Building network topology..."
 
-    # Process each network and show ALL its members
     for network in $(get_networks); do
-        local network_short=$(echo "$network" | sed 's/systemd-//')
-        local subnet=$(get_network_subnet "$network")
+        local network_short="${network#systemd-}"
+        local subnet
+        subnet=$(get_network_subnet "$network")
 
         cat >> "$OUTPUT_FILE" <<EOF
 
@@ -218,17 +193,15 @@ EOF
         direction LR
 EOF
 
-        # Add ALL services in this network
         for container in $(get_network_members "$network"); do
-            local node_name=$(echo "$container" | sed 's/-/_/g')
-            # Unique node ID per network to avoid conflicts
+            local node_name="${container//-/_}"
             echo "        ${network_short}_${node_name}[${container}]" >> "$OUTPUT_FILE"
         done
 
         echo "    end" >> "$OUTPUT_FILE"
     done
 
-    # Network styling based on function
+    # Styling based on network function
     cat >> "$OUTPUT_FILE" <<'EOF'
 
     %% Network styling
@@ -238,60 +211,67 @@ EOF
 
     class reverse_proxy gatewayNet
     class monitoring observeNet
-    class auth_services,photos,nextcloud,media_services backendNet
+    class auth_services,photos,nextcloud,media_services,gathio,home_automation backendNet
 ```
-
-**Network Functions:**
-- **reverse_proxy** (10.89.2.0/24) - Gateway for Internet-accessible services
-- **monitoring** (10.89.4.0/24) - Observability network (scrapes metrics from all services)
-- **auth_services** (10.89.3.0/24) - Authentication and session management
-- **photos** (10.89.5.0/24) - Immich stack isolation
-- **nextcloud** (10.89.10.0/24) - Nextcloud stack isolation
-- **media_services** (10.89.1.0/24) - Jellyfin media processing
-
-**Note:** Services appear in multiple network boxes if they belong to multiple networks. This accurately represents Podman network membership.
 
 ---
 
 ## Network Membership Matrix
 
-Shows which services belong to which networks. Many services are members of multiple networks.
+Shows which services belong to which networks. Dynamically generated from running container state.
 
-| Service | reverse_proxy | monitoring | auth_services | photos | nextcloud | media_services |
-|---------|:-------------:|:----------:|:-------------:|:------:|:---------:|:--------------:|
-| **Gateway & Security** |
-| traefik | ✅ | ✅ | ✅ | - | - | - |
-| crowdsec | ✅ | - | - | - | - | - |
-| authelia | ✅ | - | ✅ | - | - | - |
-| redis-authelia | - | - | ✅ | - | - | - |
-| **Public Services** |
-| jellyfin | ✅ | ✅ | - | - | - | ✅ |
-| immich-server | ✅ | ✅ | - | ✅ | - | - |
-| nextcloud | ✅ | ✅ | - | - | ✅ | - |
-| vaultwarden | ✅ | - | - | - | - | - |
-| collabora | ✅ | - | - | - | ✅ | - |
-| homepage | ✅ | - | - | - | - | - |
-| **Monitoring** |
-| prometheus | ✅ | ✅ | - | - | - | - |
-| grafana | ✅ | ✅ | - | - | - | - |
-| loki | ✅ | ✅ | - | - | - | - |
-| alertmanager | ✅ | ✅ | - | - | - | - |
-| node_exporter | - | ✅ | - | - | - | - |
-| cadvisor | - | ✅ | - | - | - | - |
-| promtail | - | ✅ | - | - | - | - |
-| alert-discord-relay | - | ✅ | - | - | - | - |
-| **Backend Services** |
-| postgresql-immich | - | - | - | ✅ | - | - |
-| redis-immich | - | - | - | ✅ | - | - |
-| immich-ml | - | - | - | ✅ | - | - |
-| nextcloud-db | - | ✅ | - | - | ✅ | - |
-| nextcloud-redis | - | ✅ | - | - | ✅ | - |
+EOF
 
-**Key Insights:**
-- **Traefik** is in 3 networks (gateway, monitoring, auth) to route traffic and be monitored
-- **Internet-facing services** are all in `reverse_proxy` (primary) + their functional network
-- **Monitoring network** has the most members (14 services) - observability across all tiers
-- **Backend databases/caches** are isolated to their functional networks only
+    # Build dynamic matrix header
+    printf "| Service |" >> "$OUTPUT_FILE"
+    for net in "${network_names[@]}"; do
+        printf " %s |" "$net" >> "$OUTPUT_FILE"
+    done
+    echo "" >> "$OUTPUT_FILE"
+
+    printf "|---------|" >> "$OUTPUT_FILE"
+    for _ in "${network_names[@]}"; do
+        printf ":---:|" >> "$OUTPUT_FILE"
+    done
+    echo "" >> "$OUTPUT_FILE"
+
+    # Group containers by role, then output matrix rows
+    local tmpfile
+    tmpfile=$(mktemp)
+    trap 'rm -f "$tmpfile"' EXIT
+
+    for container in $all_containers; do
+        local role
+        role=$(get_role "$container")
+        local nets
+        nets=$(get_container_networks "$container")
+        echo "${role}|${container}|${nets}" >> "$tmpfile"
+    done
+
+    local current_role=""
+    sort "$tmpfile" | while IFS='|' read -r role container nets; do
+        local role_name="${role#*-}"
+        if [[ "$role_name" != "$current_role" ]]; then
+            echo "| **${role_name}** |" >> "$OUTPUT_FILE"
+            current_role="$role_name"
+        fi
+
+        printf "| %s |" "$container" >> "$OUTPUT_FILE"
+        for net in "${network_names[@]}"; do
+            if echo ",$nets," | grep -q ",${net},"; then
+                printf " ✅ |" >> "$OUTPUT_FILE"
+            else
+                printf " - |" >> "$OUTPUT_FILE"
+            fi
+        done
+        echo "" >> "$OUTPUT_FILE"
+    done
+
+    rm -f "$tmpfile"
+    trap - EXIT
+
+    # Request flow diagram (static but accurate)
+    cat >> "$OUTPUT_FILE" <<'EOF'
 
 ---
 
@@ -345,11 +325,15 @@ sequenceDiagram
 
 EOF
 
-    # Add network details section with dynamic data
+    # Dynamic network details
     for network in $(get_networks); do
-        local network_short=$(echo "$network" | sed 's/systemd-//')
-        local subnet=$(get_network_subnet "$network")
-        local member_count=$(get_network_members "$network" | wc -l)
+        local network_short="${network#systemd-}"
+        local subnet
+        subnet=$(get_network_subnet "$network")
+        local members
+        members=$(get_network_members "$network")
+        local member_count
+        member_count=$(echo "$members" | wc -l)
 
         cat >> "$OUTPUT_FILE" <<EOF
 
@@ -362,101 +346,27 @@ EOF
 **Members:**
 EOF
 
-        for container in $(get_network_members "$network"); do
+        for container in $members; do
             echo "- ${container}" >> "$OUTPUT_FILE"
         done
 
         echo "" >> "$OUTPUT_FILE"
     done
 
-    # Add architecture principles
+    # Links to related documentation (not duplicating content)
     cat >> "$OUTPUT_FILE" <<'EOF'
 
 ---
 
-## Architecture Principles
+## Related Documentation
 
-### Network Segmentation Strategy
+For architecture principles, network ordering rules, and troubleshooting:
 
-Services are organized into isolated networks based on function and trust level:
-
-1. **reverse_proxy** (10.89.2.0/24) - **Gateway Network**
-   - Contains Traefik and all internet-accessible services
-   - **Critical:** First network in quadlets (gets default route for internet access)
-   - 13 members including all public-facing services
-
-2. **monitoring** (10.89.4.0/24) - **Observability Network**
-   - Prometheus, Grafana, Loki, exporters, and relay services
-   - Scrapes metrics from services across all other networks
-   - 14 members (most connected network)
-
-3. **auth_services** (10.89.3.0/24) - **Authentication Network**
-   - Authelia SSO, Redis session storage, and Traefik
-   - Isolated from direct internet except through reverse proxy
-   - 3 members (tightly controlled)
-
-4. **photos** (10.89.5.0/24) - **Photo Management Network**
-   - Immich application stack with PostgreSQL, Redis, and ML
-   - Backend services isolated from internet
-   - 4 members
-
-5. **nextcloud** (10.89.10.0/24) - **File Sync Network**
-   - Nextcloud application with MariaDB, Redis, and Collabora
-   - Backend databases accessible only within this network
-   - 4 members
-
-6. **media_services** (10.89.1.0/24) - **Media Processing Network**
-   - Jellyfin and media-related services
-   - 1 member (Jellyfin also in reverse_proxy and monitoring)
-
-### Multi-Network Services
-
-**Why multiple networks?**
-- **reverse_proxy** = Internet accessibility
-- **monitoring** = Metrics scraping
-- **Functional network** = Backend communication (databases, caches)
-
-**Examples:**
-- **Traefik (3 networks):** reverse_proxy (gateway), auth_services (Authelia access), monitoring (metrics)
-- **Jellyfin (3 networks):** reverse_proxy (internet), monitoring (metrics), media_services (function)
-- **Immich (3 networks):** reverse_proxy (internet), monitoring (metrics), photos (backend DB/cache)
-- **Nextcloud (3 networks):** reverse_proxy (internet), monitoring (metrics), nextcloud (backend DB/cache)
-
-### Network Ordering in Quadlets
-
-**Critical:** First `Network=` line in quadlet gets the default route (internet access).
-
-```ini
-# ✅ Correct - can reach internet AND internal services
-Network=systemd-reverse_proxy.network
-Network=systemd-monitoring.network
-Network=systemd-photos.network
-
-# ❌ Wrong - cannot reach internet (monitoring is internal-only)
-Network=systemd-monitoring.network
-Network=systemd-reverse_proxy.network
-```
-
-**Rule of thumb:**
-- Internet-facing services: `reverse_proxy` first
-- Internal services: Functional network first (photos, nextcloud, etc.)
-- Monitoring-only: `monitoring` network only (no internet needed)
-
-### Service Discovery (Podman DNS)
-
-Services on the same network can communicate using container names as hostnames:
-- `http://authelia:9091` - Traefik reaches Authelia (both in auth_services)
-- `http://redis-authelia:6379` - Authelia reaches Redis (both in auth_services)
-- `http://postgresql-immich:5432` - Immich reaches database (both in photos)
-- `http://prometheus:9090` - Grafana reaches Prometheus (both in monitoring)
-
----
-
-## Quick Links
-
+- [CLAUDE.md](../CLAUDE.md) - Network ordering, gotchas, and deployment patterns
+- [Homelab Architecture](20-operations/guides/homelab-architecture.md) - Full architecture overview
+- [ADR-018: Static IP Multi-Network Services](00-foundation/decisions/2026-02-04-ADR-018-static-ip-multi-network-services.md) - Static IPs and Traefik /etc/hosts override
 - [Service Catalog](AUTO-SERVICE-CATALOG.md) - Complete service inventory
 - [Dependency Graph](AUTO-DEPENDENCY-GRAPH.md) - Service dependencies
-- [Homelab Architecture](20-operations/guides/homelab-architecture.md) - Full documentation
 
 ---
 
@@ -464,13 +374,9 @@ Services on the same network can communicate using container names as hostnames:
 *GitHub renders Mermaid diagrams automatically - view this file on GitHub for best experience*
 EOF
 
-    # Replace timestamp
-    sed -i "s/TIMESTAMP/$timestamp/" "$OUTPUT_FILE"
-
     log "✓ Network topology generated: $OUTPUT_FILE"
 }
 
-# Main
 main() {
     log "Starting network topology generation..."
 

--- a/scripts/generate-service-catalog-simple.sh
+++ b/scripts/generate-service-catalog-simple.sh
@@ -1,41 +1,181 @@
 #!/bin/bash
-# Simple Service Catalog Generator
-# Quick and reliable service inventory generation
+# Service Catalog Generator
+# Generates categorized service inventory with health, uptime, URLs, and guide links
 
 set -euo pipefail
 
 OUTPUT_FILE="${HOME}/containers/docs/AUTO-SERVICE-CATALOG.md"
+ROUTERS_FILE="${HOME}/containers/config/traefik/dynamic/routers.yml"
+GUIDES_DIR="${HOME}/containers/docs/10-services/guides"
+MONITORING_GUIDE="docs/40-monitoring-and-documentation/guides/monitoring-stack.md"
 
-# Generate catalog
+# Service group assignment (matches CLAUDE.md's 13 service groups)
+get_group() {
+    case "$1" in
+        traefik|crowdsec|authelia|redis-authelia)    echo "1:Core Infrastructure" ;;
+        nextcloud|nextcloud-db|nextcloud-redis)      echo "2:Nextcloud" ;;
+        immich-server|immich-ml|postgresql-immich|redis-immich) echo "3:Immich" ;;
+        jellyfin)                                    echo "4:Jellyfin" ;;
+        vaultwarden)                                 echo "5:Vaultwarden" ;;
+        home-assistant|matter-server)                echo "6:Home Automation" ;;
+        gathio|gathio-db)                            echo "7:Gathio" ;;
+        homepage)                                    echo "8:Homepage" ;;
+        prometheus|grafana|loki|alertmanager|promtail|node_exporter|cadvisor|unpoller|alert-discord-relay)
+                                                     echo "9:Monitoring" ;;
+        *)                                           echo "10:Other" ;;
+    esac
+}
+
+# Extract public URL for a service from routers.yml
+# Maps container names to Traefik service names and finds the Host rule
+get_public_url() {
+    local container=$1
+
+    [[ ! -f "$ROUTERS_FILE" ]] && return
+
+    # Map container names to Traefik service names where they differ
+    local svc_name="$container"
+    case "$container" in
+        immich-server) svc_name="immich" ;;
+        home-assistant) svc_name="home-assistant" ;;
+        # Traefik dashboard uses api@internal, extract directly
+        traefik)
+            grep -oP 'Host\(`\K[^`]+' "$ROUTERS_FILE" | grep -m1 traefik || true
+            return
+            ;;
+    esac
+
+    # Find Host rule for this service in routers.yml
+    # Look for service: "name" then find the corresponding rule: "Host(...)"
+    awk -v svc="$svc_name" '
+        /^    [a-z][a-z0-9_-]*:/ { in_router=1; rule=""; found=0 }
+        in_router && /rule:.*Host\(/ {
+            match($0, /Host\(`([^`]+)`\)/, m)
+            if (m[1] != "") rule = m[1]
+        }
+        in_router && /service:/ {
+            match($0, /"([^"]+)"/, m)
+            if (m[1] == svc) found=1
+        }
+        in_router && found && rule != "" { print rule; exit }
+        /^  [a-z]+:/ && !/^    / { in_router=0 }
+    ' "$ROUTERS_FILE" 2>/dev/null || true
+}
+
+# Find the guide file for a service
+get_guide_link() {
+    local container=$1
+
+    # Direct match
+    if [[ -f "${GUIDES_DIR}/${container}.md" ]]; then
+        echo "10-services/guides/${container}.md"
+        return
+    fi
+
+    # Monitoring services share a guide
+    case "$container" in
+        prometheus|grafana|loki|alertmanager|promtail|node_exporter|cadvisor|unpoller)
+            echo "40-monitoring-and-documentation/guides/monitoring-stack.md"
+            return
+            ;;
+    esac
+
+    # Try parent service name (e.g., nextcloud-db → nextcloud)
+    local parent="${container%%-*}"
+    if [[ "$parent" != "$container" && -f "${GUIDES_DIR}/${parent}.md" ]]; then
+        echo "10-services/guides/${parent}.md"
+        return
+    fi
+}
+
+# Parse health and uptime from podman ps status string
+parse_status() {
+    local status="$1"
+    local health="—"
+    local uptime="—"
+
+    if echo "$status" | grep -q "(healthy)"; then
+        health="✅ healthy"
+    elif echo "$status" | grep -q "(unhealthy)"; then
+        health="⚠️ unhealthy"
+    elif echo "$status" | grep -q "Up"; then
+        health="— no check"
+    fi
+
+    # Extract uptime (e.g., "Up 10 days" → "10d", "Up 6 hours" → "6h")
+    uptime=$(echo "$status" | sed -n 's/Up \(.*\) (.*/\1/p')
+    if [[ -z "$uptime" ]]; then
+        uptime=$(echo "$status" | sed -n 's/Up \(.*\)/\1/p')
+    fi
+    # Compact format
+    uptime=$(echo "$uptime" | sed 's/ seconds\?/s/; s/ minutes\?/m/; s/ hours\?/h/; s/ days\?/d/; s/ weeks\?/w/; s/ months\?/mo/')
+    # Trim "About "
+    uptime=$(echo "$uptime" | sed 's/About /~/')
+
+    echo "$health|$uptime"
+}
+
+# Main generation
 {
+    timestamp=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+    total_running=$(podman ps -q | wc -l)
+    total_defined=$(podman ps -aq | wc -l)
+    healthy_count=$(podman ps --format "{{.Status}}" | grep -c "(healthy)" || true)
+    total_with_healthcheck=$(podman ps --format "{{.Status}}" | grep -c "(healthy)\|(unhealthy)" || true)
+
     echo "# Service Catalog (Auto-Generated)"
     echo ""
-    echo "**Generated:** $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
-    echo "**System:** $(hostname)"
+    echo "**Generated:** $timestamp"
+    echo "**System:** $(hostname) | **Services:** ${total_running}/${total_defined} running | **Health:** ${healthy_count}/${total_with_healthcheck} healthy ($(( total_running - total_with_healthcheck )) without healthcheck)"
     echo ""
     echo "---"
-    echo ""
-    echo "## Running Services"
-    echo ""
-    echo "| Service | Image | Status | Networks |"
-    echo "|---------|-------|--------|----------|"
 
-    # Get running containers
-    podman ps --format "{{.Names}}|{{.Image}}|{{.Status}}|{{.Networks}}" | while IFS='|' read -r name image status networks; do
-        # Clean up image name
-        short_image=$(echo "$image" | sed 's|docker.io/library/||' | sed 's|docker.io/||' | sed 's|ghcr.io/||' | cut -c1-40)
+    # Collect container data and group it
+    # Format: group_key|container_name|image|health|uptime|url|guide
+    tmpfile=$(mktemp)
+    trap 'rm -f "$tmpfile"' EXIT
 
-        # Clean up networks
-        clean_networks=$(echo "$networks" | sed 's/systemd-//g')
+    podman ps --format '{{.Names}}\t{{.Image}}\t{{.Status}}' | while IFS=$'\t' read -r name image status; do
+        group=$(get_group "$name")
+        short_image=$(echo "$image" | sed 's|docker.io/library/||; s|docker.io/||; s|ghcr.io/||' | cut -c1-45)
+        parsed=$(parse_status "$status")
+        health="${parsed%%|*}"
+        uptime="${parsed##*|}"
+        url=$(get_public_url "$name")
+        guide=$(get_guide_link "$name")
 
-        # Determine status icon
-        if echo "$status" | grep -q "Up"; then
-            status_icon="✅ Up"
+        # Format URL as link or dash
+        if [[ -n "$url" ]]; then
+            url_col="[${url}](https://${url})"
         else
-            status_icon="❌ Down"
+            url_col="—"
         fi
 
-        echo "| $name | $short_image | $status_icon | $clean_networks |"
+        # Format guide as link or dash
+        if [[ -n "$guide" ]]; then
+            guide_col="[guide](${guide})"
+        else
+            guide_col="—"
+        fi
+
+        echo "${group}|${name}|${short_image}|${health}|${uptime}|${url_col}|${guide_col}" >> "$tmpfile"
+    done
+
+    # Output grouped tables
+    current_group=""
+    sort "$tmpfile" | while IFS='|' read -r group name image health uptime url guide; do
+        group_name="${group#*:}"
+        if [[ "$group_name" != "$current_group" ]]; then
+            # Count services in this group
+            group_count=$(grep -c "^${group}|" "$tmpfile")
+            echo ""
+            echo "## ${group_name} (${group_count})"
+            echo ""
+            echo "| Service | Image | Health | Uptime | URL | Docs |"
+            echo "|---------|-------|--------|--------|-----|------|"
+            current_group="$group_name"
+        fi
+        echo "| ${name} | ${image} | ${health} | ${uptime} | ${url} | ${guide} |"
     done
 
     echo ""
@@ -43,17 +183,17 @@ OUTPUT_FILE="${HOME}/containers/docs/AUTO-SERVICE-CATALOG.md"
     echo ""
     echo "## Statistics"
     echo ""
-    echo "- **Total Running:** $(podman ps | tail -n +2 | wc -l)"
-    echo "- **Total Defined:** $(podman ps -a | tail -n +2 | wc -l)"
-    echo "- **System Load:** $(uptime | awk -F'load average:' '{print $2}')"
+    echo "- **Total Running:** ${total_running}"
+    echo "- **Total Defined:** ${total_defined}"
+    echo "- **System Load:**$(uptime | awk -F'load average:' '{print $2}')"
     echo ""
     echo "---"
     echo ""
     echo "## Quick Links"
     echo ""
+    echo "- [Network Topology](AUTO-NETWORK-TOPOLOGY.md)"
+    echo "- [Dependency Graph](AUTO-DEPENDENCY-GRAPH.md)"
     echo "- [Homelab Architecture](20-operations/guides/homelab-architecture.md)"
-    echo "- [Network Topology](AUTO-NETWORK-TOPOLOGY.md) (when generated)"
-    echo "- [Dependency Graph](AUTO-DEPENDENCY-GRAPH.md) (when generated)"
     echo ""
     echo "---"
     echo ""


### PR DESCRIPTION
## Summary

- **Rewrite all 4 auto-doc generators** to produce fully dynamic output from live system state, eliminating stale hardcoded content
- **Service Catalog**: Grouped by service groups, with healthcheck status, uptime, public URLs, and guide cross-references
- **Network Topology**: Dynamic membership matrix replacing hardcoded table with stale Collabora reference and wrong member counts
- **Dependency Graph**: Mermaid edges derived from quadlet `Requires=`/`After=` directives instead of hardcoded diagram; removes dead code and non-existent `immich-microservices` reference
- **Documentation Index**: Dynamic Quick Search covering all 14 primary services with auto-discovered guides, ADRs, configs, and quadlets; fixes broken `prometheus.md`/`grafana.md` links

## Motivation

Review of the auto-documentation system (originally implemented 2025-12-22) found that **dynamic sections stayed accurate while hardcoded sections drifted**. Key issues:
- Collabora (decommissioned 2026-02-06) still in network matrix
- `immich-microservices` (never existed) in startup order
- Wrong member counts (13 vs actual 14 for reverse_proxy, 14 vs actual 17 for monitoring)
- Service catalog was a flat unsorted list with no health, uptime, URL, or guide info
- Dependency graph Mermaid was 100% static (helper functions defined but never called)
- Quick Search only covered 5 of 14 services, with broken links to non-existent guides

## Verification

```
$ bash scripts/auto-doc-orchestrator.sh
✓ Service Catalog complete
✓ Network Topology complete
✓ Dependency Graph complete
✓ Documentation Index complete
Duration: 8s | Failures: 0
```

- No Collabora references in any AUTO-*.md
- No immich-microservices references in any AUTO-*.md
- Loki correctly shows "— no check" (no healthcheck configured)
- All 27 containers present in service catalog and network matrix
- All 14 primary services have documentation links in Quick Search

## Test plan

- [ ] Verify `scripts/auto-doc-orchestrator.sh` runs without errors
- [ ] Check AUTO-SERVICE-CATALOG.md groups are correct (9 groups, 27 services)
- [ ] Check AUTO-NETWORK-TOPOLOGY.md matrix matches `podman network inspect`
- [ ] Check AUTO-DEPENDENCY-GRAPH.md Mermaid edges match quadlet `Requires=` directives
- [ ] Check AUTO-DOCUMENTATION-INDEX.md Quick Search links are valid
- [ ] Verify Mermaid diagrams render on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)