### PR TITLE
fix: Switch ACME to DNS-01 challenge via Cloudflare API

### DIFF
--- a/config/traefik/traefik.yml
+++ b/config/traefik/traefik.yml
@@ -85,5 +85,8 @@ certificatesResolvers:
     acme:
       email: blyhode@hotmail.com
       storage: /letsencrypt/acme.json
-      httpChallenge:
-        entryPoint: web
+      dnsChallenge:
+        provider: cloudflare
+        resolvers:
+          - "1.1.1.1:53"
+          - "8.8.8.8:53"

--- a/docs/AUTO-DEPENDENCY-GRAPH.md
+++ b/docs/AUTO-DEPENDENCY-GRAPH.md
@@ -1,6 +1,6 @@
 # Service Dependency Graph (Auto-Generated)
 
-**Generated:** 2026-02-28 06:01:34 UTC
+**Generated:** 2026-02-28 23:00:45 UTC
 **System:** fedora-htpc
 
 ---
@@ -45,9 +45,11 @@ graph TB
 
     subgraph Supporting[Supporting — Tier 5]
         alert_discord_relay[alert-discord-relay]
+        audiobookshelf[audiobookshelf]
         cadvisor[cadvisor]
         immich_ml[immich-ml]
         matter_server[matter-server]
+        navidrome[navidrome]
         node_exporter[node_exporter]
         promtail[promtail]
         unpoller[unpoller]
@@ -61,6 +63,7 @@ graph TB
 
     %% Routing dependencies (services in reverse_proxy depend on Traefik)
     traefik -.-> alertmanager
+    traefik -.-> audiobookshelf
     traefik -.-> authelia
     traefik -.-> gathio
     traefik -.-> grafana
@@ -69,6 +72,7 @@ graph TB
     traefik -.-> immich_server
     traefik -.-> jellyfin
     traefik -.-> loki
+    traefik -.-> navidrome
     traefik -.-> nextcloud
     traefik -.-> prometheus
     traefik -.-> vaultwarden
@@ -78,6 +82,7 @@ graph TB
     prometheus -.->|scrapes| home_assistant
     prometheus -.->|scrapes| immich_server
     prometheus -.->|scrapes| jellyfin
+    prometheus -.->|scrapes| navidrome
     prometheus -.->|scrapes| nextcloud
     prometheus -.->|scrapes| nextcloud_db
     prometheus -.->|scrapes| nextcloud_redis
@@ -139,9 +144,11 @@ graph TB
 | Service | Hard Dependencies | Impact if Down |
 |---------|-------------------|----------------|
 | **alert-discord-relay** | — | 🟢 Service-specific impact |
+| **audiobookshelf** | — | 🟢 Service-specific impact |
 | **cadvisor** | — | 🟢 Service-specific impact |
 | **immich-ml** | — | 🟢 Service-specific impact |
 | **matter-server** | — | 🟢 Service-specific impact |
+| **navidrome** | — | 🟢 Service-specific impact |
 | **node_exporter** | — | 🟢 Service-specific impact |
 | **promtail** | — | 🟢 Service-specific impact |
 | **unpoller** | — | 🟢 Service-specific impact |
@@ -156,6 +163,7 @@ Derived from `After=` directives in quadlet files. systemd handles this automati
 |---------|-------------|
 | alert-discord-relay | (no ordering constraints) |
 | alertmanager | (no ordering constraints) |
+| audiobookshelf | traefik |
 | authelia | redis-authelia |
 | cadvisor | (no ordering constraints) |
 | crowdsec | (no ordering constraints) |
@@ -169,6 +177,7 @@ Derived from `After=` directives in quadlet files. systemd handles this automati
 | jellyfin | (no ordering constraints) |
 | loki | (no ordering constraints) |
 | matter-server | (no ordering constraints) |
+| navidrome | traefik |
 | nextcloud | nextcloud-db,nextcloud-redis |
 | nextcloud-db | (no ordering constraints) |
 | nextcloud-redis | (no ordering constraints) |
@@ -196,13 +205,13 @@ Services on the same network can communicate:
 
 **media_services:** jellyfin
 
