### PR TITLE
feat: Deploy Audiobookshelf and Navidrome audio services

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,9 +6,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 A learning-focused homelab project building production-ready, self-hosted infrastructure using Podman containers managed through systemd quadlets. Platform: Fedora Workstation 43.
 
-**Current Services (27 containers, 13 service groups):**
+**Current Services (29 containers, 15 service groups):**
 - **Core Infrastructure:** Traefik (reverse proxy), CrowdSec (threat intel), Authelia + Redis (SSO + YubiKey MFA)
 - **Applications:** Nextcloud + MariaDB + Redis (file sync), Vaultwarden (passwords), Jellyfin (media), Immich + PostgreSQL + Redis + ML (photos), Gathio + MongoDB (events), Homepage (dashboard)
+- **Audio:** Audiobookshelf (audiobooks/podcasts), Navidrome (music streaming)
 - **Home Automation:** Home Assistant + Matter Server (smart home, Plejd integration planned)
 - **Monitoring:** Prometheus, Grafana, Loki, Alertmanager, Promtail, cAdvisor, Node Exporter, UnPoller, Alert Discord Relay
 
@@ -336,11 +337,11 @@ systemctl --user is-active alertmanager.service  # Alert routing
 systemctl --user is-active grafana.service       # Monitoring dashboard
 ```
 
-**Expected Resource Usage (27 containers, measured February 2026):**
-- **Memory:** Total ~4-5GB | Jellyfin: ~200MB idle / 500MB-1GB transcoding | Prometheus: ~300MB | Loki: ~200MB | Grafana: ~200MB | Traefik: ~80MB | Immich-server: ~350MB | Nextcloud: ~200MB
+**Expected Resource Usage (29 containers, measured February 2026):**
+- **Memory:** Total ~4-5GB | Jellyfin: ~200MB idle / 500MB-1GB transcoding | Prometheus: ~300MB | Loki: ~200MB | Grafana: ~200MB | Traefik: ~80MB | Immich-server: ~350MB | Nextcloud: ~200MB | Audiobookshelf: ~200MB | Navidrome: ~200MB
 - **CPU:** Idle: >90% | Normal: 2-5% | Transcoding: 50-80% (normal spike)
 - **Disk:** System SSD: <70% normal (⚠️ >75%, 🚨 >85%) | BTRFS pool: ~73% used (4TB free of 14.5TB)
-- **Swap:** ~1GB typical (normal for long-running services with 27 containers)
+- **Swap:** ~1GB typical (normal for long-running services with 29 containers)
 
 **Health Checks:**
 ```bash

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -105,6 +105,14 @@ scrape_configs:
   # Nextcloud monitoring removed - ServerInfo endpoint requires auth
   # Nextcloud availability monitored via Traefik metrics (SLO recording rules)
 
+  # Navidrome - Music Streaming Server (native Prometheus metrics)
+  - job_name: 'navidrome'
+    static_configs:
+      - targets: ['navidrome:4533']
+        labels:
+          instance: 'fedora-htpc'
+          service: 'navidrome'
+
   # Home Assistant - Home Automation Hub
   - job_name: 'home-assistant'
     static_configs:

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -106,9 +106,11 @@ scrape_configs:
   # Nextcloud availability monitored via Traefik metrics (SLO recording rules)
 
   # Navidrome - Music Streaming Server (native Prometheus metrics)
+  # Static IP: Navidrome is multi-network (reverse_proxy + monitoring).
+  # Hostname resolution via aardvark-dns may return the wrong IP (ADR-018).
   - job_name: 'navidrome'
     static_configs:
-      - targets: ['navidrome:4533']
+      - targets: ['10.89.4.75:4533']
         labels:
           instance: 'fedora-htpc'
           service: 'navidrome'

--- a/config/traefik/dynamic/routers.yml
+++ b/config/traefik/dynamic/routers.yml
@@ -192,6 +192,36 @@ http:
       tls:
         certResolver: letsencrypt
 
