### PR TITLE
feat: Add SLO monitoring for audio services and fix deploy-from-pattern gaps

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -313,7 +313,7 @@ systemctl --user restart authelia.service
 
 ### SLO Monitoring
 
-**9 SLOs across 5 services.** Full targets, queries, and dashboard: `docs/40-monitoring-and-documentation/guides/slo-framework.md`
+**13 SLOs across 8 services.** Full targets, queries, and dashboard: `docs/40-monitoring-and-documentation/guides/slo-framework.md`
 
 ```bash
 # Dashboard: https://grafana.patriark.org/d/slo-dashboard
@@ -566,7 +566,7 @@ due to [reason for change].
 - Dependency management: `docs/20-operations/guides/dependency-management.md`
 
 **Monitoring & Security:**
-- SLO framework: `docs/40-monitoring-and-documentation/guides/slo-framework.md` (9 SLOs)
+- SLO framework: `docs/40-monitoring-and-documentation/guides/slo-framework.md` (13 SLOs)
 - Monitoring stack: `docs/40-monitoring-and-documentation/guides/monitoring-stack.md`
 - Loki queries: `docs/40-monitoring-and-documentation/guides/loki-remediation-queries.md`
 - Security guides: `docs/30-security/guides/` (7 guides + 5 runbooks)

--- a/config/grafana/provisioning/dashboards/json/slo-dashboard.json
+++ b/config/grafana/provisioning/dashboards/json/slo-dashboard.json
@@ -141,6 +141,24 @@
           "expr": "error_budget:home_assistant:availability:budget_remaining * 100",
           "legendFormat": "Home Assistant",
           "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "error_budget:navidrome:availability:budget_remaining * 100",
+          "legendFormat": "Navidrome",
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "error_budget:audiobookshelf:availability:budget_remaining * 100",
+          "legendFormat": "Audiobookshelf",
+          "refId": "H"
         }
       ],
       "title": "Error Budget Remaining (30-day window)",
@@ -183,7 +201,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 7,
         "w": 12,
         "x": 0,
         "y": 8
@@ -259,6 +277,24 @@
           "expr": "sli:home_assistant:availability:ratio * 100",
           "legendFormat": "Home Assistant",
           "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "sli:navidrome:availability:ratio * 100",
+          "legendFormat": "Navidrome",
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "sli:audiobookshelf:availability:ratio * 100",
+          "legendFormat": "Audiobookshelf",
+          "refId": "H"
         }
       ],
       "title": "Current Availability (5m window)",
@@ -303,7 +339,7 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 6,
+        "h": 7,
         "w": 12,
         "x": 12,
         "y": 8
@@ -379,6 +415,24 @@
           "expr": "burn_rate:home_assistant:availability:1h",
           "legendFormat": "Home Assistant (1h)",
           "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "burn_rate:navidrome:availability:1h",
+          "legendFormat": "Navidrome (1h)",
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "burn_rate:audiobookshelf:availability:1h",
+          "legendFormat": "Audiobookshelf (1h)",
+          "refId": "H"
         }
       ],
       "title": "Current Burn Rate (1-hour window)",
@@ -453,7 +507,7 @@
         "h": 8,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 15
       },
       "id": 4,
       "options": {
@@ -526,6 +580,24 @@
           "expr": "sli:home_assistant:availability:ratio * 100",
           "legendFormat": "Home Assistant (Target: 99.5%)",
           "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "sli:navidrome:availability:ratio * 100",
+          "legendFormat": "Navidrome (Target: 99.5%)",
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "sli:audiobookshelf:availability:ratio * 100",
+          "legendFormat": "Audiobookshelf (Target: 99.5%)",
+          "refId": "H"
         }
       ],
       "title": "Service Availability Trend",
@@ -593,7 +665,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 22
+        "y": 23
       },
       "id": 5,
       "options": {
@@ -717,7 +789,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 22
+        "y": 23
       },
       "id": 6,
       "options": {
@@ -790,6 +862,24 @@
           "expr": "error_budget:home_assistant:availability:budget_remaining * 100",
           "legendFormat": "Home Assistant",
           "refId": "F"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "error_budget:navidrome:availability:budget_remaining * 100",
+          "legendFormat": "Navidrome",
+          "refId": "G"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "error_budget:audiobookshelf:availability:budget_remaining * 100",
+          "legendFormat": "Audiobookshelf",
+          "refId": "H"
         }
       ],
       "title": "Error Budget Consumption (7-day trend)",

--- a/config/prometheus/alerts/slo-multiwindow-alerts.yml
+++ b/config/prometheus/alerts/slo-multiwindow-alerts.yml
@@ -632,3 +632,209 @@ groups:
           tier: "4"
         annotations:
           summary: "ℹ️ Nextcloud error budget trending above baseline"
+
+  # ===========================================================================
+  # NAVIDROME - Multi-Window Burn Rate Alerts
+  # Music streaming service with native auth
+  # ===========================================================================
+  - name: slo_multiwindow_navidrome
+    interval: 1m
+    rules:
+      # TIER 1: CRITICAL - Fast Burn (Page immediately)
+      - alert: SLOBurnRateTier1_Navidrome
+        expr: |
+          (
+            burn_rate:navidrome:availability:1h > 14.4
+            and
+            burn_rate:navidrome:availability:5m > 14.4
+          )
+          and
+          (time() - process_start_time_seconds{job="prometheus"} > 3600)
+        for: 2m
+        labels:
+          severity: critical
+          component: slo
+          service: navidrome
+          slo: availability
+          tier: "1"
+          burn_rate: "fast"
+        annotations:
+          summary: "🚨 CRITICAL: Navidrome error budget burning at 14.4x normal rate"
+          description: |
+            **IMMEDIATE ACTION REQUIRED**
+
+            Navidrome music streaming is degrading rapidly. Error budget exhausts in <3 hours.
+
+            - Burn Rate (1h): {{ $value | humanize }}x
+            - Budget Remaining: {{ query "error_budget:navidrome:availability:budget_remaining * 100" | first | value | humanize }}%
+
+            Action: systemctl --user status navidrome.service && podman logs navidrome --tail 100
+
+      # TIER 2: WARNING
+      - alert: SLOBurnRateTier2_Navidrome
+        expr: |
+          (
+            burn_rate:navidrome:availability:6h > 6
+            and
+            burn_rate:navidrome:availability:30m > 6
+          )
+          and
+          (time() - process_start_time_seconds{job="prometheus"} > 21600)
+        for: 15m
+        labels:
+          severity: warning
+          component: slo
+          service: navidrome
+          slo: availability
+          tier: "2"
+          burn_rate: "medium"
+        annotations:
+          summary: "⚠️ Navidrome error budget burning at 6x normal rate"
+          description: "Budget exhausts in <1 day. Burn: {{ $value | humanize }}x, Remaining: {{ query \"error_budget:navidrome:availability:budget_remaining * 100\" | first | value | humanize }}%"
+
+      # TIER 3: WARNING
+      - alert: SLOBurnRateTier3_Navidrome
+        expr: |
+          (
+            burn_rate:navidrome:availability:1d > 3
+            and
+            burn_rate:navidrome:availability:2h > 3
+          )
+          and
+          (time() - process_start_time_seconds{job="prometheus"} > 86400)
+        for: 1h
+        labels:
+          severity: warning
+          component: slo
+          service: navidrome
+          slo: availability
+          tier: "3"
+          burn_rate: "slow"
+        annotations:
+          summary: "📊 Navidrome error budget burning at 3x normal rate"
+          description: "Budget exhausts in <1 week. Trend monitoring needed."
+
+      # TIER 4: INFO
+      - alert: SLOBurnRateTier4_Navidrome
+        expr: |
+          (
+            burn_rate:navidrome:availability:3d > 1.5
+            and
+            burn_rate:navidrome:availability:1d > 1.5
+          )
+          and
+          (time() - process_start_time_seconds{job="prometheus"} > 259200)
+        for: 6h
+        labels:
+          severity: info
+          component: slo
+          service: navidrome
+          slo: availability
+          tier: "4"
+          burn_rate: "minimal"
+        annotations:
+          summary: "ℹ️ Navidrome error budget trending above baseline"
+          description: "Long-term trend - review in monthly report."
+
+  # ===========================================================================
+  # AUDIOBOOKSHELF - Multi-Window Burn Rate Alerts
+  # Audiobook/podcast service with native auth
+  # ===========================================================================
+  - name: slo_multiwindow_audiobookshelf
+    interval: 1m
+    rules:
+      # TIER 1: CRITICAL - Fast Burn (Page immediately)
+      - alert: SLOBurnRateTier1_Audiobookshelf
+        expr: |
+          (
+            burn_rate:audiobookshelf:availability:1h > 14.4
+            and
+            burn_rate:audiobookshelf:availability:5m > 14.4
+          )
+          and
+          (time() - process_start_time_seconds{job="prometheus"} > 3600)
+        for: 2m
+        labels:
+          severity: critical
+          component: slo
+          service: audiobookshelf
+          slo: availability
+          tier: "1"
+          burn_rate: "fast"
+        annotations:
+          summary: "🚨 CRITICAL: Audiobookshelf error budget burning at 14.4x normal rate"
+          description: |
+            **IMMEDIATE ACTION REQUIRED**
+
+            Audiobookshelf is degrading rapidly. Error budget exhausts in <3 hours.
+
+            - Burn Rate (1h): {{ $value | humanize }}x
+            - Budget Remaining: {{ query "error_budget:audiobookshelf:availability:budget_remaining * 100" | first | value | humanize }}%
+
+            Action: systemctl --user status audiobookshelf.service && podman logs audiobookshelf --tail 100
+
+      # TIER 2: WARNING
+      - alert: SLOBurnRateTier2_Audiobookshelf
+        expr: |
+          (
+            burn_rate:audiobookshelf:availability:6h > 6
+            and
+            burn_rate:audiobookshelf:availability:30m > 6
+          )
+          and
+          (time() - process_start_time_seconds{job="prometheus"} > 21600)
+        for: 15m
+        labels:
+          severity: warning
+          component: slo
+          service: audiobookshelf
+          slo: availability
+          tier: "2"
+          burn_rate: "medium"
+        annotations:
+          summary: "⚠️ Audiobookshelf error budget burning at 6x normal rate"
+          description: "Budget exhausts in <1 day. Burn: {{ $value | humanize }}x, Remaining: {{ query \"error_budget:audiobookshelf:availability:budget_remaining * 100\" | first | value | humanize }}%"
+
+      # TIER 3: WARNING
+      - alert: SLOBurnRateTier3_Audiobookshelf
+        expr: |
+          (
+            burn_rate:audiobookshelf:availability:1d > 3
+            and
+            burn_rate:audiobookshelf:availability:2h > 3
+          )
+          and
+          (time() - process_start_time_seconds{job="prometheus"} > 86400)
+        for: 1h
+        labels:
+          severity: warning
+          component: slo
+          service: audiobookshelf
+          slo: availability
+          tier: "3"
+          burn_rate: "slow"
+        annotations:
+          summary: "📊 Audiobookshelf error budget burning at 3x normal rate"
+          description: "Budget exhausts in <1 week. Trend monitoring needed."
+
+      # TIER 4: INFO
+      - alert: SLOBurnRateTier4_Audiobookshelf
+        expr: |
+          (
+            burn_rate:audiobookshelf:availability:3d > 1.5
+            and
+            burn_rate:audiobookshelf:availability:1d > 1.5
+          )
+          and
+          (time() - process_start_time_seconds{job="prometheus"} > 259200)
+        for: 6h
+        labels:
+          severity: info
+          component: slo
+          service: audiobookshelf
+          slo: availability
+          tier: "4"
+          burn_rate: "minimal"
+        annotations:
+          summary: "ℹ️ Audiobookshelf error budget trending above baseline"
+          description: "Long-term trend - review in monthly report."

--- a/config/prometheus/rules/slo-burn-rate-extended.yml
+++ b/config/prometheus/rules/slo-burn-rate-extended.yml
@@ -154,6 +154,74 @@ groups:
           ) / error_budget:authelia:availability:budget_total
 
       # ===========================================================================
+      # NAVIDROME - Extended burn rate windows
+      # ===========================================================================
+
+      - record: burn_rate:navidrome:availability:1d
+        expr: |
+          (
+            1 - (
+              sum(rate(traefik_service_requests_total{exported_service="navidrome@file", code=~"0|2..|3.."}[1d]))
+              /
+              sum(rate(traefik_service_requests_total{exported_service="navidrome@file"}[1d]))
+            )
+          ) / error_budget:navidrome:availability:budget_total
+
+      - record: burn_rate:navidrome:availability:2h
+        expr: |
+          (
+            1 - (
+              sum(rate(traefik_service_requests_total{exported_service="navidrome@file", code=~"0|2..|3.."}[2h]))
+              /
+              sum(rate(traefik_service_requests_total{exported_service="navidrome@file"}[2h]))
+            )
+          ) / error_budget:navidrome:availability:budget_total
+
+      - record: burn_rate:navidrome:availability:3d
+        expr: |
+          (
+            1 - (
+              sum(rate(traefik_service_requests_total{exported_service="navidrome@file", code=~"0|2..|3.."}[3d]))
+              /
+              sum(rate(traefik_service_requests_total{exported_service="navidrome@file"}[3d]))
+            )
+          ) / error_budget:navidrome:availability:budget_total
+
+      # ===========================================================================
+      # AUDIOBOOKSHELF - Extended burn rate windows
+      # ===========================================================================
+
+      - record: burn_rate:audiobookshelf:availability:1d
+        expr: |
+          (
+            1 - (
+              sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file", code=~"0|2..|3.."}[1d]))
+              /
+              sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file"}[1d]))
+            )
+          ) / error_budget:audiobookshelf:availability:budget_total
+
+      - record: burn_rate:audiobookshelf:availability:2h
+        expr: |
+          (
+            1 - (
+              sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file", code=~"0|2..|3.."}[2h]))
+              /
+              sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file"}[2h]))
+            )
+          ) / error_budget:audiobookshelf:availability:budget_total
+
+      - record: burn_rate:audiobookshelf:availability:3d
+        expr: |
+          (
+            1 - (
+              sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file", code=~"0|2..|3.."}[3d]))
+              /
+              sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file"}[3d]))
+            )
+          ) / error_budget:audiobookshelf:availability:budget_total
+
+      # ===========================================================================
       # TRAEFIK - Extended burn rate windows (using up metric)
       # ===========================================================================
 
@@ -253,6 +321,24 @@ groups:
             error_budget:home_assistant:availability:budget_remaining
             /
             clamp_min(burn_rate:home_assistant:availability:3d, 0.001)
+          ) * 30
+
+      # Navidrome - Days until budget exhaustion
+      - record: error_budget:navidrome:availability:days_remaining
+        expr: |
+          (
+            error_budget:navidrome:availability:budget_remaining
+            /
+            clamp_min(burn_rate:navidrome:availability:3d, 0.001)
+          ) * 30
+
+      # Audiobookshelf - Days until budget exhaustion
+      - record: error_budget:audiobookshelf:availability:days_remaining
+        expr: |
+          (
+            error_budget:audiobookshelf:availability:budget_remaining
+            /
+            clamp_min(burn_rate:audiobookshelf:availability:3d, 0.001)
           ) * 30
 
       # Nextcloud - Days until budget exhaustion

--- a/config/prometheus/rules/slo-recording-rules.yml
+++ b/config/prometheus/rules/slo-recording-rules.yml
@@ -85,6 +85,34 @@ groups:
       - record: sli:home_assistant:availability:ratio
         expr: slo:home_assistant:availability:actual
 
+      # Navidrome - Total requests
+      - record: sli:navidrome:requests:total
+        expr: |
+          sum(rate(traefik_service_requests_total{exported_service="navidrome@file"}[5m]))
+
+      # Navidrome - Successful requests (2xx/3xx)
+      - record: sli:navidrome:requests:success
+        expr: |
+          sum(rate(traefik_service_requests_total{exported_service="navidrome@file", code=~"0|2..|3.."}[5m]))
+
+      # Navidrome - Availability (use 30d SLO for current display)
+      - record: sli:navidrome:availability:ratio
+        expr: slo:navidrome:availability:actual
+
+      # Audiobookshelf - Total requests
+      - record: sli:audiobookshelf:requests:total
+        expr: |
+          sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file"}[5m]))
+
+      # Audiobookshelf - Successful requests (2xx/3xx)
+      - record: sli:audiobookshelf:requests:success
+        expr: |
+          sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file", code=~"0|2..|3.."}[5m]))
+
+      # Audiobookshelf - Availability (use 30d SLO for current display)
+      - record: sli:audiobookshelf:availability:ratio
+        expr: slo:audiobookshelf:availability:actual
+
       # Traefik Gateway - Uptime
       - record: sli:traefik:availability:ratio
         expr: |
@@ -284,6 +312,40 @@ groups:
         expr: |
           slo:home_assistant:availability:actual >= bool slo:home_assistant:availability:target
 
+      # Navidrome - 99.5% availability target over 30 days
+      # Music streaming service with Subsonic API, native auth
+      - record: slo:navidrome:availability:target
+        expr: 0.995
+
+      - record: slo:navidrome:availability:actual
+        expr: |
+          (
+            sum(increase(traefik_service_requests_total{exported_service="navidrome@file", code=~"0|2..|3.."}[30d]))
+            /
+            sum(increase(traefik_service_requests_total{exported_service="navidrome@file"}[30d]))
+          )
+
+      - record: slo:navidrome:availability:compliant
+        expr: |
+          slo:navidrome:availability:actual >= bool slo:navidrome:availability:target
+
+      # Audiobookshelf - 99.5% availability target over 30 days
+      # Audiobook/podcast service with native auth
+      - record: slo:audiobookshelf:availability:target
+        expr: 0.995
+
+      - record: slo:audiobookshelf:availability:actual
+        expr: |
+          (
+            sum(increase(traefik_service_requests_total{exported_service="audiobookshelf@file", code=~"0|2..|3.."}[30d]))
+            /
+            sum(increase(traefik_service_requests_total{exported_service="audiobookshelf@file"}[30d]))
+          )
+
+      - record: slo:audiobookshelf:availability:compliant
+        expr: |
+          slo:audiobookshelf:availability:actual >= bool slo:audiobookshelf:availability:target
+
       # Traefik - 99.95% availability target over 30 days
       - record: slo:traefik:availability:target
         expr: 0.9995
@@ -376,6 +438,36 @@ groups:
       - record: error_budget:home_assistant:availability:budget_remaining
         expr: |
           clamp_max(1 - error_budget:home_assistant:availability:budget_consumed, 1)
+
+      # Navidrome - Error budget (0.5% allowed failure = 216 min/month)
+      - record: error_budget:navidrome:availability:budget_total
+        expr: 0.005
+
+      - record: error_budget:navidrome:availability:budget_consumed
+        expr: |
+          clamp_min(
+            (1 - slo:navidrome:availability:actual) / (1 - slo:navidrome:availability:target),
+            0
+          )
+
+      - record: error_budget:navidrome:availability:budget_remaining
+        expr: |
+          clamp_max(1 - error_budget:navidrome:availability:budget_consumed, 1)
+
+      # Audiobookshelf - Error budget (0.5% allowed failure = 216 min/month)
+      - record: error_budget:audiobookshelf:availability:budget_total
+        expr: 0.005
+
+      - record: error_budget:audiobookshelf:availability:budget_consumed
+        expr: |
+          clamp_min(
+            (1 - slo:audiobookshelf:availability:actual) / (1 - slo:audiobookshelf:availability:target),
+            0
+          )
+
+      - record: error_budget:audiobookshelf:availability:budget_remaining
+        expr: |
+          clamp_max(1 - error_budget:audiobookshelf:availability:budget_consumed, 1)
 
       # Traefik - Error budget (0.05% = 21 min/month)
       - record: error_budget:traefik:availability:budget_total
@@ -607,6 +699,88 @@ groups:
           )
           / clamp_min(sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[30m])), 1e-10)
           / error_budget:nextcloud:availability:budget_total
+
+      # Navidrome - Burn rates
+      - record: burn_rate:navidrome:availability:1h
+        expr: |
+          (
+            sum(rate(traefik_service_requests_total{exported_service="navidrome@file"}[1h]))
+            -
+            sum(rate(traefik_service_requests_total{exported_service="navidrome@file", code=~"0|2..|3.."}[1h]))
+          )
+          / clamp_min(sum(rate(traefik_service_requests_total{exported_service="navidrome@file"}[1h])), 1e-10)
+          / error_budget:navidrome:availability:budget_total
+
+      - record: burn_rate:navidrome:availability:5m
+        expr: |
+          (
+            sum(rate(traefik_service_requests_total{exported_service="navidrome@file"}[5m]))
+            -
+            sum(rate(traefik_service_requests_total{exported_service="navidrome@file", code=~"0|2..|3.."}[5m]))
+          )
+          / clamp_min(sum(rate(traefik_service_requests_total{exported_service="navidrome@file"}[5m])), 1e-10)
+          / error_budget:navidrome:availability:budget_total
+
+      - record: burn_rate:navidrome:availability:6h
+        expr: |
+          (
+            sum(rate(traefik_service_requests_total{exported_service="navidrome@file"}[6h]))
+            -
+            sum(rate(traefik_service_requests_total{exported_service="navidrome@file", code=~"0|2..|3.."}[6h]))
+          )
+          / clamp_min(sum(rate(traefik_service_requests_total{exported_service="navidrome@file"}[6h])), 1e-10)
+          / error_budget:navidrome:availability:budget_total
+
+      - record: burn_rate:navidrome:availability:30m
+        expr: |
+          (
+            sum(rate(traefik_service_requests_total{exported_service="navidrome@file"}[30m]))
+            -
+            sum(rate(traefik_service_requests_total{exported_service="navidrome@file", code=~"0|2..|3.."}[30m]))
+          )
+          / clamp_min(sum(rate(traefik_service_requests_total{exported_service="navidrome@file"}[30m])), 1e-10)
+          / error_budget:navidrome:availability:budget_total
+
+      # Audiobookshelf - Burn rates
+      - record: burn_rate:audiobookshelf:availability:1h
+        expr: |
+          (
+            sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file"}[1h]))
+            -
+            sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file", code=~"0|2..|3.."}[1h]))
+          )
+          / clamp_min(sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file"}[1h])), 1e-10)
+          / error_budget:audiobookshelf:availability:budget_total
+
+      - record: burn_rate:audiobookshelf:availability:5m
+        expr: |
+          (
+            sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file"}[5m]))
+            -
+            sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file", code=~"0|2..|3.."}[5m]))
+          )
+          / clamp_min(sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file"}[5m])), 1e-10)
+          / error_budget:audiobookshelf:availability:budget_total
+
+      - record: burn_rate:audiobookshelf:availability:6h
+        expr: |
+          (
+            sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file"}[6h]))
+            -
+            sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file", code=~"0|2..|3.."}[6h]))
+          )
+          / clamp_min(sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file"}[6h])), 1e-10)
+          / error_budget:audiobookshelf:availability:budget_total
+
+      - record: burn_rate:audiobookshelf:availability:30m
+        expr: |
+          (
+            sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file"}[30m]))
+            -
+            sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file", code=~"0|2..|3.."}[30m]))
+          )
+          / clamp_min(sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file"}[30m])), 1e-10)
+          / error_budget:audiobookshelf:availability:budget_total
 
       # Traefik - Burn rates (uses up metric, always has data, no NaN risk)
       - record: burn_rate:traefik:availability:1h

--- a/docs/40-monitoring-and-documentation/guides/slo-framework.md
+++ b/docs/40-monitoring-and-documentation/guides/slo-framework.md
@@ -109,6 +109,26 @@ How fast we're consuming error budget:
 
 ---
 
+### 6. Navidrome (Music Streaming)
+
+**SLO-011: Availability**
+- **Target:** 99.5% availability over 30 days
+- **SLI:** `(traefik_service_requests_total{exported_service="navidrome@file", code=~"0|2..|3.."} / traefik_service_requests_total{exported_service="navidrome@file"}) * 100`
+- **Error Budget:** 216 minutes/month
+- **Rationale:** Music streaming with Subsonic API. Native auth (no Authelia) for mobile client compatibility.
+
+---
+
+### 7. Audiobookshelf (Audiobooks & Podcasts)
+
+**SLO-012: Availability**
+- **Target:** 99.5% availability over 30 days
+- **SLI:** `(traefik_service_requests_total{exported_service="audiobookshelf@file", code=~"0|2..|3.."} / traefik_service_requests_total{exported_service="audiobookshelf@file"}) * 100`
+- **Error Budget:** 216 minutes/month
+- **Rationale:** Audiobook/podcast service with iOS app. Native auth for mobile client compatibility.
+
+---
+
 ## Multi-Window Burn-Rate Alerting
 
 We use Google's recommended multi-window, multi-burn-rate alerting to balance sensitivity and precision:
@@ -262,10 +282,10 @@ Access the SLO dashboard at: `https://grafana.patriark.org/d/slo-dashboard`
 
 ## Implementation Status
 
