### PR TITLE
fix: Refine SLO success criteria for HA, Nextcloud, and Immich

### DIFF
--- a/config/prometheus/alerts/slo-multiwindow-alerts.yml
+++ b/config/prometheus/alerts/slo-multiwindow-alerts.yml
@@ -365,7 +365,8 @@ groups:
 
   # ===========================================================================
   # HOME ASSISTANT - Multi-Window Burn Rate Alerts
-  # WebSocket-heavy service (code=0 counted as success in recording rules)
+  # Denylist criteria (code!~"5..") - only 5xx counts as error
+  # Native auth, WebSocket-heavy, very low Traefik traffic (~37 req/day)
   # ===========================================================================
   - name: slo_multiwindow_home_assistant
     interval: 1m
@@ -840,8 +841,8 @@ groups:
           description: "Long-term trend - review in monthly report."
 
   # ===========================================================================
-  # COMPENSATING 4xx ALERTS for native-auth services
-  # Navidrome and Audiobookshelf use code!~"5.." for SLO (only 5xx = errors).
+  # COMPENSATING 4xx ALERTS for denylist services
+  # Home Assistant, Navidrome, and Audiobookshelf use code!~"5.." for SLO.
   # These alerts catch 4xx spikes that bypass burn rate detection:
   #   - 429: rate limiting firing (possible attack or misconfigured client)
   #   - 403: middleware misconfiguration
@@ -850,6 +851,30 @@ groups:
   - name: audio_services_4xx_compensating
     interval: 1m
     rules:
+      - alert: HomeAssistantHigh4xxRate
+        expr: |
+          (
+            sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code=~"4.."}[5m]))
+            / clamp_min(sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[5m])), 1e-10)
+          ) > 0.10
+        for: 10m
+        labels:
+          severity: warning
+          component: slo
+          service: home-assistant
+        annotations:
+          summary: "Home Assistant 4xx rate above 10% for 10 minutes"
+          description: |
+            Current 4xx rate: {{ $value | humanizePercentage }}
+
+            This alert compensates for the SLO denylist criteria (code!~"5..") which
+            excludes 4xx from burn rate detection. A sustained 4xx spike may indicate:
+            - 403: Middleware or auth misconfiguration
+            - 404: Broken integration or asset path change
+            - 429: Rate limiting (attack or automation loop)
+
+            Check: podman logs home-assistant --tail 100
+
       - alert: NavidromeHigh4xxRate
         expr: |
           (

--- a/config/prometheus/alerts/slo-multiwindow-alerts.yml
+++ b/config/prometheus/alerts/slo-multiwindow-alerts.yml
@@ -848,15 +848,21 @@ groups:
   #   - 403: middleware misconfiguration
   #   - sustained high 404: broken integration or misconfigured client
   # ===========================================================================
-  - name: audio_services_4xx_compensating
+  - name: denylist_services_4xx_compensating
     interval: 1m
     rules:
       - alert: HomeAssistantHigh4xxRate
+        # Uses 30m rate window (not 5m like audio services) because HA has very low
+        # Traefik traffic (~37 req/day). With a 5m window, a single 404 would show as
+        # 100% error rate and trigger the alert. The 30m window + minimum traffic guard
+        # smooths low-traffic variance while still catching sustained 4xx spikes.
         expr: |
           (
-            sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code=~"4.."}[5m]))
-            / clamp_min(sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[5m])), 1e-10)
+            sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code=~"4.."}[30m]))
+            / clamp_min(sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[30m])), 1e-10)
           ) > 0.10
+          and
+          sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[30m])) > 0.01
         for: 10m
         labels:
           severity: warning

--- a/config/prometheus/alerts/slo-multiwindow-alerts.yml
+++ b/config/prometheus/alerts/slo-multiwindow-alerts.yml
@@ -862,7 +862,7 @@ groups:
             / clamp_min(sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[30m])), 1e-10)
           ) > 0.10
           and
-          sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[30m])) > 0.01
+          sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[30m])) > 0.001
         for: 10m
         labels:
           severity: warning

