### PR TITLE
fix: Backup script operational excellence — prevent silent failure cascades

### DIFF
--- a/docs/98-journals/2026-03-21-backup-script-operational-excellence.md
+++ b/docs/98-journals/2026-03-21-backup-script-operational-excellence.md
@@ -1,0 +1,277 @@
+# 2026-03-21: BTRFS Backup Script — Operational Excellence Revision
+
+## Incident Summary
+
+Weekly external backup failed silently for 2+ weeks. User discovered manually on 2026-03-21
+that subvol1-docs, subvol3-opptak, and subvol7-containers had no valid external backup.
+
+### Root Cause Chain
+
+1. **March 7**: subvol5-music full send failed (external drive nearly full at 92%).
+   subvol6-tmp also failed. Script logged only "Command failed" — no reason captured.
+2. **March 14**: subvol3-opptak and subvol7-containers incremental sends failed.
+   The parent snapshot existed on both sides, but sends failed (likely disk space again
+   from incomplete receives left behind).
+3. **March 21**: subvol3-opptak and subvol7-containers have **no common parent** anymore.
+   Local retention (15 daily) deleted the snapshot that was last sent externally (20260307).
+   Script fell back to full send — ran for 3 hours, then failed (disk full).
+   subvol1-docs incremental also failed.
+4. Script reported "Completed" after every run. Exit code 0. No notification.
+   User had no indication anything was wrong.
+
+### Fundamental Flaws Identified
+
+| # | Problem | Impact |
+|---|---------|--------|
+| 1 | No disk space pre-check | Multi-hour sends fail silently |
+| 2 | No stderr capture from btrfs send/receive | "Command failed" with no reason |
+| 3 | Local retention deletes the last common parent | Breaks incremental chain permanently |
+| 4 | No end-of-run failure summary | Script says "Completed" even when subvols fail |
+| 5 | Exit code always 0 | systemd Restart=on-failure never triggers correctly |
+| 6 | Failed receives leave orphan subvolumes | Disk fills with incomplete data |
+| 7 | No notification to user | Failures accumulate silently for weeks |
+| 8 | Retries re-run everything from the top | 4x retry overhead, hours wasted |
+
+## Fixes Implemented
+
+All changes in `scripts/btrfs-snapshot-backup.sh` (1042 → 1361 lines).
+
+### 1. Disk space pre-check (`check_external_space()`)
+- Checks available space via `df` before every send
+- For full sends: estimates required size from `btrfs subvolume show` (exclusive data),
+  falls back to `du -sb` when btrfs show requires password
+- For incrementals: requires at least 10GB headroom
+- Aborts with clear error before starting a multi-hour send
+
+### 2. Stderr capture in send/receive
+- Replaced `eval`/`run_cmd` with dedicated pipeline capturing stderr from both sides
+- Checks `PIPESTATUS` array for send and receive exit codes independently
+- Logs actual error messages (e.g., "No space left on device")
+
+### 3. Pinned parent mechanism
+- After successful external send, writes `.last-external-parent` marker file
+- `cleanup_old_snapshots()` never deletes the pinned snapshot
+- Ensures incremental chain anchor survives regardless of retention count
+- New send updates the pin (old parent can then be cleaned up normally)
+
+### 4. Failure tracking + summary
+- `FAILED_SUBVOLS[]`, `SUCCEEDED_SUBVOLS[]`, `SKIPPED_SUBVOLS[]` arrays
+- `print_summary()` at end of every run shows counts and failure reasons
+- Clear indication of which subvolumes need manual attention
+
+### 5. Non-zero exit code
+- `exit 1` when any subvolume fails
+- Makes systemd `Restart=on-failure` work correctly
+
+### 6. Partial receive cleanup
+- On send/receive failure, checks for incomplete subvolume at destination
+- Deletes it with `btrfs subvolume delete` before returning
+- Prevents disk fill from abandoned partial receives
+
+### 7. Discord notification
+- Uses existing `alert-discord-relay` webhook pattern
+- Sends embed listing failed subvolumes with reasons
+- Only fires on failures, not success
+
+### 8. Retry state tracking
+- Writes completed subvolumes to `/tmp/btrfs-backup-completed-YYYYMMDD`
+- Skips already-completed subvolumes on retry
+- Auto-cleans stale state files from previous days
+- Dry-run mode does not write state files
+
+## Live Testing
+
+Testing against offsite backup drive (WD-18TB1) with 3-month-old snapshots.
+This drive has no common parent with current local snapshots — exercises full send path.
+
+### Test Environment
+- **Offsite drive**: /run/media/patriark/WD-18TB1 (17T, 262GB free at start)
+- **Ephemeral drive**: /run/media/patriark/2TB-backup (1.9T, 1.1TB free)
+- **Test subvolumes**: subvol7-containers (8GB), subvol1-docs (11GB)
+
+### Iteration Log
+
+#### Iteration 1: Dry run — space check bug
+- `btrfs subvolume show` needs sudo password interactively → exclusive size returns empty
+- Space check showed "estimated=0GB" — misleading but didn't block
+- **Fix**: Added `du -sb` fallback when btrfs show fails
+
+#### Iteration 2: Dry run — arithmetic error from du
+- `du -sb` output contained newline that broke bash arithmetic
+- **Fix**: Added `head -1 | tr -cd '0-9'` to sanitize du output
+
+#### Iteration 3: Dry run — verified
+- Space check now shows: `available=261GB, estimated=8GB (source: du)` — correct
+- No common parent detected correctly → falls back to full send
+- Summary, pinning, retry detection all working in dry-run mode
+
+#### Iteration 4: Dry run state file leak
+- Dry-run was writing to state file, causing second dry-run to skip everything
+- **Fix**: `mark_completed()` now checks `DRY_RUN` before writing state
+
+#### Iteration 5: Live test — subvol7-containers (SUCCESS)
+- Full send of 8GB to offsite drive (no common parent)
+- Completed in 626s (~10 minutes), used ~12GB on external (btrfs overhead)
+- Pin file created: `.last-external-parent` = `20260321-containers`
+- State file tracking works
+
+#### Iteration 6: Retry skip test (SUCCESS)
+- Re-ran `--subvolume containers` immediately after
+- Output: `subvol7-containers already completed today, skipping (retry)`
+- Shows `Retry run — previously completed: subvol7-containers`
+- 0 seconds, correctly skipped
+
+#### Iteration 7: Live test — subvol1-docs (SUCCESS)
+- Full send of 11GB to offsite drive (no common parent)
+- Completed in 223s (~4 minutes)
+- Pin file created, state file updated with both subvolumes
+
+#### Iteration 8: Space check rejection — subvol3-opptak (CORRECT FAILURE)
+- 3.2TB subvolume vs 236GB available
+- `Space check (full send): available=236GB, estimated=3189GB (source: du)`
+- `Insufficient space for full send: need ~3189GB, have 236GB`
+- Rejected instantly — no wasted hours. Exit code 1.
+
+#### Iteration 9: `set -e` bug discovery and fix
+- Script exiting before reaching `print_summary()` on failures
+- Root cause: backup functions `return 1`, `set -e` kills script in `main()`
+- **Fix**: Added `|| true` after each backup function call in `main()`
+- Failures tracked in `FAILED_SUBVOLS` array, summary and exit code handled at end
+
+#### Iteration 10: Multi-subvolume mixed success/failure — tier 1 (VALIDATED)
+- Ran all tier 1 with `--tier 1`
+- **htpc-home**: Incremental send found common parent, but failed mid-transfer with
+  `No space left on device` (stderr captured perfectly: showed exact file causing failure).
+  Partial receive cleaned up automatically — `20260321-htpc-home` not left on disk.
+- **subvol3-opptak**: Space check rejected immediately (3189GB > 235GB)
+- **subvol7-containers**: Destination snapshot already existed, correctly skipped
+- Summary: `Succeeded (1): subvol7-containers` / `FAILED (2): htpc-home, subvol3-opptak`
+- Exit code: 1
+- All critical paths validated: stderr capture, partial cleanup, space check, retry, summary
+
+## Bugs Found and Fixed During Testing
+
+| # | Bug | When Found | Fix |
+|---|-----|-----------|-----|
+| 1 | `btrfs subvolume show` needs sudo (not in NOPASSWD list) | Iteration 1 | `du -sb` fallback |
+| 2 | `du -sb` output newline breaks bash arithmetic | Iteration 2 | `head -1 \| tr -cd '0-9'` |
+| 3 | Dry-run writes to state file | Iteration 4 | Check `DRY_RUN` in `mark_completed()` |
+| 4 | `set -e` kills script before summary on failure | Iteration 9 | `\|\| true` on backup function calls |
+
+## Compression Validation
+
+### Discovery: Offsite drive missing compression
+
+The offsite drive (WD-18TB1) was automounted by udisks2 **without** `compress=zstd:3`.
+The fstab entry only targets `/run/media/patriark/WD-18TB` (primary drive mount point).
+Both drives share LUKS UUID `b6b38ff1-...` and btrfs label "WD-18TB" (cloned drives),
+but udisks2 automounts to `WD-18TB1` when the primary mount point path exists.
+
+**Fix applied:**
+1. Immediate: `sudo mount -o remount,compress=zstd:3 /run/media/patriark/WD-18TB1`
+2. Permanent: udisks2 config needed at `/etc/udisks2/mount_options.conf` matching
+   `/dev/disk/by-label/WD-18TB` with `btrfs_defaults=compress=zstd:3,nosuid,nodev`
+
+### Re-send with compression
+
+Deleted uncompressed snapshots, re-sent with `compress=zstd:3` active:
+
+| Subvolume | Duration | Uncompressed | On-disk | Compressible portion | Ratio |
+|-----------|----------|-------------|---------|---------------------|-------|
+| containers | 559s (was 626s) | 13GB | 10GB | 3.3GB → 1.0GB zstd | **31%** |
+| docs | 194s (was 223s) | 11GB | 10GB | 1.1GB → 260MB zstd | **22%** |
+
+**Key findings:**
+- Compressible data (configs, databases, text) achieves 69-78% size reduction
+- btrfs correctly skips already-compressed data (images, binaries) — no wasted CPU
+- Transfer time also improved (less I/O): containers 11% faster, docs 13% faster
+- Total savings on these two subvolumes: ~3.1GB
+- The 2026-02-02 evaluation predicted "30-40% on configs" — actual is 69-78% (better)
+
+## Bugs Found and Fixed During Testing
+
+| # | Bug | When Found | Fix |
+|---|-----|-----------|-----|
+| 1 | `btrfs subvolume show` needs sudo (not in NOPASSWD list) | Iteration 1 | `du -sb` fallback |
+| 2 | `du -sb` output newline breaks bash arithmetic | Iteration 2 | `head -1 \| tr -cd '0-9'` |
+| 3 | Dry-run writes to state file | Iteration 4 | Check `DRY_RUN` in `mark_completed()` |
+| 4 | `set -e` kills script before summary on failure | Iteration 9 | `\|\| true` on backup function calls |
+| 5 | Offsite drive automounted without compression | Compression test | `mount -o remount`, needs permanent udisks2 config |
+
+## Current State (End of Session)
+
+- **Offsite drive (WD-18TB1)**: 240GB free (99% full), compression active (remount)
+- **subvol7-containers**: Chain re-established, compressed (pinned: 20260321)
+- **subvol1-docs**: Chain re-established, compressed (pinned: 20260321)
+- **subvol3-opptak**: Needs space freed (~3.2TB full send required)
+- **htpc-home**: Needs space freed (incremental failed with ENOSPC)
+- **Primary drive (WD-18TB)**: Not connected (was swapped out for offsite testing)
+- **2TB-backup drive**: Available at /run/media/patriark/2TB-backup (1.1TB free)
+
+---
+
+## Handoff: Work Remaining for Future Session
+
+### Immediate (before next Saturday backup)
+
+1. **Create udisks2 mount config** — `/etc/udisks2/mount_options.conf`:
+   ```
+   [/dev/disk/by-label/WD-18TB]
+   btrfs_defaults=compress=zstd:3,nosuid,nodev
+   btrfs_allow=compress,compress-force,datacow,nodatacow,datasum,nodatasum,autodefrag,noautodefrag,degraded,device,discard,nodiscard,subvol,subvolid,space_cache
+   ```
+   This ensures both WD-18TB drives always get compression when automounted by udisks2.
+
+2. **Swap back to primary drive (WD-18TB)** and re-establish incremental chains
+   for subvol1, subvol3, subvol7. The primary drive has more recent snapshots
+   (up to 20260314) so some incrementals may work. Check with `--dry-run` first.
+
+3. **Verify the primary drive has compression in fstab** — already confirmed:
+   `UUID=b6b38ff1-... /run/media/patriark/WD-18TB btrfs compress=zstd:3,...`
+
+### Script refinements to consider
+
+4. **Retention policy review** — The current retention was configured before the
+   pinned parent mechanism was added. Now that the incremental chain anchor is
+   protected, the retention counts could potentially be adjusted:
+   - Local daily retention of 15 may be more than needed now that pins protect parents
+   - External weekly retention of 8 (= 2 months) seems reasonable
+   - Monthly retention concept is not actually implemented in the script — the
+     `cleanup_old_snapshots` function doesn't distinguish weekly from monthly.
+     All external snapshots use a single pattern and single retention count.
+     This means "8 weekly + 12 monthly" in the config is aspirational, not real.
+     **This is a known gap that needs design work.**
+
+5. **Backup frequency** — The 2026-02-02 evaluation proposed increasing Tier 1
+   external backups from weekly to 2-3x/week. Now that incrementals are cheap
+   and the pinned parent protects the chain, this is lower risk. The script
+   already checks `$(date +%u) -eq 6` (Saturday) — changing to
+   `[[ $(date +%u) =~ ^(2|4|6)$ ]]` (Tue/Thu/Sat) would triple external frequency
+   with minimal storage impact since incrementals are small.
+
+6. **Add `btrfs subvolume show` to sudoers NOPASSWD** — This would let the
+   space check use exclusive data size (more accurate than `du` for snapshots).
+   Add to `/etc/sudoers.d/btrfs-backup`:
+   ```
+   patriark ALL=(root) NOPASSWD: /usr/sbin/btrfs subvolume show *
+   ```
+
+7. **Discord notification testing** — The webhook file is at
+   `config/alertmanager/discord-webhook.txt`. The notification function works
+   but wasn't tested live (webhook not accessible from CLI context). Test by
+   running the script when it will produce a failure, then check Discord.
+
+8. **Prometheus alert for broken incremental chain** — The script now logs
+   "Sending full snapshot" when no common parent exists. A Prometheus metric
+   like `backup_incremental_chain_broken{subvolume="X"} 1` would let Grafana
+   alert on this before it becomes a space problem.
+
+### Context for the drives
+
+- **WD-18TB (primary)**: Always connected via SATA, fstab-managed, has recent
+  snapshots up to 20260314/20260307 depending on subvolume. Compression via fstab.
+- **WD-18TB1 (offsite)**: Swapped in periodically, udisks2-managed, has old
+  snapshots (3+ months). Needs udisks2 config for compression. Currently mounted
+  with compression (remount), has fresh chains for containers + docs.
+- **2TB-backup**: Surplus ephemeral drive, 1.1TB free. Available for experiments.
+- Both WD drives share the same LUKS UUID and btrfs label (cloned).

