### PR TITLE
fix: Reduce certificate alert noise and deduplicate Discord notifications

### DIFF
--- a/config/alertmanager/alertmanager.yml
+++ b/config/alertmanager/alertmanager.yml
@@ -74,21 +74,21 @@ route:
     # Discord notification routes (standard behavior, unchanged)
 
     # Critical alerts: Discord for instant notifications
-    - match:
-        severity: critical
+    - matchers:
+        - severity = "critical"
       receiver: 'discord-critical'
       repeat_interval: 1h
 
     # Warnings: Discord during waking hours only (7am-11pm)
-    - match:
-        severity: warning
+    - matchers:
+        - severity = "warning"
       receiver: 'discord-warnings'
       active_time_intervals:
         - waking_hours
 
     # Info alerts: Notify once per week max (architectural facts, not incidents)
-    - match:
-        severity: info
+    - matchers:
+        - severity = "info"
       receiver: 'discord-info'
       repeat_interval: 168h  # 1 week - effectively never repeat for transient info alerts
       group_interval: 5m
@@ -133,33 +133,40 @@ receivers:
 # Inhibition rules (prevent alert spam)
 inhibit_rules:
   # If a host is down, don't alert on services running on that host
-  - source_match:
-      severity: 'critical'
-      alertname: 'HostDown'
-    target_match:
-      severity: 'warning'
+  - source_matchers:
+      - severity = "critical"
+      - alertname = "HostDown"
+    target_matchers:
+      - severity = "warning"
+    equal: ['instance']
+
+  # Specific service-down alerts suppress the generic HostDown safety net
+  - source_matchers:
+      - alertname =~ "TraefikDown|GrafanaDown|LokiDown|NodeExporterDown|CrowdSecDown|AlertmanagerDown|PrometheusDown"
+    target_matchers:
+      - alertname = "HostDown"
     equal: ['instance']
 
   # If disk is critical, suppress disk warning
-  - source_match:
-      severity: 'critical'
-      alertname: 'DiskSpaceCritical'
-    target_match:
-      severity: 'warning'
-      alertname: 'DiskSpaceWarning'
+  - source_matchers:
+      - severity = "critical"
+      - alertname = "DiskSpaceCritical"
+    target_matchers:
+      - severity = "warning"
+      - alertname = "DiskSpaceWarning"
     equal: ['instance', 'mountpoint']
 
   # Global: Critical alerts for a service silence warnings for same service
-  - source_match:
-      severity: 'critical'
-    target_match:
-      severity: 'warning'
+  - source_matchers:
+      - severity = "critical"
+    target_matchers:
+      - severity = "warning"
     equal: ['service', 'instance']
 
   # If Traefik is down, suppress all service availability warnings
   # (nothing is accessible anyway)
-  - source_match:
-      alertname: 'TraefikDown'
-    target_match_re:
-      alertname: '.*(Down|Unhealthy|Unavailable).*'
+  - source_matchers:
+      - alertname = "TraefikDown"
+    target_matchers:
+      - alertname =~ ".*(Down|Unhealthy|Unavailable).*"
     equal: ['instance']

--- a/config/prometheus/alerts/infrastructure-warnings.yml
+++ b/config/prometheus/alerts/infrastructure-warnings.yml
@@ -48,18 +48,21 @@ groups:
           description: "BTRFS pool {{ $labels.instance }} has {{ $value | humanizePercentage }} free space remaining (Warning threshold: <20%)"
 
       # ========================================================================
-      # ALERT 3: TLS Certificate Expiry Warning
+      # ALERT 3: TLS Certificate Renewal Overdue
       # ========================================================================
+      # Let's Encrypt auto-renews at ~30 days remaining. If a cert reaches <14 days,
+      # renewal failed ~16 days ago -- something is wrong. The critical alert
+      # CertificateExpiringSoon (<7 days) in infrastructure-critical.yml is the escalation.
       # Only check the NEWEST certificate per domain (Traefik keeps old certs in metrics after renewal)
-      - alert: CertificateExpiryWarning
-        expr: max by(cn) ((traefik_tls_certs_not_after - time()) / 86400) < 30 and max by(cn) ((traefik_tls_certs_not_after - time()) / 86400) >= 7
-        for: 24h
+      - alert: CertificateRenewalOverdue
+        expr: max by(cn) ((traefik_tls_certs_not_after - time()) / 86400) < 14 and max by(cn) ((traefik_tls_certs_not_after - time()) / 86400) >= 7
+        for: 6h
         labels:
-          severity: warning
+          severity: info
           category: security
         annotations:
-          summary: "TLS certificate expires in less than 30 days"
-          description: "Certificate for {{ $labels.cn }} expires in {{ $value }} days. Let's Encrypt should auto-renew at ~30 days."
+          summary: "TLS certificate renewal overdue for {{ $labels.cn }}"
+          description: "Certificate for {{ $labels.cn }} expires in {{ $value | humanize }} days. Let's Encrypt should have renewed this ~16 days ago. Check Traefik ACME logs: podman logs traefik 2>&1 | grep -i acme"
 
       # ========================================================================
       # ALERT 4: High CPU Usage

--- a/config/prometheus/alerts/network-security-alerts.yml
+++ b/config/prometheus/alerts/network-security-alerts.yml
@@ -60,26 +60,3 @@ groups:
             Active password guessing/credential stuffing detected.
             CrowdSec should auto-ban after threshold. Verify it's working.
 
-      # CRITICAL: Service down that should be always running
-      # Only alert on critical services (gateway to everything)
-      - alert: CriticalServiceDown
-        expr: |
-          up{job=~"traefik|authelia|vaultwarden"} == 0
-        for: 2m
-        labels:
-          severity: critical
-          component: infrastructure
-        annotations:
-          summary: "Critical service {{ $labels.job }} is down"
-          description: |
-            {{ $labels.job }} is not responding.
-
-            Impact:
-            - traefik: ALL services inaccessible
-            - authelia: Cannot access admin services
-            - vaultwarden: Password vault unavailable
-
-            Actions:
-            1. Check service: systemctl --user status {{ $labels.job }}.service
-            2. Check logs: journalctl --user -u {{ $labels.job }}.service -n 50
-            3. Restart if needed: systemctl --user restart {{ $labels.job }}.service

