### PR TITLE
fix: Switch Nextcloud SLO to denylist criteria

### DIFF
--- a/config/prometheus/alerts/slo-multiwindow-alerts.yml
+++ b/config/prometheus/alerts/slo-multiwindow-alerts.yml
@@ -842,7 +842,7 @@ groups:
 
   # ===========================================================================
   # COMPENSATING 4xx ALERTS for denylist services
-  # Home Assistant, Navidrome, and Audiobookshelf use code!~"5.." for SLO.
+  # Home Assistant, Nextcloud, Navidrome, and Audiobookshelf use code!~"5.." for SLO.
   # These alerts catch 4xx spikes that bypass burn rate detection:
   #   - 429: rate limiting firing (possible attack or misconfigured client)
   #   - 403: middleware misconfiguration
@@ -851,6 +851,34 @@ groups:
   - name: denylist_services_4xx_compensating
     interval: 1m
     rules:
+      - alert: NextcloudHigh4xxRate
+        # Nextcloud has high traffic (~4,200 req/day) so 5m window is appropriate.
+        # WebDAV sync naturally produces 404s (moved/deleted files) and 401s, but
+        # sustained >10% 4xx rate for 10 minutes likely indicates a real problem.
+        expr: |
+          (
+            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"4.."}[5m]))
+            / clamp_min(sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[5m])), 1e-10)
+          ) > 0.10
+        for: 10m
+        labels:
+          severity: warning
+          component: slo
+          service: nextcloud
+        annotations:
+          summary: "Nextcloud 4xx rate above 10% for 10 minutes"
+          description: |
+            Current 4xx rate: {{ $value | humanizePercentage }}
+
+            This alert compensates for the SLO denylist criteria (code!~"5..") which
+            excludes 4xx from burn rate detection. A sustained 4xx spike may indicate:
+            - 404: Broken WebDAV sync or misconfigured client
+            - 401: Authentication issues
+            - 429: Rate limiting (attack or sync storm)
+
+            Check Traefik access logs in Loki for code breakdown:
+              {container_name="traefik"} |= "nextcloud" | json | status >= 400 | status < 500
+
       - alert: HomeAssistantHigh4xxRate
         # Uses 30m rate window (not 5m like audio services) because HA has very low
         # Traefik traffic (~37 req/day). With a 5m window, a single 404 would show as

--- a/config/prometheus/alerts/slo-multiwindow-alerts.yml
+++ b/config/prometheus/alerts/slo-multiwindow-alerts.yml
@@ -855,11 +855,15 @@ groups:
         # Nextcloud has high traffic (~4,200 req/day) so 5m window is appropriate.
         # WebDAV sync naturally produces 404s (moved/deleted files) and 401s, but
         # sustained >10% 4xx rate for 10 minutes likely indicates a real problem.
+        # Minimum traffic guard: 0.01 req/s (~5 req/5m) prevents false positives
+        # during restarts or traffic lulls where a single 4xx would show as 100%.
         expr: |
           (
             sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"4.."}[5m]))
             / clamp_min(sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[5m])), 1e-10)
           ) > 0.10
+          and
+          sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[5m])) > 0.01
         for: 10m
         labels:
           severity: warning

--- a/config/prometheus/rules/slo-recording-rules.yml
+++ b/config/prometheus/rules/slo-recording-rules.yml
@@ -4,6 +4,7 @@
 # Updated: 2026-03-01 - Navidrome/Audiobookshelf: count only 5xx as errors (404/499 are valid responses)
 # Updated: 2026-03-01 - Home Assistant: switch to denylist (code!~"5..") - 404s at low traffic amplified error budget
 # Updated: 2026-03-01 - Nextcloud/Immich: add 499 (client disconnect) to success criteria
+# Updated: 2026-03-15 - Nextcloud: switch to denylist (code!~"5..") - WebDAV 404s are normal sync behavior
 # Purpose: Pre-calculate Service Level Indicators for efficient querying
 #
 # Note: Traefik reports WebSocket connections as code="0" (not HTTP status).
@@ -64,10 +65,12 @@ groups:
         expr: |
           sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[5m]))
 
-      # Nextcloud - Successful requests (2xx/3xx + WebSocket code=0 + client disconnect 499)
+      # Nextcloud - Successful requests (everything except 5xx)
+      # WebDAV sync clients legitimately produce 404s when checking for moved/deleted files.
+      # Uses denylist criteria (code!~"5..") same as Navidrome/Audiobookshelf/Home Assistant.
       - record: sli:nextcloud:requests:success
         expr: |
-          sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3..|499"}[5m]))
+          sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code!~"5.."}[5m]))
 
       # Nextcloud - Availability (use 30d SLO for current display)
       - record: sli:nextcloud:availability:ratio
@@ -286,13 +289,16 @@ groups:
           slo:authelia:availability:actual >= bool slo:authelia:availability:target
 
       # Nextcloud - 99.5% availability target over 30 days