--- a/scripts/btrfs-snapshot-backup.sh
+++ b/scripts/btrfs-snapshot-backup.sh
@@ -418,34 +418,34 @@ send_snapshot_incremental() {
     fi
 
     local send_type="full"
-    local send_cmd
+    local send_args=()
 
     if [[ -n "$parent_snapshot" ]] && [[ -d "$parent_snapshot" ]]; then
         send_type="incremental"
         log INFO "Sending incremental snapshot: $new_snapshot (parent: $parent_snapshot)"
-        send_cmd="sudo btrfs send -p '$parent_snapshot' '$new_snapshot'"
+        send_args=(sudo btrfs send -p "$parent_snapshot" "$new_snapshot")
     else
         log INFO "Sending full snapshot: $new_snapshot (no common parent — this may take a long time)"
-        send_cmd="sudo btrfs send '$new_snapshot'"
+        send_args=(sudo btrfs send "$new_snapshot")
     fi
 
     # Pre-flight space check
     check_external_space "$dest_dir" "$send_type" "$new_snapshot" || return 1
 
     if [[ "$DRY_RUN" == "true" ]]; then
-        log INFO "[DRY-RUN] Would execute: $send_cmd | sudo btrfs receive '$dest_dir'"
+        log INFO "[DRY-RUN] Would execute: ${send_args[*]} | sudo btrfs receive '$dest_dir'"
         return 0
     fi
 
     if [[ "$VERBOSE" == "true" ]]; then
-        log INFO "Executing: $send_cmd | sudo btrfs receive '$dest_dir'"
+        log INFO "Executing: ${send_args[*]} | sudo btrfs receive '$dest_dir'"
     fi
 
     # Execute with stderr capture for both sides of the pipeline
     local stderr_file
     stderr_file=$(mktemp /tmp/btrfs-send-stderr.XXXXXX)
 
-    eval "$send_cmd" 2>"${stderr_file}.send" | sudo btrfs receive "$dest_dir" 2>"${stderr_file}.recv"
+    "${send_args[@]}" 2>"${stderr_file}.send" | sudo btrfs receive "$dest_dir" 2>"${stderr_file}.recv"
     local pipe_status=("${PIPESTATUS[@]}")
 
     local send_exit=${pipe_status[0]}
@@ -1251,6 +1251,11 @@ send_failure_notification() {
 
     if [[ -z "$DISCORD_WEBHOOK" ]]; then
         log WARNING "No Discord webhook configured — cannot send failure notification"
+        return 0
+    fi
+
+    if ! command -v jq &>/dev/null; then
+        log WARNING "jq not found — cannot send Discord notification"
         return 0
     fi
 

--- a/scripts/btrfs-snapshot-backup.sh
+++ b/scripts/btrfs-snapshot-backup.sh
@@ -73,6 +73,16 @@ EXTERNAL_ONLY=false
 TIER_FILTER=""
 SUBVOL_FILTER=""
 
+# Retry state: track completed subvolumes to skip on retry
+STATE_DIR="/tmp"
+STATE_FILE="$STATE_DIR/btrfs-backup-completed-${DATE_DAILY}"
+
+# Discord webhook for failure notifications
+DISCORD_WEBHOOK="${DISCORD_WEBHOOK:-}"
+if [[ -z "$DISCORD_WEBHOOK" && -f "$HOME/containers/config/alertmanager/discord-webhook.txt" ]]; then
+    DISCORD_WEBHOOK=$(cat "$HOME/containers/config/alertmanager/discord-webhook.txt" 2>/dev/null || echo "")
+fi
+
 # Metrics tracking
 declare -A BACKUP_SUCCESS
 declare -A BACKUP_DURATION
@@ -80,6 +90,12 @@ declare -A BACKUP_TIMESTAMP
 declare -A SNAPSHOT_COUNT_LOCAL
 declare -A SNAPSHOT_COUNT_EXTERNAL
 SCRIPT_START_TIME=$(date +%s)
+
+# Failure tracking
+FAILED_SUBVOLS=()
+FAILED_REASONS=()
+SUCCEEDED_SUBVOLS=()
+SKIPPED_SUBVOLS=()
 
 ################################################################################
 # TIER 1: CRITICAL - Daily local, Weekly external
@@ -233,6 +249,117 @@ run_cmd() {
     fi
 }
 
+is_completed_today() {
+    local subvol_name=$1
+    if [[ -f "$STATE_FILE" ]] && grep -q "^${subvol_name}$" "$STATE_FILE" 2>/dev/null; then
+        return 0
+    fi
+    return 1
+}
+
+mark_completed() {
+    local subvol_name=$1
+    if [[ "$DRY_RUN" != "true" ]]; then
+        echo "$subvol_name" >> "$STATE_FILE"
+    fi
+    SUCCEEDED_SUBVOLS+=("$subvol_name")
+}
+
+record_failure() {
+    local subvol_name=$1
+    local reason=$2
+    FAILED_SUBVOLS+=("$subvol_name")
+    FAILED_REASONS+=("$reason")
+}
+
+check_external_space() {
+    local dest_dir=$1
+    local is_full_send=$2        # "full" or "incremental"
+    local source_snapshot=$3
+
+    local mount_point
+    mount_point=$(df --output=target "$dest_dir" 2>/dev/null | tail -1)
+    if [[ -z "$mount_point" ]]; then
+        log WARNING "Could not determine mount point for $dest_dir"
+        return 0  # Don't block on detection failure
+    fi
+
+    local avail_bytes
+    avail_bytes=$(df --output=avail -B1 "$mount_point" 2>/dev/null | tail -1 | tr -d ' ')
+    local avail_gb=$(( avail_bytes / 1073741824 ))
+
+    if [[ "$is_full_send" == "full" ]]; then
+        # For full sends, estimate using source subvolume size
+        # Try btrfs subvolume show first (exclusive data), fall back to du
+        local required_bytes=0
+        local size_source="unknown"
+
+        local exclusive_bytes
+        exclusive_bytes=$(sudo btrfs subvolume show "$source_snapshot" 2>/dev/null | grep -i "exclusive" | head -1 | awk '{print $NF}' || echo "0")
+
+        # Parse human-readable size (e.g., "2.10TiB", "500.00GiB", "100.00MiB")
+        if [[ "$exclusive_bytes" =~ ([0-9.]+)TiB ]]; then
+            required_bytes=$(echo "${BASH_REMATCH[1]} * 1099511627776" | bc | cut -d. -f1)
+            size_source="btrfs-exclusive"
+        elif [[ "$exclusive_bytes" =~ ([0-9.]+)GiB ]]; then
+            required_bytes=$(echo "${BASH_REMATCH[1]} * 1073741824" | bc | cut -d. -f1)
+            size_source="btrfs-exclusive"
+        elif [[ "$exclusive_bytes" =~ ([0-9.]+)MiB ]]; then
+            required_bytes=$(echo "${BASH_REMATCH[1]} * 1048576" | bc | cut -d. -f1)
+            size_source="btrfs-exclusive"
+        elif [[ "$exclusive_bytes" =~ ([0-9.]+)KiB ]]; then
+            required_bytes=$(echo "${BASH_REMATCH[1]} * 1024" | bc | cut -d. -f1)
+            size_source="btrfs-exclusive"
+        fi
+
+        # Fallback: use du if btrfs subvolume show didn't return useful data
+        if [[ $required_bytes -eq 0 ]] && [[ -d "$source_snapshot" ]]; then
+            local du_output
+            du_output=$(du -sb "$source_snapshot" 2>/dev/null | head -1 | awk '{print $1}' | tr -cd '0-9')
+            required_bytes=${du_output:-0}
+            size_source="du"
+        fi
+
+        local required_gb=$(( required_bytes / 1073741824 ))
+        log INFO "Space check (full send): available=${avail_gb}GB, estimated=${required_gb}GB (source: $size_source)"
+
+        if [[ $required_bytes -gt 0 ]] && [[ $avail_bytes -lt $required_bytes ]]; then
+            log ERROR "Insufficient space for full send: need ~${required_gb}GB, have ${avail_gb}GB"
+            return 1
+        fi
+
+        # Warn if tight even when we can't estimate precisely
+        if [[ $avail_gb -lt 50 ]]; then
+            log WARNING "External drive has only ${avail_gb}GB free — full send may fail"
+        fi
+    else
+        # For incremental sends, just ensure reasonable headroom
+        log INFO "Space check (incremental): available=${avail_gb}GB"
+        if [[ $avail_gb -lt 10 ]]; then
+            log ERROR "Insufficient space for incremental send: only ${avail_gb}GB free (need at least 10GB headroom)"
+            return 1
+        fi
+    fi
+
+    return 0
+}
+
+pin_parent() {
+    local local_dir=$1
+    local snapshot_name=$2
+    local pin_file="$local_dir/.last-external-parent"
+    echo "$snapshot_name" > "$pin_file"
+    log INFO "Pinned parent for incremental chain: $snapshot_name"
+}
+
+get_pinned_parent() {
+    local local_dir=$1
+    local pin_file="$local_dir/.last-external-parent"
+    if [[ -f "$pin_file" ]]; then
+        cat "$pin_file"
+    fi
+}
+
 check_external_mounted() {
     if [[ ! -d "$EXTERNAL_BACKUP_ROOT" ]]; then
         log ERROR "External backup drive not mounted (checked: ${EXTERNAL_BACKUP_CANDIDATES[*]})"
@@ -290,15 +417,62 @@ send_snapshot_incremental() {
         return 0
     fi
 
+    local send_type="full"
+    local send_cmd
+
     if [[ -n "$parent_snapshot" ]] && [[ -d "$parent_snapshot" ]]; then
+        send_type="incremental"
         log INFO "Sending incremental snapshot: $new_snapshot (parent: $parent_snapshot)"
-        run_cmd "sudo btrfs send -p '$parent_snapshot' '$new_snapshot' | sudo btrfs receive '$dest_dir'"
+        send_cmd="sudo btrfs send -p '$parent_snapshot' '$new_snapshot'"
     else
-        log INFO "Sending full snapshot: $new_snapshot"
-        run_cmd "sudo btrfs send '$new_snapshot' | sudo btrfs receive '$dest_dir'"
+        log INFO "Sending full snapshot: $new_snapshot (no common parent — this may take a long time)"
+        send_cmd="sudo btrfs send '$new_snapshot'"
     fi
 
-    return $?
+    # Pre-flight space check
+    check_external_space "$dest_dir" "$send_type" "$new_snapshot" || return 1
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log INFO "[DRY-RUN] Would execute: $send_cmd | sudo btrfs receive '$dest_dir'"
+        return 0
+    fi
+
+    if [[ "$VERBOSE" == "true" ]]; then
+        log INFO "Executing: $send_cmd | sudo btrfs receive '$dest_dir'"
+    fi
+
+    # Execute with stderr capture for both sides of the pipeline
+    local stderr_file
+    stderr_file=$(mktemp /tmp/btrfs-send-stderr.XXXXXX)
+
+    eval "$send_cmd" 2>"${stderr_file}.send" | sudo btrfs receive "$dest_dir" 2>"${stderr_file}.recv"
+    local pipe_status=("${PIPESTATUS[@]}")
+
+    local send_exit=${pipe_status[0]}
+    local recv_exit=${pipe_status[1]}
+
+    if [[ $send_exit -ne 0 ]] || [[ $recv_exit -ne 0 ]]; then
+        local send_err recv_err
+        send_err=$(cat "${stderr_file}.send" 2>/dev/null || echo "")
+        recv_err=$(cat "${stderr_file}.recv" 2>/dev/null || echo "")
+
+        log ERROR "btrfs send/receive failed (send_exit=$send_exit, recv_exit=$recv_exit)"
+        [[ -n "$send_err" ]] && log ERROR "  send stderr: $send_err"
+        [[ -n "$recv_err" ]] && log ERROR "  recv stderr: $recv_err"
+
+        # Clean up partial receive if it exists
+        if [[ -d "$dest_snapshot" ]]; then
+            log WARNING "Cleaning up incomplete snapshot at destination: $dest_snapshot"
+            sudo btrfs subvolume delete "$dest_snapshot" 2>/dev/null || \
+                log ERROR "Failed to clean up partial snapshot: $dest_snapshot"
+        fi
+
+        rm -f "${stderr_file}" "${stderr_file}.send" "${stderr_file}.recv"
+        return 1
+    fi
+
+    rm -f "${stderr_file}" "${stderr_file}.send" "${stderr_file}.recv"
+    return 0
 }
 
 cleanup_old_snapshots() {
@@ -311,6 +485,10 @@ cleanup_old_snapshots() {
         return 0
     fi
 
+    # Check for pinned parent that must be preserved
+    local pinned_name
+    pinned_name=$(get_pinned_parent "$snapshot_dir")
+
     # Get list of snapshots matching pattern, sorted by modification time (oldest first)
     local snapshots=($(find "$snapshot_dir" -maxdepth 1 -type d -name "$pattern" -printf '%T+ %p\n' | sort | awk '{print $2}'))
 
@@ -322,13 +500,28 @@ cleanup_old_snapshots() {
     fi
 
     local to_delete=$((count - retention_count))
+    local deleted=0
     log INFO "Cleaning up $to_delete old snapshots from $snapshot_dir (keeping $retention_count)"
 
     for ((i=0; i<to_delete; i++)); do
         local snapshot="${snapshots[$i]}"
+        local snap_basename
+        snap_basename=$(basename "$snapshot")
+
+        # Never delete the pinned parent — it's the incremental chain anchor
+        if [[ -n "$pinned_name" ]] && [[ "$snap_basename" == "$pinned_name" ]]; then
+            log WARNING "Preserving pinned parent snapshot (incremental chain anchor): $snapshot"
+            continue
+        fi
+
         log INFO "Deleting old snapshot: $snapshot"
         run_cmd "sudo btrfs subvolume delete '$snapshot'"
+        ((deleted++))
     done
+
+    if [[ -n "$pinned_name" ]] && [[ $deleted -lt $to_delete ]]; then
+        log INFO "Retained $(( to_delete - deleted )) snapshot(s) due to pinned parent protection"
+    fi
 
     return 0
 }
@@ -429,12 +622,19 @@ record_backup_metrics() {
 ################################################################################
 
 backup_tier1_home() {
+    local subvol_name="htpc-home"
     local start_time=$(date +%s)
-    log INFO "=== Processing Tier 1: htpc-home ==="
+    log INFO "=== Processing Tier 1: $subvol_name ==="
+
+    if is_completed_today "$subvol_name"; then
+        log INFO "$subvol_name already completed today, skipping (retry)"
+        SKIPPED_SUBVOLS+=("$subvol_name")
+        return 0
+    fi
 
     if [[ "$TIER1_HOME_ENABLED" != "true" ]]; then
-        log INFO "htpc-home backup disabled, skipping"
-        record_backup_metrics "htpc-home" "$start_time" 1 "$TIER1_HOME_LOCAL_DIR" "$TIER1_HOME_EXTERNAL_DIR" "*-htpc-home"
+        log INFO "$subvol_name backup disabled, skipping"
+        record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER1_HOME_LOCAL_DIR" "$TIER1_HOME_EXTERNAL_DIR" "*-htpc-home"
         return 0
     fi
 
@@ -444,28 +644,31 @@ backup_tier1_home() {
     # Create local snapshot
     if [[ "$EXTERNAL_ONLY" != "true" ]]; then
         create_snapshot "$TIER1_HOME_SOURCE" "$local_snapshot" || {
-            record_backup_metrics "htpc-home" "$start_time" 0 "$TIER1_HOME_LOCAL_DIR" "$TIER1_HOME_EXTERNAL_DIR" "*-htpc-home"
+            record_failure "$subvol_name" "Local snapshot creation failed"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER1_HOME_LOCAL_DIR" "$TIER1_HOME_EXTERNAL_DIR" "*-htpc-home"
             return 1
         }
     fi
 
     # Send to external (weekly)
     if [[ "$LOCAL_ONLY" != "true" ]] && [[ "$TIER1_HOME_SCHEDULE" == "daily" ]]; then
-        # Only send on the designated weekly backup day
         if [[ $(date +%u) -eq 6 ]]; then  # Saturday
             check_external_mounted || {
-                record_backup_metrics "htpc-home" "$start_time" 0 "$TIER1_HOME_LOCAL_DIR" "$TIER1_HOME_EXTERNAL_DIR" "*-htpc-home"
+                record_failure "$subvol_name" "External drive not mounted"
+                record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER1_HOME_LOCAL_DIR" "$TIER1_HOME_EXTERNAL_DIR" "*-htpc-home"
                 return 1
             }
 
-            # Find common parent that exists on both local and external (for incremental send)
             local parent=$(find_common_parent "$TIER1_HOME_LOCAL_DIR" "$TIER1_HOME_EXTERNAL_DIR" "*-htpc-home")
             send_snapshot_incremental "$parent" "$local_snapshot" "$TIER1_HOME_EXTERNAL_DIR" || {
-                record_backup_metrics "htpc-home" "$start_time" 0 "$TIER1_HOME_LOCAL_DIR" "$TIER1_HOME_EXTERNAL_DIR" "*-htpc-home"
+                record_failure "$subvol_name" "External send failed"
+                record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER1_HOME_LOCAL_DIR" "$TIER1_HOME_EXTERNAL_DIR" "*-htpc-home"
                 return 1
             }
 
-            # Cleanup external snapshots
+            # Pin the snapshot we just sent as the incremental chain anchor
+            pin_parent "$TIER1_HOME_LOCAL_DIR" "$snapshot_name"
+
             cleanup_old_snapshots "$TIER1_HOME_EXTERNAL_DIR" "$TIER1_HOME_EXTERNAL_RETENTION_WEEKLY" "*-htpc-home"
         fi
     fi
@@ -473,409 +676,468 @@ backup_tier1_home() {
     # Cleanup local snapshots
     cleanup_old_snapshots "$TIER1_HOME_LOCAL_DIR" "$TIER1_HOME_LOCAL_RETENTION_DAILY" "*-htpc-home"
 
-    record_backup_metrics "htpc-home" "$start_time" 1 "$TIER1_HOME_LOCAL_DIR" "$TIER1_HOME_EXTERNAL_DIR" "*-htpc-home"
-    log SUCCESS "Completed Tier 1: htpc-home"
+    record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER1_HOME_LOCAL_DIR" "$TIER1_HOME_EXTERNAL_DIR" "*-htpc-home"
+    mark_completed "$subvol_name"
+    log SUCCESS "Completed Tier 1: $subvol_name"
 }
 
 backup_tier1_opptak() {
+    local subvol_name="subvol3-opptak"
     local start_time=$(date +%s)
-    log INFO "=== Processing Tier 1: subvol3-opptak ==="
+    log INFO "=== Processing Tier 1: $subvol_name ==="
+
+    if is_completed_today "$subvol_name"; then
+        log INFO "$subvol_name already completed today, skipping (retry)"
+        SKIPPED_SUBVOLS+=("$subvol_name")
+        return 0
+    fi
 
     if [[ "$TIER1_OPPTAK_ENABLED" != "true" ]]; then
-        log INFO "subvol3-opptak backup disabled, skipping"
-        record_backup_metrics "subvol3-opptak" "$start_time" 1 "$TIER1_OPPTAK_LOCAL_DIR" "$TIER1_OPPTAK_EXTERNAL_DIR" "*-opptak"
+        log INFO "$subvol_name backup disabled, skipping"
+        record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER1_OPPTAK_LOCAL_DIR" "$TIER1_OPPTAK_EXTERNAL_DIR" "*-opptak"
         return 0
     fi
 
     local snapshot_name="${DATE_DAILY}-opptak"
     local local_snapshot="$TIER1_OPPTAK_LOCAL_DIR/$snapshot_name"
 
-    # Create local snapshot
     if [[ "$EXTERNAL_ONLY" != "true" ]]; then
         create_snapshot "$TIER1_OPPTAK_SOURCE" "$local_snapshot" || {
-            record_backup_metrics "subvol3-opptak" "$start_time" 0 "$TIER1_OPPTAK_LOCAL_DIR" "$TIER1_OPPTAK_EXTERNAL_DIR" "*-opptak"
+            record_failure "$subvol_name" "Local snapshot creation failed"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER1_OPPTAK_LOCAL_DIR" "$TIER1_OPPTAK_EXTERNAL_DIR" "*-opptak"
             return 1
         }
     fi
 
-    # Send to external (weekly)
     if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%u) -eq 6 ]]; then
         check_external_mounted || {
-            record_backup_metrics "subvol3-opptak" "$start_time" 0 "$TIER1_OPPTAK_LOCAL_DIR" "$TIER1_OPPTAK_EXTERNAL_DIR" "*-opptak"
+            record_failure "$subvol_name" "External drive not mounted"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER1_OPPTAK_LOCAL_DIR" "$TIER1_OPPTAK_EXTERNAL_DIR" "*-opptak"
             return 1
         }
 
-        # Find common parent that exists on both local and external (for incremental send)
         local parent=$(find_common_parent "$TIER1_OPPTAK_LOCAL_DIR" "$TIER1_OPPTAK_EXTERNAL_DIR" "*-opptak")
         send_snapshot_incremental "$parent" "$local_snapshot" "$TIER1_OPPTAK_EXTERNAL_DIR" || {
-            record_backup_metrics "subvol3-opptak" "$start_time" 0 "$TIER1_OPPTAK_LOCAL_DIR" "$TIER1_OPPTAK_EXTERNAL_DIR" "*-opptak"
+            record_failure "$subvol_name" "External send failed"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER1_OPPTAK_LOCAL_DIR" "$TIER1_OPPTAK_EXTERNAL_DIR" "*-opptak"
             return 1
         }
 
-        # Cleanup external snapshots
+        pin_parent "$TIER1_OPPTAK_LOCAL_DIR" "$snapshot_name"
         cleanup_old_snapshots "$TIER1_OPPTAK_EXTERNAL_DIR" "$TIER1_OPPTAK_EXTERNAL_RETENTION_WEEKLY" "*-opptak"
     fi
 
-    # Cleanup local snapshots
     cleanup_old_snapshots "$TIER1_OPPTAK_LOCAL_DIR" "$TIER1_OPPTAK_LOCAL_RETENTION_DAILY" "*-opptak"
 
-    record_backup_metrics "subvol3-opptak" "$start_time" 1 "$TIER1_OPPTAK_LOCAL_DIR" "$TIER1_OPPTAK_EXTERNAL_DIR" "*-opptak"
-    log SUCCESS "Completed Tier 1: subvol3-opptak"
+    record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER1_OPPTAK_LOCAL_DIR" "$TIER1_OPPTAK_EXTERNAL_DIR" "*-opptak"
+    mark_completed "$subvol_name"
+    log SUCCESS "Completed Tier 1: $subvol_name"
 }
 
 backup_tier1_containers() {
+    local subvol_name="subvol7-containers"
     local start_time=$(date +%s)
-    log INFO "=== Processing Tier 1: subvol7-containers ==="
+    log INFO "=== Processing Tier 1: $subvol_name ==="
+
+    if is_completed_today "$subvol_name"; then
+        log INFO "$subvol_name already completed today, skipping (retry)"
+        SKIPPED_SUBVOLS+=("$subvol_name")
+        return 0
+    fi
 
     if [[ "$TIER1_CONTAINERS_ENABLED" != "true" ]]; then
-        log INFO "subvol7-containers backup disabled, skipping"
-        record_backup_metrics "subvol7-containers" "$start_time" 1 "$TIER1_CONTAINERS_LOCAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_DIR" "*-containers"
+        log INFO "$subvol_name backup disabled, skipping"
+        record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER1_CONTAINERS_LOCAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_DIR" "*-containers"
         return 0
     fi
 
     local snapshot_name="${DATE_DAILY}-containers"
     local local_snapshot="$TIER1_CONTAINERS_LOCAL_DIR/$snapshot_name"
 
-    # Create local snapshot
     if [[ "$EXTERNAL_ONLY" != "true" ]]; then
         create_snapshot "$TIER1_CONTAINERS_SOURCE" "$local_snapshot" || {
-            record_backup_metrics "subvol7-containers" "$start_time" 0 "$TIER1_CONTAINERS_LOCAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_DIR" "*-containers"
+            record_failure "$subvol_name" "Local snapshot creation failed"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER1_CONTAINERS_LOCAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_DIR" "*-containers"
             return 1
         }
     fi
 
-    # Send to external (weekly)
     if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%u) -eq 6 ]]; then
         check_external_mounted || {
-            record_backup_metrics "subvol7-containers" "$start_time" 0 "$TIER1_CONTAINERS_LOCAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_DIR" "*-containers"
+            record_failure "$subvol_name" "External drive not mounted"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER1_CONTAINERS_LOCAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_DIR" "*-containers"
             return 1
         }
 
-        # Find common parent that exists on both local and external (for incremental send)
         local parent=$(find_common_parent "$TIER1_CONTAINERS_LOCAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_DIR" "*-containers")
         send_snapshot_incremental "$parent" "$local_snapshot" "$TIER1_CONTAINERS_EXTERNAL_DIR" || {
-            record_backup_metrics "subvol7-containers" "$start_time" 0 "$TIER1_CONTAINERS_LOCAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_DIR" "*-containers"
+            record_failure "$subvol_name" "External send failed"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER1_CONTAINERS_LOCAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_DIR" "*-containers"
             return 1
         }
 
-        # Cleanup external snapshots
+        pin_parent "$TIER1_CONTAINERS_LOCAL_DIR" "$snapshot_name"
         cleanup_old_snapshots "$TIER1_CONTAINERS_EXTERNAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_RETENTION_WEEKLY" "*-containers"
     fi
 
-    # Cleanup local snapshots
     cleanup_old_snapshots "$TIER1_CONTAINERS_LOCAL_DIR" "$TIER1_CONTAINERS_LOCAL_RETENTION_DAILY" "*-containers"
 
-    record_backup_metrics "subvol7-containers" "$start_time" 1 "$TIER1_CONTAINERS_LOCAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_DIR" "*-containers"
-    log SUCCESS "Completed Tier 1: subvol7-containers"
+    record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER1_CONTAINERS_LOCAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_DIR" "*-containers"
+    mark_completed "$subvol_name"
+    log SUCCESS "Completed Tier 1: $subvol_name"
 }
 
 backup_tier2_docs() {
+    local subvol_name="subvol1-docs"
     local start_time=$(date +%s)
-    log INFO "=== Processing Tier 2: subvol1-docs ==="
+    log INFO "=== Processing Tier 2: $subvol_name ==="
+
+    if is_completed_today "$subvol_name"; then
+        log INFO "$subvol_name already completed today, skipping (retry)"
+        SKIPPED_SUBVOLS+=("$subvol_name")
+        return 0
+    fi
 
     if [[ "$TIER2_DOCS_ENABLED" != "true" ]]; then
-        log INFO "subvol1-docs backup disabled, skipping"
-        record_backup_metrics "subvol1-docs" "$start_time" 1 "$TIER2_DOCS_LOCAL_DIR" "$TIER2_DOCS_EXTERNAL_DIR" "*-docs"
+        log INFO "$subvol_name backup disabled, skipping"
+        record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER2_DOCS_LOCAL_DIR" "$TIER2_DOCS_EXTERNAL_DIR" "*-docs"
         return 0
     fi
 
     local snapshot_name="${DATE_DAILY}-docs"
     local local_snapshot="$TIER2_DOCS_LOCAL_DIR/$snapshot_name"
 
-    # Create local snapshot
     if [[ "$EXTERNAL_ONLY" != "true" ]]; then
         create_snapshot "$TIER2_DOCS_SOURCE" "$local_snapshot" || {
-            record_backup_metrics "subvol1-docs" "$start_time" 0 "$TIER2_DOCS_LOCAL_DIR" "$TIER2_DOCS_EXTERNAL_DIR" "*-docs"
+            record_failure "$subvol_name" "Local snapshot creation failed"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER2_DOCS_LOCAL_DIR" "$TIER2_DOCS_EXTERNAL_DIR" "*-docs"
             return 1
         }
     fi
 
-    # Send to external (weekly)
     if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%u) -eq 6 ]]; then
         check_external_mounted || {
-            record_backup_metrics "subvol1-docs" "$start_time" 0 "$TIER2_DOCS_LOCAL_DIR" "$TIER2_DOCS_EXTERNAL_DIR" "*-docs"
+            record_failure "$subvol_name" "External drive not mounted"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER2_DOCS_LOCAL_DIR" "$TIER2_DOCS_EXTERNAL_DIR" "*-docs"
             return 1
         }
 
