### PR TITLE
fix: Make Immich external library mount read-write

### DIFF
--- a/docs/10-services/guides/immich-configuration-review.md
+++ b/docs/10-services/guides/immich-configuration-review.md
@@ -355,7 +355,7 @@ Traefik ❌ → postgresql-immich (blocked by network segmentation)
 
 | Data Type | Location | Correct? | Notes |
 |-----------|----------|----------|-------|
-| Photo library (read-only) | `/mnt/btrfs-pool/subvol3-opptak/immich/library` → `/mnt/media:ro` | ✅ Yes | External library, read-only |
+| Photo library (read-write) | `/mnt/btrfs-pool/subvol3-opptak/immich/library` → `/mnt/media` | ✅ Yes | External library, read-write (enables asset management) |
 | Upload/processing | `/mnt/btrfs-pool/subvol3-opptak/immich` → `/usr/src/app/upload` | ✅ Yes | Working directory, read-write |
 | PostgreSQL data | `/mnt/btrfs-pool/subvol7-containers/postgresql-immich` | 🟡 Verify NOCOW | Database on BTRFS |
 | Redis data | `/mnt/btrfs-pool/subvol7-containers/redis-immich` | ✅ Yes (NOCOW) | Cache, NOCOW enabled |
@@ -485,7 +485,7 @@ User=1000:1000
 ### Principle 3: Fail-Safe Defaults 🟡 PARTIAL
 
 **Good:**
-- External library mounted read-only ✅
+- External library mounted read-write (BTRFS snapshots provide safety net) ✅
 - Network segmentation prevents direct database access ✅
 - Health checks configured ✅
 
@@ -758,7 +758,7 @@ podman exec redis-immich valkey-cli CONFIG SET appendonly no  # Disable AOF
 
 **Tier 3: Photo Files (Important but Recoverable)**
 - Files are on BTRFS pool
-- External library is read-only (original files safe)
+- External library is read-write (Immich can manage assets; BTRFS snapshots protect against accidental deletion)
 - Uploaded photos in `/usr/src/app/upload` backed up via BTRFS snapshots
 
 **Tier 4: Off-Site (Future)**
@@ -1020,8 +1020,8 @@ Environment=UPLOAD_LOCATION=/usr/src/app/upload
 # Upload/processing directory (read-write)
 Volume=/mnt/btrfs-pool/subvol3-opptak/immich:/usr/src/app/upload:Z
 
-# External library (read-only to prevent accidental modification)
-Volume=/mnt/btrfs-pool/subvol3-opptak/immich/library:/mnt/media:ro,Z
+# External library (read-write - enables asset management via Immich UI)
+Volume=/mnt/btrfs-pool/subvol3-opptak/immich/library:/mnt/media:Z
 
 # ═══════════════════════════════════════════════
 # PORTS: Use Traefik exclusively (no PublishPort)

--- a/docs/AUTO-DEPENDENCY-GRAPH.md
+++ b/docs/AUTO-DEPENDENCY-GRAPH.md
@@ -1,6 +1,6 @@
 # Service Dependency Graph (Auto-Generated)
 
-**Generated:** 2026-02-22 06:02:05 UTC
+**Generated:** 2026-02-28 06:01:34 UTC
 **System:** fedora-htpc
 
 ---

--- a/docs/AUTO-DOCUMENTATION-INDEX.md
+++ b/docs/AUTO-DOCUMENTATION-INDEX.md
@@ -1,7 +1,7 @@
 # Documentation Index (Auto-Generated)
 
-**Generated:** 2026-02-22 06:02:06 UTC
-**Total Documents:** 392
+**Generated:** 2026-02-28 06:01:34 UTC
+**Total Documents:** 397
 
 ---
 
@@ -22,7 +22,7 @@
 
 ## Documentation by Category
 
-### 00-foundation/ (12 documents)
+### 00-foundation/ (13 documents)
 
 **Fundamentals and core concepts**
 
@@ -41,6 +41,7 @@
 - ADR-016: [2025-12-31-ADR-016-configuration-design-principles](00-foundation/decisions/2025-12-31-ADR-016-configuration-design-principles.md)
 - ADR-017: [2026-01-05-ADR-017-slash-commands-and-subagents](00-foundation/decisions/2026-01-05-ADR-017-slash-commands-and-subagents.md)
 - ADR-018: [2026-02-04-ADR-018-static-ip-multi-network-services](00-foundation/decisions/2026-02-04-ADR-018-static-ip-multi-network-services.md)