+      # WebDAV sync produces expected 404s (moved/deleted files) and 401s.
+      # Uses denylist criteria: only 5xx counts as error.
+      # Compensating control: NextcloudHigh4xxRate alert in slo-multiwindow-alerts.yml.
       - record: slo:nextcloud:availability:target
         expr: 0.995
 
       - record: slo:nextcloud:availability:actual
         expr: |
           (
-            sum(increase(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3..|499"}[30d]))
+            sum(increase(traefik_service_requests_total{exported_service="nextcloud@file", code!~"5.."}[30d]))
             /
             sum(increase(traefik_service_requests_total{exported_service="nextcloud@file"}[30d]))
           )
@@ -671,13 +677,14 @@ groups:
           / clamp_min(sum(rate(traefik_service_requests_total{exported_service="authelia@file"}[30m])), 1e-10)
           / error_budget:authelia:availability:budget_total
 
-      # Nextcloud - Burn rates
+      # Nextcloud - Burn rates (denylist: only 5xx = errors)
+      # 4xx intentionally excluded: 404 (WebDAV sync tree-walking) and 401 are expected.
+      # High traffic (~4,200 req/day) means denylist is safe — 5xx-only is meaningful.
+      # Compensating control: NextcloudHigh4xxRate alert in slo-multiwindow-alerts.yml.
       - record: burn_rate:nextcloud:availability:1h
         expr: |
           (
-            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[1h]))
-            -
-            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3..|499"}[1h]))
+            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"5.."}[1h]))
           )
           / clamp_min(sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[1h])), 1e-10)
           / error_budget:nextcloud:availability:budget_total
@@ -685,9 +692,7 @@ groups:
       - record: burn_rate:nextcloud:availability:5m
         expr: |
           (
-            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[5m]))
-            -
-            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3..|499"}[5m]))
+            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"5.."}[5m]))
           )
           / clamp_min(sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[5m])), 1e-10)
           / error_budget:nextcloud:availability:budget_total
@@ -695,9 +700,7 @@ groups:
       - record: burn_rate:nextcloud:availability:6h
         expr: |
           (
-            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[6h]))
-            -
-            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3..|499"}[6h]))
+            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"5.."}[6h]))
           )
           / clamp_min(sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[6h])), 1e-10)
           / error_budget:nextcloud:availability:budget_total
@@ -705,9 +708,7 @@ groups:
       - record: burn_rate:nextcloud:availability:30m
         expr: |
           (
-            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[30m]))
-            -
-            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"0|2..|3..|499"}[30m]))
+            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"5.."}[30m]))
           )
           / clamp_min(sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[30m])), 1e-10)
           / error_budget:nextcloud:availability:budget_total

--- a/docs/40-monitoring-and-documentation/guides/slo-framework.md
+++ b/docs/40-monitoring-and-documentation/guides/slo-framework.md
@@ -28,10 +28,10 @@ Three approaches are used depending on service characteristics:
 
 **Current assignments:**
 - **Allowlist:** Jellyfin, Authelia
-- **Allowlist + 499:** Nextcloud, Immich (client disconnects during sync/upload are not server errors)
-- **Denylist:** Navidrome, Audiobookshelf, Home Assistant
+- **Allowlist + 499:** Immich (client disconnects during upload are not server errors)
+- **Denylist:** Nextcloud, Navidrome, Audiobookshelf, Home Assistant
 
-**Trade-off:** Denylist services exclude 4xx from burn rate alerts. Compensating 4xx alerts (`HomeAssistantHigh4xxRate`, `NavidromeHigh4xxRate`, `AudiobookshelfHigh4xxRate`) fire when the 4xx rate exceeds 10% for 10 minutes, catching 403/429 spikes that could indicate misconfiguration or attack. Note: The HA alert uses a 30m rate window (vs 5m for audio services) and a lower minimum traffic guard (0.001 req/s) to account for HA's very low Traefik traffic (~37 req/day).
+**Trade-off:** Denylist services exclude 4xx from burn rate alerts. Compensating 4xx alerts (`NextcloudHigh4xxRate`, `HomeAssistantHigh4xxRate`, `NavidromeHigh4xxRate`, `AudiobookshelfHigh4xxRate`) fire when the 4xx rate exceeds 10% for 10 minutes, catching 403/429 spikes that could indicate misconfiguration or attack. Note: The HA alert uses a 30m rate window (vs 5m for other services) and a lower minimum traffic guard (0.001 req/s) to account for HA's very low Traefik traffic (~37 req/day).
 
 ### SLO (Service Level Objective)
 The target reliability level. Examples:


### PR DESCRIPTION
## Summary

- Switch Nextcloud SLO from allowlist (`code=~"0|2..|3..|499"`) to denylist (`code!~"5.."`) — WebDAV sync clients produce 404s for moved/deleted files, which consumed 89% of error budget from normal operations
- Add `NextcloudHigh4xxRate` compensating alert (>10% 4xx rate sustained 10m) to catch genuine problems excluded from burn rate detection
- Update SLO framework documentation with new criteria assignments

## Root Cause

527 WebDAV 404s in March (from sync tree-walking) + 26 5xx errors from a container restart consumed 94.2% of the 0.5% error budget. The 404s alone accounted for 89% of all SLO-counted errors — but they're expected behavior, not service failures.

## Verification

- `promtool check rules`: 115 recording rules, 32 alert rules pass
- Prometheus reloaded, `burn_rate:nextcloud:availability:1h` = 0
- Error budget (5.8% remaining) will recover as old 404s age out of 30-day rolling window

## Test Plan

- [x] Validate Prometheus rule syntax with promtool
- [x] Reload Prometheus and verify burn rate = 0
- [ ] Monitor error budget recovery over coming days
- [ ] Verify `NextcloudHigh4xxRate` alert would fire on genuine 4xx spike (check Alertmanager rules page)

🤖 Generated with [Claude Code](https://claude.com/claude-code)