-        # Find common parent that exists on both local and external (for incremental send)
         local parent=$(find_common_parent "$TIER2_DOCS_LOCAL_DIR" "$TIER2_DOCS_EXTERNAL_DIR" "*-docs")
         send_snapshot_incremental "$parent" "$local_snapshot" "$TIER2_DOCS_EXTERNAL_DIR" || {
-            record_backup_metrics "subvol1-docs" "$start_time" 0 "$TIER2_DOCS_LOCAL_DIR" "$TIER2_DOCS_EXTERNAL_DIR" "*-docs"
+            record_failure "$subvol_name" "External send failed"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER2_DOCS_LOCAL_DIR" "$TIER2_DOCS_EXTERNAL_DIR" "*-docs"
             return 1
         }
 
-        # Cleanup external snapshots
+        pin_parent "$TIER2_DOCS_LOCAL_DIR" "$snapshot_name"
         cleanup_old_snapshots "$TIER2_DOCS_EXTERNAL_DIR" "$TIER2_DOCS_EXTERNAL_RETENTION_WEEKLY" "*-docs"
     fi
 
-    # Cleanup local snapshots
     cleanup_old_snapshots "$TIER2_DOCS_LOCAL_DIR" "$TIER2_DOCS_LOCAL_RETENTION_DAILY" "*-docs"
 