+    # Audiobookshelf - Uses native authentication (no Authelia SSO)
+    # iOS app (abs) and web UI use Audiobookshelf's built-in auth
+    audiobookshelf-secure:
+      rule: "Host(`audiobookshelf.patriark.org`)"
+      service: "audiobookshelf"
+      entryPoints:
+        - websecure
+      middlewares:
+        - crowdsec-bouncer@file
+        - rate-limit-public@file
+        - compression@file
+        - security-headers@file
+      tls:
+        certResolver: letsencrypt
+
+    # Navidrome - Uses native authentication (no Authelia SSO)
+    # Subsonic-compatible clients and web UI use Navidrome's built-in auth
+    navidrome-secure:
+      rule: "Host(`musikk.patriark.org`)"
+      service: "navidrome"
+      entryPoints:
+        - websecure
+      middlewares:
+        - crowdsec-bouncer@file
+        - rate-limit-public@file
+        - compression@file
+        - security-headers@file
+      tls:
+        certResolver: letsencrypt
+
   services:
     homepage:
       loadBalancer:
@@ -249,6 +279,16 @@ http:
       loadBalancer:
         servers:
           - url: "http://home-assistant:8123"
+
+    audiobookshelf:
+      loadBalancer:
+        servers:
+          - url: "http://audiobookshelf:80"
+
+    navidrome:
+      loadBalancer:
+        servers:
+          - url: "http://navidrome:4533"
 
   middlewares:
     # CalDAV/.well-known redirects for Nextcloud

--- a/config/traefik/dynamic/routers.yml
+++ b/config/traefik/dynamic/routers.yml
@@ -209,8 +209,9 @@ http:
 
     # Navidrome - Uses native authentication (no Authelia SSO)
     # Subsonic-compatible clients and web UI use Navidrome's built-in auth
+    # Block /metrics from public access (Prometheus scrapes direct via monitoring network)
     navidrome-secure:
-      rule: "Host(`musikk.patriark.org`)"
+      rule: "Host(`musikk.patriark.org`) && !PathPrefix(`/metrics`)"
       service: "navidrome"
       entryPoints:
         - websecure

--- a/config/traefik/hosts
+++ b/config/traefik/hosts
@@ -21,6 +21,8 @@
 # Media & Collaboration
 10.89.2.13  jellyfin
 10.89.2.14  nextcloud
+10.89.2.74  audiobookshelf
+10.89.2.75  navidrome
 
 # Photos & Events
 10.89.2.12  immich-server