-- [x] SLO definitions documented (11 SLOs across 6 services)
-- [x] Prometheus recording rules created (113 rules: SLI, error budget, burn rate)
-- [x] Error budget calculations implemented (15 tracking rules)
-- [x] Multi-window burn-rate alerts configured (11 alerts: critical + warning)
+- [x] SLO definitions documented (13 SLOs across 8 services)
+- [x] Prometheus recording rules created (143 rules: SLI, error budget, burn rate)
+- [x] Error budget calculations implemented (21 tracking rules)
+- [x] Multi-window burn-rate alerts configured (19 alerts: critical + warning per service)
 - [x] Grafana dashboards created (SLO dashboard + fixed 6 existing dashboards)
 - [x] Monthly reporting automated (systemd timer + Discord webhook integration)
 

--- a/docs/98-journals/2026-02-28-slo-and-pattern-improvements.md
+++ b/docs/98-journals/2026-02-28-slo-and-pattern-improvements.md
@@ -1,0 +1,79 @@
+# SLO Framework Expansion + Deploy-from-Pattern Fixes
+
+**Date:** 2026-02-28
+**Scope:** Add Navidrome + Audiobookshelf to SLO monitoring; fix deploy-from-pattern skill gaps
+**Result:** 13 SLOs across 8 services; 4 deploy-from-pattern improvements shipped
+
+---
+
+## SLO Expansion
+
+Added availability SLOs (99.5% / 30-day) for both audio services deployed earlier today. No latency SLOs — streaming services have highly variable response times that make latency targets meaningless.
+
+### New Rules
+
+| Type | Count | File |
+|---|---|---|
+| Recording rules | 34 | `slo-recording-rules.yml` (+174 lines) |
+| Extended burn rates | 8 | `slo-burn-rate-extended.yml` (+86 lines) |
+| Alert rules | 8 | `slo-multiwindow-alerts.yml` (+206 lines) |
+
+Both services follow the Jellyfin pattern: Traefik-based SLIs with `code=~"0|2..|3.."`, 4-tier multi-window burn-rate alerting, error budget forecasting.
+
+### Dashboard
+
+Grafana SLO dashboard updated — all 6 panels now show 8 services (was 6). Gauge panels increased from 6h to 7h height to prevent crowding with the additional indicators.
+
+### Monthly Report
+
+Discord embed now includes Navidrome and Audiobookshelf fields. Service count updated 6 → 8.
+
+### Verification
+
+- Prometheus reloaded: all 34 recording rules + 8 alert rules confirmed active
+- Grafana restarted: dashboard provisioning picked up
+- Data will populate over the next few hours as SLI rates accumulate
+
+---
+
+## Deploy-from-Pattern Fixes
+
+Addressed the 4 most actionable gaps from the earlier skill gap analysis.
+
+### 1. Template variable validation
+
+After variable substitution, the script now scans output for unresolved `{{VARIABLES}}` and fails hard (or warns in dry-run). This was the highest-value fix — previously, unresolved variables silently produced broken quadlet files.
+
+### 2. Quadlet symlink convention
+
+Changed from `cp` directly to `~/.config/containers/systemd/` to the project convention: generate in `~/containers/quadlets/`, then `ln -sf` to the systemd directory.
+
+### 3. Port and health endpoint configurability
+
+New `--port` and `--health-cmd` CLI flags. Pattern loading now extracts `port:` and `health_cmd:` from YAML. Variable substitution switched from `sed` to `awk` for values containing shell-hostile characters (`||`, `/`).
+
+### 4. More pattern variable extraction
+
+Now extracts `memory_high`, `config_dir`, `data_dir` from pattern YAML. Resolves `{service_name}` placeholders in paths. Both lowercase and UPPERCASE key variants are substituted.
+
+### Remaining gaps (not addressed)
+
+- Template files still have unresolved structural variables (`SERVICE_DESCRIPTION`, `DOCS_URL`, `STATIC_IP_*`, `NETWORK_SERVICES_AFTER/REQUIRES`) — these require template rewrites
+- Array-type pattern fields (middleware, volumes, environment) still not extracted — needs proper YAML parsing
+- Multi-component patterns (database + webapp) still treated as single service
+- Prerequisites script tries to `mkdir` empty strings when `config_dir`/`data_dir` are unresolved
+
+---
+
+## Files Changed
+
+| File | Change |
+|---|---|
+| `config/prometheus/rules/slo-recording-rules.yml` | +174: SLI, SLO, error budget, burn rate for 2 services |
+| `config/prometheus/rules/slo-burn-rate-extended.yml` | +86: Extended windows + forecasting |
+| `config/prometheus/alerts/slo-multiwindow-alerts.yml` | +206: 4-tier alerts for 2 services |
+| `config/grafana/provisioning/dashboards/json/slo-dashboard.json` | +100: 8 targets per panel, layout adjustments |
+| `scripts/monthly-slo-report.sh` | +24: 2 new services in Discord report |
+| `docs/40-monitoring-and-documentation/guides/slo-framework.md` | +28: SLO-011, SLO-012 definitions |
+| `CLAUDE.md` | Updated SLO counts (9→13, 5→8) |
+| `.claude/skills/homelab-deployment/scripts/deploy-from-pattern.sh` | +85: 4 fixes |

