### PR TITLE
fix: Harden Jellyfin CSP by removing unsafe-inline from script-src

### DIFF
--- a/config/traefik/dynamic/middleware.yml
+++ b/config/traefik/dynamic/middleware.yml
@@ -261,7 +261,7 @@ http:
         stsIncludeSubdomains: true
         stsPreload: true
         forceSTSHeader: true
-        contentSecurityPolicy: "default-src 'self'; script-src 'self' 'unsafe-inline' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' wss:; media-src 'self' blob: data:; worker-src 'self' blob:; frame-src 'self'; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self';"
+        contentSecurityPolicy: "default-src 'self'; script-src 'self' 'unsafe-eval' blob:; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: blob:; font-src 'self' data:; connect-src 'self' wss:; media-src 'self' blob: data:; worker-src 'self' blob:; frame-src 'self'; frame-ancestors 'self'; object-src 'none'; base-uri 'self'; form-action 'self';"
         referrerPolicy: "strict-origin-when-cross-origin"
         permissionsPolicy: "geolocation=(), microphone=(), camera=(), payment=(), usb=(), magnetometer=(), gyroscope=(), accelerometer=()"
         customResponseHeaders:


### PR DESCRIPTION
## Summary

- Replace `'unsafe-inline'` with `'unsafe-eval'` in Jellyfin's `script-src` CSP directive
- Follows up on code review feedback from #95

## Investigation

Inspected Jellyfin v10.11.6 web client inside the running container:

- **`index.html`**: Zero inline `<script>` blocks — all 29+ script tags use external `src` with `defer`
- **Zero** inline event handlers (`onclick`, `onload`, etc.)
- **Webpack chunk loader**: Creates `<script>` elements with external `src` attributes (CSP-compliant)
- **Built-in nonce support** exists (`__webpack_nonce__`) but isn't needed

**`'unsafe-eval'` IS required**: `new Function()` is used in webpack runtime and Emotion (MUI's CSS-in-JS library)

## Verification

- [x] CSP header confirmed via `curl -sI` — `unsafe-inline` removed, `unsafe-eval` present
- [x] Traefik auto-reloaded config (no restart needed)

## Test Plan

- [ ] Open jellyfin.patriark.org — verify no CSP violations in DevTools console
- [ ] Play a video — confirm playback works (MediaSource API, WebSocket)
- [ ] Browse library — verify chapter thumbnails, trickplay images load

🤖 Generated with [Claude Code](https://claude.com/claude-code)