-    record_backup_metrics "subvol1-docs" "$start_time" 1 "$TIER2_DOCS_LOCAL_DIR" "$TIER2_DOCS_EXTERNAL_DIR" "*-docs"
-    log SUCCESS "Completed Tier 2: subvol1-docs"
+    record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER2_DOCS_LOCAL_DIR" "$TIER2_DOCS_EXTERNAL_DIR" "*-docs"
+    mark_completed "$subvol_name"
+    log SUCCESS "Completed Tier 2: $subvol_name"
 }
 
 backup_tier2_root() {
+    local subvol_name="htpc-root"
     local start_time=$(date +%s)
-    log INFO "=== Processing Tier 2: htpc-root ==="
+    log INFO "=== Processing Tier 2: $subvol_name ==="
+
+    if is_completed_today "$subvol_name"; then
+        log INFO "$subvol_name already completed today, skipping (retry)"
+        SKIPPED_SUBVOLS+=("$subvol_name")
+        return 0
+    fi
 
     if [[ "$TIER2_ROOT_ENABLED" != "true" ]]; then
-        log INFO "htpc-root backup disabled, skipping"
-        record_backup_metrics "htpc-root" "$start_time" 1 "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root"
+        log INFO "$subvol_name backup disabled, skipping"
+        record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root"
         return 0
     fi
 
     # Root is monthly only
     if [[ $(date +%d) -ne 01 ]]; then
-        log INFO "htpc-root backup runs on 1st of month only, skipping"
-        record_backup_metrics "htpc-root" "$start_time" 1 "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root"
+        log INFO "$subvol_name backup runs on 1st of month only, skipping"
+        record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root"
         return 0
     fi
 
     local snapshot_name="${DATE_MONTHLY}-htpc-root"
     local local_snapshot="$TIER2_ROOT_LOCAL_DIR/$snapshot_name"
 
-    # Create local snapshot
     if [[ "$EXTERNAL_ONLY" != "true" ]]; then
         create_snapshot "$TIER2_ROOT_SOURCE" "$local_snapshot" || {
-            record_backup_metrics "htpc-root" "$start_time" 0 "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root"
+            record_failure "$subvol_name" "Local snapshot creation failed"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root"
             return 1
         }
     fi
 
-    # Send to external (monthly)
     if [[ "$LOCAL_ONLY" != "true" ]]; then
         check_external_mounted || {
-            record_backup_metrics "htpc-root" "$start_time" 0 "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root"
+            record_failure "$subvol_name" "External drive not mounted"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root"
             return 1
         }
 
-        # Find common parent that exists on both local and external (for incremental send)
         local parent=$(find_common_parent "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root")
         send_snapshot_incremental "$parent" "$local_snapshot" "$TIER2_ROOT_EXTERNAL_DIR" || {
-            record_backup_metrics "htpc-root" "$start_time" 0 "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root"
+            record_failure "$subvol_name" "External send failed"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root"
             return 1
         }
 
-        # Cleanup external snapshots
+        pin_parent "$TIER2_ROOT_LOCAL_DIR" "$snapshot_name"
         cleanup_old_snapshots "$TIER2_ROOT_EXTERNAL_DIR" "$TIER2_ROOT_EXTERNAL_RETENTION_MONTHLY" "*-htpc-root"
     fi
 
-    # Cleanup local snapshots - keep only 1
     cleanup_old_snapshots "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_LOCAL_RETENTION_MONTHLY" "*-htpc-root"
 
-    record_backup_metrics "htpc-root" "$start_time" 1 "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root"
-    log SUCCESS "Completed Tier 2: htpc-root"
+    record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root"
+    mark_completed "$subvol_name"
+    log SUCCESS "Completed Tier 2: $subvol_name"
 }
 
 backup_tier3_pics() {
+    local subvol_name="subvol2-pics"
     local start_time=$(date +%s)
-    log INFO "=== Processing Tier 3: subvol2-pics ==="
+    log INFO "=== Processing Tier 3: $subvol_name ==="
 
-    if [[ "$TIER3_PICS_ENABLED" != "true" ]]; then
-        log INFO "subvol2-pics backup disabled, skipping"
-        record_backup_metrics "subvol2-pics" "$start_time" 1 "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*"
+    if is_completed_today "$subvol_name"; then
+        log INFO "$subvol_name already completed today, skipping (retry)"
+        SKIPPED_SUBVOLS+=("$subvol_name")
         return 0
     fi
 
-    # Weekly local snapshots
+    if [[ "$TIER3_PICS_ENABLED" != "true" ]]; then
+        log INFO "$subvol_name backup disabled, skipping"
+        record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*"
+        return 0
+    fi
+
     if [[ $(date +%u) -ne 6 ]]; then
-        log INFO "subvol2-pics local backup runs on Saturdays only, skipping"
-        record_backup_metrics "subvol2-pics" "$start_time" 1 "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*"
+        log INFO "$subvol_name local backup runs on Saturdays only, skipping"
+        record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*"
         return 0
     fi
 
     local snapshot_name="${DATE_WEEKLY}-pics"
     local local_snapshot="$TIER3_PICS_LOCAL_DIR/$snapshot_name"
 
-    # Create local snapshot
     if [[ "$EXTERNAL_ONLY" != "true" ]]; then
         create_snapshot "$TIER3_PICS_SOURCE" "$local_snapshot" || {
-            record_backup_metrics "subvol2-pics" "$start_time" 0 "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*"
+            record_failure "$subvol_name" "Local snapshot creation failed"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*"
             return 1
         }
     fi
 
-    # Send to external (monthly)
-    if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%d) -le 7 ]]; then  # First week of month
+    if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%d) -le 7 ]]; then
         check_external_mounted || {
-            record_backup_metrics "subvol2-pics" "$start_time" 0 "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*"
+            record_failure "$subvol_name" "External drive not mounted"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*"
             return 1
         }
 