+- ADR-019: [2026-02-22-ADR-019-filesystem-permission-model](00-foundation/decisions/2026-02-22-ADR-019-filesystem-permission-model.md)
 
 ---
 
@@ -198,7 +199,7 @@
 
 ---
 
-### 98-journals/ (171 documents)
+### 98-journals/ (175 documents)
 
 **Chronological project history (append-only log)**
 
@@ -216,15 +217,20 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 
 ## Recently Updated (Last 7 Days)
 
-- 2026-02-15: [2026-02-15-community-tool-sharing-platform-architecture.md](98-journals/2026-02-15-community-tool-sharing-platform-architecture.md)
-- 2026-02-16: [2026-02-16-gnome-freeze-system-update.md](98-journals/2026-02-16-gnome-freeze-system-update.md)
-- 2026-02-16: [2026-02-16-post-reboot-handoff.md](98-journals/2026-02-16-post-reboot-handoff.md)
-- 2026-02-20: [2026-02-18-loose-ends-audit.md](98-journals/2026-02-18-loose-ends-audit.md)
-- 2026-02-16: [remediation-monthly-202601.md](99-reports/remediation-monthly-202601.md)
-- 2026-02-22: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
-- 2026-02-22: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
-- 2026-02-22: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
-- 2026-02-22: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
+- 2026-02-22: [2026-02-22-ADR-019-filesystem-permission-model.md](00-foundation/decisions/2026-02-22-ADR-019-filesystem-permission-model.md)
+- 2026-02-27: [automation-reference.md](20-operations/guides/automation-reference.md)
+- 2026-02-22: [permission-optimization-nextcloud.md](20-operations/guides/permission-optimization-nextcloud.md)
+- 2026-02-24: [slo-framework.md](40-monitoring-and-documentation/guides/slo-framework.md)
+- 2026-02-24: [2026-02-18-loose-ends-audit.md](98-journals/2026-02-18-loose-ends-audit.md)
+- 2026-02-22: [2026-02-22-filesystem-permission-optimization.md](98-journals/2026-02-22-filesystem-permission-optimization.md)
+- 2026-02-24: [2026-02-23-loose-ends-audit-review.md](98-journals/2026-02-23-loose-ends-audit-review.md)
+- 2026-02-26: [2026-02-26-slo-system-diagnostic-fixes.md](98-journals/2026-02-26-slo-system-diagnostic-fixes.md)
+- 2026-02-27: [2026-02-27-automation-audit-and-improvements.md](98-journals/2026-02-27-automation-audit-and-improvements.md)
+- 2026-02-22: [remediation-monthly-202601.md](99-reports/remediation-monthly-202601.md)
+- 2026-02-28: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
+- 2026-02-28: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
+- 2026-02-28: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
+- 2026-02-28: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
 
 ---
 

--- a/docs/AUTO-NETWORK-TOPOLOGY.md
+++ b/docs/AUTO-NETWORK-TOPOLOGY.md
@@ -1,6 +1,6 @@
 # Network Topology (Auto-Generated)
 
-**Generated:** 2026-02-22 06:02:01 UTC
+**Generated:** 2026-02-28 06:01:30 UTC
 **System:** fedora-htpc | **Networks:** 8 | **Containers:** 27
 
 ---

--- a/docs/AUTO-SERVICE-CATALOG.md
+++ b/docs/AUTO-SERVICE-CATALOG.md
@@ -1,6 +1,6 @@
 # Service Catalog (Auto-Generated)
 
-**Generated:** 2026-02-22 06:02:00 UTC
+**Generated:** 2026-02-28 06:01:30 UTC
 **System:** fedora-htpc | **Services:** 27/27 running | **Health:** 25/25 healthy (2 without healthcheck)
 
 ---
@@ -12,13 +12,13 @@
 | authelia | authelia/authelia:latest | ✅ healthy | 5d | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
 | crowdsec | crowdsecurity/crowdsec:latest | ✅ healthy | 5d | — | [guide](10-services/guides/crowdsec.md) |
 | redis-authelia | redis:7-alpine | ✅ healthy | 5d | — | — |
-| traefik | traefik:latest | ✅ healthy | 13h | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
+| traefik | traefik:latest | ✅ healthy | 5d | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
 
 ## Nextcloud (3)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| nextcloud-db | mariadb:11 | ✅ healthy | 4h | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-db | mariadb:11 | ✅ healthy | 5d | — | [guide](10-services/guides/nextcloud.md) |
 | nextcloud | nextcloud:latest | ✅ healthy | 5d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
 | nextcloud-redis | redis:7-alpine | ✅ healthy | 5d | — | [guide](10-services/guides/nextcloud.md) |
 