-**monitoring:** alert-discord-relay,alertmanager,cadvisor,gathio,grafana,home-assistant,immich-server,jellyfin,loki,nextcloud,nextcloud-db,nextcloud-redis,node_exporter,prometheus,promtail,traefik,unpoller
+**monitoring:** alert-discord-relay,alertmanager,cadvisor,gathio,grafana,home-assistant,immich-server,jellyfin,loki,navidrome,nextcloud,nextcloud-db,nextcloud-redis,node_exporter,prometheus,promtail,traefik,unpoller
 
 **nextcloud:** nextcloud,nextcloud-db,nextcloud-redis
 
 **photos:** immich-ml,immich-server,postgresql-immich,redis-immich
 
-**reverse_proxy:** alertmanager,authelia,crowdsec,gathio,grafana,home-assistant,homepage,immich-server,jellyfin,loki,nextcloud,prometheus,traefik,vaultwarden
+**reverse_proxy:** alertmanager,audiobookshelf,authelia,crowdsec,gathio,grafana,home-assistant,homepage,immich-server,jellyfin,loki,navidrome,nextcloud,prometheus,traefik,vaultwarden
 
 ---
 

--- a/docs/AUTO-DOCUMENTATION-INDEX.md
+++ b/docs/AUTO-DOCUMENTATION-INDEX.md
@@ -1,7 +1,7 @@
 # Documentation Index (Auto-Generated)
 
-**Generated:** 2026-02-28 06:01:34 UTC
-**Total Documents:** 397
+**Generated:** 2026-02-28 23:00:46 UTC
+**Total Documents:** 399
 
 ---
 
@@ -199,7 +199,7 @@
 
 ---
 
-### 98-journals/ (175 documents)
+### 98-journals/ (177 documents)
 
 **Chronological project history (append-only log)**
 
@@ -218,19 +218,22 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 ## Recently Updated (Last 7 Days)
 
 - 2026-02-22: [2026-02-22-ADR-019-filesystem-permission-model.md](00-foundation/decisions/2026-02-22-ADR-019-filesystem-permission-model.md)
+- 2026-02-28: [immich-configuration-review.md](10-services/guides/immich-configuration-review.md)
 - 2026-02-27: [automation-reference.md](20-operations/guides/automation-reference.md)
 - 2026-02-22: [permission-optimization-nextcloud.md](20-operations/guides/permission-optimization-nextcloud.md)
-- 2026-02-24: [slo-framework.md](40-monitoring-and-documentation/guides/slo-framework.md)
+- 2026-02-28: [slo-framework.md](40-monitoring-and-documentation/guides/slo-framework.md)
 - 2026-02-24: [2026-02-18-loose-ends-audit.md](98-journals/2026-02-18-loose-ends-audit.md)
 - 2026-02-22: [2026-02-22-filesystem-permission-optimization.md](98-journals/2026-02-22-filesystem-permission-optimization.md)
 - 2026-02-24: [2026-02-23-loose-ends-audit-review.md](98-journals/2026-02-23-loose-ends-audit-review.md)
 - 2026-02-26: [2026-02-26-slo-system-diagnostic-fixes.md](98-journals/2026-02-26-slo-system-diagnostic-fixes.md)
 - 2026-02-27: [2026-02-27-automation-audit-and-improvements.md](98-journals/2026-02-27-automation-audit-and-improvements.md)
+- 2026-02-28: [2026-02-28-audiobookshelf-navidrome-deployment.md](98-journals/2026-02-28-audiobookshelf-navidrome-deployment.md)
+- 2026-02-28: [2026-02-28-slo-and-pattern-improvements.md](98-journals/2026-02-28-slo-and-pattern-improvements.md)
 - 2026-02-22: [remediation-monthly-202601.md](99-reports/remediation-monthly-202601.md)
-- 2026-02-28: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
-- 2026-02-28: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
-- 2026-02-28: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
-- 2026-02-28: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
+- 2026-03-01: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
+- 2026-03-01: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
+- 2026-03-01: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
+- 2026-03-01: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
 
 ---
 

--- a/docs/AUTO-NETWORK-TOPOLOGY.md
+++ b/docs/AUTO-NETWORK-TOPOLOGY.md
@@ -1,7 +1,7 @@
 # Network Topology (Auto-Generated)
 