-        # Find common parent that exists on both local and external (for incremental send)
         local parent=$(find_common_parent "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*")
         send_snapshot_incremental "$parent" "$local_snapshot" "$TIER3_PICS_EXTERNAL_DIR" || {
-            record_backup_metrics "subvol2-pics" "$start_time" 0 "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*"
+            record_failure "$subvol_name" "External send failed"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*"
             return 1
         }
 
-        # Cleanup external snapshots
+        pin_parent "$TIER3_PICS_LOCAL_DIR" "$snapshot_name"
         cleanup_old_snapshots "$TIER3_PICS_EXTERNAL_DIR" "$TIER3_PICS_EXTERNAL_RETENTION_MONTHLY" "*-pics*"
     fi
 
-    # Cleanup local snapshots
     cleanup_old_snapshots "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_LOCAL_RETENTION_WEEKLY" "*-pics*"
 
-    record_backup_metrics "subvol2-pics" "$start_time" 1 "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*"
-    log SUCCESS "Completed Tier 3: subvol2-pics"
+    record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*"
+    mark_completed "$subvol_name"
+    log SUCCESS "Completed Tier 3: $subvol_name"
 }
 
 backup_tier3_multimedia() {
+    local subvol_name="subvol4-multimedia"
     local start_time=$(date +%s)
-    log INFO "=== Processing Tier 3: subvol4-multimedia ==="
+    log INFO "=== Processing Tier 3: $subvol_name ==="
 
-    if [[ "$TIER3_MULTIMEDIA_ENABLED" != "true" ]]; then
-        log INFO "subvol4-multimedia backup disabled, skipping"
-        record_backup_metrics "subvol4-multimedia" "$start_time" 1 "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*"
+    if is_completed_today "$subvol_name"; then
+        log INFO "$subvol_name already completed today, skipping (retry)"
+        SKIPPED_SUBVOLS+=("$subvol_name")
         return 0
     fi
 
-    # Weekly local snapshots
+    if [[ "$TIER3_MULTIMEDIA_ENABLED" != "true" ]]; then
+        log INFO "$subvol_name backup disabled, skipping"
+        record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*"
+        return 0
+    fi
+
     if [[ $(date +%u) -ne 6 ]]; then
-        log INFO "subvol4-multimedia local backup runs on Saturdays only, skipping"
-        record_backup_metrics "subvol4-multimedia" "$start_time" 1 "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*"
+        log INFO "$subvol_name local backup runs on Saturdays only, skipping"
+        record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*"
         return 0
     fi
 
     local snapshot_name="${DATE_WEEKLY}-multimedia"
     local local_snapshot="$TIER3_MULTIMEDIA_LOCAL_DIR/$snapshot_name"
 
-    # Create local snapshot
     if [[ "$EXTERNAL_ONLY" != "true" ]]; then
         create_snapshot "$TIER3_MULTIMEDIA_SOURCE" "$local_snapshot" || {
-            record_backup_metrics "subvol4-multimedia" "$start_time" 0 "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*"
+            record_failure "$subvol_name" "Local snapshot creation failed"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*"
             return 1
         }
     fi
 
-    # Send to external (monthly) - only if TIER3_MULTIMEDIA_EXTERNAL_ENABLED=true
     if [[ "$TIER3_MULTIMEDIA_EXTERNAL_ENABLED" == "true" ]] && [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%d) -le 7 ]]; then