--- a/docs/AUTO-DEPENDENCY-GRAPH.md
+++ b/docs/AUTO-DEPENDENCY-GRAPH.md
@@ -1,75 +1,87 @@
 # Service Dependency Graph (Auto-Generated)
 
-**Generated:** 2026-02-15 06:03:21 UTC
+**Generated:** 2026-02-21 06:02:54 UTC
 **System:** fedora-htpc
-
-This document visualizes service dependencies and critical paths in the homelab infrastructure.
 
 ---
 
 ## Dependency Overview
 
-Shows how services depend on each other, organized by tier.
+Shows how services depend on each other, organized by tier. Edges are derived from quadlet `Requires=` and `After=` directives.
 
 ```mermaid
 graph TB
-    subgraph Critical[Critical Path - Tier 1]
-        traefik[Traefik<br/>Gateway]
+    subgraph Critical[Critical — Tier 1]
         authelia[Authelia<br/>SSO + MFA]
-        redis_authelia[Redis<br/>Sessions]
+        redis_authelia[Redis<br/>Auth Sessions]
+        traefik[Traefik<br/>Gateway]
     end
 
-    subgraph Infrastructure[Infrastructure - Tier 2]
-        prometheus[Prometheus<br/>Metrics]
+    subgraph Infrastructure[Infrastructure — Tier 2]
+        alertmanager[Alertmanager<br/>Alerts]
+        crowdsec[CrowdSec<br/>Security]
         grafana[Grafana<br/>Dashboards]
         loki[Loki<br/>Logs]
-        crowdsec[CrowdSec<br/>Security]
-        alertmanager[Alertmanager<br/>Alerts]
+        prometheus[Prometheus<br/>Metrics]
     end
 
-    subgraph Applications[Applications - Tier 3]
+    subgraph Applications[Applications — Tier 3]
+        gathio[Gathio<br/>Events]
+        home_assistant[Home Assistant<br/>Automation]
+        homepage[Homepage<br/>Dashboard]
+        immich_server[Immich<br/>Photos]
         jellyfin[Jellyfin<br/>Media]
-        immich[Immich<br/>Photos]
         nextcloud[Nextcloud<br/>Files]
         vaultwarden[Vaultwarden<br/>Passwords]
     end
 
-    subgraph Data[Data Layer - Tier 4]
-        nextcloud_db[Nextcloud DB<br/>MariaDB]
-        immich_db[Immich DB<br/>PostgreSQL]
-        immich_redis[Immich Redis]
-        nextcloud_redis[Nextcloud Redis]
+    subgraph Data[Data — Tier 4]
+        gathio_db[MongoDB<br/>Gathio DB]
+        nextcloud_db[MariaDB<br/>Nextcloud DB]
+        nextcloud_redis[Redis<br/>Nextcloud Cache]
+        postgresql_immich[PostgreSQL<br/>Immich DB]
+        redis_immich[Redis<br/>Immich Cache]
     end
 
-    %% Critical path dependencies
-    traefik --> crowdsec
-    traefik --> authelia
+    subgraph Supporting[Supporting — Tier 5]
+        alert_discord_relay[alert-discord-relay]
+        cadvisor[cadvisor]
+        immich_ml[immich-ml]
+        matter_server[matter-server]
+        node_exporter[node_exporter]
+        promtail[promtail]
+        unpoller[unpoller]
+    end
+
+    %% Hard dependencies (from Requires= directives)
     authelia --> redis_authelia
+    gathio --> gathio_db
+    immich_server --> postgresql_immich
+    immich_server --> redis_immich
+    vaultwarden --> traefik
 
-    %% Application → Gateway dependencies
-    traefik --> jellyfin
-    traefik --> immich
-    traefik --> nextcloud
-    traefik --> vaultwarden
-    traefik --> prometheus
-    traefik --> grafana
+    %% Routing dependencies (services in reverse_proxy depend on Traefik)
+    traefik -.-> alertmanager
+    traefik -.-> authelia
+    traefik -.-> gathio
+    traefik -.-> grafana
+    traefik -.-> home_assistant
+    traefik -.-> homepage
+    traefik -.-> immich_server
+    traefik -.-> jellyfin
+    traefik -.-> loki
+    traefik -.-> nextcloud
+    traefik -.-> prometheus
 
-    %% Application → Data dependencies
-    nextcloud --> nextcloud_db
-    nextcloud --> nextcloud_redis
-    immich --> immich_db
-    immich --> immich_redis
-
-    %% Monitoring dependencies
-    grafana --> prometheus
-    grafana --> loki
-    alertmanager --> prometheus
-
-    %% Prometheus scrapes (dotted = soft dependency)
-    prometheus -.->|scrapes| traefik
+    %% Monitoring (Prometheus scrapes via monitoring network)
+    prometheus -.->|scrapes| gathio
+    prometheus -.->|scrapes| home_assistant
+    prometheus -.->|scrapes| immich_server
     prometheus -.->|scrapes| jellyfin
-    prometheus -.->|scrapes| immich
     prometheus -.->|scrapes| nextcloud
+    prometheus -.->|scrapes| nextcloud_db
+    prometheus -.->|scrapes| nextcloud_redis
+    prometheus -.->|scrapes| traefik
 
     %% Styling
     style traefik fill:#f9f,stroke:#333,stroke-width:4px
@@ -82,97 +94,99 @@ graph TB
 
 ## Critical Path Analysis
 
-### Tier 1: Critical Services
+### Tier 1: Critical
 
-These services must be running for the homelab to function:
+| Service | Hard Dependencies | Impact if Down |
+|---------|-------------------|----------------|
+| **authelia** | redis-authelia | 🟡 Cannot access Authelia-protected services (monitoring, dashboard) |
+| **redis-authelia** | — | 🟡 All SSO sessions lost, users must re-authenticate |
+| **traefik** | — | 🔴 Total outage — no external access to any service |
 
-| Service | Role | Dependent Services | Impact if Down |
-|---------|------|-------------------|----------------|
-| **Traefik** | Gateway | All public services | 🔴 Total outage - no external access |
-| **Authelia** | Authentication | Protected services | 🟡 Cannot access protected services |
-| **Redis (Authelia)** | Session storage | Authelia | 🟡 All users logged out, must re-auth |
+### Tier 2: Infrastructure
 
-**Critical path:** Internet → Traefik → Authelia → Redis
+| Service | Hard Dependencies | Impact if Down |
+|---------|-------------------|----------------|
+| **alertmanager** | — | 🟢 Alerts not routed, monitoring continues |
+| **crowdsec** | — | 🟡 Reduced security — no IP reputation filtering |
+| **grafana** | — | 🟢 Dashboards unavailable, metrics still collected |
+| **loki** | — | 🟢 Log queries unavailable, logs still forwarded |
+| **prometheus** | — | 🟡 No metrics collection, blind operation |
 
-### Tier 2: Infrastructure Services
+### Tier 3: Applications
 
-Supporting services for operations:
+| Service | Hard Dependencies | Impact if Down |
+|---------|-------------------|----------------|
+| **gathio** | gathio-db | 🟢 Event management unavailable |
+| **home-assistant** | — | 🟡 Automations stop, smart home degraded |
+| **homepage** | — | 🟢 Dashboard unavailable |
+| **immich-server** | postgresql-immich,redis-immich | 🟢 Photo management unavailable |
+| **jellyfin** | — | 🟢 Media streaming unavailable |
+| **nextcloud** | — | 🟢 File sync unavailable |
+| **vaultwarden** | traefik | 🟡 Password vault inaccessible (keep local cache) |
 
-| Service | Role | Dependent Services | Impact if Down |
-|---------|------|-------------------|----------------|
-| **Prometheus** | Metrics collection | Grafana, Alertmanager | 🟡 No metrics, blind operation |
-| **Grafana** | Visualization | Users (dashboards) | 🟢 Dashboards unavailable, metrics still collected |
-| **Loki** | Log aggregation | Grafana (logs view) | 🟢 Log queries unavailable |
-| **CrowdSec** | Security | Traefik (IP blocking) | 🟡 Reduced security posture |
-| **Alertmanager** | Alerting | Prometheus | 🟢 Alerts not sent, monitoring continues |
+### Tier 4: Data
 
-### Tier 3: Application Services
+| Service | Hard Dependencies | Impact if Down |
+|---------|-------------------|----------------|
+| **gathio-db** | — | 🔴 Gathio completely non-functional |
+| **nextcloud-db** | — | 🔴 Nextcloud completely non-functional |
+| **nextcloud-redis** | — | 🟡 Nextcloud degraded performance |
+| **postgresql-immich** | — | 🔴 Immich completely non-functional |
+| **redis-immich** | — | 🟡 Immich degraded (queue processing affected) |
 
-End-user applications:
+### Tier 5: Supporting
 
-| Service | Role | Dependencies | Impact if Down |
-|---------|------|--------------|----------------|
-| **Jellyfin** | Media streaming | Traefik | 🟢 Media unavailable, other services OK |
-| **Immich** | Photo management | Traefik, PostgreSQL, Redis | 🟢 Photos unavailable |
-| **Nextcloud** | File sync | Traefik, MariaDB, Redis | 🟢 Files unavailable |
-| **Vaultwarden** | Password manager | Traefik | 🟡 Passwords inaccessible (keep local vault) |
-
-### Tier 4: Data Layer
-
-Backend data services:
-
-| Service | Role | Used By | Impact if Down |
-|---------|------|---------|----------------|
-| **PostgreSQL (Immich)** | Database | Immich | 🔴 Immich completely non-functional |
-| **MariaDB (Nextcloud)** | Database | Nextcloud | 🔴 Nextcloud completely non-functional |
-| **Redis (Immich)** | Cache/Queue | Immich | 🟡 Immich degraded performance |
-| **Redis (Nextcloud)** | Cache | Nextcloud | 🟡 Nextcloud degraded performance |
+| Service | Hard Dependencies | Impact if Down |
+|---------|-------------------|----------------|
+| **alert-discord-relay** | — | 🟢 Service-specific impact |
+| **cadvisor** | — | 🟢 Service-specific impact |
+| **immich-ml** | — | 🟢 Service-specific impact |
+| **matter-server** | — | 🟢 Service-specific impact |
+| **node_exporter** | — | 🟢 Service-specific impact |
+| **promtail** | — | 🟢 Service-specific impact |
+| **unpoller** | — | 🟢 Service-specific impact |
 
 ---
 
-## Startup Order Recommendations
+## Startup Order
 
-Based on dependencies, services should start in this order:
+Derived from `After=` directives in quadlet files. systemd handles this automatically.
 
-1. **Data Layer** (databases and caches)
-   - redis-authelia
-   - postgresql-immich
-   - nextcloud-db
-   - redis-immich
-   - nextcloud-redis
-
-2. **Critical Services**
-   - traefik
-   - crowdsec
-   - authelia
-
-3. **Infrastructure**
-   - prometheus
-   - loki
-   - alertmanager
-
-4. **Visualization**
-   - grafana
-
-5. **Applications** (can start in parallel)
-   - jellyfin
-   - immich-server, immich-ml, immich-microservices
-   - nextcloud
-   - vaultwarden
-
-6. **Monitoring Exporters**
-   - node-exporter
-   - cadvisor
-   - promtail
-
-**Note:** systemd handles this automatically via `After=` directives in quadlet files.
+| Service | Starts After |
+|---------|-------------|
+| alert-discord-relay | (no ordering constraints) |
+| alertmanager | (no ordering constraints) |
+| authelia | redis-authelia |
+| cadvisor | (no ordering constraints) |
+| crowdsec | (no ordering constraints) |
+| gathio | gathio-db |
+| gathio-db | (no ordering constraints) |
+| grafana | (no ordering constraints) |
+| home-assistant | (no ordering constraints) |
+| homepage | (no ordering constraints) |
+| immich-ml | (no ordering constraints) |
+| immich-server | postgresql-immich,redis-immich |
+| jellyfin | (no ordering constraints) |
+| loki | (no ordering constraints) |
+| matter-server | (no ordering constraints) |
+| nextcloud | nextcloud-db,nextcloud-redis |
+| nextcloud-db | (no ordering constraints) |
+| nextcloud-redis | (no ordering constraints) |
+| node_exporter | (no ordering constraints) |
+| postgresql-immich | (no ordering constraints) |
+| prometheus | node_exporter |
+| promtail | loki |
+| redis-authelia | (no ordering constraints) |
+| redis-immich | (no ordering constraints) |
+| traefik | (no ordering constraints) |
+| unpoller | prometheus |
+| vaultwarden | traefik |
 
 ---
 
 ## Network-Based Dependencies
 
 Services on the same network can communicate:
-
 
 **auth_services:** authelia,redis-authelia,traefik
 
@@ -190,29 +204,27 @@ Services on the same network can communicate:
 
 **reverse_proxy:** alertmanager,authelia,crowdsec,gathio,grafana,home-assistant,homepage,immich-server,jellyfin,loki,nextcloud,prometheus,traefik,vaultwarden
 
-
 ---
 
 ## Service Overrides
 
-Some services have special handling in autonomous operations:
+Services with restricted auto-restart in autonomous operations:
 
 | Service | Auto-Restart | Rationale |
 |---------|--------------|-----------|
-| traefik | ❌ No | Gateway service - manual intervention required |
-| authelia | ❌ No | Authentication service - manual intervention required |
+| traefik | ❌ No | Gateway — manual intervention required |
+| authelia | ❌ No | Authentication — manual intervention required |
 | Others | ✅ Yes | Can be automatically restarted if unhealthy |
-
-See `~/containers/.claude/context/preferences.yml` for configuration.
 
 ---
 
-## Quick Links
+## Related Documentation
 
 - [Service Catalog](AUTO-SERVICE-CATALOG.md) - What's running
 - [Network Topology](AUTO-NETWORK-TOPOLOGY.md) - Network architecture
 - [Homelab Architecture](20-operations/guides/homelab-architecture.md) - Full documentation
 - [Autonomous Operations](20-operations/guides/autonomous-operations.md) - OODA loop
+- [ADR-011: Service Dependency Mapping](10-services/decisions/2025-11-15-ADR-011-service-dependency-mapping.md) - Dependency design decisions
 
 ---
 

--- a/docs/AUTO-DOCUMENTATION-INDEX.md
+++ b/docs/AUTO-DOCUMENTATION-INDEX.md
@@ -1,7 +1,7 @@
 # Documentation Index (Auto-Generated)
 
-**Generated:** 2026-02-15 06:03:21 UTC
-**Total Documents:** 388
+**Generated:** 2026-02-21 06:02:55 UTC
+**Total Documents:** 392
 
 ---
 
@@ -198,7 +198,7 @@
 
 ---
 
-### 98-journals/ (167 documents)
+### 98-journals/ (171 documents)
 
 **Chronological project history (append-only log)**
 
@@ -217,17 +217,101 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 ## Recently Updated (Last 7 Days)
 
 - 2026-02-14: [HOMELAB-FIELD-GUIDE.md](00-foundation/guides/HOMELAB-FIELD-GUIDE.md)
-- 2026-02-08: [immich.md](10-services/guides/immich.md)
-- 2026-02-08: [2026-02-07-immich-operational-excellence-phase1.md](98-journals/2026-02-07-immich-operational-excellence-phase1.md)
-- 2026-02-08: [2026-02-08-ambilight-hue-research-and-alternatives.md](98-journals/2026-02-08-ambilight-hue-research-and-alternatives.md)
-- 2026-02-08: [2026-02-08-immich-bulk-upload-stress-test.md](98-journals/2026-02-08-immich-bulk-upload-stress-test.md)
-- 2026-02-09: [2026-02-09-ha-presence-detection-fix.md](98-journals/2026-02-09-ha-presence-detection-fix.md)
-- 2026-02-11: [2026-02-10-ansible-silverblue-disaster-recovery-playbook.md](98-journals/2026-02-10-ansible-silverblue-disaster-recovery-playbook.md)
-- 2026-02-11: [2026-02-10-nixos-homelab-architecture-handoff.md](98-journals/2026-02-10-nixos-homelab-architecture-handoff.md)
-- 2026-02-15: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
-- 2026-02-15: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
-- 2026-02-15: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
-- 2026-02-15: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
+- 2026-02-15: [2026-02-15-community-tool-sharing-platform-architecture.md](98-journals/2026-02-15-community-tool-sharing-platform-architecture.md)
+- 2026-02-16: [2026-02-16-gnome-freeze-system-update.md](98-journals/2026-02-16-gnome-freeze-system-update.md)
+- 2026-02-16: [2026-02-16-post-reboot-handoff.md](98-journals/2026-02-16-post-reboot-handoff.md)
+- 2026-02-20: [2026-02-18-loose-ends-audit.md](98-journals/2026-02-18-loose-ends-audit.md)
+- 2026-02-16: [remediation-monthly-202601.md](99-reports/remediation-monthly-202601.md)
+- 2026-02-21: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
+- 2026-02-21: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
+- 2026-02-21: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
+- 2026-02-21: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
+
+---
+
+## Quick Search by Service
+
+**Traefik:**
+- Guide: [traefik.md](10-services/guides/traefik.md)
+- Config: `~/containers/config/traefik/`
+- Quadlet: `~/.config/containers/systemd/traefik.container`
+
+**Authelia:**
+- Guide: [authelia.md](10-services/guides/authelia.md)
+- ADR: [ADR-005](30-security/decisions/2025-11-10-ADR-005-authelia-sso-mfa-architecture.md)
+- ADR: [ADR-006](30-security/decisions/2025-11-11-ADR-006-authelia-sso-yubikey-deployment.md)
+- Config: `~/containers/config/authelia/`
+- Quadlet: `~/.config/containers/systemd/authelia.container`
+
+**Crowdsec:**
+- Guide: [crowdsec.md](10-services/guides/crowdsec.md)
+- ADR: [ADR-008](30-security/decisions/2025-11-12-ADR-008-crowdsec-security-architecture.md)
+- Quadlet: `~/.config/containers/systemd/crowdsec.container`
+
+**Jellyfin:**
+- Guide: [jellyfin.md](10-services/guides/jellyfin.md)
+- Related: [jellyfin-gpu-acceleration-troubleshooting.md](10-services/guides/jellyfin-gpu-acceleration-troubleshooting.md)
+- Quadlet: `~/.config/containers/systemd/jellyfin.container`
+
+**Immich Server:**
+- Guide: [immich.md](10-services/guides/immich.md)
+- Related: [immich-configuration-review.md](10-services/guides/immich-configuration-review.md)
+- Related: [immich-deployment-checklist.md](10-services/guides/immich-deployment-checklist.md)
+- Related: [immich-ml-troubleshooting.md](10-services/guides/immich-ml-troubleshooting.md)
+- Quadlet: `~/.config/containers/systemd/immich-server.container`
+
+**Nextcloud:**
+- Guide: [nextcloud.md](10-services/guides/nextcloud.md)
+- ADR: [ADR-013](10-services/decisions/2025-12-20-ADR-013-nextcloud-native-authentication.md)
+- ADR: [ADR-014](10-services/decisions/2025-12-20-ADR-014-nextcloud-passwordless-authentication.md)
+- Config: `~/containers/config/nextcloud/`
+- Quadlet: `~/.config/containers/systemd/nextcloud.container`
+
+**Vaultwarden:**
+- Related: [vaultwarden-deployment.md](10-services/guides/vaultwarden-deployment.md)
+- ADR: [ADR-007](10-services/decisions/2025-11-12-ADR-007-vaultwarden-architecture.md)
+- Config: `~/containers/config/vaultwarden/`
+- Quadlet: `~/.config/containers/systemd/vaultwarden.container`
+
+**Home Assistant:**
+- Guide: [home-assistant.md](10-services/guides/home-assistant.md)
+- Related: [home-assistant.md](10-services/guides/home-assistant.md)
+- Config: `~/containers/config/home-assistant/`
+- Quadlet: `~/.config/containers/systemd/home-assistant.container`
+
+**Homepage:**
+- Related: [homepage-widget-configuration.md](10-services/guides/homepage-widget-configuration.md)
+- Config: `~/containers/config/homepage/`
+- Quadlet: `~/.config/containers/systemd/homepage.container`
+
+**Gathio:**
+- Related: [gathio-email-setup.md](10-services/guides/gathio-email-setup.md)
+- Config: `~/containers/config/gathio/`
+- Quadlet: `~/.config/containers/systemd/gathio.container`
+
+**Prometheus:**
+- Config: `~/containers/config/prometheus/`
+- Quadlet: `~/.config/containers/systemd/prometheus.container`
+- Stack Guide: [monitoring-stack.md](40-monitoring-and-documentation/guides/monitoring-stack.md)
+- SLO Framework: [slo-framework.md](40-monitoring-and-documentation/guides/slo-framework.md)
+
+**Grafana:**
+- Config: `~/containers/config/grafana/`
+- Quadlet: `~/.config/containers/systemd/grafana.container`
+- Stack Guide: [monitoring-stack.md](40-monitoring-and-documentation/guides/monitoring-stack.md)
+- SLO Framework: [slo-framework.md](40-monitoring-and-documentation/guides/slo-framework.md)
+
+**Loki:**
+- Config: `~/containers/config/loki/`
+- Quadlet: `~/.config/containers/systemd/loki.container`
+- Stack Guide: [monitoring-stack.md](40-monitoring-and-documentation/guides/monitoring-stack.md)
+- SLO Framework: [slo-framework.md](40-monitoring-and-documentation/guides/slo-framework.md)
+
+**Alertmanager:**
+- Config: `~/containers/config/alertmanager/`
+- Quadlet: `~/.config/containers/systemd/alertmanager.container`
+- Stack Guide: [monitoring-stack.md](40-monitoring-and-documentation/guides/monitoring-stack.md)
+- SLO Framework: [slo-framework.md](40-monitoring-and-documentation/guides/slo-framework.md)
 
 ---
 
@@ -248,32 +332,6 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 - **Reports:** `TYPE-YYYYMMDD-HHMMSS.json` or `.md`
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for full documentation guidelines.
-
----
-
-## Quick Search by Service
-
-**Traefik:**
-- Guide: [traefik.md](10-services/guides/traefik.md)
-- Config: `~/containers/config/traefik/`
-- Quadlet: `~/.config/containers/systemd/traefik.container`
-
-**Authelia:**
-- Guide: [authelia.md](10-services/guides/authelia.md)
-- ADR: [ADR-006](30-security/decisions/2025-11-11-ADR-006-authelia-sso-yubikey-deployment.md)
-- Config: `~/containers/config/authelia/`
-
-**Jellyfin:**
-- Guide: [jellyfin.md](10-services/guides/jellyfin.md)
-- Management: `~/containers/scripts/jellyfin-manage.sh`
-
-**Immich:**
-- Guide: [immich.md](10-services/guides/immich.md)
-- ADR: [ADR-004](10-services/decisions/2025-11-08-ADR-004-immich-deployment-architecture.md)
-
-**Prometheus/Grafana:**
-- Guides: [prometheus.md](10-services/guides/prometheus.md), [grafana.md](10-services/guides/grafana.md)
-- SLO Framework: [slo-framework.md](40-monitoring-and-documentation/guides/slo-framework.md)
 
 ---
 

--- a/docs/AUTO-NETWORK-TOPOLOGY.md
+++ b/docs/AUTO-NETWORK-TOPOLOGY.md
@@ -1,9 +1,7 @@
 # Network Topology (Auto-Generated)
 
-**Generated:** 2026-02-15 06:03:18 UTC
-**System:** fedora-htpc
-
-This document provides comprehensive visualizations of the homelab network architecture, combining traffic flow analysis with network-centric topology views.
+**Generated:** 2026-02-21 06:02:51 UTC
+**System:** fedora-htpc | **Networks:** 8 | **Containers:** 27
 
 ---
 
@@ -44,7 +42,7 @@ graph TB
 **Key Insights:**
 - **CrowdSec** checks ALL traffic (fail-fast: reject banned IPs immediately)
 - **Authelia** protects administrative/monitoring services (SSO with YubiKey)
-- **Native auth** services handle their own authentication (Jellyfin, Immich, Nextcloud, Vaultwarden)
+- **Native auth** services handle their own authentication (bypass Authelia)
 
 ---
 
@@ -140,60 +138,48 @@ graph TB
 
     class reverse_proxy gatewayNet
     class monitoring observeNet
-    class auth_services,photos,nextcloud,media_services backendNet
+    class auth_services,photos,nextcloud,media_services,gathio,home_automation backendNet
 ```