--- a/config/prometheus/rules/slo-burn-rate-extended.yml
+++ b/config/prometheus/rules/slo-burn-rate-extended.yml
@@ -3,6 +3,7 @@
 # FIXED: 2026-01-22 - Calculate actual short-term failure rates, not 30-day averages
 # FIXED: 2026-02-07 - Include WebSocket code=0 as successful (was counted as failure)
 # FIXED: 2026-03-01 - Navidrome/Audiobookshelf: count only 5xx as errors
+# FIXED: 2026-03-01 - Home Assistant: switch to denylist (code!~"5.."), Nextcloud/Immich: add 499
 # Purpose: Add longer time windows for multi-tier burn rate detection
 #
 # Burn Rate Tiers (Google SRE Book methodology):
@@ -60,7 +61,7 @@ groups:
         expr: |
           (
             1 - (
-              sum(rate(traefik_service_requests_total{exported_service="immich@file", code=~"0|2..|3.."}[1d]))
+              sum(rate(traefik_service_requests_total{exported_service="immich@file", code=~"0|2..|3..|499"}[1d]))
               /
               sum(rate(traefik_service_requests_total{exported_service="immich@file"}[1d]))
             )
@@ -70,7 +71,7 @@ groups:
         expr: |
           (
             1 - (
-              sum(rate(traefik_service_requests_total{exported_service="immich@file", code=~"0|2..|3.."}[2h]))
+              sum(rate(traefik_service_requests_total{exported_service="immich@file", code=~"0|2..|3..|499"}[2h]))
               /
               sum(rate(traefik_service_requests_total{exported_service="immich@file"}[2h]))
             )
@@ -80,21 +81,22 @@ groups:
         expr: |
           (
             1 - (
-              sum(rate(traefik_service_requests_total{exported_service="immich@file", code=~"0|2..|3.."}[3d]))
+              sum(rate(traefik_service_requests_total{exported_service="immich@file", code=~"0|2..|3..|499"}[3d]))
               /
               sum(rate(traefik_service_requests_total{exported_service="immich@file"}[3d]))
             )
           ) / error_budget:immich:availability:budget_total
 
       # ===========================================================================
-      # HOME ASSISTANT - Extended burn rate windows
+      # HOME ASSISTANT - Extended burn rate windows (denylist: only 5xx = errors)
+      # 404s at ~37 req/day via Traefik caused 4x budget overrun with allowlist criteria
       # ===========================================================================
 
       - record: burn_rate:home_assistant:availability:1d
         expr: |
           (
             1 - (
-              sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code=~"0|2..|3.."}[1d]))
+              sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code!~"5.."}[1d]))
               /
               sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[1d]))
             )
@@ -104,7 +106,7 @@ groups:
         expr: |
           (
             1 - (
-              sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code=~"0|2..|3.."}[2h]))
+              sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code!~"5.."}[2h]))
               /
               sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[2h]))
             )
@@ -114,7 +116,7 @@ groups:
         expr: |
           (
             1 - (
-              sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code=~"0|2..|3.."}[3d]))
+              sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code!~"5.."}[3d]))
               /
               sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[3d]))
             )
@@ -241,7 +243,7 @@ groups:
         expr: |
           (
             1 - (
-              sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3.."}[1d]))
+              sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3..|499"}[1d]))
               /
               sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[1d]))
             )
@@ -251,7 +253,7 @@ groups:
         expr: |
           (
             1 - (
-              sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3.."}[2h]))
+              sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3..|499"}[2h]))
               /
               sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[2h]))
             )
@@ -261,7 +263,7 @@ groups:
         expr: |
           (
             1 - (
-              sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3.."}[3d]))
+              sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3..|499"}[3d]))
               /
               sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[3d]))
             )

--- a/config/prometheus/rules/slo-recording-rules.yml
+++ b/config/prometheus/rules/slo-recording-rules.yml
@@ -2,6 +2,8 @@
 # Created: 2025-11-27
 # Updated: 2026-02-07 - Fix WebSocket code=0 counted as failure, upload NaN, Immich SLO target
 # Updated: 2026-03-01 - Navidrome/Audiobookshelf: count only 5xx as errors (404/499 are valid responses)
+# Updated: 2026-03-01 - Home Assistant: switch to denylist (code!~"5..") - 404s at low traffic amplified error budget
+# Updated: 2026-03-01 - Nextcloud/Immich: add 499 (client disconnect) to success criteria
 # Purpose: Pre-calculate Service Level Indicators for efficient querying
 #
 # Note: Traefik reports WebSocket connections as code="0" (not HTTP status).