-        log INFO "subvol4-multimedia external backup enabled (5.8TB - may take ~27h for initial backup)"
+        log INFO "$subvol_name external backup enabled (5.8TB - may take ~27h for initial backup)"
         check_external_mounted || {
-            record_backup_metrics "subvol4-multimedia" "$start_time" 0 "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*"
+            record_failure "$subvol_name" "External drive not mounted"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*"
             return 1
         }
 
         local parent=$(find_common_parent "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*")
         send_snapshot_incremental "$parent" "$local_snapshot" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" || {
-            record_backup_metrics "subvol4-multimedia" "$start_time" 0 "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*"
+            record_failure "$subvol_name" "External send failed"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*"
             return 1
         }
 
+        pin_parent "$TIER3_MULTIMEDIA_LOCAL_DIR" "$snapshot_name"
         cleanup_old_snapshots "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_RETENTION_MONTHLY" "*-multimedia*"
     elif [[ "$TIER3_MULTIMEDIA_EXTERNAL_ENABLED" != "true" ]]; then
-        log WARNING "subvol4-multimedia external backup is DISABLED (set TIER3_MULTIMEDIA_EXTERNAL_ENABLED=true to enable)"
+        log WARNING "$subvol_name external backup is DISABLED (set TIER3_MULTIMEDIA_EXTERNAL_ENABLED=true to enable)"
         log WARNING "Do initial manual backup first (see docs/20-operations/guides/tier3-initial-backup.md)"
     fi
 