--- a/docs/98-journals/2026-02-28-audiobookshelf-navidrome-deployment.md
+++ b/docs/98-journals/2026-02-28-audiobookshelf-navidrome-deployment.md
@@ -1,0 +1,164 @@
+# Deploy Audiobookshelf + Navidrome
+
+**Date:** 2026-02-28
+**Scope:** Two new self-hosted audio services — audiobooks/podcasts + music streaming
+**Result:** 27 → 29 containers, both healthy, libraries scanning
+
+---
+
+## Motivation
+
+Three audio use cases had no self-hosted solution:
+- **Audiobooks** — large Norwegian audiobook collection sitting unused on disk
+- **Podcasts** — existing archive (Podder) plus new downloads
+- **Music streaming** — 1.1TB music library only accessible via Jellyfin (wrong tool for the job)
+
+After evaluating alternatives, selected **Audiobookshelf** (audiobooks + podcasts, single container, excellent iOS app) and **Navidrome** (music, Subsonic-compatible, native Prometheus metrics).
+
+Secondary goal: **test the deploy-from-pattern skill** in dry-run mode to document gaps.
+
+---
+
+## Architecture Decisions
+
+### Network topology
+- **Audiobookshelf:** `reverse_proxy` only — standalone SQLite service, no inter-service communication, no metrics endpoint. Matches Vaultwarden pattern.
+- **Navidrome:** `reverse_proxy` + `monitoring` — has native Prometheus metrics (`ND_PROMETHEUS_ENABLED`), needs scraping from monitoring network.
+
+### Static IPs
+| Service | reverse_proxy | monitoring |
+|---|---|---|
+| Audiobookshelf | 10.89.2.74 | — |
+| Navidrome | 10.89.2.75 | 10.89.4.75 |
+
+### Authentication
+Both use native auth (no Authelia) — same pattern as Jellyfin, Immich, Nextcloud. Mobile apps (Subsonic clients, ABS iOS app) need direct auth without SSO redirect.
+
+### Middleware chain
+```
+crowdsec-bouncer → rate-limit-public → compression → security-headers
+```
+Matches Jellyfin pattern.
+
+### SELinux labels
+- `:Z` for exclusive container data (config, metadata, database)
+- `:ro,z` for shared read-only media libraries
+- `:z` for writable shared directories (podcast downloads)
+
+---
+
+## Implementation
+
+### Files created
+- `quadlets/audiobookshelf.container` — symlinked to `~/.config/containers/systemd/`
+- `quadlets/navidrome.container` — symlinked to `~/.config/containers/systemd/`
+
+### Files modified
+- `config/traefik/hosts` — added 2 host entries (audiobookshelf, navidrome)
+- `config/traefik/dynamic/routers.yml` — added 2 routers + 2 services
+- `config/prometheus/prometheus.yml` — added navidrome scrape job
+
+### Directories created (BTRFS)
+```
+/mnt/btrfs-pool/subvol7-containers/audiobookshelf/config    (NOCOW)
+/mnt/btrfs-pool/subvol7-containers/audiobookshelf/metadata   (NOCOW)
+/mnt/btrfs-pool/subvol7-containers/navidrome                 (NOCOW)
+/mnt/btrfs-pool/subvol4-multimedia/audiobookshelf            (podcast downloads)
+```
+
+---
+
+## Issues Found and Fixed
+
+### 1. Audiobookshelf listens on port 80, not 13378
+
+The ABS documentation says default port is 13378, but the Docker image sets `PORT=80` internally. Logs confirmed: `Listening on port :80`. Fixed Traefik service URL and healthcheck accordingly.
+
+### 2. No curl in official ABS image
+
+Healthcheck `curl -f ... || exit 1` would fail silently. Switched to `wget --no-verbose --tries=1 --spider` which is available in the image.
+
+### 3. Navidrome has no `/api/ping` endpoint
+
+The plan assumed `/api/ping` existed — it returns 404. The Subsonic API at `/rest/ping` requires auth parameters. Root `/` returns 200 (or 302 for unauthenticated). Used `wget --spider http://127.0.0.1:4533/` for healthcheck.
+
+### 4. wget resolves localhost to IPv6 first
+
+Initial healthchecks connected to `[::1]` which returned connection refused (services bind to IPv4 only inside containers). Fixed by using `127.0.0.1` explicitly in all healthcheck URLs.
+
+### 5. Library paths are container paths, not host paths
+
+User initially added host paths (`/mnt/btrfs-pool/subvol4-multimedia/Lydbøker`) in ABS UI. Libraries showed empty because those paths don't exist inside the container. Correct paths are the mount destinations from the quadlet: `/audiobooks`, `/ebooks`, `/podcasts-archive`, `/podcasts`.
+
+---
+
+## Deploy-from-Pattern Skill Gap Analysis
+
+Ran `deploy-from-pattern.sh --dry-run` for both services using `media-server-stack` pattern. The test revealed significant gaps between the pattern system and real deployment needs.
+
+### What the pattern got right
+- Traefik route template structure (router + service, native auth comment)
+- Service naming convention (`{service}-secure`)
+- TLS with letsencrypt certResolver
+- General quadlet structure (Unit, Container, Service, Install sections)
+
+### What the pattern got wrong
+
+| Gap | Pattern output | Actual need |
+|---|---|---|
+| **Image** | `docker.io/jellyfin/jellyfin:latest` (hardcoded) | Service-specific image |
+| **Port** | 8080 (template default) | 80 (ABS), 4533 (Navidrome) |
+| **Networks** | Always 3 (reverse_proxy, media_services, monitoring) | 1 for ABS, 2 for Navidrome |
+| **Volumes** | 2 generic mounts, hardcoded `:Z` | 6 mounts for ABS with mixed labels |
+| **Middleware** | `rate-limit@file` | `rate-limit-public@file` + `compression@file` |
+| **Health endpoint** | `/health` (Jellyfin) | `/healthcheck` (ABS), `/` (Navidrome) |
+| **Template vars** | `{{SERVICE_DESCRIPTION}}`, `{{DOCS_URL}}` unresolved | Should have defaults or be required |
+| **Quadlet location** | Copies directly to `~/.config/containers/systemd/` | Should use `quadlets/` + symlink |
+| **Env vars** | Only `TZ` + Jellyfin-specific | Each service needs unique env vars |
+
+### Root cause
+
+The pattern system is **Jellyfin-shaped** — designed around one specific deployment and insufficiently parameterized. The `media-server-stack` pattern is really a "Jellyfin deployment template" rather than a generic media server pattern.
+
+### Recommendations for improvement
+1. **Separate image from pattern** — `--image` flag exists but the template still contains Jellyfin's image
+2. **Make port a required variable** — no sensible default across services
+3. **Network count should be configurable** — pattern should specify minimum required networks, not fixed list
+4. **Volume specification needs a DSL** — `--var volume.1=/host:/container:label` or a YAML override file
+5. **Health endpoint must be per-service** — add `--health-path` and `--health-port` flags
+6. **Template variable validation** — fail on unresolved `{{variables}}` instead of leaving them in output
+7. **Respect quadlet symlink convention** — generate in `quadlets/`, symlink to systemd dir
+
+---
+
+## Verification Results
+
+| Check | Result |
+|---|---|
+| Container health | Both healthy |
+| Static IPs | 10.89.2.74 (ABS), 10.89.2.75 + 10.89.4.75 (Navidrome) |
+| Traefik DNS | Both resolve to reverse_proxy IPs |
+| Routing | ABS: 200, Navidrome: 302 (redirect to login) |
+| TLS | Default cert (ACME port forwarding issue — pre-existing, all services) |
+| Logs | No errors |
+| Prometheus | Navidrome target UP |
+| Traefik routers | Both loaded (`@file`) |
+| SELinux | No denials, existing services unaffected |
+| Existing services | Jellyfin + Nextcloud still healthy (shared `:ro,z` mounts) |
+
+---
+
+## Post-Deployment State
+
+- **Container count:** 29 (was 27)
+- **Service groups:** 15 (was 13)
+- **Audiobookshelf:** v2.32.1, scanning audiobooks/ebooks/podcasts
+- **Navidrome:** v0.60.3, scanning 1.1TB music library
+- **Estimated additional RAM:** ~200MB per service at idle
+- **Next available static IP:** .76
+
+---
+
+## Pre-Existing Issue Noted
+
+Traefik ACME certificate renewal is failing for **all** domains with "Timeout during connect (likely firewall problem)". Port forwarding to port 80 appears to be blocked upstream. This is not related to this deployment but should be investigated.