@@ -34,10 +36,10 @@ groups:
         expr: |
           sum(rate(traefik_service_requests_total{exported_service="immich@file"}[5m]))
 
-      # Immich - Successful requests (2xx/3xx + WebSocket code=0)
+      # Immich - Successful requests (2xx/3xx + WebSocket code=0 + client disconnect 499)
       - record: sli:immich:requests:success
         expr: |
-          sum(rate(traefik_service_requests_total{exported_service="immich@file", code=~"0|2..|3.."}[5m]))
+          sum(rate(traefik_service_requests_total{exported_service="immich@file", code=~"0|2..|3..|499"}[5m]))
 
       # Immich - Availability (use 30d SLO for current display)
       - record: sli:immich:availability:ratio
@@ -62,10 +64,10 @@ groups:
         expr: |
           sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[5m]))
 
-      # Nextcloud - Successful requests (2xx/3xx + WebSocket code=0)
+      # Nextcloud - Successful requests (2xx/3xx + WebSocket code=0 + client disconnect 499)
       - record: sli:nextcloud:requests:success
         expr: |
-          sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3.."}[5m]))
+          sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3..|499"}[5m]))
 
       # Nextcloud - Availability (use 30d SLO for current display)
       - record: sli:nextcloud:availability:ratio
@@ -76,11 +78,12 @@ groups:
         expr: |
           sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[5m]))
 
-      # Home Assistant - Successful requests (2xx/3xx + WebSocket code=0)
-      # HA uses heavy WebSocket for real-time updates - code=0 is critical here
+      # Home Assistant - Successful requests (everything except 5xx)
+      # Native auth + WebSocket-heavy: 404 (asset lookups) and 4xx are expected, not server errors
+      # Uses denylist criteria (code!~"5..") same as Navidrome/Audiobookshelf
       - record: sli:home_assistant:requests:success
         expr: |
-          sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code=~"0|2..|3.."}[5m]))
+          sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code!~"5.."}[5m]))
 
       # Home Assistant - Availability (use 30d SLO for current display)
       - record: sli:home_assistant:availability:ratio
@@ -257,7 +260,7 @@ groups:
       - record: slo:immich:availability:actual
         expr: |
           (
-            sum(increase(traefik_service_requests_total{exported_service="immich@file", code=~"0|2..|3.."}[30d]))
+            sum(increase(traefik_service_requests_total{exported_service="immich@file", code=~"0|2..|3..|499"}[30d]))
             /
             sum(increase(traefik_service_requests_total{exported_service="immich@file"}[30d]))
           )