-**Generated:** 2026-02-28 06:01:30 UTC
-**System:** fedora-htpc | **Networks:** 8 | **Containers:** 27
+**Generated:** 2026-02-28 23:00:41 UTC
+**System:** fedora-htpc | **Networks:** 8 | **Containers:** 29
 
 ---
 
@@ -28,8 +28,10 @@ graph TB
 
     %% Services with native authentication (bypass Authelia)
     CrowdSec -->|Rate Limit| alertmanager[alertmanager]
+    CrowdSec -->|Rate Limit| audiobookshelf[audiobookshelf]
     CrowdSec -->|Rate Limit| immich_server[immich-server]
     CrowdSec -->|Rate Limit| jellyfin[jellyfin]
+    CrowdSec -->|Rate Limit| navidrome[navidrome]
     CrowdSec -->|Rate Limit| nextcloud[nextcloud]
     CrowdSec -->|Rate Limit| vaultwarden[vaultwarden]
 
@@ -88,6 +90,7 @@ graph TB
         monitoring_immich_server[immich-server]
         monitoring_jellyfin[jellyfin]
         monitoring_loki[loki]
+        monitoring_navidrome[navidrome]
         monitoring_nextcloud[nextcloud]
         monitoring_nextcloud_db[nextcloud-db]
         monitoring_nextcloud_redis[nextcloud-redis]
@@ -116,6 +119,7 @@ graph TB
     subgraph reverse_proxy["reverse_proxy<br/>10.89.2.0/24"]
         direction LR
         reverse_proxy_alertmanager[alertmanager]
+        reverse_proxy_audiobookshelf[audiobookshelf]
         reverse_proxy_authelia[authelia]
         reverse_proxy_crowdsec[crowdsec]
         reverse_proxy_gathio[gathio]
@@ -125,6 +129,7 @@ graph TB
         reverse_proxy_immich_server[immich-server]
         reverse_proxy_jellyfin[jellyfin]
         reverse_proxy_loki[loki]
+        reverse_proxy_navidrome[navidrome]
         reverse_proxy_nextcloud[nextcloud]
         reverse_proxy_prometheus[prometheus]
         reverse_proxy_traefik[traefik]
@@ -155,11 +160,13 @@ Shows which services belong to which networks. Dynamically generated from runnin
 | redis-authelia | ✅ | - | - | - | - | - | - | - |
 | traefik | ✅ | - | - | - | ✅ | - | - | ✅ |
 | **Public Services** |
+| audiobookshelf | - | - | - | - | - | - | - | ✅ |
 | gathio | - | ✅ | - | - | ✅ | - | - | ✅ |
 | home-assistant | - | - | ✅ | - | ✅ | - | - | ✅ |
 | homepage | - | - | - | - | - | - | - | ✅ |
 | immich-server | - | - | - | - | ✅ | - | ✅ | ✅ |
 | jellyfin | - | - | - | ✅ | ✅ | - | - | ✅ |
+| navidrome | - | - | - | - | ✅ | - | - | ✅ |
 | nextcloud | - | - | - | - | ✅ | ✅ | - | ✅ |
 | vaultwarden | - | - | - | - | - | - | - | ✅ |
 | **Monitoring** |
@@ -280,7 +287,7 @@ sequenceDiagram
 
 - **Full Name:** `systemd-monitoring`
 - **Subnet:** 10.89.4.0/24
-- **Services:** 17
+- **Services:** 18
 
 **Members:**
 - alert-discord-relay
@@ -292,6 +299,7 @@ sequenceDiagram
 - immich-server
 - jellyfin
 - loki
+- navidrome
 - nextcloud
 - nextcloud-db
 - nextcloud-redis
@@ -331,10 +339,11 @@ sequenceDiagram
 
 - **Full Name:** `systemd-reverse_proxy`
 - **Subnet:** 10.89.2.0/24
-- **Services:** 14
+- **Services:** 16
 
 **Members:**
 - alertmanager
+- audiobookshelf
 - authelia
 - crowdsec
 - gathio
@@ -344,6 +353,7 @@ sequenceDiagram
 - immich-server
 - jellyfin
 - loki
+- navidrome
 - nextcloud
 - prometheus
 - traefik