-
-**Network Functions:**
-- **reverse_proxy** (10.89.2.0/24) - Gateway for Internet-accessible services
-- **monitoring** (10.89.4.0/24) - Observability network (scrapes metrics from all services)
-- **auth_services** (10.89.3.0/24) - Authentication and session management
-- **photos** (10.89.5.0/24) - Immich stack isolation
-- **nextcloud** (10.89.10.0/24) - Nextcloud stack isolation
-- **media_services** (10.89.1.0/24) - Jellyfin media processing
-
-**Note:** Services appear in multiple network boxes if they belong to multiple networks. This accurately represents Podman network membership.
 
 ---
 
 ## Network Membership Matrix
 
-Shows which services belong to which networks. Many services are members of multiple networks.
+Shows which services belong to which networks. Dynamically generated from running container state.
 
-| Service | reverse_proxy | monitoring | auth_services | photos | nextcloud | media_services |
-|---------|:-------------:|:----------:|:-------------:|:------:|:---------:|:--------------:|
+| Service | auth_services | gathio | home_automation | media_services | monitoring | nextcloud | photos | reverse_proxy |
+|---------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **Gateway & Security** |
-| traefik | ✅ | ✅ | ✅ | - | - | - |
-| crowdsec | ✅ | - | - | - | - | - |
-| authelia | ✅ | - | ✅ | - | - | - |
-| redis-authelia | - | - | ✅ | - | - | - |
+| authelia | ✅ | - | - | - | - | - | - | ✅ |
+| crowdsec | - | - | - | - | - | - | - | ✅ |
+| redis-authelia | ✅ | - | - | - | - | - | - | - |
+| traefik | ✅ | - | - | - | ✅ | - | - | ✅ |
 | **Public Services** |