@@ -289,7 +292,7 @@ groups:
       - record: slo:nextcloud:availability:actual
         expr: |
           (
-            sum(increase(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3.."}[30d]))
+            sum(increase(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3..|499"}[30d]))
             /
             sum(increase(traefik_service_requests_total{exported_service="nextcloud@file"}[30d]))
           )
@@ -299,14 +302,15 @@ groups:
           slo:nextcloud:availability:actual >= bool slo:nextcloud:availability:target
 
       # Home Assistant - 99.5% availability target over 30 days
-      # WebSocket-heavy service with native auth (no Authelia)
+      # WebSocket-heavy, native auth, very low Traefik traffic (~37 req/day)
+      # Uses denylist criteria: only 5xx counts as error (404 is normal at this volume)
       - record: slo:home_assistant:availability:target
         expr: 0.995
 
       - record: slo:home_assistant:availability:actual
         expr: |
           (
-            sum(increase(traefik_service_requests_total{exported_service="home-assistant@file", code=~"0|2..|3.."}[30d]))
+            sum(increase(traefik_service_requests_total{exported_service="home-assistant@file", code!~"5.."}[30d]))
             /
             sum(increase(traefik_service_requests_total{exported_service="home-assistant@file"}[30d]))
           )
@@ -547,7 +551,7 @@ groups:
           (
             sum(rate(traefik_service_requests_total{exported_service="immich@file"}[1h]))
             -
-            sum(rate(traefik_service_requests_total{exported_service="immich@file", code=~"0|2..|3.."}[1h]))
+            sum(rate(traefik_service_requests_total{exported_service="immich@file", code=~"0|2..|3..|499"}[1h]))
           )
           / clamp_min(sum(rate(traefik_service_requests_total{exported_service="immich@file"}[1h])), 1e-10)
           / error_budget:immich:availability:budget_total
@@ -557,7 +561,7 @@ groups:
           (
             sum(rate(traefik_service_requests_total{exported_service="immich@file"}[5m]))
             -
-            sum(rate(traefik_service_requests_total{exported_service="immich@file", code=~"0|2..|3.."}[5m]))
+            sum(rate(traefik_service_requests_total{exported_service="immich@file", code=~"0|2..|3..|499"}[5m]))
           )
           / clamp_min(sum(rate(traefik_service_requests_total{exported_service="immich@file"}[5m])), 1e-10)
           / error_budget:immich:availability:budget_total
@@ -567,7 +571,7 @@ groups:
           (
             sum(rate(traefik_service_requests_total{exported_service="immich@file"}[6h]))
             -
-            sum(rate(traefik_service_requests_total{exported_service="immich@file", code=~"0|2..|3.."}[6h]))
+            sum(rate(traefik_service_requests_total{exported_service="immich@file", code=~"0|2..|3..|499"}[6h]))
           )
           / clamp_min(sum(rate(traefik_service_requests_total{exported_service="immich@file"}[6h])), 1e-10)
           / error_budget:immich:availability:budget_total
@@ -577,18 +581,21 @@ groups:
           (
             sum(rate(traefik_service_requests_total{exported_service="immich@file"}[30m]))
             -
-            sum(rate(traefik_service_requests_total{exported_service="immich@file", code=~"0|2..|3.."}[30m]))
+            sum(rate(traefik_service_requests_total{exported_service="immich@file", code=~"0|2..|3..|499"}[30m]))
           )
           / clamp_min(sum(rate(traefik_service_requests_total{exported_service="immich@file"}[30m])), 1e-10)
           / error_budget:immich:availability:budget_total
 
-      # Home Assistant - Burn rates (WebSocket-heavy, code=0 included)
+      # Home Assistant - Burn rates (denylist: only 5xx = errors)
+      # 4xx intentionally excluded: 404 (asset lookups, API probes) are expected.
+      # Low traffic (~37 req/day) means each 4xx would have outsized SLO impact.
+      # Compensating control: HomeAssistantHigh4xxRate alert in slo-multiwindow-alerts.yml.
       - record: burn_rate:home_assistant:availability:1h
         expr: |
           (
             sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[1h]))
             -
-            sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code=~"0|2..|3.."}[1h]))
+            sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code!~"5.."}[1h]))
           )
           / clamp_min(sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[1h])), 1e-10)
           / error_budget:home_assistant:availability:budget_total
@@ -598,7 +605,7 @@ groups:
           (
             sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[5m]))
             -
-            sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code=~"0|2..|3.."}[5m]))
+            sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code!~"5.."}[5m]))
           )
           / clamp_min(sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[5m])), 1e-10)
           / error_budget:home_assistant:availability:budget_total
@@ -608,7 +615,7 @@ groups:
           (
             sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[6h]))
             -
-            sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code=~"0|2..|3.."}[6h]))
+            sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code!~"5.."}[6h]))
           )
           / clamp_min(sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[6h])), 1e-10)
           / error_budget:home_assistant:availability:budget_total
@@ -618,7 +625,7 @@ groups:
           (
             sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[30m]))
             -
-            sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code=~"0|2..|3.."}[30m]))
+            sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code!~"5.."}[30m]))
           )
           / clamp_min(sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[30m])), 1e-10)
           / error_budget:home_assistant:availability:budget_total
@@ -670,7 +677,7 @@ groups:
           (
             sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[1h]))
             -
-            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3.."}[1h]))
+            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3..|499"}[1h]))
           )
           / clamp_min(sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[1h])), 1e-10)
           / error_budget:nextcloud:availability:budget_total
@@ -680,7 +687,7 @@ groups:
           (
             sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[5m]))
             -