-    # Cleanup local snapshots
     cleanup_old_snapshots "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_LOCAL_RETENTION_WEEKLY" "*-multimedia*"
 
-    record_backup_metrics "subvol4-multimedia" "$start_time" 1 "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*"
-    log SUCCESS "Completed Tier 3: subvol4-multimedia"
+    record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*"
+    mark_completed "$subvol_name"
+    log SUCCESS "Completed Tier 3: $subvol_name"
 }
 
 backup_tier3_music() {
+    local subvol_name="subvol5-music"
     local start_time=$(date +%s)
-    log INFO "=== Processing Tier 3: subvol5-music ==="
+    log INFO "=== Processing Tier 3: $subvol_name ==="
 
-    if [[ "$TIER3_MUSIC_ENABLED" != "true" ]]; then
-        log INFO "subvol5-music backup disabled, skipping"
-        record_backup_metrics "subvol5-music" "$start_time" 1 "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*"
+    if is_completed_today "$subvol_name"; then
+        log INFO "$subvol_name already completed today, skipping (retry)"
+        SKIPPED_SUBVOLS+=("$subvol_name")
         return 0
     fi
 
-    # Weekly local snapshots
+    if [[ "$TIER3_MUSIC_ENABLED" != "true" ]]; then
+        log INFO "$subvol_name backup disabled, skipping"
+        record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*"
+        return 0
+    fi
+
     if [[ $(date +%u) -ne 6 ]]; then
-        log INFO "subvol5-music local backup runs on Saturdays only, skipping"
-        record_backup_metrics "subvol5-music" "$start_time" 1 "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*"
+        log INFO "$subvol_name local backup runs on Saturdays only, skipping"
+        record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*"
         return 0
     fi
 
     local snapshot_name="${DATE_WEEKLY}-music"
     local local_snapshot="$TIER3_MUSIC_LOCAL_DIR/$snapshot_name"
 
-    # Create local snapshot
     if [[ "$EXTERNAL_ONLY" != "true" ]]; then
         create_snapshot "$TIER3_MUSIC_SOURCE" "$local_snapshot" || {
-            record_backup_metrics "subvol5-music" "$start_time" 0 "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*"
+            record_failure "$subvol_name" "Local snapshot creation failed"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*"
             return 1
         }
     fi
 
-    # Send to external (monthly)
     if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%d) -le 7 ]]; then
         check_external_mounted || {
-            record_backup_metrics "subvol5-music" "$start_time" 0 "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*"
+            record_failure "$subvol_name" "External drive not mounted"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*"
             return 1
         }
 
         local parent=$(find_common_parent "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*")
         send_snapshot_incremental "$parent" "$local_snapshot" "$TIER3_MUSIC_EXTERNAL_DIR" || {
-            record_backup_metrics "subvol5-music" "$start_time" 0 "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*"
+            record_failure "$subvol_name" "External send failed"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*"
             return 1
         }
 
+        pin_parent "$TIER3_MUSIC_LOCAL_DIR" "$snapshot_name"
         cleanup_old_snapshots "$TIER3_MUSIC_EXTERNAL_DIR" "$TIER3_MUSIC_EXTERNAL_RETENTION_MONTHLY" "*-music*"
     fi
 
-    # Cleanup local snapshots
     cleanup_old_snapshots "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_LOCAL_RETENTION_WEEKLY" "*-music*"
 
-    record_backup_metrics "subvol5-music" "$start_time" 1 "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*"
-    log SUCCESS "Completed Tier 3: subvol5-music"
+    record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*"
+    mark_completed "$subvol_name"
+    log SUCCESS "Completed Tier 3: $subvol_name"
 }
 
 backup_tier3_tmp() {
+    local subvol_name="subvol6-tmp"
     local start_time=$(date +%s)
-    log INFO "=== Processing Tier 3: subvol6-tmp ==="
+    log INFO "=== Processing Tier 3: $subvol_name ==="
 
-    if [[ "$TIER3_TMP_ENABLED" != "true" ]]; then
-        log INFO "subvol6-tmp backup disabled, skipping"
-        record_backup_metrics "subvol6-tmp" "$start_time" 1 "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*"
+    if is_completed_today "$subvol_name"; then
+        log INFO "$subvol_name already completed today, skipping (retry)"
+        SKIPPED_SUBVOLS+=("$subvol_name")
         return 0
     fi
 
-    # Weekly local snapshots
+    if [[ "$TIER3_TMP_ENABLED" != "true" ]]; then
+        log INFO "$subvol_name backup disabled, skipping"
+        record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*"
+        return 0
+    fi
+
     if [[ $(date +%u) -ne 6 ]]; then
-        log INFO "subvol6-tmp local backup runs on Saturdays only, skipping"
-        record_backup_metrics "subvol6-tmp" "$start_time" 1 "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*"
+        log INFO "$subvol_name local backup runs on Saturdays only, skipping"
+        record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*"
         return 0
     fi
 
     local snapshot_name="${DATE_WEEKLY}-tmp"
     local local_snapshot="$TIER3_TMP_LOCAL_DIR/$snapshot_name"
 
-    # Create local snapshot
     if [[ "$EXTERNAL_ONLY" != "true" ]]; then
         create_snapshot "$TIER3_TMP_SOURCE" "$local_snapshot" || {
-            record_backup_metrics "subvol6-tmp" "$start_time" 0 "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*"
+            record_failure "$subvol_name" "Local snapshot creation failed"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*"
             return 1
         }
     fi
 
-    # Send to external (monthly)
     if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%d) -le 7 ]]; then
         check_external_mounted || {
-            record_backup_metrics "subvol6-tmp" "$start_time" 0 "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*"
+            record_failure "$subvol_name" "External drive not mounted"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*"
             return 1
         }
 
         local parent=$(find_common_parent "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*")
         send_snapshot_incremental "$parent" "$local_snapshot" "$TIER3_TMP_EXTERNAL_DIR" || {
-            record_backup_metrics "subvol6-tmp" "$start_time" 0 "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*"
+            record_failure "$subvol_name" "External send failed"
+            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*"
             return 1
         }
 
+        pin_parent "$TIER3_TMP_LOCAL_DIR" "$snapshot_name"
         cleanup_old_snapshots "$TIER3_TMP_EXTERNAL_DIR" "$TIER3_TMP_EXTERNAL_RETENTION_MONTHLY" "*-tmp*"
     fi
 
-    # Cleanup local snapshots
     cleanup_old_snapshots "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_LOCAL_RETENTION_WEEKLY" "*-tmp*"
 
-    record_backup_metrics "subvol6-tmp" "$start_time" 1 "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*"
-    log SUCCESS "Completed Tier 3: subvol6-tmp"
+    record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*"
+    mark_completed "$subvol_name"
+    log SUCCESS "Completed Tier 3: $subvol_name"
 }
 
 ################################################################################
@@ -982,59 +1244,133 @@ export_prometheus_metrics() {
     fi
 }
 