-| jellyfin | ✅ | ✅ | - | - | - | ✅ |
-| immich-server | ✅ | ✅ | - | ✅ | - | - |
-| nextcloud | ✅ | ✅ | - | - | ✅ | - |
-| vaultwarden | ✅ | - | - | - | - | - |
-| collabora | ✅ | - | - | - | ✅ | - |
-| homepage | ✅ | - | - | - | - | - |
+| gathio | - | ✅ | - | - | ✅ | - | - | ✅ |
+| home-assistant | - | - | ✅ | - | ✅ | - | - | ✅ |
+| homepage | - | - | - | - | - | - | - | ✅ |
+| immich-server | - | - | - | - | ✅ | - | ✅ | ✅ |
+| jellyfin | - | - | - | ✅ | ✅ | - | - | ✅ |
+| nextcloud | - | - | - | - | ✅ | ✅ | - | ✅ |
+| vaultwarden | - | - | - | - | - | - | - | ✅ |
 | **Monitoring** |
-| prometheus | ✅ | ✅ | - | - | - | - |
-| grafana | ✅ | ✅ | - | - | - | - |
-| loki | ✅ | ✅ | - | - | - | - |
-| alertmanager | ✅ | ✅ | - | - | - | - |
-| node_exporter | - | ✅ | - | - | - | - |
-| cadvisor | - | ✅ | - | - | - | - |
-| promtail | - | ✅ | - | - | - | - |
-| alert-discord-relay | - | ✅ | - | - | - | - |
+| alert-discord-relay | - | - | - | - | ✅ | - | - | - |
+| alertmanager | - | - | - | - | ✅ | - | - | ✅ |
+| cadvisor | - | - | - | - | ✅ | - | - | - |
+| grafana | - | - | - | - | ✅ | - | - | ✅ |
+| loki | - | - | - | - | ✅ | - | - | ✅ |
+| node_exporter | - | - | - | - | ✅ | - | - | - |
+| prometheus | - | - | - | - | ✅ | - | - | ✅ |
+| promtail | - | - | - | - | ✅ | - | - | - |
+| unpoller | - | - | - | - | ✅ | - | - | - |
 | **Backend Services** |