-            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3.."}[5m]))
+            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3..|499"}[5m]))
           )
           / clamp_min(sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[5m])), 1e-10)
           / error_budget:nextcloud:availability:budget_total
@@ -690,7 +697,7 @@ groups:
           (
             sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[6h]))
             -
-            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3.."}[6h]))
+            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3..|499"}[6h]))
           )
           / clamp_min(sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[6h])), 1e-10)
           / error_budget:nextcloud:availability:budget_total
@@ -700,7 +707,7 @@ groups:
           (
             sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[30m]))
             -
-            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3.."}[30m]))
+            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3..|499"}[30m]))
           )
           / clamp_min(sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[30m])), 1e-10)
           / error_budget:nextcloud:availability:budget_total

--- a/docs/40-monitoring-and-documentation/guides/slo-framework.md
+++ b/docs/40-monitoring-and-documentation/guides/slo-framework.md
@@ -31,7 +31,7 @@ Three approaches are used depending on service characteristics:
 - **Allowlist + 499:** Nextcloud, Immich (client disconnects during sync/upload are not server errors)
 - **Denylist:** Navidrome, Audiobookshelf, Home Assistant
 
-**Trade-off:** Denylist services exclude 4xx from burn rate alerts. Compensating 4xx alerts (`NavidromeHigh4xxRate`, `AudiobookshelfHigh4xxRate`) fire when the 4xx rate exceeds 10% for 10 minutes, catching 403/429 spikes that could indicate misconfiguration or attack.
+**Trade-off:** Denylist services exclude 4xx from burn rate alerts. Compensating 4xx alerts (`HomeAssistantHigh4xxRate`, `NavidromeHigh4xxRate`, `AudiobookshelfHigh4xxRate`) fire when the 4xx rate exceeds 10% for 10 minutes, catching 403/429 spikes that could indicate misconfiguration or attack. Note: The HA alert uses a 30m rate window (vs 5m for audio services) and a lower minimum traffic guard (0.001 req/s) to account for HA's very low Traefik traffic (~37 req/day).
 
 ### SLO (Service Level Objective)
 The target reliability level. Examples:


### PR DESCRIPTION
## Summary

- **Home Assistant:** Switch from allowlist to denylist (`code!~"5.."`) — 22 normal 404s at ~37 req/day were causing 4x budget overrun (97.99% → 100%)
- **Nextcloud/Immich:** Add 499 (client disconnect) to success criteria — client-initiated aborts are not server errors (Immich: 3.9% → 67.9% budget remaining)
- **Compensating alert:** Add `HomeAssistantHigh4xxRate` to catch 4xx spikes that bypass denylist SLO detection

## Root Cause Analysis

| Service | Before | After | Root Cause |
|---------|--------|-------|------------|
| Home Assistant | 97.99% (-302% budget) | 100.00% (100% budget) | 22 404s at 37 req/day — each costs 0.09% availability with allowlist |
| Immich | 99.52% (3.9% budget) | 99.84% (67.9% budget) | 38 client disconnects (499) counted as server errors |
| Nextcloud | 98.98% (-105% budget) | 99.07% (-87% budget) | Historical 503/403 event >14d ago + 101 client disconnects |

Nextcloud's remaining deficit is from a historical event that will roll out of the 30-day window naturally. Current 7-day rate is 99.91%.

## Files Changed

- `config/prometheus/rules/slo-recording-rules.yml` — SLI definitions + short-window burn rates (1h/5m/6h/30m)
- `config/prometheus/rules/slo-burn-rate-extended.yml` — Extended burn rates (1d/2h/3d)
- `config/prometheus/alerts/slo-multiwindow-alerts.yml` — Added HA compensating 4xx alert
- `docs/40-monitoring-and-documentation/guides/slo-framework.md` — Updated success criteria table

## Test Plan

- [x] YAML validation passes on all 3 config files
- [x] Prometheus reloaded successfully (SIGHUP)
- [x] All 27 updated recording rules loaded (9 HA + 9 NC + 9 Immich)
- [x] 3 compensating 4xx alerts active (HA + Navidrome + Audiobookshelf)
- [x] SLO metrics recalculated and verified after 2-minute interval
- [ ] Monitor over 24h that burn rates stay healthy

🤖 Generated with [Claude Code](https://claude.com/claude-code)