--- a/quadlets/audiobookshelf.container
+++ b/quadlets/audiobookshelf.container
@@ -18,6 +18,7 @@ Wants=network-online.target traefik.service
 [Container]
 Image=ghcr.io/advplyr/audiobookshelf:latest
 ContainerName=audiobookshelf
+HostName=audiobookshelf
 AutoUpdate=registry
 
 # Network (single network - standalone service, no inter-service communication)
@@ -57,6 +58,7 @@ RestartSec=10s
 # Resource Limits
 MemoryMax=2G
 MemoryHigh=1600M
+MemorySwapMax=1G
 
 # ═══════════════════════════════════════════════════════════
 # INSTALLATION

--- a/quadlets/audiobookshelf.container
+++ b/quadlets/audiobookshelf.container
@@ -26,6 +26,7 @@ Network=systemd-reverse_proxy:ip=10.89.2.74
 
 # Environment
 Environment=TZ=Europe/Oslo
+Environment=PORT=80
 
 # Config & metadata (exclusive - NOCOW for SQLite)
 Volume=/mnt/btrfs-pool/subvol7-containers/audiobookshelf/config:/config:Z

--- a/quadlets/audiobookshelf.container
+++ b/quadlets/audiobookshelf.container
@@ -1,0 +1,65 @@
+# ~/.config/containers/systemd/audiobookshelf.container
+# Audiobookshelf - Self-hosted Audiobook & Podcast Server
+# Created: 2026-02-28
+# Documentation: https://www.audiobookshelf.org/docs
+
+# ═══════════════════════════════════════════════════════════
+# DEPENDENCIES
+# ═══════════════════════════════════════════════════════════
+[Unit]
+Description=Audiobookshelf Audiobook & Podcast Server
+Documentation=https://github.com/advplyr/audiobookshelf
+After=network-online.target traefik.service
+Wants=network-online.target traefik.service
+
+# ═══════════════════════════════════════════════════════════
+# CONTAINER CONFIGURATION
+# ═══════════════════════════════════════════════════════════
+[Container]
+Image=ghcr.io/advplyr/audiobookshelf:latest
+ContainerName=audiobookshelf
+AutoUpdate=registry
+
+# Network (single network - standalone service, no inter-service communication)
+Network=systemd-reverse_proxy:ip=10.89.2.74
+
+# Environment
+Environment=TZ=Europe/Oslo
+
+# Config & metadata (exclusive - NOCOW for SQLite)
+Volume=/mnt/btrfs-pool/subvol7-containers/audiobookshelf/config:/config:Z
+Volume=/mnt/btrfs-pool/subvol7-containers/audiobookshelf/metadata:/metadata:Z
+
+# Media libraries (shared read-only)
+Volume=/mnt/btrfs-pool/subvol4-multimedia/Lydbøker:/audiobooks:ro,z
+Volume=/mnt/btrfs-pool/subvol4-multimedia/Bøker:/ebooks:ro,z
+Volume=/mnt/btrfs-pool/subvol4-multimedia/Podder:/podcasts-archive:ro,z
+
+# Podcast downloads (writable, shared context under multimedia)
+Volume=/mnt/btrfs-pool/subvol4-multimedia/audiobookshelf:/podcasts:z
+
+# Health check (no curl in official image, use wget)
+HealthCmd=wget --no-verbose --tries=1 --spider http://127.0.0.1:80/healthcheck || exit 1
+HealthInterval=30s
+HealthTimeout=5s
+HealthRetries=3
+HealthStartPeriod=30s
+
+# ═══════════════════════════════════════════════════════════
+# SERVICE BEHAVIOR
+# ═══════════════════════════════════════════════════════════
+[Service]
+Slice=container.slice
+Restart=on-failure
+TimeoutStartSec=300
+RestartSec=10s
+
+# Resource Limits
+MemoryMax=2G
+MemoryHigh=1600M
+
+# ═══════════════════════════════════════════════════════════
+# INSTALLATION
+# ═══════════════════════════════════════════════════════════
+[Install]
+WantedBy=default.target