--- a/scripts/monthly-slo-report.sh
+++ b/scripts/monthly-slo-report.sh
@@ -64,6 +64,16 @@ ha_actual=$(query_prom 'slo:home_assistant:availability:actual')
 ha_budget=$(query_prom 'error_budget:home_assistant:availability:budget_remaining')
 ha_compliant=$(query_prom 'slo:home_assistant:availability:compliant')
 
+# Navidrome
+navidrome_actual=$(query_prom 'slo:navidrome:availability:actual')
+navidrome_budget=$(query_prom 'error_budget:navidrome:availability:budget_remaining')
+navidrome_compliant=$(query_prom 'slo:navidrome:availability:compliant')
+
+# Audiobookshelf
+audiobookshelf_actual=$(query_prom 'slo:audiobookshelf:availability:actual')
+audiobookshelf_budget=$(query_prom 'error_budget:audiobookshelf:availability:budget_remaining')
+audiobookshelf_compliant=$(query_prom 'slo:audiobookshelf:availability:compliant')
+
 # ============================================================================
 # FORMAT REPORT
 # ============================================================================
@@ -125,6 +135,8 @@ overall_violations=0
 [ "$traefik_compliant" = "0" ] && ((overall_violations++)) || true
 [ "$nextcloud_compliant" = "0" ] && ((overall_violations++)) || true
 [ "$ha_compliant" = "0" ] && ((overall_violations++)) || true