-| postgresql-immich | - | - | - | ✅ | - | - |
-| redis-immich | - | - | - | ✅ | - | - |
-| immich-ml | - | - | - | ✅ | - | - |
-| nextcloud-db | - | ✅ | - | - | ✅ | - |
-| nextcloud-redis | - | ✅ | - | - | ✅ | - |
-
-**Key Insights:**
-- **Traefik** is in 3 networks (gateway, monitoring, auth) to route traffic and be monitored
-- **Internet-facing services** are all in `reverse_proxy` (primary) + their functional network
-- **Monitoring network** has the most members (14 services) - observability across all tiers
-- **Backend databases/caches** are isolated to their functional networks only
+| gathio-db | - | ✅ | - | - | - | - | - | - |
+| immich-ml | - | - | - | - | - | - | ✅ | - |
+| matter-server | - | - | ✅ | - | - | - | - | - |
+| nextcloud-db | - | - | - | - | ✅ | ✅ | - | - |
+| nextcloud-redis | - | - | - | - | ✅ | ✅ | - | - |
+| postgresql-immich | - | - | - | - | - | - | ✅ | - |
+| redis-immich | - | - | - | - | - | - | ✅ | - |
 
 ---
 
@@ -366,89 +352,15 @@ sequenceDiagram
 
 ---
 
