### PR TITLE
fix: Nextcloud auto-update race condition detection and auto-remediation

### DIFF
--- a/quadlets/nextcloud.container
+++ b/quadlets/nextcloud.container
@@ -55,8 +55,8 @@ Network=systemd-reverse_proxy:ip=10.89.2.14
 Network=systemd-nextcloud:ip=10.89.10.4
 Network=systemd-monitoring:ip=10.89.4.21
 
-# Health check
-HealthCmd=curl -f http://localhost:80/status.php
+# Health check (verifies both reachability AND no pending DB upgrade)
+HealthCmd=curl -sf http://localhost:80/status.php | grep -q '"needsDbUpgrade":false'
 HealthInterval=30s
 HealthTimeout=10s
 HealthRetries=5

--- a/scripts/post-update-health-check.sh
+++ b/scripts/post-update-health-check.sh
@@ -3,6 +3,7 @@
 # Post-Update Service Validation and Notification
 #
 # Purpose: Verify services are healthy after auto-update
+# Includes Nextcloud-specific DB upgrade detection and auto-remediation
 # Sends Discord notification with results
 
 set -euo pipefail
@@ -25,6 +26,7 @@ echo "$(date -Iseconds)" > /home/patriark/containers/data/last-auto-update.log
 
 CHECKS_FAILED=0
 FAILED_SERVICES=""
+NC_UPGRADE_PERFORMED=""
 
 # Give services time to start
 echo "Waiting 30 seconds for services to stabilize..."
@@ -35,6 +37,7 @@ echo "Checking service health..."
 CRITICAL_SERVICES=(
     "traefik.service"
     "authelia.service"
+    "nextcloud.service"
     "immich-server.service"
     "prometheus.service"
     "grafana.service"
@@ -56,6 +59,7 @@ echo ""
 echo "Checking container health..."
 HEALTH_CHECK_CONTAINERS=(
     "traefik"
+    "nextcloud"
     "immich-server"
 )
 
@@ -68,6 +72,57 @@ for container in "${HEALTH_CHECK_CONTAINERS[@]}"; do
     fi
 done
 
+# Nextcloud-specific: check for pending DB upgrade
+# Race condition: podman auto-update restarts Nextcloud and MariaDB simultaneously.
+# The entrypoint rsync's version.php BEFORE running occ upgrade. If MariaDB isn't
+# ready yet, occ upgrade fails but version.php is already updated, making the failure
+# unrecoverable on subsequent restarts. We detect and auto-remediate this here.
+echo ""
+echo "Checking Nextcloud database upgrade status..."
+if systemctl --user is-active --quiet nextcloud.service; then
+    NC_STATUS=$(podman exec -u www-data nextcloud php occ status --output=json 2>/dev/null || echo '{}')
+    NEEDS_UPGRADE=$(echo "$NC_STATUS" | python3 -c "import sys,json; print(json.load(sys.stdin).get('needsDbUpgrade', False))" 2>/dev/null || echo "Unknown")
+
+    if [ "$NEEDS_UPGRADE" = "True" ]; then
+        echo -e "  needsDbUpgrade: ${YELLOW}TRUE${NC} — attempting auto-remediation..."
+
+        # Wait for MariaDB to accept connections (up to 60 seconds)
+        DB_READY=false
+        for i in $(seq 1 12); do
+            if podman exec nextcloud-db healthcheck 2>/dev/null || podman healthcheck run nextcloud-db >/dev/null 2>&1; then
+                DB_READY=true
+                break
+            fi
+            echo "  Waiting for MariaDB... (attempt $i/12)"
+            sleep 5
+        done
+
+        if [ "$DB_READY" = true ]; then
+            echo "  MariaDB is ready, running occ upgrade..."
+            if podman exec -u www-data nextcloud php occ upgrade 2>&1; then
+                echo -e "  ${GREEN}Nextcloud DB upgrade completed successfully${NC}"
+                NC_UPGRADE_PERFORMED="auto-remediated"
+            else
+                echo -e "  ${RED}Nextcloud DB upgrade FAILED${NC}"
+                CHECKS_FAILED=$((CHECKS_FAILED + 1))
+                FAILED_SERVICES="${FAILED_SERVICES}\n- nextcloud (DB upgrade failed)"
+                NC_UPGRADE_PERFORMED="failed"
+            fi
+        else
+            echo -e "  ${RED}MariaDB not ready after 60 seconds, cannot run occ upgrade${NC}"
+            CHECKS_FAILED=$((CHECKS_FAILED + 1))
+            FAILED_SERVICES="${FAILED_SERVICES}\n- nextcloud (DB upgrade pending, MariaDB unreachable)"
+            NC_UPGRADE_PERFORMED="failed-db-unreachable"
+        fi
+    elif [ "$NEEDS_UPGRADE" = "False" ]; then
+        echo -e "  needsDbUpgrade: ${GREEN}false${NC}"
+    else
+        echo -e "  ${YELLOW}Could not determine upgrade status${NC}"
+    fi
+else
+    echo -e "  ${YELLOW}Nextcloud not running, skipping DB upgrade check${NC}"
+fi
+
 # Send Discord notification
 echo ""
 echo "Sending Discord notification..."
@@ -75,11 +130,21 @@ echo "Sending Discord notification..."
 DISCORD_WEBHOOK=$(podman exec alert-discord-relay env 2>/dev/null | grep DISCORD_WEBHOOK_URL | cut -d= -f2 || echo "")
 
 if [ -n "$DISCORD_WEBHOOK" ]; then
+    # Build extra fields for Nextcloud upgrade if it happened
+    NC_FIELD=""
+    if [ -n "$NC_UPGRADE_PERFORMED" ]; then
+        if [ "$NC_UPGRADE_PERFORMED" = "auto-remediated" ]; then
+            NC_FIELD=',{"name":"Nextcloud","value":"DB upgrade auto-remediated after auto-update race condition","inline":false}'
+        else
+            NC_FIELD=',{"name":"Nextcloud","value":"DB upgrade FAILED: '"$NC_UPGRADE_PERFORMED"'","inline":false}'
+        fi
+    fi
+
     if [ "$CHECKS_FAILED" -eq 0 ]; then
         # Success notification
         PAYLOAD='{
   "embeds": [{
-    "title": "✅ Auto-Update Completed",
+    "title": "Auto-Update Completed",
     "description": "Container auto-update completed successfully. All services are healthy.",
     "color": 5763719,
     "fields": [
@@ -92,10 +157,10 @@ if [ -n "$DISCORD_WEBHOOK" ]; then
         "name": "Timestamp",
         "value": "'"$(date '+%Y-%m-%d %H:%M:%S')"'",
         "inline": true
-      }
+      }'"$NC_FIELD"'
     ],
     "footer": {
-      "text": "Homelab Operations • Next vulnerability scan: Today 06:00"
+      "text": "Homelab Operations"
     },
     "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"'"
   }]
