### PR TITLE
fix: Add qBittorrent permission checks to verify-permissions.sh

### DIFF
--- a/scripts/verify-permissions.sh
+++ b/scripts/verify-permissions.sh
@@ -31,7 +31,8 @@ fail() { echo -e "${RED}❌ FAIL:${NC} $1"; ((FAIL++)) || true; }
 info() { echo -e "${BLUE}ℹ️  INFO:${NC} $1"; }
 
 POOL="/mnt/btrfs-pool"
-NC_UID=100032  # Nextcloud www-data (container UID 33 + 100000 offset)
+NC_UID=100032   # Nextcloud www-data (container UID 33 + subuid base 100000)
+QB_UID=100999   # qBittorrent abc user (container UID 1000 + subuid base 100000 - 1)
 DOWNLOADS="$POOL/subvol6-tmp/Downloads"
 
 echo ""
@@ -80,6 +81,8 @@ ACL_PATHS=(
     "$DOWNLOADS:Downloads"
 )
 
+HOST_UID=1000  # patriark
+
 for entry in "${ACL_PATHS[@]}"; do
     IFS=':' read -r path name <<< "$entry"
     if [[ ! -d "$path" ]]; then
@@ -87,17 +90,70 @@ for entry in "${ACL_PATHS[@]}"; do
         continue
     fi
 
-    # Check access ACL
+    # Check Nextcloud (100032) access + default ACL
     ACCESS_ACL=$(getfacl -c "$path" 2>/dev/null | grep "^user:$NC_UID:" || true)
-    # Check default ACL
     DEFAULT_ACL=$(getfacl -c "$path" 2>/dev/null | grep "^default:user:$NC_UID:" || true)
 
     if [[ -n "$ACCESS_ACL" ]] && [[ -n "$DEFAULT_ACL" ]]; then
-        pass "$name: ACL access($ACCESS_ACL) + default($DEFAULT_ACL)"
+        pass "$name: NC ACL access($ACCESS_ACL) + default($DEFAULT_ACL)"
     elif [[ -n "$ACCESS_ACL" ]]; then
-        warn "$name: has access ACL but missing default ACL"
+        warn "$name: has NC access ACL but missing default ACL"
     else
         fail "$name: missing ACL for user:$NC_UID"
+    fi
+
+    # Check patriark default ACL (without this, subdirs created by Nextcloud
+    # are unwritable by host user — only gets group r-x)
+    # Match by UID or username since getfacl resolves names
+    HOST_USER=$(id -nu "$HOST_UID" 2>/dev/null || echo "$HOST_UID")
+    PATRIARK_DEFAULT=$(getfacl -c "$path" 2>/dev/null | grep -E "^default:user:($HOST_UID|$HOST_USER):" || true)
+    if [[ -n "$PATRIARK_DEFAULT" ]]; then
+        pass "$name: host user default ACL ($PATRIARK_DEFAULT)"
+    else
+        fail "$name: missing default ACL for patriark — NC-created subdirs will be read-only for host user"
+    fi
+
+    # Spot-check: sample subdirs for missing default ACL inheritance
+    MISSING_INHERIT=0
+    while IFS= read -r subdir; do
+        if ! getfacl -c "$subdir" 2>/dev/null | grep -qE "^default:user:($HOST_UID|$HOST_USER):"; then
+            ((MISSING_INHERIT++)) || true
+        fi
+    done < <(find "$path" -maxdepth 2 -mindepth 1 -type d 2>/dev/null | head -20)
+    if [[ "$MISSING_INHERIT" -gt 0 ]]; then
+        warn "$name: $MISSING_INHERIT subdirs missing d:u:patriark:rwx (run: sudo find $path -type d -exec setfacl -m d:u:patriark:rwx {} +)"
+    elif [[ "$MISSING_INHERIT" -eq 0 ]]; then
+        pass "$name: subdirectory default ACL inheritance OK"
+    fi
+done
+
+# ============================================================================
+# Check 2b: POSIX ACLs for qBittorrent
+# ============================================================================
+echo ""
+echo "[2b] Checking POSIX ACLs for qBittorrent (user:$QB_UID)..."
+
+QB_ACL_PATHS=(
+    "$POOL/subvol4-multimedia:subvol4-multimedia"
+    "$DOWNLOADS:Downloads"
+)
+
+for entry in "${QB_ACL_PATHS[@]}"; do
+    IFS=':' read -r path name <<< "$entry"
+    if [[ ! -d "$path" ]]; then
+        warn "$name not found"
+        continue
+    fi
+
+    ACCESS_ACL=$(getfacl -c "$path" 2>/dev/null | grep "^user:$QB_UID:" || true)
+    DEFAULT_ACL=$(getfacl -c "$path" 2>/dev/null | grep "^default:user:$QB_UID:" || true)
+
+    if [[ -n "$ACCESS_ACL" ]] && [[ -n "$DEFAULT_ACL" ]]; then
+        pass "$name: QB ACL access($ACCESS_ACL) + default($DEFAULT_ACL)"
+    elif [[ -n "$ACCESS_ACL" ]]; then
+        warn "$name: has QB access ACL but missing default ACL"
+    else
+        fail "$name: missing ACL for user:$QB_UID (qBittorrent cannot write)"
     fi
 done
 
@@ -192,6 +248,32 @@ else
             fail "Nextcloud www-data cannot write to $name ($mount_path)"
             # Clean up just in case touch succeeded but rm failed
             podman exec nextcloud rm -f "$TEST_FILE" 2>/dev/null || true
