### PR TITLE
fix: Jellyfin CSP headers, transcode cleanup, and operational polish

### DIFF
--- a/config/traefik/dynamic/middleware.yml
+++ b/config/traefik/dynamic/middleware.yml
@@ -250,6 +250,27 @@ http:
           Server: ""
           X-Powered-By: ""
 
+    # Jellyfin - Relaxed CSP for MediaSource API, WebSocket, and web workers
+    security-headers-jellyfin:
+      headers:
+        frameDeny: false
+        customFrameOptionsValue: "SAMEORIGIN"
+        browserXssFilter: true
+        contentTypeNosniff: true
+        stsSeconds: 31536000
+        stsIncludeSubdomains: true
+        stsPreload: true
+        forceSTSHeader: true
+        contentSecurityPolicy: "default-src 'self'; script-src 'self' 'unsafe-inline' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' wss:; media-src 'self' blob: data:; worker-src 'self' blob:; frame-src 'self'; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self';"
+        referrerPolicy: "strict-origin-when-cross-origin"
+        permissionsPolicy: "geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()"
+        customResponseHeaders:
+          X-Content-Type-Options: "nosniff"
+          X-Frame-Options: "SAMEORIGIN"
+          X-XSS-Protection: "1; mode=block"
+          Server: ""
+          X-Powered-By: ""
+
     # HSTS-only for Nextcloud (sets own CSP, just needs HSTS)
     hsts-only:
       headers:

--- a/config/traefik/dynamic/routers.yml
+++ b/config/traefik/dynamic/routers.yml
@@ -76,7 +76,8 @@ http:
       middlewares:
         - crowdsec-bouncer@file
         - rate-limit-public@file
-        - security-headers@file
+        - compression@file
+        - security-headers-jellyfin@file
       tls:
         certResolver: letsencrypt
 

--- a/quadlets/jellyfin.container
+++ b/quadlets/jellyfin.container
@@ -32,7 +32,6 @@ DNSSearch=lokal
 Volume=/mnt/btrfs-pool/subvol7-containers/jellyfin-config:/config:Z
 Volume=/mnt/btrfs-pool/subvol7-containers/jellyfin/data:/data:Z
 Volume=/mnt/btrfs-pool/subvol6-tmp/jellyfin-cache:/cache:Z
-Volume=/mnt/btrfs-pool/subvol6-tmp/jellyfin-transcodes:/config/transcodes:Z
 
 # Media Libraries (read-only, shared with Nextcloud)
 Volume=/mnt/btrfs-pool/subvol4-multimedia:/media/multimedia:ro,z


### PR DESCRIPTION
## Summary

- **Fix blank page on first load:** Add Jellyfin-specific CSP middleware allowing WebSocket (`wss:`), MediaSource API (`blob:`), web workers, and chapter thumbnails — the generic CSP was blocking Jellyfin's modern web features
- **Reclaim 72GB disk:** Clean 1,356 orphaned HLS transcode segments and enable automatic segment deletion (120s retention) to prevent re-accumulation
- **Enable HW acceleration features:** 10-bit HEVC/VP9 decode, trickplay frame extraction + encoding via VA-API (Radeon Vega iGPU)
- **Performance & observability:** Triple SQLite cache (1200→4096), add response compression, enable Prometheus `/metrics` endpoint, add Intro Skipper plugin repository
- **Remove unused volume mount:** `/config/transcodes` was empty — transcodes route to `/cache/transcodes` via encoding.xml

## Files Changed

| File | Change |
|------|--------|
| `config/traefik/dynamic/middleware.yml` | Add `security-headers-jellyfin` middleware with Jellyfin-specific CSP |
| `config/traefik/dynamic/routers.yml` | Switch Jellyfin to new middleware + add `compression@file` |
| `quadlets/jellyfin.container` | Remove unused `/config/transcodes` volume mount |

## Runtime Changes (not in git)

| File | Change |
|------|--------|
| `encoding.xml` | `EnableSegmentDeletion=true`, `SegmentKeepSeconds=120`, 10-bit HEVC/VP9 decode |
| `system.xml` | Trickplay HW accel, `CacheSize=4096`, Intro Skipper repo, `EnableMetrics=true` |

## Verification

- [x] CSP headers confirmed via `curl -sI` (wss:, blob:, worker-src present)
- [x] Healthcheck passes
- [x] Prometheus metrics endpoint active (`/metrics`)
- [x] Transcode cache cleaned (72GB → 0)
- [x] Volume mounts correct (5 mounts, no /config/transcodes)
- [x] VAAPI GPU detected in startup logs

## Test Plan

- [ ] Open jellyfin.patriark.org in incognito — verify no blank page
- [ ] Play a video — confirm WebSocket and MediaSource work
- [ ] Install Intro Skipper plugin from Dashboard > Plugins > Catalog
- [ ] Run "Analyze Episodes" scheduled task

🤖 Generated with [Claude Code](https://claude.com/claude-code)