--- a/quadlets/navidrome.container
+++ b/quadlets/navidrome.container
@@ -18,6 +18,7 @@ Wants=network-online.target traefik.service
 [Container]
 Image=docker.io/deluan/navidrome:latest
 ContainerName=navidrome
+HostName=navidrome
 AutoUpdate=registry
 
 # Networks (reverse_proxy FIRST for internet access, monitoring for Prometheus scraping)

--- a/quadlets/navidrome.container
+++ b/quadlets/navidrome.container
@@ -34,6 +34,7 @@ Environment=ND_PROMETHEUS_ENABLED=true
 Environment=ND_LOGLEVEL=info
 
 # Last.fm scrobbling (podman secrets, type=env)
+# Note: secrets must exist before starting (podman secret create navidrome_lastfm_apikey -)
 Secret=navidrome_lastfm_apikey,type=env,target=ND_LASTFM_APIKEY
 Secret=navidrome_lastfm_secret,type=env,target=ND_LASTFM_SECRET
 

--- a/quadlets/navidrome.container
+++ b/quadlets/navidrome.container
@@ -1,0 +1,65 @@
+# ~/.config/containers/systemd/navidrome.container
+# Navidrome - Self-hosted Music Streaming Server
+# Created: 2026-02-28
+# Documentation: https://www.navidrome.org/docs
+
+# ═══════════════════════════════════════════════════════════
+# DEPENDENCIES
+# ═══════════════════════════════════════════════════════════
+[Unit]
+Description=Navidrome Music Streaming Server
+Documentation=https://github.com/navidrome/navidrome
+After=network-online.target traefik.service
+Wants=network-online.target traefik.service
+
+# ═══════════════════════════════════════════════════════════
+# CONTAINER CONFIGURATION
+# ═══════════════════════════════════════════════════════════
+[Container]
+Image=docker.io/deluan/navidrome:latest
+ContainerName=navidrome
+AutoUpdate=registry
+
+# Networks (reverse_proxy FIRST for internet access, monitoring for Prometheus scraping)
+Network=systemd-reverse_proxy:ip=10.89.2.75
+Network=systemd-monitoring:ip=10.89.4.75
+
+# Environment
+Environment=TZ=Europe/Oslo
+Environment=ND_MUSICFOLDER=/music
+Environment=ND_DATAFOLDER=/data
+Environment=ND_SCANSCHEDULE=1h
+Environment=ND_PROMETHEUS_ENABLED=true
+Environment=ND_LOGLEVEL=info
+
+# Data directory (exclusive - NOCOW for SQLite)
+Volume=/mnt/btrfs-pool/subvol7-containers/navidrome:/data:Z
+
+# Music library (shared read-only)
+Volume=/mnt/btrfs-pool/subvol5-music:/music:ro,z
+
+# Health check
+HealthCmd=wget --no-verbose --tries=1 --spider http://127.0.0.1:4533/ || exit 1
+HealthInterval=30s
+HealthTimeout=5s
+HealthRetries=3
+HealthStartPeriod=30s
+
+# ═══════════════════════════════════════════════════════════
+# SERVICE BEHAVIOR
+# ═══════════════════════════════════════════════════════════
+[Service]
+Slice=container.slice
+Restart=on-failure
+TimeoutStartSec=300
+RestartSec=10s
+
+# Resource Limits
+MemoryMax=1G
+MemoryHigh=800M
+
+# ═══════════════════════════════════════════════════════════
+# INSTALLATION
+# ═══════════════════════════════════════════════════════════
+[Install]
+WantedBy=default.target