+send_failure_notification() {
+    if [[ ${#FAILED_SUBVOLS[@]} -eq 0 ]]; then
+        return 0
+    fi
+
+    if [[ -z "$DISCORD_WEBHOOK" ]]; then
+        log WARNING "No Discord webhook configured — cannot send failure notification"
+        return 0
+    fi
+
+    local fail_list=""
+    for i in "${!FAILED_SUBVOLS[@]}"; do
+        fail_list="${fail_list}• **${FAILED_SUBVOLS[$i]}**: ${FAILED_REASONS[$i]}\n"
+    done
+
+    local summary="Backup failures on $(date '+%Y-%m-%d %H:%M'):\n${fail_list}\nSucceeded: ${#SUCCEEDED_SUBVOLS[@]} | Failed: ${#FAILED_SUBVOLS[@]} | Skipped: ${#SKIPPED_SUBVOLS[@]}"
+
+    local payload
+    payload=$(jq -n \
+        --arg msg "$summary" \
+        '{
+          embeds: [{
+            title: "BTRFS Backup Failed",
+            description: $msg,
+            color: 15158332,
+            timestamp: (now | strftime("%Y-%m-%dT%H:%M:%SZ"))
+          }]
+        }')
+
+    curl -s -X POST "$DISCORD_WEBHOOK" \
+        -H "Content-Type: application/json" \
+        -d "$payload" >/dev/null 2>&1 || log WARNING "Failed to send Discord notification"
+}
+
+print_summary() {
+    local script_end_time=$(date +%s)
+    local total_duration=$(( script_end_time - SCRIPT_START_TIME ))
+
+    log INFO "=========================================="
+    log INFO "BACKUP RUN SUMMARY (${total_duration}s)"
+    log INFO "=========================================="
+
+    if [[ ${#SUCCEEDED_SUBVOLS[@]} -gt 0 ]]; then
+        log SUCCESS "Succeeded (${#SUCCEEDED_SUBVOLS[@]}): ${SUCCEEDED_SUBVOLS[*]}"
+    fi
+
+    if [[ ${#SKIPPED_SUBVOLS[@]} -gt 0 ]]; then
+        log INFO "Skipped (${#SKIPPED_SUBVOLS[@]}): ${SKIPPED_SUBVOLS[*]}"
+    fi
+
+    if [[ ${#FAILED_SUBVOLS[@]} -gt 0 ]]; then
+        log ERROR "FAILED (${#FAILED_SUBVOLS[@]}):"
+        for i in "${!FAILED_SUBVOLS[@]}"; do
+            log ERROR "  ${FAILED_SUBVOLS[$i]}: ${FAILED_REASONS[$i]}"
+        done
+        log ERROR "Manual intervention may be required — check logs above for details"
+    fi
+
+    log INFO "=========================================="
+}
+
 main() {
     parse_args "$@"
+
+    # Clean up stale state files from previous days
+    find "$STATE_DIR" -maxdepth 1 -name "btrfs-backup-completed-*" \
+        ! -name "btrfs-backup-completed-${DATE_DAILY}" -delete 2>/dev/null || true
 
     log INFO "=========================================="
     log INFO "BTRFS Snapshot & Backup Script Starting"
     log INFO "Date: $(date)"
     log INFO "Dry Run: $DRY_RUN"
+    if [[ -f "$STATE_FILE" ]]; then
+        log INFO "Retry run — previously completed: $(cat "$STATE_FILE" | tr '\n' ' ')"
+    fi
     log INFO "=========================================="
 
     # Run backups based on filters
+    # Individual failures are tracked in FAILED_SUBVOLS — don't let set -e kill the script
     if [[ -z "$TIER_FILTER" ]] || [[ "$TIER_FILTER" == "1" ]]; then
         if [[ -z "$SUBVOL_FILTER" ]] || [[ "$SUBVOL_FILTER" == "home" ]]; then
-            backup_tier1_home
+            backup_tier1_home || true
         fi
         if [[ -z "$SUBVOL_FILTER" ]] || [[ "$SUBVOL_FILTER" == "opptak" ]]; then
-            backup_tier1_opptak
+            backup_tier1_opptak || true
         fi
         if [[ -z "$SUBVOL_FILTER" ]] || [[ "$SUBVOL_FILTER" == "containers" ]]; then
-            backup_tier1_containers
+            backup_tier1_containers || true
         fi
     fi
 
     if [[ -z "$TIER_FILTER" ]] || [[ "$TIER_FILTER" == "2" ]]; then
         if [[ -z "$SUBVOL_FILTER" ]] || [[ "$SUBVOL_FILTER" == "docs" ]]; then
-            backup_tier2_docs
+            backup_tier2_docs || true
         fi
         if [[ -z "$SUBVOL_FILTER" ]] || [[ "$SUBVOL_FILTER" == "root" ]]; then
-            backup_tier2_root
+            backup_tier2_root || true
         fi
     fi
 
     if [[ -z "$TIER_FILTER" ]] || [[ "$TIER_FILTER" == "3" ]]; then
         if [[ -z "$SUBVOL_FILTER" ]] || [[ "$SUBVOL_FILTER" == "pics" ]]; then
-            backup_tier3_pics
+            backup_tier3_pics || true
         fi
         if [[ -z "$SUBVOL_FILTER" ]] || [[ "$SUBVOL_FILTER" == "multimedia" ]]; then
-            backup_tier3_multimedia
+            backup_tier3_multimedia || true
         fi
         if [[ -z "$SUBVOL_FILTER" ]] || [[ "$SUBVOL_FILTER" == "music" ]]; then
-            backup_tier3_music
+            backup_tier3_music || true
         fi
         if [[ -z "$SUBVOL_FILTER" ]] || [[ "$SUBVOL_FILTER" == "tmp" ]]; then
-            backup_tier3_tmp
+            backup_tier3_tmp || true
         fi
     fi
 
-    log INFO "=========================================="
-    log SUCCESS "BTRFS Snapshot & Backup Script Completed"
-    log INFO "=========================================="
+    # Print summary
+    print_summary
 
     # Export metrics (unless dry-run)
     if [[ "$DRY_RUN" != "true" ]]; then
         export_prometheus_metrics
+    fi
+
+    # Send Discord notification on failures
+    if [[ ${#FAILED_SUBVOLS[@]} -gt 0 ]] && [[ "$DRY_RUN" != "true" ]]; then
+        send_failure_notification
+        exit 1
     fi
 }
 

--- a/scripts/btrfs-snapshot-backup.sh
+++ b/scripts/btrfs-snapshot-backup.sh
@@ -298,17 +298,18 @@ check_external_space() {
         exclusive_bytes=$(sudo btrfs subvolume show "$source_snapshot" 2>/dev/null | grep -i "exclusive" | head -1 | awk '{print $NF}' || echo "0")
 
         # Parse human-readable size (e.g., "2.10TiB", "500.00GiB", "100.00MiB")
+        # Uses awk instead of bc to avoid dependency on bc package
         if [[ "$exclusive_bytes" =~ ([0-9.]+)TiB ]]; then
-            required_bytes=$(echo "${BASH_REMATCH[1]} * 1099511627776" | bc | cut -d. -f1)
+            required_bytes=$(awk "BEGIN {printf \"%.0f\", ${BASH_REMATCH[1]} * 1099511627776}")
             size_source="btrfs-exclusive"
         elif [[ "$exclusive_bytes" =~ ([0-9.]+)GiB ]]; then
-            required_bytes=$(echo "${BASH_REMATCH[1]} * 1073741824" | bc | cut -d. -f1)
+            required_bytes=$(awk "BEGIN {printf \"%.0f\", ${BASH_REMATCH[1]} * 1073741824}")
             size_source="btrfs-exclusive"
         elif [[ "$exclusive_bytes" =~ ([0-9.]+)MiB ]]; then
-            required_bytes=$(echo "${BASH_REMATCH[1]} * 1048576" | bc | cut -d. -f1)
+            required_bytes=$(awk "BEGIN {printf \"%.0f\", ${BASH_REMATCH[1]} * 1048576}")
             size_source="btrfs-exclusive"
         elif [[ "$exclusive_bytes" =~ ([0-9.]+)KiB ]]; then
-            required_bytes=$(echo "${BASH_REMATCH[1]} * 1024" | bc | cut -d. -f1)
+            required_bytes=$(awk "BEGIN {printf \"%.0f\", ${BASH_REMATCH[1]} * 1024}")
             size_source="btrfs-exclusive"
         fi
 


### PR DESCRIPTION
## Summary

- **8 improvements** to `scripts/btrfs-snapshot-backup.sh` to prevent the silent backup failure cascade discovered on 2026-03-21
- Disk space pre-check, stderr capture, pinned parent protection, failure summary, non-zero exit code, partial receive cleanup, Discord notification, retry state tracking
- **5 bugs found and fixed** during live testing on offsite drive
- **Compression validated**: zstd:3 gives 69-78% reduction on compressible data, transfers 11-13% faster

## Context

Weekly external backup failed silently for 2+ weeks. 3 subvolumes (opptak, containers, docs) had no valid external backup. The backup system is the ONLY protection against data loss (BTRFS Single profile, no parity). Root cause was a cascading failure: disk full → retention deleted common parent → broke incremental chain → forced full sends that also failed → script reported "Completed" every time.

## Verification

Live-tested on offsite drive with real data:
- ✓ Full send with no common parent (containers 8GB in 559s, docs 11GB in 194s)
- ✓ Space check rejection (3.2TB subvol vs 236GB available — instant rejection)
- ✓ Stderr capture (caught exact "No space left on device" error with file path)
- ✓ Partial receive cleanup (incomplete snapshot deleted automatically)
- ✓ Retry state (re-run correctly skips completed subvolumes)
- ✓ Summary output (succeeded/failed/skipped with reasons)
- ✓ Exit code 1 on failure (systemd Restart=on-failure works correctly)
- ✓ Compression working (zstd:3 on compressible data: 69-78% reduction)

## Test plan

- [x] `--dry-run --verbose` verifies new logic paths without executing
- [x] Single subvolume live send validates end-to-end
- [x] Space check correctly blocks oversized sends
- [x] Retry correctly skips completed subvolumes
- [x] Mixed success/failure run produces correct summary and exit code
- [x] Compression verified with `compsize` on re-sent snapshots
- [ ] Discord notification (needs webhook access from container network)
- [ ] Pinned parent cleanup protection (needs a retention cycle to trigger)

🤖 Generated with [Claude Code](https://claude.com/claude-code)