### PR TITLE
fix: Stop Promtail counting all Immich logs as thumbnail failures

### DIFF
--- a/config/promtail/promtail-config.yml
+++ b/config/promtail/promtail-config.yml
@@ -53,18 +53,19 @@ scrape_configs:
       #               action: inc
 
       # METRIC 2: Immich thumbnail failures
+      # Only counts lines matching "AssetGenerateThumbnails" + "ERROR" (not all immich-server lines)
       - match:
           selector: '{syslog_id="immich-server"}'
           pipeline_name: "immich_metrics"
           stages:
             - regex:
-                expression: '.*AssetGenerateThumbnails.*ERROR.*'
+                expression: '(?P<thumb_error>AssetGenerateThumbnails.*ERROR)'
             - metrics:
                 immich_thumbnail_failures_total:
                   type: Counter
                   description: "Immich thumbnail generation failures"
+                  source: thumb_error
                   config:
-                    match_all: true
                     action: inc
 
       # METRIC 3: Nextcloud cron success counter (NOT a traditional counter - just tracks successes)


### PR DESCRIPTION
## Summary

- **Root cause:** `match_all: true` in Promtail's immich thumbnail metric config caused every immich-server log line (websocket connects, library scans, backups) to increment the `immich_thumbnail_failures_total` counter — not just actual `AssetGenerateThumbnails` errors
- **Impact:** ~1,757 false "failures" per week, triggering chronic `ImmichThumbnailFailureHigh` Discord alerts (>5/hr threshold hit constantly)
- **Fix:** Named capture group `(?P<thumb_error>...)` with `source: thumb_error` replaces `match_all: true`, so the counter only increments on actual regex matches

## Investigation

- Prometheus range query showed failures every hour for weeks, yet zero `AssetGenerateThumbnails.*ERROR` lines in container logs or journal
- Loki confirmed only **2 real incidents** in 30 days (1 corrupt JPEG, 1 missing XMP sidecar) vs thousands of false positives
- The 7 images and 84 videos without thumbnails are a separate cleanup task (trash + re-run thumbnail jobs)

## Verification

- [x] Promtail restarted and healthy after config change
- [x] No config errors in Promtail logs
- [x] Old stale metric will expire from Prometheus within 5 minutes

## Test Plan

- [ ] Confirm `ImmichThumbnailFailureHigh` alert stops firing in Prometheus
- [ ] Verify no more false positive Discord alerts over 24h
- [ ] Optionally trigger a real thumbnail failure to confirm metric still works on genuine errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)