+        fi
+    done
+fi
+
+# ============================================================================
+# Check 7: qBittorrent abc write test
+# ============================================================================
+echo ""
+echo "[7] Checking qBittorrent write access..."
+
+if ! podman ps --format '{{.Names}}' 2>/dev/null | grep -q '^qbittorrent$'; then
+    warn "qBittorrent container not running, skipping write tests"
+else
+    QB_MOUNTS=(
+        "/mnt/btrfs-pool/subvol4-multimedia:Multimedia"
+        "/mnt/btrfs-pool/subvol6-tmp/Downloads:Downloads"
+    )
+    for entry in "${QB_MOUNTS[@]}"; do
+        IFS=':' read -r mount_path name <<< "$entry"
+        TEST_FILE="$mount_path/.perm-test-$$"
+        if podman exec -u abc qbittorrent touch "$TEST_FILE" 2>/dev/null && \
+           podman exec -u abc qbittorrent rm -f "$TEST_FILE" 2>/dev/null; then
+            pass "qBittorrent abc can write to $name ($mount_path)"
+        else
+            fail "qBittorrent abc cannot write to $name ($mount_path)"
+            podman exec qbittorrent rm -f "$TEST_FILE" 2>/dev/null || true
         fi
     done
 fi

--- a/scripts/verify-permissions.sh
+++ b/scripts/verify-permissions.sh
@@ -31,8 +31,9 @@ fail() { echo -e "${RED}❌ FAIL:${NC} $1"; ((FAIL++)) || true; }
 info() { echo -e "${BLUE}ℹ️  INFO:${NC} $1"; }
 
 POOL="/mnt/btrfs-pool"
-NC_UID=100032   # Nextcloud www-data (container UID 33 + subuid base 100000)
-QB_UID=100999   # qBittorrent abc user (container UID 1000 + subuid base 100000 - 1)
+HOST_UID=1000   # patriark
+NC_UID=100032   # Nextcloud www-data (container UID 33 → subuid base 100000 + 32)
+QB_UID=100999   # qBittorrent abc (container UID 1000 → subuid base 100000 + 999)
 DOWNLOADS="$POOL/subvol6-tmp/Downloads"
 
 echo ""
@@ -81,8 +82,6 @@ ACL_PATHS=(
     "$DOWNLOADS:Downloads"
 )
 
-HOST_UID=1000  # patriark
-
 for entry in "${ACL_PATHS[@]}"; do
     IFS=':' read -r path name <<< "$entry"
     if [[ ! -d "$path" ]]; then
@@ -115,15 +114,19 @@ for entry in "${ACL_PATHS[@]}"; do
 
     # Spot-check: sample subdirs for missing default ACL inheritance
     MISSING_INHERIT=0
+    CHECKED_SUBDIRS=0
     while IFS= read -r subdir; do
+        ((CHECKED_SUBDIRS++)) || true
         if ! getfacl -c "$subdir" 2>/dev/null | grep -qE "^default:user:($HOST_UID|$HOST_USER):"; then
             ((MISSING_INHERIT++)) || true
         fi
     done < <(find "$path" -maxdepth 2 -mindepth 1 -type d 2>/dev/null | head -20)
-    if [[ "$MISSING_INHERIT" -gt 0 ]]; then
-        warn "$name: $MISSING_INHERIT subdirs missing d:u:patriark:rwx (run: sudo find $path -type d -exec setfacl -m d:u:patriark:rwx {} +)"
-    elif [[ "$MISSING_INHERIT" -eq 0 ]]; then
-        pass "$name: subdirectory default ACL inheritance OK"
+    if [[ "$CHECKED_SUBDIRS" -eq 0 ]]; then
+        info "$name: no subdirectories to verify ACL inheritance"
+    elif [[ "$MISSING_INHERIT" -gt 0 ]]; then
+        warn "$name: $MISSING_INHERIT/$CHECKED_SUBDIRS subdirs missing d:u:$HOST_USER:rwx (run: find $path -type d -exec setfacl -m d:u:$HOST_USER:rwx {} +)"
+    else
+        pass "$name: subdirectory default ACL inheritance OK ($CHECKED_SUBDIRS checked)"
     fi
 done
 


### PR DESCRIPTION
## Summary

- Add POSIX ACL verification for qBittorrent's mapped host UID (100999) on `subvol4-multimedia` and `Downloads`
- Add live write test running as the `abc` user inside the qBittorrent container
- Clarify existing Nextcloud UID comments and add host user default ACL inheritance checks

## Context

qBittorrent's linuxserver.io `abc` user (container UID 1000) maps to host UID 100999 in rootless Podman (subuid base 100000 + 999). No POSIX ACLs were configured for this UID, causing "Permission denied" on all torrent writes. The existing `user:100032` ACL on Downloads was for Nextcloud's `www-data` (container UID 33), not qBittorrent.

The permission script previously only verified Nextcloud ACLs — this adds equivalent checks for qBittorrent so future permission drift is caught automatically.

## Test Plan

- [ ] Run `./scripts/verify-permissions.sh` — expect Check 2b to FAIL (ACLs not yet set)
- [ ] Set ACLs: `setfacl -R -m u:100999:rwx` + `setfacl -R -d -m u:100999:rwx` on both paths
- [ ] Re-run script — expect all checks to PASS
- [ ] Resume Mark Normand torrent — verify download starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)