-## Architecture Principles
+## Related Documentation
 
-### Network Segmentation Strategy
+For architecture principles, network ordering rules, and troubleshooting:
 
-Services are organized into isolated networks based on function and trust level:
-
-1. **reverse_proxy** (10.89.2.0/24) - **Gateway Network**
-   - Contains Traefik and all internet-accessible services
-   - **Critical:** First network in quadlets (gets default route for internet access)
-   - 13 members including all public-facing services
-
-2. **monitoring** (10.89.4.0/24) - **Observability Network**
-   - Prometheus, Grafana, Loki, exporters, and relay services
-   - Scrapes metrics from services across all other networks
-   - 14 members (most connected network)
-
-3. **auth_services** (10.89.3.0/24) - **Authentication Network**
-   - Authelia SSO, Redis session storage, and Traefik
-   - Isolated from direct internet except through reverse proxy
-   - 3 members (tightly controlled)
-
-4. **photos** (10.89.5.0/24) - **Photo Management Network**
-   - Immich application stack with PostgreSQL, Redis, and ML
-   - Backend services isolated from internet
-   - 4 members
-
-5. **nextcloud** (10.89.10.0/24) - **File Sync Network**
-   - Nextcloud application with MariaDB, Redis, and Collabora
-   - Backend databases accessible only within this network
-   - 4 members
-
-6. **media_services** (10.89.1.0/24) - **Media Processing Network**
-   - Jellyfin and media-related services
-   - 1 member (Jellyfin also in reverse_proxy and monitoring)
-
-### Multi-Network Services
-
-**Why multiple networks?**
-- **reverse_proxy** = Internet accessibility
-- **monitoring** = Metrics scraping
-- **Functional network** = Backend communication (databases, caches)
-
-**Examples:**
-- **Traefik (3 networks):** reverse_proxy (gateway), auth_services (Authelia access), monitoring (metrics)
-- **Jellyfin (3 networks):** reverse_proxy (internet), monitoring (metrics), media_services (function)
-- **Immich (3 networks):** reverse_proxy (internet), monitoring (metrics), photos (backend DB/cache)
-- **Nextcloud (3 networks):** reverse_proxy (internet), monitoring (metrics), nextcloud (backend DB/cache)
-
-### Network Ordering in Quadlets
-
-**Critical:** First `Network=` line in quadlet gets the default route (internet access).
-
-```ini
-# ✅ Correct - can reach internet AND internal services
-Network=systemd-reverse_proxy.network
-Network=systemd-monitoring.network
-Network=systemd-photos.network
-
-# ❌ Wrong - cannot reach internet (monitoring is internal-only)
-Network=systemd-monitoring.network
-Network=systemd-reverse_proxy.network
-```
-
-**Rule of thumb:**
-- Internet-facing services: `reverse_proxy` first
-- Internal services: Functional network first (photos, nextcloud, etc.)
-- Monitoring-only: `monitoring` network only (no internet needed)
-
-### Service Discovery (Podman DNS)
-
-Services on the same network can communicate using container names as hostnames:
-- `http://authelia:9091` - Traefik reaches Authelia (both in auth_services)
-- `http://redis-authelia:6379` - Authelia reaches Redis (both in auth_services)
-- `http://postgresql-immich:5432` - Immich reaches database (both in photos)
-- `http://prometheus:9090` - Grafana reaches Prometheus (both in monitoring)
-
----
-
-## Quick Links
-
+- [CLAUDE.md](../CLAUDE.md) - Network ordering, gotchas, and deployment patterns
+- [Homelab Architecture](20-operations/guides/homelab-architecture.md) - Full architecture overview
+- [ADR-018: Static IP Multi-Network Services](00-foundation/decisions/2026-02-04-ADR-018-static-ip-multi-network-services.md) - Static IPs and Traefik /etc/hosts override
 - [Service Catalog](AUTO-SERVICE-CATALOG.md) - Complete service inventory
 - [Dependency Graph](AUTO-DEPENDENCY-GRAPH.md) - Service dependencies
