### PR TITLE
security: Remove HA and Navidrome from monitoring network

### DIFF
--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -106,11 +106,10 @@ scrape_configs:
   # Nextcloud availability monitored via Traefik metrics (SLO recording rules)
 
   # Navidrome - Music Streaming Server (native Prometheus metrics)
-  # Static IP: Navidrome is multi-network (reverse_proxy + monitoring).
-  # Hostname resolution via aardvark-dns may return the wrong IP (ADR-018).
+  # Scraped via reverse_proxy network (Navidrome no longer on monitoring)
   - job_name: 'navidrome'
     static_configs:
-      - targets: ['10.89.4.75:4533']
+      - targets: ['10.89.2.75:4533']
         labels:
           instance: 'fedora-htpc'
           service: 'navidrome'

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -115,9 +115,11 @@ scrape_configs:
           service: 'navidrome'
 
   # Home Assistant - Home Automation Hub
+  # Static IP: HA is multi-network (reverse_proxy + home_automation),
+  # hostname resolution non-deterministic per ADR-018
   - job_name: 'home-assistant'
     static_configs:
-      - targets: ['home-assistant:8123']
+      - targets: ['10.89.2.76:8123']
         labels:
           instance: 'fedora-htpc'
           service: 'home-assistant'

--- a/docs/98-journals/2026-03-17-traefik-network-attack-surface-reduction.md
+++ b/docs/98-journals/2026-03-17-traefik-network-attack-surface-reduction.md
@@ -179,7 +179,7 @@ Completed the follow-up audit. Home Assistant and Navidrome were the last two ap
 **Changes:**
 - Removed `Network=systemd-monitoring` from `home-assistant.container` and `navidrome.container`
 - Updated Prometheus target for Navidrome from `10.89.4.75:4533` → `10.89.2.75:4533`
-- Home Assistant target unchanged (uses DNS hostname, now resolves only to reverse_proxy IP)
+- Updated Prometheus target for Home Assistant from `home-assistant:8123` → `10.89.2.76:8123` (ADR-018 static IP pattern — HA remains multi-network, so hostname resolution is non-deterministic)
 
 **Verified:** Both Prometheus targets report `health=up`. Traefik backend routing unaffected.
 

--- a/docs/98-journals/2026-03-17-traefik-network-attack-surface-reduction.md
+++ b/docs/98-journals/2026-03-17-traefik-network-attack-surface-reduction.md
@@ -169,3 +169,18 @@ Several application services (nextcloud, home-assistant, jellyfin, immich, gathi
 2. **Follow-up: Audit all application services on monitoring.** Determine whether each application's monitoring network membership serves a real purpose or is historical artifact. Remove where unnecessary.
 
 3. **Longer-term: Evaluate per-service scraping architecture.** If Prometheus needs metrics from application services, consider whether cAdvisor + Traefik metrics provide sufficient observability without requiring direct network access to every application.
+
+---
+
+## Follow-up: Application Services Removed from Monitoring (2026-03-19)
+
+Completed the follow-up audit. Home Assistant and Navidrome were the last two application services on the monitoring network without justification. Prometheus (which is on both reverse_proxy and monitoring) can scrape them via their reverse_proxy IPs — no monitoring membership needed.
+
+**Changes:**
+- Removed `Network=systemd-monitoring` from `home-assistant.container` and `navidrome.container`
+- Updated Prometheus target for Navidrome from `10.89.4.75:4533` → `10.89.2.75:4533`
+- Home Assistant target unchanged (uses DNS hostname, now resolves only to reverse_proxy IP)
+
+**Verified:** Both Prometheus targets report `health=up`. Traefik backend routing unaffected.
+
+The other services listed in the broader audit (nextcloud, immich, jellyfin, gathio) had already been removed from monitoring prior to this entry. All application service monitoring network memberships are now resolved.

--- a/quadlets/home-assistant.container
+++ b/quadlets/home-assistant.container
@@ -1,8 +1,8 @@
 [Unit]
 Description=Home Assistant - Home Automation Hub
-After=network-online.target reverse_proxy-network.service home_automation-network.service monitoring-network.service
+After=network-online.target reverse_proxy-network.service home_automation-network.service
 Wants=network-online.target
-Requires=reverse_proxy-network.service home_automation-network.service monitoring-network.service
+Requires=reverse_proxy-network.service home_automation-network.service
 
 [Container]
 Image=ghcr.io/home-assistant/home-assistant:stable
@@ -14,7 +14,6 @@ AutoUpdate=registry
 # Static IPs assigned to ensure consistent routing (see ADR-018)
 Network=systemd-reverse_proxy:ip=10.89.2.76
 Network=systemd-home_automation:ip=10.89.6.76
-Network=systemd-monitoring:ip=10.89.4.76
 
 # Environment
 Environment=TZ=Europe/Oslo

--- a/quadlets/navidrome.container
+++ b/quadlets/navidrome.container
@@ -21,9 +21,8 @@ ContainerName=navidrome
 HostName=navidrome
 AutoUpdate=registry
 
-# Networks (reverse_proxy FIRST for internet access, monitoring for Prometheus scraping)
+# Networks (reverse_proxy FIRST for internet access)
 Network=systemd-reverse_proxy:ip=10.89.2.75
-Network=systemd-monitoring:ip=10.89.4.75
 
 # Environment
 Environment=TZ=Europe/Oslo


### PR DESCRIPTION
## Summary

- Remove Home Assistant and Navidrome from monitoring network — completes the follow-up audit from PR #124
- Prometheus scrapes both via reverse_proxy (verified reachable before change)
- Update Navidrome Prometheus target from monitoring IP (`10.89.4.75`) to reverse_proxy IP (`10.89.2.75`)
- Journal entry updated with resolution

## Context

PR #124 removed Traefik from auth_services and monitoring. The journal entry identified several application services on monitoring as candidates for removal. This PR resolves the last two: Home Assistant and Navidrome.

**Design principle:** A service only needs monitoring network membership if it communicates with monitoring-only services (exporters, promtail) or IS a monitoring-only service. HA and Navidrome just expose metrics endpoints — Prometheus reaches them via reverse_proxy where both already reside.

## Verification

- ✓ Prometheus targets `navidrome` and `home-assistant` report `health=up` after restart
- ✓ Navidrome: single interface `eth0` (10.89.2.75, reverse_proxy)
- ✓ Home Assistant: `eth0` (10.89.2.76, reverse_proxy) + `eth1` (10.89.6.76, home_automation)
- ✓ Traefik backend routing confirmed for both services
- ✓ All three services (HA, Navidrome, Prometheus) active post-restart

## Test Plan

- [x] Verify Prometheus scrape targets healthy
- [x] Verify services accessible via Traefik
- [x] Verify no monitoring network interfaces remain
- [ ] Monitor Prometheus target health over 24h for stability

🤖 Generated with [Claude Code](https://claude.com/claude-code)