--- a/quadlets/navidrome.container
+++ b/quadlets/navidrome.container
@@ -32,6 +32,10 @@ Environment=ND_SCANSCHEDULE=1h
 Environment=ND_PROMETHEUS_ENABLED=true
 Environment=ND_LOGLEVEL=info
 
+# Last.fm scrobbling (podman secrets, type=env)
+Secret=navidrome_lastfm_apikey,type=env,target=ND_LASTFM_APIKEY
+Secret=navidrome_lastfm_secret,type=env,target=ND_LASTFM_SECRET
+
 # Data directory (exclusive - NOCOW for SQLite)
 Volume=/mnt/btrfs-pool/subvol7-containers/navidrome:/data:Z
 

--- a/quadlets/navidrome.container
+++ b/quadlets/navidrome.container
@@ -63,6 +63,7 @@ RestartSec=10s
 # Resource Limits
 MemoryMax=1G
 MemoryHigh=800M
+MemorySwapMax=512M
 
 # ═══════════════════════════════════════════════════════════
 # INSTALLATION


### PR DESCRIPTION
## Summary

- Deploy **Audiobookshelf** (audiobooks, ebooks, podcasts) at `audiobookshelf.patriark.org`
- Deploy **Navidrome** (music streaming) at `musikk.patriark.org`
- Add Prometheus scrape config for Navidrome metrics
- Test deploy-from-pattern skill (dry-run) and document gaps

Container count: 27 → 29 | Service groups: 13 → 15

## Deployment Details

| Service | Image | Networks | Memory | Static IP |
|---|---|---|---|---|
| Audiobookshelf | ghcr.io/advplyr/audiobookshelf:latest | reverse_proxy | 2G/1600M | 10.89.2.74 |
| Navidrome | docker.io/deluan/navidrome:latest | reverse_proxy + monitoring | 1G/800M | 10.89.2.75, 10.89.4.75 |

**Middleware chain (both):** crowdsec-bouncer → rate-limit-public → compression → security-headers
**Auth:** Native (no Authelia) — mobile apps need direct auth

## Issues Found During Deployment

1. **ABS port is 80** (not 13378) — Docker image overrides default
2. **No curl in ABS image** — healthcheck uses wget
3. **Navidrome `/api/ping` returns 404** — use root `/` for healthcheck
4. **wget resolves localhost to IPv6** — use 127.0.0.1 explicitly
5. **Library paths must be container paths** in ABS UI (e.g. `/audiobooks` not host path)

## Pattern Skill Gap Analysis

Dry-run of `deploy-from-pattern.sh` revealed the media-server-stack pattern is Jellyfin-shaped:
- Hardcoded image, port, 3 networks, volume structure
- Unresolved template variables (`{{SERVICE_DESCRIPTION}}`, etc.)
- No support for mixed SELinux labels or per-service middleware
- Full analysis in journal entry

## Verification

- [x] Both containers healthy (`podman healthcheck run`)
- [x] Static IPs correct (10.89.2.74, 10.89.2.75)
- [x] Traefik DNS resolves to reverse_proxy IPs
- [x] Routing: ABS returns 200, Navidrome returns 302 (login redirect)
- [x] Navidrome Prometheus target UP
- [x] No SELinux denials
- [x] Existing services (Jellyfin, Nextcloud) unaffected by shared `:ro,z` mounts
- [x] Both services scanning libraries successfully

## Test Plan

- [ ] Verify Audiobookshelf accessible at https://audiobookshelf.patriark.org
- [ ] Verify Navidrome accessible at https://musikk.patriark.org
- [ ] Confirm audiobook/ebook/podcast libraries populated after scan
- [ ] Confirm music library populated after scan (~1.1TB, 30-60 min)
- [ ] Test Subsonic client connectivity to Navidrome
- [ ] Verify Navidrome metrics in Grafana Explore
- [ ] Monitor logs for errors (24h observation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)