@@ -104,7 +169,7 @@ if [ -n "$DISCORD_WEBHOOK" ]; then
         # Failure notification
         PAYLOAD='{
   "embeds": [{
-    "title": "⚠️ Auto-Update: Service Issues Detected",
+    "title": "Auto-Update: Service Issues Detected",
     "description": "Container auto-update completed but some services failed health checks.",
     "color": 16753920,
     "fields": [
@@ -117,10 +182,10 @@ if [ -n "$DISCORD_WEBHOOK" ]; then
         "name": "Action Required",
         "value": "Check service logs: `journalctl --user -u <service> -n 50`",
         "inline": false
-      }
+      }'"$NC_FIELD"'
     ],
     "footer": {
-      "text": "Homelab Operations • Manual intervention may be required"
+      "text": "Homelab Operations - Manual intervention may be required"
     },
     "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%S.000Z)"'"
   }]


### PR DESCRIPTION
## Summary

- **Root cause:** `podman auto-update` restarts Nextcloud and MariaDB simultaneously. The Nextcloud entrypoint rsync's `version.php` before `occ upgrade`, so if MariaDB isn't ready, the upgrade fails but version.php is poisoned — subsequent restarts silently skip the upgrade, leaving Nextcloud returning 503 indefinitely.
- **Healthcheck fix:** `nextcloud.container` healthcheck now verifies `needsDbUpgrade:false` via `status.php` JSON, not just HTTP 200 reachability.
- **Auto-remediation:** `post-update-health-check.sh` now queries `occ status` after auto-update, waits for MariaDB readiness (up to 60s), and runs `occ upgrade` automatically if needed.
- **Visibility:** Nextcloud added to critical services and healthcheck containers lists; Discord notification includes upgrade status.

## Incident Context

2026-02-15: Weekly auto-update at 03:00 upgraded Nextcloud 32.0.5→32.0.6 and MariaDB simultaneously. The entrypoint's `occ upgrade` failed with `SQLSTATE[HY000] [2002] Connection refused`. All clients (iPhone, iPad, MacBook, Windows, Evolution) received 503 errors for 11+ hours until manual `occ upgrade` resolved it.

## Test Plan

- [ ] Verify `bash -n scripts/post-update-health-check.sh` passes (syntax check)
- [ ] Verify healthcheck logic: `curl -sf status.php | grep -q '"needsDbUpgrade":false'` on running container
- [ ] Next auto-update (Sunday 2026-02-22 03:00) validates end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)