+[ "$navidrome_compliant" = "0" ] && ((overall_violations++)) || true
+[ "$audiobookshelf_compliant" = "0" ] && ((overall_violations++)) || true
 
 if [ "$overall_violations" -eq 0 ]; then
     report_color="3066993"  # Green
@@ -181,8 +193,18 @@ read -r -d '' DISCORD_PAYLOAD <<EOF || true
         "inline": true
       },
       {
+        "name": "🎵 Navidrome Music",
+        "value": "$(compliance_emoji "$navidrome_compliant") **Availability:** $(format_pct "$navidrome_actual")\n**Target:** 99.50%\n**Error Budget:** $(format_pct "$navidrome_budget") remaining",
+        "inline": true
+      },
+      {
+        "name": "🎧 Audiobookshelf",
+        "value": "$(compliance_emoji "$audiobookshelf_compliant") **Availability:** $(format_pct "$audiobookshelf_actual")\n**Target:** 99.50%\n**Error Budget:** $(format_pct "$audiobookshelf_budget") remaining",
+        "inline": true
+      },
+      {
         "name": "📈 Key Insights",
-        "value": "• Services monitored: 6\n• SLOs met: $((6 - overall_violations))/6\n• Reporting period: 30 days",
+        "value": "• Services monitored: 8\n• SLOs met: $((8 - overall_violations))/8\n• Reporting period: 30 days",
         "inline": false
       },
       {


### PR DESCRIPTION
## Summary

- **SLO Framework expanded** from 6 to 8 services (11→13 SLOs) with Navidrome and Audiobookshelf availability monitoring
- **Deploy-from-pattern skill** improved with 4 fixes from the gap analysis in the Audiobookshelf/Navidrome deployment journal
- All Prometheus rules verified active, Grafana dashboard reloaded

## SLO Changes

| Service | SLO ID | Target | Window | Type |
|---|---|---|---|---|
| Navidrome | SLO-011 | 99.5% | 30 days | Availability |
| Audiobookshelf | SLO-012 | 99.5% | 30 days | Availability |

**New Prometheus rules:** 34 recording rules + 8 alert rules (4-tier burn-rate per service)
**Dashboard:** All 6 Grafana panels updated for 8 services, gauge heights adjusted to prevent crowding
**Monthly report:** Discord embed updated with 2 new service fields

## Deploy-from-Pattern Fixes

1. **Template variable validation** — fails on unresolved `{{VARIABLES}}` (warns in dry-run)
2. **Quadlet symlink convention** — generates in `quadlets/` + symlinks to systemd dir
3. **Port + health configurability** — new `--port` and `--health-cmd` CLI flags, extracted from pattern YAML
4. **More pattern extraction** — `memory_high`, `config_dir`, `data_dir` now extracted and substituted

## Files Changed (9 files, +764/-22)

- `config/prometheus/rules/slo-recording-rules.yml` — SLI, SLO, error budget, burn rate
- `config/prometheus/rules/slo-burn-rate-extended.yml` — Extended windows + forecasting
- `config/prometheus/alerts/slo-multiwindow-alerts.yml` — 4-tier alerts
- `config/grafana/provisioning/dashboards/json/slo-dashboard.json` — 8-service layout
- `scripts/monthly-slo-report.sh` — Discord report expansion
- `docs/40-monitoring-and-documentation/guides/slo-framework.md` — SLO-011, SLO-012
- `CLAUDE.md` — Updated SLO counts
- `.claude/skills/homelab-deployment/scripts/deploy-from-pattern.sh` — 4 fixes
- `docs/98-journals/2026-02-28-slo-and-pattern-improvements.md` — Journal entry

## Test Plan

- [x] Prometheus reloaded: 34 recording rules + 8 alert rules confirmed active
- [x] Grafana restarted: dashboard provisioning picked up
- [x] YAML validation: all Prometheus rule files pass `yaml.safe_load()`
- [x] JSON validation: Grafana dashboard valid, 6 panels with 8 targets each
- [x] Deploy-from-pattern dry-run: template validation catches 7 unresolved variables correctly
- [ ] Verify SLO data populates in Grafana after traffic accumulates (~1-2 hours)
- [ ] Verify monthly report includes new services (run `scripts/monthly-slo-report.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)