### PR TITLE
fix: Decommission Samba and standardize filesystem permissions (ADR-019)

### DIFF
--- a/docs/00-foundation/decisions/2026-02-22-ADR-019-filesystem-permission-model.md
+++ b/docs/00-foundation/decisions/2026-02-22-ADR-019-filesystem-permission-model.md
@@ -1,0 +1,135 @@
+# ADR-019: Filesystem Permission Model
+
+**Status:** Accepted
+**Date:** 2026-02-22
+**Context:** Samba-era permissions causing write failures in Nextcloud external storage
+
+---
+
+## Context
+
+The homelab filesystem grew organically from a Samba file server into a multi-service container platform. Three BTRFS subvolumes (subvol1-docs, subvol2-pics, subvol3-opptak) still carried Samba-era group ownership (`patriark:samba`, GID 1001) and SGID bits (mode 2775). The Downloads directory used world-writable mode 2777 as a workaround.
+
+**Problem:** Rootless Podman's UID namespace mapping means container processes run as host UIDs outside the owner's primary group. Specifically, Nextcloud's `www-data` (container UID 33) maps to host UID 100032, which has no relationship to the `samba` group (GID 1001). Since GID 1001 has no subgid mapping in rootless containers, it appears as `nogroup` — and the `samba` group ownership provides zero access benefit to any container.
+
+**Impact:** Nextcloud external storage mounts failed writes on subvol1-docs, subvol2-pics, and Downloads because host UID 100032 fell into "others" (r-x only on 2775, or needed the 2777 workaround on Downloads).
+
+**Trigger:** SLO burn rate investigation (2026-02-22) traced 502 errors to Nextcloud write failures on external storage mounts.
+
+## Decision
+
+**Standardize all BTRFS subvolumes to `patriark:patriark` (0755) ownership. Use POSIX ACLs for cross-UID container write access. Decommission Samba.**
+
+### Permission Model
+
+| Path | Owner | Mode | ACLs | Reason |
+|------|-------|------|------|--------|
+| subvol1-docs | patriark:patriark | 0755 | `user:100032:rwx` (access+default) | Nextcloud www-data writes |
+| subvol2-pics | patriark:patriark | 0755 | `user:100032:rwx` (access+default) | Nextcloud www-data writes |
+| subvol3-opptak | patriark:patriark | 0755 | None | Read-only in Nextcloud; Immich writes as owner (UID 1000) |
+| subvol4-multimedia | patriark:patriark | 0755 | None | Read-only in Nextcloud; Jellyfin reads as owner |
+| subvol5-music | patriark:patriark | 0755 | None | Read-only access only |
+| subvol6-tmp | patriark:patriark | 0755 | None | Host-only (except Downloads) |
+| subvol6-tmp/Downloads | patriark:patriark | 0755 | `user:100032:rwx` (access+default) | Nextcloud www-data writes |
+| subvol7-containers | patriark:patriark | 0755 | None | Container root = host patriark = owner |
+
+### Key Principles
+
+1. **Owner-based access by default:** Container root (UID 0) maps to host UID 1000 (patriark) via rootless Podman. Files owned by `patriark` are writable by container root without ACLs.
+
+2. **ACLs for non-root container users:** When a container process runs as a non-root user (e.g., Nextcloud's www-data, UID 33 → host 100032), POSIX ACLs grant explicit access.
+
+3. **Default ACLs for inheritance:** Default ACLs on directories ensure new files/subdirectories automatically inherit the correct permissions.
+
+4. **No world-writable, no SGID:** These are legacy patterns from Samba that serve no purpose in a container-only environment.
+
+### Implementation
+
+```bash
+# Phase 0: BTRFS snapshots for rollback
+sudo btrfs subvolume snapshot -r /mnt/btrfs-pool/subvol1-docs /mnt/btrfs-pool/.snapshots/subvol1-docs-pre-perms
+
+# Phase 1: Decommission Samba
+sudo systemctl stop smb.service nmb.service
+sudo systemctl disable smb.service nmb.service
+sudo firewall-cmd --permanent --remove-service=samba --remove-service=samba-client
+sudo firewall-cmd --reload
+
+# Phase 2: Fix Downloads (replace 2777 with ACLs)
+sudo chmod 0755 /mnt/btrfs-pool/subvol6-tmp/Downloads
+sudo setfacl -R -m u:100032:rwx /mnt/btrfs-pool/subvol6-tmp/Downloads
+sudo setfacl -R -d -m u:100032:rwx /mnt/btrfs-pool/subvol6-tmp/Downloads
+
+# Phase 3: Standardize subvolumes
+sudo chgrp -R patriark /mnt/btrfs-pool/subvol{1-docs,2-pics,3-opptak}
+# Remove SGID, set 0755/0644
+```
+
+**Automated script:** `scripts/optimize-permissions.sh`
+**Drift detection:** `scripts/verify-permissions.sh`
+
+## Consequences
+
+### Positive
+
+**Clean permission model:** Single, consistent ownership pattern across all subvolumes. No ambiguity about which group or mode is correct.
+
+**Explicit access grants:** POSIX ACLs make container access visible and auditable (`getfacl` shows exactly who can access what).
+
+**Default ACL inheritance:** New files automatically get correct permissions. No manual fixup needed after file creation.
+
+**Samba decommissioned:** Eliminates unused attack surface (ports 139/445 closed). Samba was slated for decommission since Dec 2025.
+
+**Drift detection:** `verify-permissions.sh` catches permission regressions before they cause service failures.
+
+### Negative
+
+**ACL complexity:** POSIX ACLs are less visible than standard UNIX permissions (`ls -l` shows `+` suffix but not details). Operators must use `getfacl` to inspect.
+
+**Recursive operations on spinning disks:** Initial migration takes 5-15 minutes on 53K files across HDDs.
+
+**Samba re-enable cost:** If Samba is needed again, must re-add group ownership and firewall rules (mitigated: package kept installed, snapshots available).
+
+### Neutral
+
+**No service restarts needed:** Kernel checks permissions at access time, so running containers see changes immediately.
+
+**BTRFS CoW impact:** `chgrp` and `chmod` on BTRFS trigger metadata-only CoW (not full data copy). Impact is minimal.
+
+## Alternatives Considered
+
+**1. Keep Samba-era permissions (status quo):** Rejected — the `samba` group provides zero benefit to containers and the permission model is confusing. World-writable Downloads is a security antipattern.
+
+**2. Supplementary groups in containers:** Podman supports `--group-add` but rootless containers cannot map arbitrary host GIDs. The `samba` GID (1001) has no subgid mapping.
+
+**3. Run Nextcloud as root (UID 0 → host 1000):** Would eliminate ACL need but Nextcloud explicitly drops to www-data for security. Overriding this is unsupported.
+
+**4. Bind-mount with `:U` flag (user namespace remapping):** Podman's `:U` flag recursively chowns on every container start. Prohibitively slow for large volumes and destructive to shared mounts.
+
+## Supersedes
+
+- `docs/20-operations/guides/permission-optimization-nextcloud.md` (2025-12-29) — that guide recommended keeping Samba-era permissions. This ADR reverses that recommendation based on evidence that the permission model causes container write failures.
+
+## Verification
+
+```bash
+# Drift detection (run periodically)
+./scripts/verify-permissions.sh
+
+# Manual verification
+getfacl /mnt/btrfs-pool/subvol1-docs
+getfacl /mnt/btrfs-pool/subvol2-pics
+stat -c '%U:%G %a' /mnt/btrfs-pool/subvol{1..7}-*
+
+# Nextcloud write test
+podman exec -u www-data nextcloud touch /external/user-documents/.test
+podman exec -u www-data nextcloud rm /external/user-documents/.test
+```
+
+## References
+
+- Investigation: SLO burn rate analysis session (2026-02-22)
+- Previous guide: `docs/20-operations/guides/permission-optimization-nextcloud.md` (superseded)
+- ADR-001: Rootless Containers (UID namespace mapping)
+- ADR-013: Nextcloud Native Authentication
+- Memory: Rootless container UID mapping (MEMORY.md)

--- a/docs/20-operations/guides/permission-optimization-nextcloud.md
+++ b/docs/20-operations/guides/permission-optimization-nextcloud.md
@@ -1,8 +1,10 @@
 # Permission Optimization for Nextcloud Migration
 
 **Date:** 2025-12-29
-**Status:** Recommendation
+**Status:** Superseded by [ADR-019](../../00-foundation/decisions/2026-02-22-ADR-019-filesystem-permission-model.md)
 **Context:** Migrating from Samba to Nextcloud as primary file distribution method
+
+> **Note:** This guide recommended keeping Samba-era permissions. ADR-019 (2026-02-22) reverses this recommendation based on evidence that the `samba` group ownership causes container write failures via rootless Podman's UID namespace mapping. The correct approach is POSIX ACLs for cross-UID container access. See ADR-019 for the current permission model.
 
 ## Current State
 

--- a/docs/98-journals/2026-02-22-filesystem-permission-optimization.md
+++ b/docs/98-journals/2026-02-22-filesystem-permission-optimization.md
@@ -1,0 +1,61 @@
+# Filesystem Permission Optimization & Samba Decommission
+
+**Date:** 2026-02-22
+**Trigger:** Nextcloud SLO burn rate investigation traced 502 errors to external storage write failures
+**Result:** Clean POSIX ACL permission model, Samba decommissioned, drift detection added
+
+## Root Cause
+
+Nextcloud external storage mounts (Documents, Photos, Downloads) failed writes because:
+1. Subvol1-3 had Samba-era ownership (`patriark:samba`, mode 2775)
+2. The `samba` GID (1001) has no rootless Podman subgid mapping — provides zero container access
+3. Nextcloud's www-data (container UID 33 → host 100032) fell into "others" (r-x only)
+4. Downloads used world-writable 2777 as a workaround
+
+## Changes
+
+**Samba decommission (Phase 1):**
+- Stopped and disabled `smb.service` / `nmb.service`
+- Removed firewall services `samba` / `samba-client`
+- Removed `patriark` from `samba` group
+- Package kept installed (zero cost, easy rollback)
+
+**Downloads fix (Phase 2):**
+- Replaced mode 2777 with 0755 + POSIX ACLs (`user:100032:rwx` access+default)
+
+**Subvolume standardization (Phase 3):**
+- `chgrp -R patriark` on subvol1-docs (17K items), subvol2-pics (28K), subvol3-opptak (91K)
+- Removed all SGID bits, set dirs 0755, files 0644
+- Re-applied ACLs on subvol1/subvol2 after chmod (mask correction)
+
+**New files:**
+- `scripts/optimize-permissions.sh` — sudo script for all phases (with BTRFS snapshots)
+- `scripts/verify-permissions.sh` — drift detection (6 checks, matches security-audit.sh style)
+- `docs/00-foundation/decisions/2026-02-22-ADR-019-filesystem-permission-model.md`
+
+**Modified files:**
+- `scripts/security-audit.sh` — removed ports 139/445 from expected ports
+- `docs/20-operations/guides/permission-optimization-nextcloud.md` — marked superseded by ADR-019
+
+## Bugs Hit During Execution
+
+1. **`((STEP++))` silent exit:** When STEP=0, result is falsy → `set -e` kills script silently. Fix: `|| true`
+2. **Wrong Downloads path:** Script had `/subvol6-tmp/10-downloads`, correct is `/subvol6-tmp/Downloads`
+3. **`chmod` resets ACL mask:** `chmod 0755` sets mask to `r-x`, limiting named ACL entries to `#effective:r-x`. Fix: re-apply ACLs after chmod
+
+## Verification
+
+All 9 service access tests passed:
+- Nextcloud www-data: write Documents, Photos, Downloads ✅
+- Nextcloud www-data: read Multimedia, Music, Opptak ✅
+- Immich: read+write library ✅
+- Jellyfin: read media ✅
+- Nextcloud file rescan: complete ✅
+- Health score: 95/100 (SSD at 75% — pre-existing)
+
+## Rollback
+
+BTRFS read-only snapshots available until manually deleted:
+```bash
+sudo btrfs subvolume delete /mnt/btrfs-pool/.snapshots/subvol{1-docs,2-pics,3-opptak,6-tmp}-pre-perms
+```

--- a/docs/AUTO-DEPENDENCY-GRAPH.md
+++ b/docs/AUTO-DEPENDENCY-GRAPH.md
@@ -1,6 +1,6 @@
 # Service Dependency Graph (Auto-Generated)
 
-**Generated:** 2026-02-21 06:02:54 UTC
+**Generated:** 2026-02-22 06:02:05 UTC
 **System:** fedora-htpc
 
 ---
@@ -58,7 +58,6 @@ graph TB
     gathio --> gathio_db
     immich_server --> postgresql_immich
     immich_server --> redis_immich
-    vaultwarden --> traefik
 
     %% Routing dependencies (services in reverse_proxy depend on Traefik)
     traefik -.-> alertmanager
@@ -72,6 +71,7 @@ graph TB
     traefik -.-> loki
     traefik -.-> nextcloud
     traefik -.-> prometheus
+    traefik -.-> vaultwarden
 
     %% Monitoring (Prometheus scrapes via monitoring network)
     prometheus -.->|scrapes| gathio
@@ -122,7 +122,7 @@ graph TB
 | **immich-server** | postgresql-immich,redis-immich | 🟢 Photo management unavailable |
 | **jellyfin** | — | 🟢 Media streaming unavailable |
 | **nextcloud** | — | 🟢 File sync unavailable |
-| **vaultwarden** | traefik | 🟡 Password vault inaccessible (keep local cache) |
+| **vaultwarden** | — | 🟡 Password vault inaccessible (keep local cache) |
 
 ### Tier 4: Data
 

--- a/docs/AUTO-DOCUMENTATION-INDEX.md
+++ b/docs/AUTO-DOCUMENTATION-INDEX.md
@@ -1,6 +1,6 @@
 # Documentation Index (Auto-Generated)
 
-**Generated:** 2026-02-21 06:02:55 UTC
+**Generated:** 2026-02-22 06:02:06 UTC
 **Total Documents:** 392
 
 ---
@@ -216,16 +216,15 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 
 ## Recently Updated (Last 7 Days)
 
-- 2026-02-14: [HOMELAB-FIELD-GUIDE.md](00-foundation/guides/HOMELAB-FIELD-GUIDE.md)
 - 2026-02-15: [2026-02-15-community-tool-sharing-platform-architecture.md](98-journals/2026-02-15-community-tool-sharing-platform-architecture.md)
 - 2026-02-16: [2026-02-16-gnome-freeze-system-update.md](98-journals/2026-02-16-gnome-freeze-system-update.md)
 - 2026-02-16: [2026-02-16-post-reboot-handoff.md](98-journals/2026-02-16-post-reboot-handoff.md)
 - 2026-02-20: [2026-02-18-loose-ends-audit.md](98-journals/2026-02-18-loose-ends-audit.md)
 - 2026-02-16: [remediation-monthly-202601.md](99-reports/remediation-monthly-202601.md)
-- 2026-02-21: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
-- 2026-02-21: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
-- 2026-02-21: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
-- 2026-02-21: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
+- 2026-02-22: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
+- 2026-02-22: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
+- 2026-02-22: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
+- 2026-02-22: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
 
 ---
 

--- a/docs/AUTO-NETWORK-TOPOLOGY.md
+++ b/docs/AUTO-NETWORK-TOPOLOGY.md
@@ -1,6 +1,6 @@
 # Network Topology (Auto-Generated)
 
-**Generated:** 2026-02-21 06:02:51 UTC
+**Generated:** 2026-02-22 06:02:01 UTC
 **System:** fedora-htpc | **Networks:** 8 | **Containers:** 27
 
 ---

--- a/docs/AUTO-SERVICE-CATALOG.md
+++ b/docs/AUTO-SERVICE-CATALOG.md
@@ -1,7 +1,7 @@
 # Service Catalog (Auto-Generated)
 
-**Generated:** 2026-02-21 06:02:50 UTC
-**System:** fedora-htpc | **Services:** 27/27 running | **Health:** 26/26 healthy (1 without healthcheck)
+**Generated:** 2026-02-22 06:02:00 UTC
+**System:** fedora-htpc | **Services:** 27/27 running | **Health:** 25/25 healthy (2 without healthcheck)
 
 ---
 
@@ -9,73 +9,73 @@
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| authelia | authelia/authelia:latest | ✅ healthy | 4d | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
-| crowdsec | crowdsecurity/crowdsec:latest | ✅ healthy | 4d | — | [guide](10-services/guides/crowdsec.md) |
-| redis-authelia | redis:7-alpine | ✅ healthy | 4d | — | — |
-| traefik | traefik:latest | ✅ healthy | 4d | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
+| authelia | authelia/authelia:latest | ✅ healthy | 5d | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
+| crowdsec | crowdsecurity/crowdsec:latest | ✅ healthy | 5d | — | [guide](10-services/guides/crowdsec.md) |
+| redis-authelia | redis:7-alpine | ✅ healthy | 5d | — | — |
+| traefik | traefik:latest | ✅ healthy | 13h | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
 
 ## Nextcloud (3)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| nextcloud-db | mariadb:11 | ✅ healthy | 4d | — | [guide](10-services/guides/nextcloud.md) |
-| nextcloud | nextcloud:latest | ✅ healthy | 4d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
-| nextcloud-redis | redis:7-alpine | ✅ healthy | 4d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-db | mariadb:11 | ✅ healthy | 4h | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud | nextcloud:latest | ✅ healthy | 5d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-redis | redis:7-alpine | ✅ healthy | 5d | — | [guide](10-services/guides/nextcloud.md) |
 
 ## Immich (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| immich-ml | immich-app/immich-machine-learning:v2.5.5 | ✅ healthy | 4d | — | [guide](10-services/guides/immich.md) |
-| immich-server | immich-app/immich-server:v2.5.5 | ✅ healthy | 4d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
-| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3-pgvec | ✅ healthy | 4d | — | — |
-| redis-immich | valkey/valkey:latest | ✅ healthy | 4d | — | — |
+| immich-ml | immich-app/immich-machine-learning:v2.5.5 | ✅ healthy | 5d | — | [guide](10-services/guides/immich.md) |
+| immich-server | immich-app/immich-server:v2.5.5 | ✅ healthy | 5d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
+| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3-pgvec | ✅ healthy | 5d | — | — |
+| redis-immich | valkey/valkey:latest | ✅ healthy | 5d | — | — |
 
 ## Jellyfin (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| jellyfin | jellyfin/jellyfin:latest | ✅ healthy | 4d | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
+| jellyfin | jellyfin/jellyfin:latest | ✅ healthy | 5d | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
 
 ## Vaultwarden (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| vaultwarden | vaultwarden/server:latest | ✅ healthy | 4d | [vault.patriark.org](https://vault.patriark.org) | — |
+| vaultwarden | vaultwarden/server:latest | ✅ healthy | 13h | [vault.patriark.org](https://vault.patriark.org) | — |
 
 ## Home Automation (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 4d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
-| matter-server | home-assistant-libs/python-matter-server:stab | ✅ healthy | 4d | — | [guide](10-services/guides/matter-server.md) |
+| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 4h | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
+| matter-server | home-assistant-libs/python-matter-server:stab | ✅ healthy | 5d | — | [guide](10-services/guides/matter-server.md) |
 
 ## Gathio (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| gathio-db | mongo:7 | ✅ healthy | 4d | — | — |
-| gathio | lowercasename/gathio:latest | ✅ healthy | 4d | [events.patriark.org](https://events.patriark.org) | — |
+| gathio-db | mongo:7 | ✅ healthy | 4h | — | — |
+| gathio | lowercasename/gathio:latest | ✅ healthy | 4h | [events.patriark.org](https://events.patriark.org) | — |
 
 ## Homepage (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| homepage | gethomepage/homepage:latest | ✅ healthy | 4d | [patriark.org](https://patriark.org) | — |
+| homepage | gethomepage/homepage:latest | ✅ healthy | 5d | [patriark.org](https://patriark.org) | — |
 
 ## Monitoring (9)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| alert-discord-relay | localhost/alert-discord-relay:latest | ✅ healthy | 4d | — | [guide](10-services/guides/alert-discord-relay.md) |
-| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ healthy | 4d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ healthy | 4d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| grafana | grafana/grafana:latest | ✅ healthy | 4d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| loki | grafana/loki:latest | — no check | 4d | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| node_exporter | quay.io/prometheus/node-exporter:latest | ✅ healthy | 4d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 4d | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| promtail | grafana/promtail:latest | ✅ healthy | 4d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| unpoller | unpoller/unpoller:latest | ✅ healthy | 4d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| alert-discord-relay | localhost/alert-discord-relay:latest | ✅ healthy | 5d | — | [guide](10-services/guides/alert-discord-relay.md) |
+| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ healthy | 13h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ healthy | 5d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| grafana | grafana/grafana:latest | ✅ healthy | 5d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| loki | grafana/loki:latest | — no check | 4h | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| node_exporter | quay.io/prometheus/node-exporter:latest | ✅ healthy | 5d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 13h | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| promtail | grafana/promtail:latest | ✅ healthy | 4h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| unpoller | unpoller/unpoller:latest | — no check | 4h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
 
 ---
 
@@ -83,7 +83,7 @@
 
 - **Total Running:** 27
 - **Total Defined:** 27
-- **System Load:** 0,63, 0,68, 0,60
+- **System Load:** 0,65, 0,43, 0,41
 
 ---
 

--- a/scripts/optimize-permissions.sh
+++ b/scripts/optimize-permissions.sh
@@ -1,0 +1,312 @@
+#!/bin/bash
+# optimize-permissions.sh
+# Homelab Filesystem Permission Optimization
+#
+# Purpose: Decommission Samba, standardize subvolume ownership,
+#          establish POSIX ACL-based permission model
+#
+# Run: sudo ~/containers/scripts/optimize-permissions.sh
+#
+# Phases:
+#   0: Pre-flight safety (BTRFS snapshots + ACL preservation test)
+#   1: Decommission Samba (stop service, close firewall ports)
+#   2: Fix Downloads permissions (replace 2777 with ACLs)
+#   3: Standardize subvolume ownership (chgrp, remove SGID, set modes)
+#
+# Rollback: sudo btrfs subvolume delete /mnt/btrfs-pool/.snapshots/subvol*-pre-perms
+#
+# See: ADR-019 (Filesystem Permission Model)
+# Status: ACTIVE
+# Created: 2026-02-22
+
+set -euo pipefail
+
+# Must run as root
+if [[ $EUID -ne 0 ]]; then
+    echo "ERROR: This script must be run as root (sudo)"
+    exit 1
+fi
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# Paths
+POOL="/mnt/btrfs-pool"
+SNAP_DIR="$POOL/.snapshots"
+DOWNLOADS="$POOL/subvol6-tmp/Downloads"
+OWNER="patriark"
+OWNER_UID=1000
+OWNER_GID=1000
+NC_UID=100032  # Nextcloud www-data (container UID 33 + 100000 offset)
+
+# Counters
+STEP=0
+ERRORS=0
+
+step() {
+    ((STEP++)) || true
+    echo ""
+    echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+    echo -e "${BOLD}  Step $STEP: $1${NC}"
+    echo -e "${BLUE}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
+}
+
+ok()   { echo -e "  ${GREEN}✅ $1${NC}"; }
+warn() { echo -e "  ${YELLOW}⚠️  $1${NC}"; }
+fail() { echo -e "  ${RED}❌ $1${NC}"; ((ERRORS++)) || true; }
+info() { echo -e "  ${BLUE}ℹ️  $1${NC}"; }
+
+abort() {
+    echo ""
+    echo -e "${RED}ABORT: $1${NC}"
+    echo -e "${RED}No changes have been made. Fix the issue and re-run.${NC}"
+    exit 1
+}
+
+echo ""
+echo -e "${BLUE}═══════════════════════════════════════════════════${NC}"
+echo -e "${BLUE}    HOMELAB FILESYSTEM PERMISSION OPTIMIZATION${NC}"
+echo -e "${BLUE}═══════════════════════════════════════════════════${NC}"
+echo -e "  Date: $(date '+%Y-%m-%d %H:%M:%S')"
+echo -e "  Host: $(hostname)"
+echo ""
+
+# ============================================================================
+# Phase 0: Pre-flight Safety
+# ============================================================================
+step "Pre-flight: BTRFS snapshots"
+
+mkdir -p "$SNAP_DIR"
+
+SUBVOLS=(subvol1-docs subvol2-pics subvol3-opptak subvol6-tmp)
+for sv in "${SUBVOLS[@]}"; do
+    SNAP_NAME="${sv}-pre-perms"
+    if btrfs subvolume show "$SNAP_DIR/$SNAP_NAME" &>/dev/null; then
+        warn "Snapshot $SNAP_NAME already exists (from previous run?), skipping"
+    else
+        btrfs subvolume snapshot -r "$POOL/$sv" "$SNAP_DIR/$SNAP_NAME"
+        ok "Snapshot: $SNAP_NAME"
+    fi
+done
+
+step "Pre-flight: ACL preservation test"
+
+# Create a test file, set an ACL, chgrp it, verify ACL survives
+TEST_DIR="$POOL/subvol6-tmp"
+TEST_FILE="$TEST_DIR/.acl-test-$$"
+
+touch "$TEST_FILE"
+chown "$OWNER:$OWNER" "$TEST_FILE"
+setfacl -m u:$NC_UID:rw "$TEST_FILE"
+
+# Capture ACL before chgrp
+ACL_BEFORE=$(getfacl -c "$TEST_FILE" 2>/dev/null | grep "user:$NC_UID")
+
+chgrp "$OWNER" "$TEST_FILE"
+
+# Capture ACL after chgrp
+ACL_AFTER=$(getfacl -c "$TEST_FILE" 2>/dev/null | grep "user:$NC_UID")
+
+rm -f "$TEST_FILE"
+
+if [[ "$ACL_BEFORE" == "$ACL_AFTER" ]] && [[ -n "$ACL_BEFORE" ]]; then
+    ok "ACL preserved after chgrp ($ACL_AFTER)"
+else
+    abort "chgrp destroyed ACLs! Before: '$ACL_BEFORE', After: '$ACL_AFTER'"
+fi
+
+# ============================================================================
+# Phase 1: Decommission Samba
+# ============================================================================
+step "Decommission Samba services"
+
+# Stop and disable SMB/NMB
+for svc in smb.service nmb.service; do
+    if systemctl is-active "$svc" &>/dev/null; then
+        systemctl stop "$svc"
+        ok "Stopped $svc"
+    else
+        info "$svc already stopped"
+    fi
+    if systemctl is-enabled "$svc" &>/dev/null; then
+        systemctl disable "$svc"
+        ok "Disabled $svc"
+    else
+        info "$svc already disabled"
+    fi
+done
+
+step "Close Samba firewall ports"
+
+CHANGED=false
+for fw_svc in samba samba-client; do
+    if firewall-cmd --query-service="$fw_svc" --permanent &>/dev/null; then
+        firewall-cmd --permanent --remove-service="$fw_svc"
+        ok "Removed firewall service: $fw_svc"
+        CHANGED=true
+    else
+        info "Firewall service $fw_svc not present"
+    fi
+done
+
+if $CHANGED; then
+    firewall-cmd --reload
+    ok "Firewall reloaded"
+else
+    info "No firewall changes needed"
+fi
+
+step "Remove user from samba group"
+
+if id -nG "$OWNER" | grep -qw samba; then
+    gpasswd -d "$OWNER" samba
+    ok "Removed $OWNER from samba group"
+else
+    info "$OWNER not in samba group"
+fi
+
+info "Samba package kept installed (zero cost, easy re-enable)"
+
+# ============================================================================
+# Phase 2: Fix Downloads Permissions
+# ============================================================================
+step "Fix Downloads directory permissions"
+
+if [[ ! -d "$DOWNLOADS" ]]; then
+    fail "Downloads directory not found: $DOWNLOADS"
+else
+    FILE_COUNT=$(find "$DOWNLOADS" -maxdepth 0 -printf '%y' 2>/dev/null | wc -c)
+    TOTAL_FILES=$(find "$DOWNLOADS" -type f 2>/dev/null | wc -l)
+    TOTAL_DIRS=$(find "$DOWNLOADS" -type d 2>/dev/null | wc -l)
+    info "Downloads contains $TOTAL_FILES files, $TOTAL_DIRS directories"
+
+    # Set directory permissions: 0755 + ACLs
+    info "Setting directory permissions to 0755 + ACL u:$NC_UID:rwx..."
+    find "$DOWNLOADS" -type d -exec chmod 0755 {} +
+    find "$DOWNLOADS" -type d -exec setfacl -m u:$NC_UID:rwx {} +
+    find "$DOWNLOADS" -type d -exec setfacl -d -m u:$NC_UID:rwx {} +
+    ok "Directories: 0755 + ACL access+default u:$NC_UID:rwx"
+
+    # Set file permissions: 0644 + ACLs
+    info "Setting file permissions to 0644 + ACL u:$NC_UID:rw..."
+    find "$DOWNLOADS" -type f -exec chmod 0644 {} +
+    find "$DOWNLOADS" -type f -exec setfacl -m u:$NC_UID:rw {} +
+    ok "Files: 0644 + ACL u:$NC_UID:rw"
+
+    # Remove any world-writable bits
+    find "$DOWNLOADS" -perm -o+w -exec chmod o-w {} +
+    ok "Removed all world-writable bits"
+
+    # Verify
+    # Note: setfacl -d (default ACL) auto-sets SGID bit, and ACL mask raises
+    # apparent group bits. stat -c %a will show 2775 not 755 — this is correct.
+    DL_ACL=$(getfacl -c "$DOWNLOADS" 2>/dev/null | grep "user:$NC_UID" | head -1)
+    DL_DEFAULT=$(getfacl -c "$DOWNLOADS" 2>/dev/null | grep "default:user:$NC_UID" || true)
+    DL_WORLD=$(stat -c %a "$DOWNLOADS" | grep -o '.$')  # last digit = others
+    if [[ -n "$DL_ACL" ]] && [[ -n "$DL_DEFAULT" ]] && [[ "$DL_WORLD" != "7" ]] && [[ "$DL_WORLD" != "6" ]]; then
+        ok "Verified: Downloads has ACL $DL_ACL + default, others=r-x"
+    else
+        fail "Downloads verification failed: ACL=$DL_ACL, default=$DL_DEFAULT, others=$DL_WORLD"
+    fi
+fi
+
+# ============================================================================
+# Phase 3: Standardize Subvolume Ownership
+# ============================================================================
+SUBVOLS_TO_FIX=(subvol1-docs subvol2-pics subvol3-opptak)
+
+for sv in "${SUBVOLS_TO_FIX[@]}"; do
+    SV_PATH="$POOL/$sv"
+    step "Standardize $sv"
+
+    if [[ ! -d "$SV_PATH" ]]; then
+        fail "$sv not found at $SV_PATH"
+        continue
+    fi
+
+    # Count files for progress
+    TOTAL=$(find "$SV_PATH" -mindepth 1 2>/dev/null | wc -l)
+    info "$sv: $TOTAL items to process"
+
+    # Change group ownership from samba to patriark
+    info "Changing group ownership to $OWNER..."
+    chgrp -R "$OWNER" "$SV_PATH"
+    ok "Group ownership changed to $OWNER"
+
+    # Remove SGID bits from all directories
+    info "Removing SGID bits from directories..."
+    find "$SV_PATH" -type d -perm -g+s -exec chmod g-s {} +
+    ok "SGID bits removed"
+
+    # Set standard directory permissions
+    info "Setting directory permissions to 0755..."
+    find "$SV_PATH" -type d -exec chmod 0755 {} +
+    ok "Directories set to 0755"
+
+    # Set standard file permissions
+    info "Setting file permissions to 0644..."
+    find "$SV_PATH" -type f -exec chmod 0644 {} +
+    ok "Files set to 0644"
+
+    # Re-apply ACL masks on subvol1 and subvol2
+    # chmod resets ACL mask to match traditional group bits (r-x for 0755),
+    # which limits named ACL entries. Re-applying ACLs auto-corrects the mask.
+    if [[ "$sv" == "subvol1-docs" ]] || [[ "$sv" == "subvol2-pics" ]]; then
+        info "Re-applying ACLs after chmod (mask correction)..."
+        find "$SV_PATH" -type d -exec setfacl -m u:$NC_UID:rwx {} +
+        find "$SV_PATH" -type d -exec setfacl -d -m u:$NC_UID:rwx {} +
+        find "$SV_PATH" -type f -exec setfacl -m u:$NC_UID:rw {} +
+        ok "ACLs re-applied on $sv (mask corrected to rwx/rw)"
+    fi
+
+    # Verify final state
+    SV_OWNER=$(stat -c '%U:%G' "$SV_PATH")
+    SV_PERMS=$(stat -c '%a' "$SV_PATH")
+    SGID_COUNT=$(find "$SV_PATH" -type d -perm -g+s 2>/dev/null | wc -l)
+    WORLD_WRITE=$(find "$SV_PATH" -perm -o+w 2>/dev/null | wc -l)
+
+    info "Final state: owner=$SV_OWNER, mode=$SV_PERMS, SGID dirs=$SGID_COUNT, world-writable=$WORLD_WRITE"
+
+    if [[ "$SV_OWNER" == "$OWNER:$OWNER" ]] && [[ "$SGID_COUNT" -eq 0 ]] && [[ "$WORLD_WRITE" -eq 0 ]]; then
+        ok "$sv standardized successfully"
+    else
+        fail "$sv has issues (see above)"
+    fi
+done
+
+# ============================================================================
+# Summary
+# ============================================================================
+echo ""
+echo -e "${BLUE}═══════════════════════════════════════════════════${NC}"
+echo -e "${BLUE}                    SUMMARY${NC}"
+echo -e "${BLUE}═══════════════════════════════════════════════════${NC}"
+echo ""
+echo -e "  Steps completed: $STEP"
+echo -e "  Errors: $ERRORS"
+echo ""
+
+if [[ $ERRORS -gt 0 ]]; then
+    echo -e "${RED}Completed with $ERRORS error(s). Review output above.${NC}"
+    echo ""
+    echo -e "${YELLOW}Rollback snapshots available:${NC}"
+    for sv in "${SUBVOLS[@]}"; do
+        echo "  sudo btrfs subvolume delete $SNAP_DIR/${sv}-pre-perms"
+    done
+    exit 1
+else
+    echo -e "${GREEN}All phases completed successfully!${NC}"
+    echo ""
+    echo -e "Next steps:"
+    echo -e "  1. Return to Claude Code for service verification (Phase 4)"
+    echo -e "  2. After verification, clean up snapshots:"
+    for sv in "${SUBVOLS[@]}"; do
+        echo "      sudo btrfs subvolume delete $SNAP_DIR/${sv}-pre-perms"
+    done
+fi
+echo ""

--- a/scripts/security-audit.sh
+++ b/scripts/security-audit.sh
@@ -140,12 +140,10 @@ for port in $LISTENING_PORTS; do
     # - 80, 443: HTTP/HTTPS (Traefik)
     # - 22: SSH (hardened)
     # - 53: DNS (systemd-resolved)
-    # - 139, 445: SMB (internal file sharing)
     # - 631: CUPS (printing service)
     if [ "$port" -lt 1024 ] && \
        [ "$port" != "80" ] && [ "$port" != "443" ] && \
        [ "$port" != "22" ] && [ "$port" != "53" ] && \
-       [ "$port" != "139" ] && [ "$port" != "445" ] && \
        [ "$port" != "631" ]; then
         UNEXPECTED="$UNEXPECTED $port"
     fi

--- a/scripts/verify-permissions.sh
+++ b/scripts/verify-permissions.sh
@@ -1,0 +1,219 @@
+#!/bin/bash
+# verify-permissions.sh
+# Filesystem Permission Drift Detection
+#
+# Purpose: Verify the POSIX ACL-based permission model is intact
+# Run: ./scripts/verify-permissions.sh
+#
+# Exit codes: 0 = all pass, 1 = warnings, 2 = failures
+#
+# See: ADR-019 (Filesystem Permission Model)
+# Status: ACTIVE
+# Created: 2026-02-22
+
+set -euo pipefail
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Counters
+PASS=0
+WARN=0
+FAIL=0
+
+pass() { echo -e "${GREEN}✅ PASS:${NC} $1"; ((PASS++)) || true; }
+warn() { echo -e "${YELLOW}⚠️  WARN:${NC} $1"; ((WARN++)) || true; }
+fail() { echo -e "${RED}❌ FAIL:${NC} $1"; ((FAIL++)) || true; }
+info() { echo -e "${BLUE}ℹ️  INFO:${NC} $1"; }
+
+POOL="/mnt/btrfs-pool"
+NC_UID=100032  # Nextcloud www-data (container UID 33 + 100000 offset)
+DOWNLOADS="$POOL/subvol6-tmp/Downloads"
+
+echo ""
+echo -e "${BLUE}═══════════════════════════════════════════════${NC}"
+echo -e "${BLUE}     FILESYSTEM PERMISSION DRIFT DETECTION${NC}"
+echo -e "${BLUE}═══════════════════════════════════════════════${NC}"
+echo ""
+
+# ============================================================================
+# Check 1: Subvolume root ownership and mode
+# ============================================================================
+echo "[1] Checking subvolume ownership..."
+
+SUBVOLS=(subvol1-docs subvol2-pics subvol3-opptak subvol4-multimedia subvol5-music subvol6-tmp subvol7-containers)
+for sv in "${SUBVOLS[@]}"; do
+    SV_PATH="$POOL/$sv"
+    if [[ ! -d "$SV_PATH" ]]; then
+        warn "$sv not found"
+        continue
+    fi
+    OWNER=$(stat -c '%U:%G' "$SV_PATH")
+    PERMS=$(stat -c '%a' "$SV_PATH")
+    if [[ "$OWNER" == "patriark:patriark" ]] && [[ "$PERMS" == "755" ]]; then
+        pass "$sv: $OWNER mode $PERMS"
+    elif [[ "$OWNER" != "patriark:patriark" ]]; then
+        fail "$sv: owner is $OWNER (expected patriark:patriark)"
+    elif [[ "$PERMS" != "755" ]]; then
+        warn "$sv: mode is $PERMS (expected 755)"
+    fi
+done
+
+# ============================================================================
+# Check 2: POSIX ACLs on writable mounts
+# ============================================================================
+echo ""
+echo "[2] Checking POSIX ACLs for Nextcloud (user:$NC_UID)..."
+
+ACL_PATHS=(
+    "$POOL/subvol1-docs:subvol1-docs"
+    "$POOL/subvol2-pics:subvol2-pics"
+    "$DOWNLOADS:Downloads"
+)
+
+for entry in "${ACL_PATHS[@]}"; do
+    IFS=':' read -r path name <<< "$entry"
+    if [[ ! -d "$path" ]]; then
+        warn "$name not found"
+        continue
+    fi
+
+    # Check access ACL
+    ACCESS_ACL=$(getfacl -c "$path" 2>/dev/null | grep "^user:$NC_UID:" || true)
+    # Check default ACL
+    DEFAULT_ACL=$(getfacl -c "$path" 2>/dev/null | grep "^default:user:$NC_UID:" || true)
+
+    if [[ -n "$ACCESS_ACL" ]] && [[ -n "$DEFAULT_ACL" ]]; then
+        pass "$name: ACL access($ACCESS_ACL) + default($DEFAULT_ACL)"
+    elif [[ -n "$ACCESS_ACL" ]]; then
+        warn "$name: has access ACL but missing default ACL"
+    else
+        fail "$name: missing ACL for user:$NC_UID"
+    fi
+done
+
+# ============================================================================
+# Check 3: No world-writable directories
+# ============================================================================
+echo ""
+echo "[3] Checking for world-writable directories..."
+
+WORLD_WRITE=0
+for sv in subvol1-docs subvol2-pics subvol3-opptak subvol6-tmp; do
+    SV_PATH="$POOL/$sv"
+    [[ -d "$SV_PATH" ]] || continue
+    COUNT=$(find "$SV_PATH" -maxdepth 3 -type d -perm -o+w 2>/dev/null | wc -l)
+    if [[ "$COUNT" -gt 0 ]]; then
+        WORLD_WRITE=$((WORLD_WRITE + COUNT))
+        EXAMPLES=$(find "$SV_PATH" -maxdepth 3 -type d -perm -o+w 2>/dev/null | head -3 | tr '\n' ' ')
+        fail "$sv: $COUNT world-writable dirs (e.g. $EXAMPLES)"
+    fi
+done
+if [[ "$WORLD_WRITE" -eq 0 ]]; then
+    pass "No world-writable directories found"
+fi
+
+# ============================================================================
+# Check 4: No SGID directories on standardized subvolumes
+# ============================================================================
+echo ""
+echo "[4] Checking for SGID directories..."
+
+SGID_TOTAL=0
+for sv in subvol1-docs subvol2-pics subvol3-opptak; do
+    SV_PATH="$POOL/$sv"
+    [[ -d "$SV_PATH" ]] || continue
+    COUNT=$(find "$SV_PATH" -maxdepth 3 -type d -perm -g+s 2>/dev/null | wc -l)
+    if [[ "$COUNT" -gt 0 ]]; then
+        SGID_TOTAL=$((SGID_TOTAL + COUNT))
+        fail "$sv: $COUNT SGID directories found"
+    fi
+done
+if [[ "$SGID_TOTAL" -eq 0 ]]; then
+    pass "No SGID directories on subvol1/2/3"
+fi
+
+# ============================================================================
+# Check 5: Samba decommissioned
+# ============================================================================
+echo ""
+echo "[5] Checking Samba decommission state..."
+
+# Service state
+if systemctl is-active smb.service &>/dev/null; then
+    fail "Samba (smb.service) is running"
+elif systemctl is-enabled smb.service &>/dev/null; then
+    warn "Samba (smb.service) is stopped but still enabled"
+else
+    pass "Samba service stopped and disabled"
+fi
+
+# Firewall ports
+SMB_FW=false
+for fw_svc in samba samba-client; do
+    if sudo firewall-cmd --query-service="$fw_svc" --permanent &>/dev/null 2>&1; then
+        SMB_FW=true
+    fi
+done
+if $SMB_FW; then
+    fail "Samba firewall ports still open"
+else
+    pass "Samba firewall ports closed"
+fi
+
+# ============================================================================
+# Check 6: Nextcloud www-data write test
+# ============================================================================
+echo ""
+echo "[6] Checking Nextcloud write access..."
+
+if ! podman ps --format '{{.Names}}' 2>/dev/null | grep -q '^nextcloud$'; then
+    warn "Nextcloud container not running, skipping write tests"
+else
+    MOUNTS=(
+        "/external/user-documents:Documents"
+        "/external/user-photos:Photos"
+        "/external/downloads:Downloads"
+    )
+    for entry in "${MOUNTS[@]}"; do
+        IFS=':' read -r mount_path name <<< "$entry"
+        TEST_FILE="$mount_path/.perm-test-$$"
+        if podman exec -u www-data nextcloud touch "$TEST_FILE" 2>/dev/null && \
+           podman exec -u www-data nextcloud rm -f "$TEST_FILE" 2>/dev/null; then
+            pass "Nextcloud www-data can write to $name ($mount_path)"
+        else
+            fail "Nextcloud www-data cannot write to $name ($mount_path)"
+            # Clean up just in case touch succeeded but rm failed
+            podman exec nextcloud rm -f "$TEST_FILE" 2>/dev/null || true
+        fi
+    done
+fi
+
+# ============================================================================
+# Summary
+# ============================================================================
+echo ""
+echo -e "${BLUE}═══════════════════════════════════════════════${NC}"
+echo -e "${BLUE}                 SUMMARY${NC}"
+echo -e "${BLUE}═══════════════════════════════════════════════${NC}"
+echo ""
+echo -e "  ${GREEN}✅ Passed:${NC}  $PASS"
+echo -e "  ${YELLOW}⚠️  Warnings:${NC} $WARN"
+echo -e "  ${RED}❌ Failed:${NC}  $FAIL"
+echo ""
+
+# Exit code
+if [[ "$FAIL" -gt 0 ]]; then
+    echo -e "${RED}Permission check: FAILED${NC}"
+    exit 2
+elif [[ "$WARN" -gt 0 ]]; then
+    echo -e "${YELLOW}Permission check: WARNINGS${NC}"
+    exit 1
+else
+    echo -e "${GREEN}Permission check: PASSED${NC}"
+    exit 0
+fi


### PR DESCRIPTION
## Summary

- Decommission Samba (stop/disable services, close firewall ports 139/445, remove group membership)
- Standardize all BTRFS subvolumes to `patriark:patriark` 0755, replacing Samba-era `samba` group + SGID bits
- Replace world-writable Downloads (2777) with POSIX ACLs (`user:100032:rwx`)
- Add `scripts/optimize-permissions.sh` (sudo script with BTRFS snapshots) and `scripts/verify-permissions.sh` (drift detection)
- Document as ADR-019; supersede previous permission guide

## Context

Nextcloud SLO burn rate investigation traced 502 errors to external storage write failures. Root cause: `samba` GID (1001) has no rootless Podman subgid mapping, so Samba-era group ownership provided zero container access. Nextcloud's www-data (host UID 100032) fell into "others" (r-x only).

## Verification

All 9 service access tests passed post-migration:
- [x] Nextcloud www-data write: Documents, Photos, Downloads
- [x] Nextcloud www-data read: Multimedia, Music, Opptak
- [x] Immich read+write library
- [x] Jellyfin read media
- [x] Nextcloud file rescan complete
- [x] Health score: 95/100 (SSD at 75% — pre-existing)

## Test Plan

- [ ] Run `scripts/verify-permissions.sh` to confirm drift detection works
- [ ] Verify Nextcloud sync on mobile devices
- [ ] Monitor for permission errors in logs (24h observation)
- [ ] Clean up BTRFS snapshots after confidence period

🤖 Generated with [Claude Code](https://claude.com/claude-code)