@@ -41,21 +41,21 @@
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| vaultwarden | vaultwarden/server:latest | ✅ healthy | 13h | [vault.patriark.org](https://vault.patriark.org) | — |
+| vaultwarden | vaultwarden/server:latest | ✅ healthy | 5d | [vault.patriark.org](https://vault.patriark.org) | — |
 
 ## Home Automation (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 4h | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
+| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 5d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
 | matter-server | home-assistant-libs/python-matter-server:stab | ✅ healthy | 5d | — | [guide](10-services/guides/matter-server.md) |
 
 ## Gathio (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| gathio-db | mongo:7 | ✅ healthy | 4h | — | — |
-| gathio | lowercasename/gathio:latest | ✅ healthy | 4h | [events.patriark.org](https://events.patriark.org) | — |
+| gathio-db | mongo:7 | ✅ healthy | 5d | — | — |
+| gathio | lowercasename/gathio:latest | ✅ healthy | 5d | [events.patriark.org](https://events.patriark.org) | — |
 
 ## Homepage (1)
 
@@ -68,14 +68,14 @@
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
 | alert-discord-relay | localhost/alert-discord-relay:latest | ✅ healthy | 5d | — | [guide](10-services/guides/alert-discord-relay.md) |
-| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ healthy | 13h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ healthy | 5d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
 | cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ healthy | 5d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| grafana | grafana/grafana:latest | ✅ healthy | 5d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| loki | grafana/loki:latest | — no check | 4h | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| grafana | grafana/grafana:latest | ✅ healthy | 4d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| loki | grafana/loki:latest | — no check | 5d | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
 | node_exporter | quay.io/prometheus/node-exporter:latest | ✅ healthy | 5d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 13h | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| promtail | grafana/promtail:latest | ✅ healthy | 4h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| unpoller | unpoller/unpoller:latest | — no check | 4h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 5d | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| promtail | grafana/promtail:latest | ✅ healthy | 5d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| unpoller | unpoller/unpoller:latest | — no check | 5d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
 
 ---
 
@@ -83,7 +83,7 @@
 
 - **Total Running:** 27
 - **Total Defined:** 27
-- **System Load:** 0,65, 0,43, 0,41
+- **System Load:** 0,86, 0,69, 0,62
 
 ---
 

--- a/quadlets/immich-server.container
+++ b/quadlets/immich-server.container
@@ -42,8 +42,8 @@ Environment=UPLOAD_LOCATION=/usr/src/app/upload
 # Storage - Photo library on BTRFS pool
 Volume=/mnt/btrfs-pool/subvol3-opptak/immich:/usr/src/app/upload:Z
 
-# NEW: Mount library folder to a DIFFERENT container path (outside /usr/src/app/upload)
-Volume=/mnt/btrfs-pool/subvol3-opptak/immich/library:/mnt/media:ro,Z
+# External library - read-write so Immich can manage (delete/move) assets directly
+Volume=/mnt/btrfs-pool/subvol3-opptak/immich/library:/mnt/media:Z
 
 # Hardware Acceleration - GPU access for VAAPI transcoding
 AddDevice=/dev/dri:/dev/dri


### PR DESCRIPTION
## Summary

- Remove `:ro` flag from Immich's `/mnt/media` external library mount, enabling Immich to manage (delete/move) assets directly through the UI
- Triggered by 8 corrupt 2006 Olympus camera assets that fail thumbnail generation every midnight, causing daily Discord alerts
- BTRFS snapshots on subvol3-opptak provide safety net against accidental deletion

## Changes

- `quadlets/immich-server.container`: `:ro,Z` → `:Z` on `/mnt/media` mount
- `docs/immich-configuration-review.md`: Updated 4 references to reflect read-write state and BTRFS snapshot safety rationale
- Auto-docs refreshed

## Verification

- ✅ Mount `RW: true` confirmed via `podman inspect`
- ✅ Write test passed (touch + rm inside container)
- ✅ Healthcheck passed
- ✅ No errors in post-restart logs

## Test Plan

- [x] Verify mount is read-write (`podman inspect`)
- [x] Write test inside container
- [x] Service healthy after restart
- [ ] Delete one of the 8 corrupt Olympus assets via Immich UI
- [ ] Confirm nightly thumbnail job completes without errors (next midnight run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)