--- a/docs/AUTO-SERVICE-CATALOG.md
+++ b/docs/AUTO-SERVICE-CATALOG.md
@@ -1,89 +1,96 @@
 # Service Catalog (Auto-Generated)
 
-**Generated:** 2026-02-28 06:01:30 UTC
-**System:** fedora-htpc | **Services:** 27/27 running | **Health:** 25/25 healthy (2 without healthcheck)
+**Generated:** 2026-02-28 23:00:40 UTC
+**System:** fedora-htpc | **Services:** 29/29 running | **Health:** 27/27 healthy (2 without healthcheck)
 
 ---
+
+## Other (2)
+
+| Service | Image | Health | Uptime | URL | Docs |
+|---------|-------|--------|--------|-----|------|
+| audiobookshelf | advplyr/audiobookshelf:latest | ✅ healthy | 2h | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
+| navidrome | deluan/navidrome:latest | ✅ healthy | 2h | [musikk.patriark.org](https://musikk.patriark.org) | — |
 
 ## Core Infrastructure (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| authelia | authelia/authelia:latest | ✅ healthy | 5d | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
-| crowdsec | crowdsecurity/crowdsec:latest | ✅ healthy | 5d | — | [guide](10-services/guides/crowdsec.md) |
-| redis-authelia | redis:7-alpine | ✅ healthy | 5d | — | — |
-| traefik | traefik:latest | ✅ healthy | 5d | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
+| authelia | authelia/authelia:latest | ✅ healthy | 6d | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
+| crowdsec | crowdsecurity/crowdsec:latest | ✅ healthy | 6d | — | [guide](10-services/guides/crowdsec.md) |
+| redis-authelia | redis:7-alpine | ✅ healthy | 6d | — | — |
+| traefik | traefik:latest | ✅ healthy | 8m | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
 
 ## Nextcloud (3)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| nextcloud-db | mariadb:11 | ✅ healthy | 5d | — | [guide](10-services/guides/nextcloud.md) |
-| nextcloud | nextcloud:latest | ✅ healthy | 5d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
-| nextcloud-redis | redis:7-alpine | ✅ healthy | 5d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-db | mariadb:11 | ✅ healthy | 6d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud | nextcloud:latest | ✅ healthy | 6d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-redis | redis:7-alpine | ✅ healthy | 6d | — | [guide](10-services/guides/nextcloud.md) |
 
 ## Immich (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| immich-ml | immich-app/immich-machine-learning:v2.5.5 | ✅ healthy | 5d | — | [guide](10-services/guides/immich.md) |
-| immich-server | immich-app/immich-server:v2.5.5 | ✅ healthy | 5d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
-| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3-pgvec | ✅ healthy | 5d | — | — |
-| redis-immich | valkey/valkey:latest | ✅ healthy | 5d | — | — |
+| immich-ml | immich-app/immich-machine-learning:v2.5.5 | ✅ healthy | 6d | — | [guide](10-services/guides/immich.md) |
+| immich-server | immich-app/immich-server:v2.5.5 | ✅ healthy | 11h | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
+| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3-pgvec | ✅ healthy | 6d | — | — |
+| redis-immich | valkey/valkey:latest | ✅ healthy | 6d | — | — |
 
 ## Jellyfin (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| jellyfin | jellyfin/jellyfin:latest | ✅ healthy | 5d | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
+| jellyfin | jellyfin/jellyfin:latest | ✅ healthy | 6d | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
 
 ## Vaultwarden (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| vaultwarden | vaultwarden/server:latest | ✅ healthy | 5d | [vault.patriark.org](https://vault.patriark.org) | — |
+| vaultwarden | vaultwarden/server:latest | ✅ healthy | 6d | [vault.patriark.org](https://vault.patriark.org) | — |
 
 ## Home Automation (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 5d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
-| matter-server | home-assistant-libs/python-matter-server:stab | ✅ healthy | 5d | — | [guide](10-services/guides/matter-server.md) |
+| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 6d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
+| matter-server | home-assistant-libs/python-matter-server:stab | ✅ healthy | 6d | — | [guide](10-services/guides/matter-server.md) |
 
 ## Gathio (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| gathio-db | mongo:7 | ✅ healthy | 5d | — | — |
-| gathio | lowercasename/gathio:latest | ✅ healthy | 5d | [events.patriark.org](https://events.patriark.org) | — |
+| gathio-db | mongo:7 | ✅ healthy | 6d | — | — |
+| gathio | lowercasename/gathio:latest | ✅ healthy | 6d | [events.patriark.org](https://events.patriark.org) | — |
 
 ## Homepage (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| homepage | gethomepage/homepage:latest | ✅ healthy | 5d | [patriark.org](https://patriark.org) | — |
+| homepage | gethomepage/homepage:latest | ✅ healthy | 6d | [patriark.org](https://patriark.org) | — |
 
 ## Monitoring (9)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| alert-discord-relay | localhost/alert-discord-relay:latest | ✅ healthy | 5d | — | [guide](10-services/guides/alert-discord-relay.md) |
-| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ healthy | 5d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ healthy | 5d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| grafana | grafana/grafana:latest | ✅ healthy | 4d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| loki | grafana/loki:latest | — no check | 5d | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| node_exporter | quay.io/prometheus/node-exporter:latest | ✅ healthy | 5d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 5d | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| promtail | grafana/promtail:latest | ✅ healthy | 5d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| unpoller | unpoller/unpoller:latest | — no check | 5d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| alert-discord-relay | localhost/alert-discord-relay:latest | ✅ healthy | 6d | — | [guide](10-services/guides/alert-discord-relay.md) |
+| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ healthy | 6d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ healthy | 6d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| grafana | grafana/grafana:latest | ✅ healthy | 59m | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| loki | grafana/loki:latest | — no check | 6d | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| node_exporter | quay.io/prometheus/node-exporter:latest | ✅ healthy | 6d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 2h | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| promtail | grafana/promtail:latest | ✅ healthy | 6d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| unpoller | unpoller/unpoller:latest | — no check | 6d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
 
 ---
 
 ## Statistics
 
-- **Total Running:** 27
-- **Total Defined:** 27
-- **System Load:** 0,86, 0,69, 0,62
+- **Total Running:** 29
+- **Total Defined:** 29
+- **System Load:** 4,03, 3,84, 2,76
 
 ---
 

--- a/quadlets/traefik.container
+++ b/quadlets/traefik.container
@@ -29,6 +29,7 @@ Volume=/mnt/btrfs-pool/subvol7-containers/traefik-logs:/var/log/traefik:z
 Volume=%h/containers/config/traefik/hosts:/etc/hosts:ro,Z
 
 Secret=crowdsec_api_key
+Secret=cloudflare_dns_token,type=env,target=CF_DNS_API_TOKEN
 Entrypoint=/traefik-entrypoint.sh
 Exec=traefik
 SecurityLabelDisable=true


### PR DESCRIPTION
## Summary

- Switch Let's Encrypt ACME from HTTP-01 (`httpChallenge`) to DNS-01 (`dnsChallenge`) via Cloudflare API
- Add `cloudflare_dns_token` podman secret to Traefik quadlet (exposed as `CF_DNS_API_TOKEN` env var)
- All 18 domains issued fresh certificates successfully

## Context

UDM Pro firewall was changed from default-allow to Norway-only inbound, which blocked Let's Encrypt's globally distributed validation servers. New services (Audiobookshelf, Navidrome) couldn't obtain certificates and served Traefik's self-signed default cert. All 16 existing certificates (expiring March 23) would also have failed renewal.

DNS-01 validates via Cloudflare DNS API — no inbound connections required. This is compatible with any firewall configuration.

## Verification

- All 18 Let's Encrypt certificates issued via DNS-01 (Feb 28 2026, valid to May 29 2026)
- audiobookshelf.patriark.org: valid cert, Prologue iOS app connects successfully
- musikk.patriark.org: valid cert, no browser warnings
- jellyfin.patriark.org: renewed (was expiring Mar 23)
- Traefik pre-commit validation passed

## Test Plan

- [x] Verify audiobookshelf.patriark.org — no cert warning in Safari/Firefox
- [x] Verify musikk.patriark.org — no cert warning
- [x] Prologue iOS app connects to Audiobookshelf server
- [x] Existing services (Jellyfin, Immich, Nextcloud) unaffected
- [x] Traefik healthy after restart with new config

🤖 Generated with [Claude Code](https://claude.com/claude-code)