-- [Homelab Architecture](20-operations/guides/homelab-architecture.md) - Full documentation
 
 ---
 

--- a/docs/AUTO-SERVICE-CATALOG.md
+++ b/docs/AUTO-SERVICE-CATALOG.md
@@ -1,41 +1,81 @@
 # Service Catalog (Auto-Generated)
 
-**Generated:** 2026-02-15 06:03:18 UTC
-**System:** fedora-htpc
+**Generated:** 2026-02-21 06:02:50 UTC
+**System:** fedora-htpc | **Services:** 27/27 running | **Health:** 26/26 healthy (1 without healthcheck)
 
 ---
 
-## Running Services
+## Core Infrastructure (4)
 
-| Service | Image | Status | Networks |
-|---------|-------|--------|----------|
-| node_exporter | quay.io/prometheus/node-exporter:latest | ✅ Up | monitoring |
-| redis-authelia | redis:7-alpine | ✅ Up | auth_services |
-| nextcloud-redis | redis:7-alpine | ✅ Up | monitoring,nextcloud |
-| alert-discord-relay | localhost/alert-discord-relay:latest | ✅ Up | monitoring |
-| matter-server | home-assistant-libs/python-matter-server | ✅ Up | home_automation |
-| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3- | ✅ Up | photos |
-| cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ Up | monitoring |
-| redis-immich | valkey/valkey:latest | ✅ Up | photos |
-| crowdsec | crowdsecurity/crowdsec:latest | ✅ Up | reverse_proxy |
-| jellyfin | jellyfin/jellyfin:latest | ✅ Up | media_services,monitoring,reverse_proxy |
-| prometheus | quay.io/prometheus/prometheus:latest | ✅ Up | monitoring,reverse_proxy |
-| authelia | authelia/authelia:latest | ✅ Up | auth_services,reverse_proxy |
-| immich-ml | immich-app/immich-machine-learning:v2.5. | ✅ Up | photos |
-| homepage | gethomepage/homepage:latest | ✅ Up | reverse_proxy |
-| loki | grafana/loki:latest | ✅ Up | monitoring,reverse_proxy |
-| unpoller | unpoller/unpoller:latest | ✅ Up | monitoring |
-| immich-server | immich-app/immich-server:v2.5.5 | ✅ Up | monitoring,photos,reverse_proxy |
-| promtail | grafana/promtail:latest | ✅ Up | monitoring |
-| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ Up | monitoring,reverse_proxy |
-| home-assistant | home-assistant/home-assistant:stable | ✅ Up | home_automation,monitoring,reverse_proxy |
-| gathio-db | mongo:7 | ✅ Up | gathio |
-| grafana | grafana/grafana:latest | ✅ Up | monitoring,reverse_proxy |
-| traefik | traefik:latest | ✅ Up | auth_services,monitoring,reverse_proxy |
-| vaultwarden | vaultwarden/server:latest | ✅ Up | reverse_proxy |
-| gathio | lowercasename/gathio:latest | ✅ Up | gathio,monitoring,reverse_proxy |
-| nextcloud-db | mariadb:11 | ✅ Up | monitoring,nextcloud |
-| nextcloud | nextcloud:latest | ✅ Up | nextcloud,reverse_proxy,monitoring |
+| Service | Image | Health | Uptime | URL | Docs |
+|---------|-------|--------|--------|-----|------|
+| authelia | authelia/authelia:latest | ✅ healthy | 4d | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
+| crowdsec | crowdsecurity/crowdsec:latest | ✅ healthy | 4d | — | [guide](10-services/guides/crowdsec.md) |
+| redis-authelia | redis:7-alpine | ✅ healthy | 4d | — | — |
+| traefik | traefik:latest | ✅ healthy | 4d | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
+
+## Nextcloud (3)
+
+| Service | Image | Health | Uptime | URL | Docs |
+|---------|-------|--------|--------|-----|------|
+| nextcloud-db | mariadb:11 | ✅ healthy | 4d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud | nextcloud:latest | ✅ healthy | 4d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-redis | redis:7-alpine | ✅ healthy | 4d | — | [guide](10-services/guides/nextcloud.md) |
+
+## Immich (4)
+
+| Service | Image | Health | Uptime | URL | Docs |
+|---------|-------|--------|--------|-----|------|
+| immich-ml | immich-app/immich-machine-learning:v2.5.5 | ✅ healthy | 4d | — | [guide](10-services/guides/immich.md) |
+| immich-server | immich-app/immich-server:v2.5.5 | ✅ healthy | 4d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
+| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3-pgvec | ✅ healthy | 4d | — | — |
+| redis-immich | valkey/valkey:latest | ✅ healthy | 4d | — | — |
+
+## Jellyfin (1)
+
+| Service | Image | Health | Uptime | URL | Docs |
+|---------|-------|--------|--------|-----|------|
+| jellyfin | jellyfin/jellyfin:latest | ✅ healthy | 4d | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
+
+## Vaultwarden (1)
+
+| Service | Image | Health | Uptime | URL | Docs |
+|---------|-------|--------|--------|-----|------|
+| vaultwarden | vaultwarden/server:latest | ✅ healthy | 4d | [vault.patriark.org](https://vault.patriark.org) | — |
+
+## Home Automation (2)
+
+| Service | Image | Health | Uptime | URL | Docs |
+|---------|-------|--------|--------|-----|------|
+| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 4d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
+| matter-server | home-assistant-libs/python-matter-server:stab | ✅ healthy | 4d | — | [guide](10-services/guides/matter-server.md) |
+
+## Gathio (2)
+
+| Service | Image | Health | Uptime | URL | Docs |
+|---------|-------|--------|--------|-----|------|
+| gathio-db | mongo:7 | ✅ healthy | 4d | — | — |
+| gathio | lowercasename/gathio:latest | ✅ healthy | 4d | [events.patriark.org](https://events.patriark.org) | — |
+
+## Homepage (1)
+
+| Service | Image | Health | Uptime | URL | Docs |
+|---------|-------|--------|--------|-----|------|
+| homepage | gethomepage/homepage:latest | ✅ healthy | 4d | [patriark.org](https://patriark.org) | — |
+
+## Monitoring (9)
+
+| Service | Image | Health | Uptime | URL | Docs |
+|---------|-------|--------|--------|-----|------|
+| alert-discord-relay | localhost/alert-discord-relay:latest | ✅ healthy | 4d | — | [guide](10-services/guides/alert-discord-relay.md) |
+| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ healthy | 4d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ healthy | 4d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| grafana | grafana/grafana:latest | ✅ healthy | 4d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| loki | grafana/loki:latest | — no check | 4d | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| node_exporter | quay.io/prometheus/node-exporter:latest | ✅ healthy | 4d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 4d | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| promtail | grafana/promtail:latest | ✅ healthy | 4d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| unpoller | unpoller/unpoller:latest | ✅ healthy | 4d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
 
 ---
 
@@ -43,15 +83,15 @@
 
 - **Total Running:** 27
 - **Total Defined:** 27
-- **System Load:**  0,61, 0,45, 0,54
+- **System Load:** 0,63, 0,68, 0,60
 
 ---
 
 ## Quick Links
 
+- [Network Topology](AUTO-NETWORK-TOPOLOGY.md)
+- [Dependency Graph](AUTO-DEPENDENCY-GRAPH.md)
 - [Homelab Architecture](20-operations/guides/homelab-architecture.md)
-- [Network Topology](AUTO-NETWORK-TOPOLOGY.md) (when generated)
-- [Dependency Graph](AUTO-DEPENDENCY-GRAPH.md) (when generated)
 
 ---
 

--- a/quadlets/vaultwarden.container
+++ b/quadlets/vaultwarden.container
@@ -10,8 +10,7 @@
 Description=Vaultwarden Password Manager
 Documentation=https://github.com/dani-garcia/vaultwarden
 After=network-online.target traefik.service
-Wants=network-online.target
-Requires=traefik.service
+Wants=network-online.target traefik.service
 
 # ═══════════════════════════════════════════════════════════
 # CONTAINER CONFIGURATION


### PR DESCRIPTION
## Summary

- **Replace CertificateExpiryWarning with CertificateRenewalOverdue** -- the old alert fired at <30 days, but Let's Encrypt auto-renews at the 30-day mark, making every certificate trigger this alert as part of its normal lifecycle. New alert fires at <14 days (renewal failed ~16 days ago), severity `info` with 168h repeat (once/week max)
- **Remove stale collabora.patriark.org certificate** from acme.json -- service decommissioned 2026-02-06, cert would never auto-renew
- **Remove redundant CriticalServiceDown alert** -- authelia/vaultwarden are not Prometheus scrape targets (dead code), and for traefik it duplicated the existing TraefikDown alert
- **Add *Down→HostDown inhibition rule** -- specific service-down alerts (TraefikDown, GrafanaDown, LokiDown, etc.) now suppress the generic HostDown safety net for the same instance, preventing duplicate Discord notifications
- **Modernize alertmanager.yml syntax** -- migrate deprecated `source_match`/`target_match` to `source_matchers`/`target_matchers`

## Verification

- All 3 services restarted and verified active (Traefik, Prometheus, Alertmanager)
- 0 rule evaluation errors across all alert groups
- 0 active alerts (clean slate)
- `collabora.patriark.org` confirmed absent from `traefik_tls_certs_not_after` metrics (16 certs remaining)
- Critical alert `CertificateExpiringSoon` (<7 days) unchanged as escalation path

## Test Plan

- [x] Prometheus rules load without errors
- [x] Alertmanager config accepted (cluster status: ready)
- [x] Traefik starts with cleaned acme.json (16 certs)
- [x] No `collabora.patriark.org` in cert metrics
- [x] CertificateExpiryWarning no longer in active rules
- [x] CertificateRenewalOverdue present in rules
- [x] CriticalServiceDown no longer in active rules
- [ ] Monitor Discord for 24h -- no spurious cert warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)