### PR TITLE
feat: Daily external backups with graduated retention (ADR-020)

### DIFF
--- a/docs/00-foundation/decisions/2026-03-21-ADR-020-daily-external-backups.md
+++ b/docs/00-foundation/decisions/2026-03-21-ADR-020-daily-external-backups.md
@@ -38,7 +38,7 @@ Replace flat 15-daily retention with graduated tiers:
 - **15-60 days:** 1 per week (newest in each ISO week)
 - **61-90 days:** 1 per month (newest in each month)
 
-~21 snapshots per subvolume, covering 3 months. This ensures the offsite drive's pinned parent survives the quarterly rotation cycle.
+~21 snapshots per subvolume, covering ~149 days (~5 months). This ensures the offsite drive's pinned parent survives even beyond the planned quarterly rotation cycle.
 
 ### 4. Dual pin files per drive
 
@@ -66,7 +66,7 @@ When no external drive is mounted, the script logs INFO and skips external sends
 - **Offsite drive needs full send after 3+ months without common parent** — if graduated retention is thinned before the drive returns, falls back to full send (slow but safe).
 
 ### Constraints
-- **Offsite cycle must not exceed ~90 days** (the graduated retention window). Beyond this, full sends are required.
+- **Offsite cycle must not exceed ~149 days** (the graduated retention window covers ~5 months). Beyond this, full sends are required.
 - **Primary external drive must be always connected** for daily sends to work.
 
 ## Related

--- a/docs/00-foundation/decisions/2026-03-21-ADR-020-daily-external-backups.md
+++ b/docs/00-foundation/decisions/2026-03-21-ADR-020-daily-external-backups.md
@@ -1,0 +1,74 @@
+# ADR-020: Daily External Backups with Incremental Sends
+
+**Date:** 2026-03-21
+**Status:** Accepted
+**Supersedes:** None (updates the weekly-only external backup model from initial implementation)
+
+## Context
+
+The BTRFS pool runs Single profile — no data redundancy. External backups to WD-18TB drives are the **only protection** against disk failure. The original design sent to external drives weekly (Saturdays only) because every send was a full send: multi-hour, high I/O, wearing on the SATA external drive.
+
+The March 2026 operational excellence work (pinned parent mechanism, space pre-checks, stderr capture) proved that **incremental sends work reliably**. Tested results:
+- Full send of 8GB: ~10 minutes
+- Incremental send of 11GB: ~4 minutes
+- Incremental sends transfer only changed extents, not entire subvolumes
+
+With weekly-only external sends, the RPO was **7 days** — meaning up to a week of data could be lost if the pool fails between Saturday backups. For Tier 1 critical data (home directory, recordings, operational containers), this is unacceptable on a pool with no RAID.
+
+Additionally, the offsite drive (WD-18TB1) will be stored at a friend's location and cycled roughly **every 3 months**. The old 15-daily local retention would delete the offsite pinned parent long before the drive returns, forcing a slow full send on every offsite cycle.
+
+## Decision
+
+### 1. Daily external sends for Tier 1/2
+
+Replace the Saturday-only external gate with per-subvolume `EXTERNAL_SCHEDULE` configuration:
+- **Tier 1/2 (critical/important):** External sends every night at 02:00
+- **Tier 3 (standard):** External sends monthly (1st of month), local snapshots weekly (Saturdays)
+
+This reduces RPO from 7 days to ~1 day for critical data.
+
+### 2. Single nightly timer replaces daily+weekly
+
+The daily timer runs the full script (no `--local-only`). The weekly timer is disabled. Per-subvolume schedule config determines when each subvolume creates snapshots and sends externally.
+
+### 3. Graduated local retention (Time Machine-style)
+
+Replace flat 15-daily retention with graduated tiers:
+- **Last 14 days:** All daily snapshots kept
+- **15-60 days:** 1 per week (newest in each ISO week)
+- **61-90 days:** 1 per month (newest in each month)
+
+~21 snapshots per subvolume, covering 3 months. This ensures the offsite drive's pinned parent survives the quarterly rotation cycle.
+
+### 4. Dual pin files per drive
+
+Separate `.last-external-parent-WD-18TB` and `.last-external-parent-WD-18TB1` files maintain independent incremental chains. Both pinned parents are protected during cleanup, regardless of which drive is currently mounted.
+
+### 5. Simplified external retention
+
+Replaced the never-implemented "weekly + monthly" external retention with a single count: 14 for Tier 1/2, existing counts for Tier 3. The cleanup function uses a single count — there is no weekly/monthly distinction in snapshot naming.
+
+### 6. Graceful external drive absence
+
+When no external drive is mounted, the script logs INFO and skips external sends without recording a failure or firing Discord alerts. This prevents false-alarm notifications when the offsite drive is at the remote location.
+
+## Consequences
+
+### Positive
+- **RPO reduced from 7 days to ~1 day** for critical data
+- **Offsite rotation safe** — graduated retention keeps snapshots for 3 months
+- **No additional system load** — incremental sends take minutes, not hours
+- **Simpler scheduling** — one timer instead of two
+- **Drive-independent chains** — primary and offsite drives maintain separate incremental state
+
+### Negative
+- **External drive fills faster** — 14 daily snapshots vs 4-8 weekly. Mitigated by incremental deltas being small and 14-day retention cleanup.
+- **Offsite drive needs full send after 3+ months without common parent** — if graduated retention is thinned before the drive returns, falls back to full send (slow but safe).
+
+### Constraints
+- **Offsite cycle must not exceed ~90 days** (the graduated retention window). Beyond this, full sends are required.
+- **Primary external drive must be always connected** for daily sends to work.
+
+## Related
+- Journal: `docs/98-journals/2026-03-21-backup-script-operational-excellence.md`
+- Strategy guide: `docs/20-operations/guides/backup-strategy.md`

--- a/docs/20-operations/guides/backup-strategy.md
+++ b/docs/20-operations/guides/backup-strategy.md
@@ -1,749 +1,219 @@
 # BTRFS Backup Strategy Guide
 
 **Created:** 2025-11-07
+**Updated:** 2026-03-21 (ADR-020: daily external backups with incremental sends)
 **System:** fedora-htpc
-**Storage:** 128GB NVMe (system) + BTRFS multi-device pool + 18TB external (LUKS)
+**Storage:** 128GB NVMe (system) + BTRFS multi-device pool (Single profile) + 2x 18TB external (LUKS)
 
 ---
 
 ## Overview
 
-This guide documents the automated BTRFS snapshot and backup strategy, optimized for:
-- **Minimal local storage** (128GB NVMe constraint)
-- **Weekly external backups** (daily backups cause too much system load)
-- **Risk tolerance** (can accept data loss between weekly backups)
-- **Easy parameter adjustment** as needs change
+Automated BTRFS snapshot and incremental backup strategy, optimized for:
+- **Daily external backups** for critical data (RPO ~1 day, down from 7 days)
+- **Time Machine-style local retention** (14 daily + 6 weekly + 3 monthly = ~90 days coverage)
+- **Offsite rotation** with dual incremental chains (quarterly drive swaps)
+- **Minimal system load** — incremental sends transfer only changed extents (~minutes, not hours)
+
+**Key architecture decision:** See ADR-020 for rationale.
 
 ---
 
 ## Quick Reference
 
-### Backup Script Location
+### Script and Logs
 ```bash
-~/containers/scripts/btrfs-snapshot-backup.sh
+~/containers/scripts/btrfs-snapshot-backup.sh     # Main backup script
+~/containers/data/backup-logs/backup-$(date +%Y%m).log  # Monthly log files
+~/containers/data/backup-metrics/backup.prom       # Prometheus metrics
 ```
 
-### Log Location
+### External Backup Drives
 ```bash
-~/containers/data/backup-logs/backup-$(date +%Y%m).log
-```
-
-### External Backup Location
-```bash
-/run/media/patriark/WD-18TB/.snapshots/
+/run/media/patriark/WD-18TB/.snapshots/   # Primary (fstab, always connected)
+/run/media/patriark/WD-18TB1/.snapshots/  # Offsite (udisks2, cycled ~quarterly)
 ```
 
 ### Current Schedule
 
-| Tier | Subvolume | Local Frequency | Local Retention | External Frequency | External Retention |
-|------|-----------|-----------------|-----------------|-------------------|-------------------|
-| 1 | htpc-home | Daily (02:00) | 7 days | Weekly (Saturday 04:00) | 8 weekly + 12 monthly |
-| 1 | subvol3-opptak | Daily (02:00) | 7 days | Weekly (Saturday 04:00) | 8 weekly + 12 monthly |
-| 1 | subvol7-containers | Daily (02:00) | 7 days | Weekly (Saturday 04:00) | 4 weekly + 6 monthly |
-| 2 | subvol1-docs | Daily (02:00) | 7 days | Weekly (Saturday 04:00) | 8 weekly + 6 monthly |
-| 2 | htpc-root | Monthly (1st, 04:00) | 1 month | Monthly | 6 monthly |
-| 3 | subvol2-pics | Weekly (Saturday 02:00) | 4 weeks | Monthly (1st Saturday) | 12 monthly |
+**Single nightly timer at 02:00 AM** — the script determines per-subvolume what to do.
+
+| Tier | Subvolume | Local Schedule | External Schedule | External Retention |
+|------|-----------|---------------|-------------------|-------------------|
+| 1 | htpc-home | Daily | Daily | 14 snapshots |
+| 1 | subvol3-opptak | Daily | Daily | 14 snapshots |
+| 1 | subvol7-containers | Daily | Daily | 14 snapshots |
+| 2 | subvol1-docs | Daily | Daily | 14 snapshots |
+| 2 | htpc-root | Monthly | Monthly | 6 snapshots |
+| 3 | subvol2-pics | Weekly (Sat) | Monthly (1st) | 6 snapshots |
+| 3 | subvol4-multimedia | Weekly (Sat) | Monthly (1st) | 3 snapshots |
+| 3 | subvol5-music | Weekly (Sat) | Monthly (1st) | 6 snapshots |
+| 3 | subvol6-tmp | Weekly (Sat) | Monthly (1st) | 3 snapshots |
+
+### Local Retention (Graduated / Time Machine-style)
+
+For daily-schedule subvolumes (Tier 1/2):
+- **Last 14 days:** All snapshots kept
+- **15-60 days:** 1 per ISO week
+- **61-90 days:** 1 per month
+- ~21 snapshots total, covering 3 months
+
+For weekly-schedule subvolumes (Tier 3): simple count (4-8 snapshots).
 
 ---
 
-## How to Adjust Backup Parameters
+## How It Works
 
-### 1. Changing Local Retention (Free Up NVMe Space)
+### Incremental Sends
 
-**Problem:** Running low on NVMe storage, need to keep fewer local snapshots.
+BTRFS `send -p` transfers only the delta between a parent snapshot and a new snapshot. The parent must exist on both the local system and the external drive. The script:
 
-**Solution:** Edit the `*_LOCAL_RETENTION_*` variables in the script:
+1. Calls `find_common_parent()` to find the most recent local snapshot that also exists on external
+2. If found: incremental send (fast, minutes)
+3. If not found: full send (slow, hours — happens on first sync or broken chain)
 
-```bash
-nano ~/containers/scripts/btrfs-snapshot-backup.sh
-```
+### Pinned Parent Mechanism
 
-Find the configuration section (lines 34-150) and adjust:
+After a successful send, the script writes a `.last-external-parent-<DRIVE_LABEL>` file with the snapshot name. This "pinned parent" is never deleted by cleanup, even if it's older than the retention window. This prevents the incremental chain from breaking.
 
-```bash
-# Example: Reduce htpc-home local retention from 7 to 3 days
-TIER1_HOME_LOCAL_RETENTION_DAILY=3  # Changed from 7
+**Dual pin files:** Each external drive has its own pin file (e.g., `.last-external-parent-WD-18TB` and `.last-external-parent-WD-18TB1`). This supports offsite rotation — when the offsite drive returns after months, its pinned parent still exists locally (protected by graduated retention).
 
-# Example: Reduce subvol3-opptak local retention
-TIER1_OPPTAK_LOCAL_RETENTION_DAILY=3  # Changed from 7
+### Graceful Drive Absence
 
-# Example: Keep fewer weekly snapshots for subvol2-pics
-TIER3_PICS_LOCAL_RETENTION_WEEKLY=2  # Changed from 4
-```
-
-**Impact:** Less disk space used locally, but larger gap between snapshots if external drive fails.
+When no external drive is mounted, the script logs INFO and skips external sends without recording a failure. No Discord alerts fire. This is the expected state when the offsite drive is at the remote location.
 
 ---
 
-### 2. Changing External Retention (Free Up Backup Drive Space)
+## Automation (Systemd Timer)
 
-**Problem:** External drive filling up, need to keep fewer old backups.
-
-**Solution:** Adjust `*_EXTERNAL_RETENTION_*` variables:
+**Single timer:** `btrfs-backup-daily.timer` at 02:00 AM nightly.
 
 ```bash
-# Example: Keep fewer weekly backups of containers
-TIER1_CONTAINERS_EXTERNAL_RETENTION_WEEKLY=2  # Changed from 4
-TIER1_CONTAINERS_EXTERNAL_RETENTION_MONTHLY=3  # Changed from 6
+# Check timer status
+systemctl --user list-timers | grep backup
 
-# Example: Keep fewer monthly backups of pics
-TIER3_PICS_EXTERNAL_RETENTION_MONTHLY=6  # Changed from 12
+# View last run logs
+journalctl --user -u btrfs-backup-daily.service -n 50
+
+# Manual run
+~/containers/scripts/btrfs-snapshot-backup.sh --verbose
 ```
 
-**Impact:** Shorter backup history, less recovery flexibility.
+### Monitoring
+
+- **Discord:** Failure-only notifications (red embed with failed subvolumes and reasons)
+- **Prometheus:** `backup.prom` metrics scraped by node_exporter textfile collector
+  - `backup_success{subvolume}` — 1 or 0
+  - `backup_last_success_timestamp{subvolume}` — Unix timestamp
+  - `backup_duration_seconds{subvolume}` — time taken
+  - `backup_snapshot_count{subvolume,location}` — snapshot inventory
+  - `backup_send_type{subvolume}` — 1=incremental, 0=full
+  - `backup_external_drive_mounted` — 1 or 0
+  - `backup_external_free_bytes` — external drive free space
 
 ---
 
-### 3. Disabling Backups for Specific Subvolumes
+## Offsite Rotation Guide
 
-**Problem:** Don't need to back up a subvolume anymore (e.g., subvol2-pics if you decide it's not worth backing up).
+The offsite drive (WD-18TB1) is stored at a friend's location and cycled roughly quarterly.
 
-**Solution:** Set the `*_ENABLED` variable to `false`:
+### Rotation Procedure
 
-```bash
-# Example: Disable subvol2-pics backups entirely
-TIER3_PICS_ENABLED=false  # Changed from true
+1. **Bring offsite drive home** — mount it (udisks2 auto-mounts)
+2. **Run full backup:** `~/containers/scripts/btrfs-snapshot-backup.sh --verbose`
+   - Script auto-detects the mounted drive
+   - Incremental send from the pinned parent (if still within 90-day graduated retention)
+   - If no common parent: full send (slow, but correct)
+3. **Verify sends completed** — check log output
+4. **Take drive back to offsite location**
+5. **Primary drive resumes daily** — next 02:00 run picks up WD-18TB automatically
 
-# Example: Disable subvol1-docs if using Nextcloud sync instead
-TIER2_DOCS_ENABLED=false
-```
+### Constraints
 
-**Impact:** No backups created for that subvolume. Use with caution!
-
----
-
-### 4. Changing Backup Frequency
-
-**Problem:** Want to back up critical data more often (or less often).
-
-**Current Limitation:** Script runs daily and checks day-of-week/day-of-month internally.
-
-**To increase frequency (e.g., daily external backups):**
-
-```bash
-# In backup_tier1_home() function (around line 280)
-# Remove the Saturday check:
-
-# BEFORE:
-if [[ $(date +%u) -eq 6 ]]; then  # Saturday
-    check_external_mounted || return 1
-    ...
-fi
-
-# AFTER (backs up externally every day):
-check_external_mounted || return 1
-...
-```
-
-**Warning:** Daily external backups increase system load and may wear out external drive faster.
-
-**To decrease frequency (e.g., monthly instead of weekly):**
-
-```bash
-# Change the day check (e.g., for monthly instead of weekly):
-if [[ $(date +%d) -eq 01 ]]; then  # 1st of month
-    check_external_mounted || return 1
-    ...
-fi
-
-# Or change the day of week (current: Saturday = 6):
-if [[ $(date +%u) -eq 1 ]]; then  # Monday
-    check_external_mounted || return 1
-    ...
-fi
-```
-
----
-
-### 5. Adding a New Subvolume to Backup
-
-**Problem:** Created a new subvolume (e.g., `subvol8-projects`) and want to back it up.
-
-**Solution:** Add a new configuration block:
-
-```bash
-# Add to appropriate tier (e.g., Tier 2 for important but not critical)
-
-# subvol8-projects (new projects folder)
-TIER2_PROJECTS_ENABLED=true
-TIER2_PROJECTS_SOURCE="/mnt/btrfs-pool/subvol8-projects"
-TIER2_PROJECTS_LOCAL_DIR="$LOCAL_POOL_SNAPSHOTS/subvol8-projects"
-TIER2_PROJECTS_EXTERNAL_DIR="$EXTERNAL_BACKUP_ROOT/subvol8-projects"
-TIER2_PROJECTS_LOCAL_RETENTION_DAILY=7
-TIER2_PROJECTS_EXTERNAL_RETENTION_WEEKLY=8
-TIER2_PROJECTS_EXTERNAL_RETENTION_MONTHLY=6
-TIER2_PROJECTS_SCHEDULE="daily"
-```
-
-Then create a corresponding backup function (copy and modify an existing one):
-
-```bash
-backup_tier2_projects() {
-    log INFO "=== Processing Tier 2: subvol8-projects ==="
-
-    if [[ "$TIER2_PROJECTS_ENABLED" != "true" ]]; then
-        log INFO "subvol8-projects backup disabled, skipping"
-        return 0
-    fi
-
-    local snapshot_name="${DATE_DAILY}-projects"
-    local local_snapshot="$TIER2_PROJECTS_LOCAL_DIR/$snapshot_name"
-
-    # Create local snapshot
-    if [[ "$EXTERNAL_ONLY" != "true" ]]; then
-        create_snapshot "$TIER2_PROJECTS_SOURCE" "$local_snapshot"
-    fi
-
-    # Send to external (weekly)
-    if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%u) -eq 6 ]]; then
-        check_external_mounted || return 1
-
-        local parent=$(get_latest_snapshot "$TIER2_PROJECTS_EXTERNAL_DIR" "*-projects")
-        send_snapshot_incremental "$parent" "$local_snapshot" "$TIER2_PROJECTS_EXTERNAL_DIR"
-
-        cleanup_old_snapshots "$TIER2_PROJECTS_EXTERNAL_DIR" "$TIER2_PROJECTS_EXTERNAL_RETENTION_WEEKLY" "*-projects"
-    fi
-
-    # Cleanup local snapshots
-    cleanup_old_snapshots "$TIER2_PROJECTS_LOCAL_DIR" "$TIER2_PROJECTS_LOCAL_RETENTION_DAILY" "*-projects"
-
-    log SUCCESS "Completed Tier 2: subvol8-projects"
-}
-```
-
-Finally, call it in the `main()` function:
-
-```bash
-if [[ -z "$TIER_FILTER" ]] || [[ "$TIER_FILTER" == "2" ]]; then
-    ...
-    if [[ -z "$SUBVOL_FILTER" ]] || [[ "$SUBVOL_FILTER" == "projects" ]]; then
-        backup_tier2_projects
-    fi
-fi
-```
-
----
-
-### 6. Changing Snapshot Naming Convention
-
-**Problem:** Want different snapshot names (e.g., add hostname or more descriptive names).
-
-**Solution:** Modify the `snapshot_name` variable in each backup function:
-
-```bash
-# BEFORE:
-local snapshot_name="${DATE_DAILY}-htpc-home"
-
-# AFTER (add more context):
-local snapshot_name="${DATE_DAILY}-$(hostname)-home-auto"
-
-# OR (add description):
-local snapshot_name="${DATE_DAILY}-htpc-home-automated"
-```
-
-**Pattern matching for cleanup:**
-Make sure to update the cleanup pattern to match:
-
-```bash
-cleanup_old_snapshots "$TIER1_HOME_LOCAL_DIR" "$TIER1_HOME_LOCAL_RETENTION_DAILY" "*-home-auto"
-```
+- Offsite cycle must not exceed **~90 days** (graduated retention window)
+- If exceeded: full sends required (slow, but data integrity maintained)
+- Both drives maintain independent incremental chains
 
 ---
 
 ## Usage Examples
 
-### 1. Test Run (Dry Run)
-
-See what would happen without actually executing:
-
 ```bash
+# Dry run (see what would happen)
 ~/containers/scripts/btrfs-snapshot-backup.sh --dry-run --verbose
-```
 
-### 2. Create Local Snapshots Only
-
-Skip external backup (e.g., external drive not connected):
-
-```bash
+# Local snapshots only (skip external sends)
 ~/containers/scripts/btrfs-snapshot-backup.sh --local-only
-```
 
-### 3. Send Existing Snapshots to External
-
-Don't create new local snapshots, just send existing ones:
-
-```bash
+# External sends only (use existing local snapshots)
 ~/containers/scripts/btrfs-snapshot-backup.sh --external-only
-```
 
-### 4. Backup Specific Tier Only
-
-```bash
-# Only Tier 1 (critical)
+# Specific tier
 ~/containers/scripts/btrfs-snapshot-backup.sh --tier 1
 
-# Only Tier 2 (important)
-~/containers/scripts/btrfs-snapshot-backup.sh --tier 2
+# Specific subvolume
+~/containers/scripts/btrfs-snapshot-backup.sh --subvolume containers --verbose
 ```
-
-### 5. Backup Specific Subvolume
-
-```bash
-# Only backup /home
-~/containers/scripts/btrfs-snapshot-backup.sh --subvolume home
-
-# Only backup subvol3-opptak
-~/containers/scripts/btrfs-snapshot-backup.sh --subvolume opptak
-```
-
-### 6. Manual Backup Before Major Change
-
-```bash
-# Before system upgrade or major config change
-~/containers/scripts/btrfs-snapshot-backup.sh --verbose
-
-# Or create manual snapshot with descriptive name:
-sudo btrfs subvolume snapshot -r /home ~/.snapshots/htpc-home/$(date +%Y%m%d)-pre-upgrade
-```
-
----
-
-## Automation Setup (Systemd Timers)
-
-### Prerequisites: Passwordless Sudo for BTRFS Commands
-
-**Required for automated backups via systemd user services.**
-
-The backup script uses `sudo` for BTRFS operations (snapshot, send, receive, delete). Since systemd user services cannot provide interactive password prompts, you must configure passwordless sudo for specific BTRFS commands.
-
-**Create sudoers file:**
-
-```bash
-sudo visudo -f /etc/sudoers.d/btrfs-backup
-```
-
-**Add the following rules:**
-
-```
-# BTRFS Backup Automation - Passwordless sudo for specific commands
-# Created: 2025-11-12
-# Purpose: Allow automated BTRFS snapshot backups via systemd user services
-#
-# Security: Only specific BTRFS commands allowed, no wildcards in command paths
-
-patriark ALL=(root) NOPASSWD: /usr/sbin/btrfs subvolume snapshot *
-patriark ALL=(root) NOPASSWD: /usr/sbin/btrfs subvolume delete *
-patriark ALL=(root) NOPASSWD: /usr/sbin/btrfs send *
-patriark ALL=(root) NOPASSWD: /usr/sbin/btrfs receive *
-```
-
-**Set correct permissions:**
-
-```bash
-sudo chmod 0440 /etc/sudoers.d/btrfs-backup
-```
-
-**Verify syntax:**
-
-```bash
-sudo visudo -c
-# Should output: /etc/sudoers: parsed OK
-```
-
-**Security notes:**
-- ✅ Only specific BTRFS subcommands are allowed (snapshot, delete, send, receive)
-- ✅ Command path is absolute (`/usr/sbin/btrfs`), preventing PATH manipulation
-- ✅ Wildcards only in arguments, not in command path
-- ✅ File permissions (0440) prevent unauthorized modification
-- ⚠️ User can create/delete any BTRFS snapshot - acceptable for single-user homelab
-
-**Test the configuration:**
-
-```bash
-# This should work without password prompt:
-sudo -n btrfs subvolume list / | head -5
-
-# Run backup script manually to verify:
-~/containers/scripts/btrfs-snapshot-backup.sh --local-only --verbose
-```
-
----
-
-### Daily Backup Timer
-
-Create systemd timer for daily local snapshots:
-
-```bash
-nano ~/.config/systemd/user/btrfs-backup-daily.timer
-```
-
-```ini
-[Unit]
-Description=Daily BTRFS Snapshot Timer
-Requires=btrfs-backup-daily.service
-
-[Timer]
-OnCalendar=daily
-Persistent=true
-OnBootSec=10min
-
-[Install]
-WantedBy=timers.target
-```
-
-Create corresponding service:
-
-```bash
-nano ~/.config/systemd/user/btrfs-backup-daily.service
-```
-
-```ini
-[Unit]
-Description=Daily BTRFS Snapshot Creation
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=%h/containers/scripts/btrfs-snapshot-backup.sh --local-only
-StandardOutput=journal
-StandardError=journal
-```
-
-Enable and start:
-
-```bash
-systemctl --user daemon-reload
-systemctl --user enable --now btrfs-backup-daily.timer
-systemctl --user list-timers
-```
-
-### Weekly External Backup Timer
-
-```bash
-nano ~/.config/systemd/user/btrfs-backup-weekly.timer
-```
-
-```ini
-[Unit]
-Description=Weekly BTRFS External Backup Timer
-Requires=btrfs-backup-weekly.service
-
-[Timer]
-OnCalendar=Sat 04:00
-Persistent=true
-
-[Install]
-WantedBy=timers.target
-```
-
-```bash
-nano ~/.config/systemd/user/btrfs-backup-weekly.service
-```
-
-```ini
-[Unit]
-Description=Weekly BTRFS External Backup
-After=network-online.target
-
-[Service]
-Type=oneshot
-ExecStart=%h/containers/scripts/btrfs-snapshot-backup.sh
-StandardOutput=journal
-StandardError=journal
-TimeoutStartSec=6h
-```
-
-Enable:
-
-```bash
-systemctl --user enable --now btrfs-backup-weekly.timer
-```
-
----
-
-## Monitoring Backups
-
-### Check Last Backup Status
-
-```bash
-# View last backup log
-tail -50 ~/containers/data/backup-logs/backup-$(date +%Y%m).log
-
-# Check for errors
-grep ERROR ~/containers/data/backup-logs/backup-$(date +%Y%m).log
-
-# Check for successes
-grep SUCCESS ~/containers/data/backup-logs/backup-$(date +%Y%m).log
-```
-
-### Check Snapshot Inventory
-
-```bash
-# Local snapshots
-ls -lh ~/.snapshots/htpc-home/
-ls -lh /mnt/btrfs-pool/.snapshots/subvol3-opptak/
-
-# External snapshots
-ls -lh /run/media/patriark/WD-18TB/.snapshots/htpc-home/
-ls -lh /run/media/patriark/WD-18TB/.snapshots/subvol3-opptak/
-```
-
-### Check Disk Space Usage
-
-```bash
-# Local NVMe space
-df -h /home
-sudo btrfs filesystem usage /
-
-# External drive space
-df -h /run/media/patriark/WD-18TB
-sudo btrfs filesystem usage /run/media/patriark/WD-18TB
-```
-
-### Add Prometheus Monitoring (Future)
-
-Consider adding metrics for:
-- Last successful backup timestamp
-- Snapshot count per subvolume
-- Backup script duration
-- Disk space used by snapshots
 
 ---
 
 ## Recovery Procedures
 
-### Restore File from Snapshot
-
+### Restore File from Local Snapshot
 ```bash
-# List available snapshots
-ls ~/.snapshots/htpc-home/
-
-# Browse snapshot contents
-ls ~/.snapshots/htpc-home/20251107-htpc-home/containers/config/
-
-# Copy file from snapshot
-cp ~/.snapshots/htpc-home/20251107-htpc-home/containers/config/traefik/traefik.yml ~/containers/config/traefik/traefik.yml.restored
-```
-
-### Restore Entire Subvolume
-
-```bash
-# 1. Rename current subvolume
-sudo mv /home /home.broken
-
-# 2. Restore from snapshot (creates writable copy)
-sudo btrfs subvolume snapshot ~/.snapshots/htpc-home/20251107-htpc-home /home
-
-# 3. Reboot
-sudo systemctl reboot
+ls ~/.snapshots/htpc-home/                          # List available snapshots
+cp ~/.snapshots/htpc-home/20260321-htpc-home/path/to/file ~/restored-file
 ```
 
 ### Restore from External Drive
-
 ```bash
-# 1. Mount external drive
-# (usually auto-mounted at /run/media/patriark/WD-18TB)
+ls /run/media/patriark/WD-18TB/.snapshots/htpc-home/  # List external snapshots
+sudo btrfs send /run/media/patriark/WD-18TB/.snapshots/htpc-home/20260321-htpc-home | \
+    sudo btrfs receive ~/.snapshots/htpc-home/
+sudo btrfs subvolume snapshot ~/.snapshots/htpc-home/20260321-htpc-home /home
+```
 
-# 2. List available snapshots
-ls /run/media/patriark/WD-18TB/.snapshots/htpc-home/
-
-# 3. Send snapshot back to system
-sudo btrfs send /run/media/patriark/WD-18TB/.snapshots/htpc-home/20251101-htpc-home | sudo btrfs receive ~/.snapshots/htpc-home/
-
-# 4. Restore from that snapshot
-sudo btrfs subvolume snapshot ~/.snapshots/htpc-home/20251101-htpc-home /home
+### Restore Entire Subvolume from Local
+```bash
+sudo mv /home /home.broken
+sudo btrfs subvolume snapshot ~/.snapshots/htpc-home/20260321-htpc-home /home
+sudo systemctl reboot
 ```
 
 ---
 
 ## Troubleshooting
 
-### Problem: Backup service fails with "sudo: a password is required"
+### Backup service fails with "sudo: a password is required"
+Configure passwordless sudo for BTRFS commands — see `backup-automation-setup.md`.
 
-**Symptom:**
+### "No space left on device" when creating snapshot
 ```bash
-systemctl --user status btrfs-backup-daily.service
-# Shows: Active: failed (Result: exit-code)
-
-journalctl --user -u btrfs-backup-daily.service
-# Shows: sudo: a terminal is required to read the password
-```
-
-**Cause:** The backup script uses `sudo` for BTRFS operations, but systemd user services cannot provide interactive password prompts.
-
-**Solution:** Configure passwordless sudo for BTRFS commands (see "Automation Setup" section above).
-
-**Quick fix:**
-```bash
-# 1. Create sudoers file
-sudo bash -c 'cat > /etc/sudoers.d/btrfs-backup << EOF
-patriark ALL=(root) NOPASSWD: /usr/sbin/btrfs subvolume snapshot *
-patriark ALL=(root) NOPASSWD: /usr/sbin/btrfs subvolume delete *
-patriark ALL=(root) NOPASSWD: /usr/sbin/btrfs send *
-patriark ALL=(root) NOPASSWD: /usr/sbin/btrfs receive *
-EOF'
-
-# 2. Set permissions
-sudo chmod 0440 /etc/sudoers.d/btrfs-backup
-
-# 3. Verify syntax
-sudo visudo -c
-
-# 4. Test manually
-~/containers/scripts/btrfs-snapshot-backup.sh --local-only --verbose
-
-# 5. Test via systemd
-systemctl --user start btrfs-backup-daily.service
-systemctl --user status btrfs-backup-daily.service
-```
-
-**Verification:**
-- ✅ Service status shows `status=0/SUCCESS`
-- ✅ Logs show "BTRFS Snapshot & Backup Script Completed"
-- ✅ New snapshots appear in `~/.snapshots/` directories
-- ✅ No sudo password prompts in logs
-
----
-
-### Problem: "No space left on device" when creating snapshot
-
-**Cause:** NVMe full or BTRFS metadata full.
-
-**Solution:**
-
-```bash
-# Check actual usage
-df -h /
+df -h /home
 sudo btrfs filesystem usage /
-
-# Free up space
 sudo btrfs balance start -dusage=10 /
-sudo btrfs balance start -musage=10 /
-
-# Delete old snapshots manually
-sudo btrfs subvolume delete ~/.snapshots/htpc-home/20251101-htpc-home
-
-# Adjust retention in script to keep fewer local snapshots
 ```
 
-### Problem: External backup fails with "parent snapshot not found"
+### External backup fails with "no common parent"
+The incremental chain is broken. Script will fall back to full send automatically. If space is insufficient for full send, it will abort with a clear error.
 
-**Cause:** Parent snapshot was deleted from external drive.
-
-**Solution:** Send a full snapshot (not incremental):
-
+### Script hangs during external backup
 ```bash
-# Send full snapshot (will be slow)
-sudo btrfs send ~/.snapshots/htpc-home/20251107-htpc-home | sudo btrfs receive /run/media/patriark/WD-18TB/.snapshots/htpc-home/
+sudo dmesg | tail -50              # Check for USB/disk errors
+mountpoint /run/media/patriark/WD-18TB  # Verify mount
+sudo smartctl -H /dev/sdX          # Check drive health
 ```
-
-### Problem: Script hangs during external backup
-
-**Cause:** External drive disconnected or very slow.
-
-**Solution:**
-
-```bash
-# Check if drive is mounted
-mountpoint /run/media/patriark/WD-18TB
-
-# Check drive health
-sudo smartctl -H /dev/sdX
-
-# Check dmesg for USB errors
-sudo dmesg | tail -50
-
-# Kill stuck btrfs operation
-sudo pkill -9 btrfs
-
-# Remount drive
-sudo umount /run/media/patriark/WD-18TB
-sudo mount /dev/mapper/WD-18TB /run/media/patriark/WD-18TB
-```
-
-### Problem: Snapshot cleanup not working
-
-**Cause:** Pattern mismatch in cleanup function.
-
-**Solution:**
-
-```bash
-# Test pattern matching manually
-find ~/.snapshots/htpc-home/ -maxdepth 1 -type d -name "*-htpc-home"
-
-# If no results, check actual snapshot names
-ls ~/.snapshots/htpc-home/
-
-# Adjust pattern in script to match actual names
-```
-
----
-
-## Best Practices
-
-1. **Test restores periodically** - Backups are useless if you can't restore
-2. **Monitor external drive health** - Run `smartctl -H` monthly
-3. **Keep external drive disconnected** when not backing up (protection against ransomware)
-4. **Document manual snapshots** - Use descriptive names like `20251107-pre-upgrade`
-5. **Review logs monthly** - Check for backup failures
-6. **Verify snapshot sizes** - Large unexpected growth may indicate issues
-7. **Test dry-run before changes** - Always use `--dry-run` when testing script modifications
-8. **Use NOCOW for database directories** - Disable Copy-on-Write for database workloads to prevent fragmentation:
-   ```bash
-   # For new database directories (must be empty)
-   mkdir -p /mnt/btrfs-pool/subvol7-containers/prometheus
-   chattr +C /mnt/btrfs-pool/subvol7-containers/prometheus
-   lsattr -d /mnt/btrfs-pool/subvol7-containers/prometheus  # Verify 'C' flag
-
-   # Apply to: PostgreSQL, MariaDB, Prometheus, Grafana, Loki databases
-   # WHY: COW causes severe fragmentation on database write patterns
-   # NOTE: Only works on empty directories - cannot convert existing data
-   ```
-
----
-
-## Parameter Quick Reference
-
-### Common Adjustments
-
-```bash
-# Make NVMe last longer (reduce local snapshots)
-TIER1_HOME_LOCAL_RETENTION_DAILY=3      # Instead of 7
-TIER1_OPPTAK_LOCAL_RETENTION_DAILY=3    # Instead of 7
-
-# Free up external drive space (reduce retention)
-TIER1_HOME_EXTERNAL_RETENTION_WEEKLY=4  # Instead of 8
-TIER1_HOME_EXTERNAL_RETENTION_MONTHLY=6 # Instead of 12
-
-# Disable non-critical backups
-TIER3_PICS_ENABLED=false
-TIER2_DOCS_ENABLED=false  # If using Nextcloud sync
-
-# Speed up backups (skip external)
-~/containers/scripts/btrfs-snapshot-backup.sh --local-only
-```
-
----
-
-## Future Enhancements
-
-Consider implementing:
-1. **Compression during send** - Add `--compressed-data` flag to `btrfs send`
-2. **Email notifications** - Send email on backup failure
-3. **Prometheus metrics** - Track backup success/failure, snapshot counts
-4. **Automatic external drive mounting** - Detect drive and mount automatically
-5. **Off-site replication** - Add third backup destination (cloud or remote server)
-6. **Deduplication tracking** - Monitor shared extents between snapshots
 
 ---
 
 ## Related Documentation
 
-- Storage Architecture: `~/containers/docs/99-reports/20251025-storage-architecture-authoritative-rev2.md`
-- Monitoring Stack: `~/containers/docs/monitoring-stack-guide.md`
-- BTRFS Commands: Section 1.2-1.3 in storage architecture addendum
+- **ADR-020:** Daily External Backups — `docs/00-foundation/decisions/2026-03-21-ADR-020-daily-external-backups.md`
+- **Automation Setup:** `docs/20-operations/guides/backup-automation-setup.md`
+- **Disaster Recovery:** `docs/20-operations/guides/disaster-recovery.md`
+- **Storage Layout:** `docs/20-operations/guides/storage-layout.md`
+- **Operational Excellence Journal:** `docs/98-journals/2026-03-21-backup-script-operational-excellence.md`
 
 ---
 
-**Last Updated:** 2025-12-22 (Added NOCOW best practice for database directories)
-**Script Version:** 1.0
+**Last Updated:** 2026-03-21 (ADR-020: daily external, graduated retention, dual pin files)

--- a/docs/20-operations/guides/backup-strategy.md
+++ b/docs/20-operations/guides/backup-strategy.md
@@ -45,10 +45,10 @@ Automated BTRFS snapshot and incremental backup strategy, optimized for:
 | 1 | subvol7-containers | Daily | Daily | 14 snapshots |
 | 2 | subvol1-docs | Daily | Daily | 14 snapshots |
 | 2 | htpc-root | Monthly | Monthly | 6 snapshots |
-| 3 | subvol2-pics | Weekly (Sat) | Monthly (1st) | 6 snapshots |
-| 3 | subvol4-multimedia | Weekly (Sat) | Monthly (1st) | 3 snapshots |
-| 3 | subvol5-music | Weekly (Sat) | Monthly (1st) | 6 snapshots |
-| 3 | subvol6-tmp | Weekly (Sat) | Monthly (1st) | 3 snapshots |
+| 3 | subvol2-pics | Weekly (Sat) | First Saturday | 6 snapshots |
+| 3 | subvol4-multimedia | Weekly (Sat) | First Saturday | 3 snapshots |
+| 3 | subvol5-music | Weekly (Sat) | First Saturday | 6 snapshots |
+| 3 | subvol6-tmp | Weekly (Sat) | First Saturday | 3 snapshots |
 
 ### Local Retention (Graduated / Time Machine-style)
 
@@ -56,7 +56,7 @@ For daily-schedule subvolumes (Tier 1/2):
 - **Last 14 days:** All snapshots kept
 - **15-60 days:** 1 per ISO week
 - **61-90 days:** 1 per month
-- ~21 snapshots total, covering 3 months
+- ~21 snapshots total, covering ~5 months (149 days)
 
 For weekly-schedule subvolumes (Tier 3): simple count (4-8 snapshots).
 
@@ -130,7 +130,7 @@ The offsite drive (WD-18TB1) is stored at a friend's location and cycled roughly
 
 ### Constraints
 
-- Offsite cycle must not exceed **~90 days** (graduated retention window)
+- Offsite cycle must not exceed **~149 days** (graduated retention window covers ~5 months)
 - If exceeded: full sends required (slow, but data integrity maintained)
 - Both drives maintain independent incremental chains
 

--- a/docs/98-journals/2026-03-21-backup-script-operational-excellence.md
+++ b/docs/98-journals/2026-03-21-backup-script-operational-excellence.md
@@ -275,3 +275,87 @@ Deleted uncompressed snapshots, re-sent with `compress=zstd:3` active:
   with compression (remount), has fresh chains for containers + docs.
 - **2TB-backup**: Surplus ephemeral drive, 1.1TB free. Available for experiments.
 - Both WD drives share the same LUKS UUID and btrfs label (cloned).
+
+---
+
+## Addendum: Backup Strategy Overhaul (2026-03-21, evening session)
+
+Following the operational excellence fixes above, a broader review of the entire backup strategy
+was conducted. The core insight: now that incremental sends work reliably (pinned parents,
+space pre-checks, stderr capture), the weekly-only external schedule is no longer justified.
+The weekly gate was a constraint of the full-send era — incremental sends take minutes, not hours.
+
+### ADR-020: Daily External Backups
+
+Created `docs/00-foundation/decisions/2026-03-21-ADR-020-daily-external-backups.md` documenting
+the architectural shift. Key decisions:
+
+**1. Daily external sends for Tier 1/2** — RPO reduced from 7 days to ~1 day.
+Per-subvolume `EXTERNAL_SCHEDULE` config variable (`daily`/`weekly`/`monthly`) replaces
+all hardcoded `date +%u -eq 6` Saturday checks. Tier 3 remains weekly/monthly.
+
+**2. Single nightly timer** — The daily timer at 02:00 now runs the full script (removed
+`--local-only`). The weekly Saturday timer is disabled. The script internally determines
+per-subvolume whether to create local snapshots and/or send externally.
+
+**3. Graduated local retention (Time Machine-style)** — Replaced flat 15-daily retention
+with: 14 daily + 1/week for 6 weeks + 1/month for 3 months (~21 snapshots, 90-day coverage).
+This was driven by the offsite rotation plan: WD-18TB1 will live at a friend's location
+and cycle roughly quarterly. The old 15-daily retention would delete the offsite pinned
+parent long before the drive returns. New `cleanup_graduated()` function handles the
+date-based window logic.
+
+**4. Dual pin files** — `.last-external-parent-WD-18TB` and `.last-external-parent-WD-18TB1`
+maintain independent incremental chains. Both pinned parents are protected during cleanup,
+regardless of which drive is mounted. `get_all_pinned_parents()` collects all pin files
+for the cleanup functions.
+
+**5. Graceful drive absence** — When no external drive is mounted, the script logs INFO
+and skips external sends without recording a failure or triggering Discord alerts.
+Previously, an unmounted drive would register as a failure for every subvolume.
+
+**6. Simplified external retention** — Replaced the never-implemented "8 weekly + 12 monthly"
+config with a single `_EXTERNAL_RETENTION` count (14 for Tier 1/2). The cleanup function
+never distinguished weekly from monthly — the dual-count config was aspirational fiction.
+This resolves handoff item #4 above.
+
+**7. New Prometheus metrics** — `backup_send_type` (incremental vs full),
+`backup_external_drive_mounted`, `backup_external_free_bytes`. These enable Grafana
+alerting for chain breaks (handoff item #8 above) and drive capacity.
+
+### Additional bug fixes
+
+- `pin_parent()` now respects `--dry-run` (previously wrote pin files during dry runs)
+- Added `-mindepth 1` to all `find` commands in cleanup/query functions (the search
+  directory itself could match patterns like `*-containers` and get included in results)
+
+### Handoff items resolved
+
+| # | Item | Resolution |
+|---|------|-----------|
+| 3 | Review retention policy | Graduated retention (Time Machine-style) replaces flat 15-daily |
+| 4 | Monthly retention design | Dropped — single count per subvolume, no weekly/monthly distinction |
+| 5 | Increase Tier 1 frequency | Done — daily external sends for all Tier 1 + Tier 2 |
+| 8 | Prometheus chain break alert | `backup_send_type` metric tracks incremental vs full sends |
+
+### Remaining items
+
+- `/etc/udisks2/mount_options.conf` for offsite drive compression (item #1)
+- Swap back to primary WD-18TB drive and re-establish incremental chains (item #2)
+- `btrfs subvolume show` sudoers NOPASSWD (item #6)
+- Live Discord notification test (item #7)
+- subvol4-multimedia initial external backup (5.8TB, still disabled)
+
+### Verification
+
+Dry-run tested successfully. All 9 subvolumes processed correctly:
+- Tier 1/2: external sends attempted (daily schedule working)
+- Tier 3: Saturday-only local snapshots, monthly external gate working
+- htpc-root: monthly gate skipped correctly (not 1st of month)
+- Graduated cleanup: parsed dates, preserved pinned parents, kept all snapshots within 14-day window
+- Drive-specific pin files: "Pinned parent for WD-18TB1 incremental chain"
+
+**Next verification:** Check morning logs after tonight's 02:00 run:
+```bash
+journalctl --user -u btrfs-backup-daily.service -n 100
+```

--- a/docs/98-journals/2026-03-21-backup-script-operational-excellence.md
+++ b/docs/98-journals/2026-03-21-backup-script-operational-excellence.md
@@ -345,6 +345,11 @@ alerting for chain breaks (handoff item #8 above) and drive capacity.
 - `btrfs subvolume show` sudoers NOPASSWD (item #6)
 - Live Discord notification test (item #7)
 - subvol4-multimedia initial external backup (5.8TB, still disabled)
+- **2026-04-21:** Remove legacy `.last-external-parent` files and the fallback code path
+  in `get_pinned_parent()`. By then, both drives will have drive-specific pin files.
+  Search for "Legacy pin file" in `btrfs-snapshot-backup.sh`.
+- Weekly timer unit files left on disk for rollback — remove after 2026-04-07 if daily
+  model is stable: `rm ~/.config/systemd/user/btrfs-backup-weekly.{timer,service}`
 
 ### Verification
 

--- a/scripts/btrfs-snapshot-backup.sh
+++ b/scripts/btrfs-snapshot-backup.sh
@@ -19,10 +19,11 @@
 #   --verbose           Verbose output
 #   --help              Show this help message
 #
-# Schedule (via systemd timers):
-#   - Daily:   02:00 AM - Tier 1 local snapshots + cleanup
-#   - Weekly:  Saturday 04:00 AM - All tiers external backup
-#   - Monthly: 1st of month 04:00 AM - Monthly snapshots + external
+# Schedule (via systemd timer at 02:00 AM nightly):
+#   - Tier 1/2 (daily): Local snapshot + incremental external send
+#   - Tier 3 (weekly):  Local snapshot on Saturdays only
+#   - External sends:   Per-subvolume schedule (daily/weekly/monthly)
+#   - Local retention:  Graduated (14 daily + 6 weekly + 3 monthly)
 #
 ################################################################################
 
@@ -46,6 +47,17 @@ for candidate in "${EXTERNAL_BACKUP_CANDIDATES[@]}"; do
 done
 # Fallback to first candidate (check_external_mounted will catch if not mounted)
 EXTERNAL_BACKUP_ROOT="${EXTERNAL_BACKUP_ROOT:-${EXTERNAL_BACKUP_CANDIDATES[0]}/.snapshots}"
+
+# Detect which external drive is mounted (for drive-specific pin files)
+EXTERNAL_DRIVE_LABEL=""
+for candidate in "${EXTERNAL_BACKUP_CANDIDATES[@]}"; do
+    if mountpoint -q "$candidate" 2>/dev/null; then
+        EXTERNAL_DRIVE_LABEL=$(basename "$candidate")
+        break
+    fi
+done
+EXTERNAL_DRIVE_MOUNTED=false
+[[ -n "$EXTERNAL_DRIVE_LABEL" ]] && EXTERNAL_DRIVE_MOUNTED=true
 
 # Local snapshot directories
 LOCAL_HOME_SNAPSHOTS="$HOME/.snapshots"
@@ -97,6 +109,9 @@ FAILED_REASONS=()
 SUCCEEDED_SUBVOLS=()
 SKIPPED_SUBVOLS=()
 
+# Send type tracking (for Prometheus metrics)
+declare -A SEND_TYPE  # "incremental", "full", or "" (no send)
+
 ################################################################################
 # TIER 1: CRITICAL - Daily local, Weekly external
 ################################################################################
@@ -106,30 +121,27 @@ TIER1_HOME_ENABLED=true
 TIER1_HOME_SOURCE="/home"
 TIER1_HOME_LOCAL_DIR="$LOCAL_HOME_SNAPSHOTS/htpc-home"
 TIER1_HOME_EXTERNAL_DIR="$EXTERNAL_BACKUP_ROOT/htpc-home"
-TIER1_HOME_LOCAL_RETENTION_DAILY=15     # Keep 15 daily snapshots locally
-TIER1_HOME_EXTERNAL_RETENTION_WEEKLY=8  # Keep 8 weekly snapshots on external
-TIER1_HOME_EXTERNAL_RETENTION_MONTHLY=12 # Keep 12 monthly snapshots on external
-TIER1_HOME_SCHEDULE="daily"             # daily | weekly | monthly
+TIER1_HOME_LOCAL_SCHEDULE="daily"              # daily | weekly | monthly
+TIER1_HOME_EXTERNAL_SCHEDULE="daily"           # daily | weekly | monthly
+TIER1_HOME_EXTERNAL_RETENTION=14               # Keep 14 daily snapshots on external
 
 # subvol3-opptak (private recordings - HEIGHTENED BACKUP DEMANDS)
 TIER1_OPPTAK_ENABLED=true
 TIER1_OPPTAK_SOURCE="/mnt/btrfs-pool/subvol3-opptak"
 TIER1_OPPTAK_LOCAL_DIR="$LOCAL_POOL_SNAPSHOTS/subvol3-opptak"
 TIER1_OPPTAK_EXTERNAL_DIR="$EXTERNAL_BACKUP_ROOT/subvol3-opptak"
-TIER1_OPPTAK_LOCAL_RETENTION_DAILY=15
-TIER1_OPPTAK_EXTERNAL_RETENTION_WEEKLY=8
-TIER1_OPPTAK_EXTERNAL_RETENTION_MONTHLY=12
-TIER1_OPPTAK_SCHEDULE="daily"
+TIER1_OPPTAK_LOCAL_SCHEDULE="daily"
+TIER1_OPPTAK_EXTERNAL_SCHEDULE="daily"
+TIER1_OPPTAK_EXTERNAL_RETENTION=14
 
 # subvol7-containers (operational data)
 TIER1_CONTAINERS_ENABLED=true
 TIER1_CONTAINERS_SOURCE="/mnt/btrfs-pool/subvol7-containers"
 TIER1_CONTAINERS_LOCAL_DIR="$LOCAL_POOL_SNAPSHOTS/subvol7-containers"
 TIER1_CONTAINERS_EXTERNAL_DIR="$EXTERNAL_BACKUP_ROOT/subvol7-containers"
-TIER1_CONTAINERS_LOCAL_RETENTION_DAILY=15
-TIER1_CONTAINERS_EXTERNAL_RETENTION_WEEKLY=4
-TIER1_CONTAINERS_EXTERNAL_RETENTION_MONTHLY=6
-TIER1_CONTAINERS_SCHEDULE="daily"
+TIER1_CONTAINERS_LOCAL_SCHEDULE="daily"
+TIER1_CONTAINERS_EXTERNAL_SCHEDULE="daily"
+TIER1_CONTAINERS_EXTERNAL_RETENTION=14
 
 ################################################################################
 # TIER 2: IMPORTANT - Daily/Monthly local, Weekly/Monthly external
@@ -140,19 +152,19 @@ TIER2_DOCS_ENABLED=true
 TIER2_DOCS_SOURCE="/mnt/btrfs-pool/subvol1-docs"
 TIER2_DOCS_LOCAL_DIR="$LOCAL_POOL_SNAPSHOTS/subvol1-docs"
 TIER2_DOCS_EXTERNAL_DIR="$EXTERNAL_BACKUP_ROOT/subvol1-docs"
-TIER2_DOCS_LOCAL_RETENTION_DAILY=15
-TIER2_DOCS_EXTERNAL_RETENTION_WEEKLY=8
-TIER2_DOCS_EXTERNAL_RETENTION_MONTHLY=6
-TIER2_DOCS_SCHEDULE="daily"
+TIER2_DOCS_LOCAL_SCHEDULE="daily"
+TIER2_DOCS_EXTERNAL_SCHEDULE="daily"
+TIER2_DOCS_EXTERNAL_RETENTION=14
 
 # htpc-root (/ root subvolume - monthly only per architecture doc)
 TIER2_ROOT_ENABLED=true
 TIER2_ROOT_SOURCE="/"
 TIER2_ROOT_LOCAL_DIR="$LOCAL_HOME_SNAPSHOTS/htpc-root"
 TIER2_ROOT_EXTERNAL_DIR="$EXTERNAL_BACKUP_ROOT/htpc-root"
-TIER2_ROOT_LOCAL_RETENTION_MONTHLY=1    # Keep ONLY 1 local snapshot
-TIER2_ROOT_EXTERNAL_RETENTION_MONTHLY=6
-TIER2_ROOT_SCHEDULE="monthly"
+TIER2_ROOT_LOCAL_SCHEDULE="monthly"
+TIER2_ROOT_EXTERNAL_SCHEDULE="monthly"
+TIER2_ROOT_LOCAL_RETENTION=1             # Keep ONLY 1 local snapshot
+TIER2_ROOT_EXTERNAL_RETENTION=6
 
 ################################################################################
 # TIER 3: STANDARD - Weekly local, Monthly external
@@ -163,9 +175,10 @@ TIER3_PICS_ENABLED=true
 TIER3_PICS_SOURCE="/mnt/btrfs-pool/subvol2-pics"
 TIER3_PICS_LOCAL_DIR="$LOCAL_POOL_SNAPSHOTS/subvol2-pics"
 TIER3_PICS_EXTERNAL_DIR="$EXTERNAL_BACKUP_ROOT/subvol2-pics"
-TIER3_PICS_LOCAL_RETENTION_WEEKLY=4
-TIER3_PICS_EXTERNAL_RETENTION_MONTHLY=12
-TIER3_PICS_SCHEDULE="weekly"
+TIER3_PICS_LOCAL_SCHEDULE="weekly"
+TIER3_PICS_EXTERNAL_SCHEDULE="monthly"
+TIER3_PICS_LOCAL_RETENTION=8             # 8 weekly = 2 months
+TIER3_PICS_EXTERNAL_RETENTION=6
 
 # subvol4-multimedia (Jellyfin media - 5.8TB, replaceable but time-consuming)
 # NOTE: Initially disabled for external backup - do initial backup manually first!
@@ -175,27 +188,36 @@ TIER3_MULTIMEDIA_SOURCE="/mnt/btrfs-pool/subvol4-multimedia"
 TIER3_MULTIMEDIA_LOCAL_DIR="$LOCAL_POOL_SNAPSHOTS/subvol4-multimedia"
 TIER3_MULTIMEDIA_EXTERNAL_DIR="$EXTERNAL_BACKUP_ROOT/subvol4-multimedia"
 TIER3_MULTIMEDIA_EXTERNAL_ENABLED=false  # Set to true after initial manual backup
-TIER3_MULTIMEDIA_LOCAL_RETENTION_WEEKLY=4
-TIER3_MULTIMEDIA_EXTERNAL_RETENTION_MONTHLY=6
-TIER3_MULTIMEDIA_SCHEDULE="weekly"
+TIER3_MULTIMEDIA_LOCAL_SCHEDULE="weekly"
+TIER3_MULTIMEDIA_EXTERNAL_SCHEDULE="monthly"
+TIER3_MULTIMEDIA_LOCAL_RETENTION=4
+TIER3_MULTIMEDIA_EXTERNAL_RETENTION=3
 
 # subvol5-music (Music library - 1.1TB, replaceable)
 TIER3_MUSIC_ENABLED=true
 TIER3_MUSIC_SOURCE="/mnt/btrfs-pool/subvol5-music"
 TIER3_MUSIC_LOCAL_DIR="$LOCAL_POOL_SNAPSHOTS/subvol5-music"
 TIER3_MUSIC_EXTERNAL_DIR="$EXTERNAL_BACKUP_ROOT/subvol5-music"
-TIER3_MUSIC_LOCAL_RETENTION_WEEKLY=4
-TIER3_MUSIC_EXTERNAL_RETENTION_MONTHLY=6
-TIER3_MUSIC_SCHEDULE="weekly"
+TIER3_MUSIC_LOCAL_SCHEDULE="weekly"
+TIER3_MUSIC_EXTERNAL_SCHEDULE="monthly"
+TIER3_MUSIC_LOCAL_RETENTION=8            # 8 weekly = 2 months
+TIER3_MUSIC_EXTERNAL_RETENTION=6
 
 # subvol6-tmp (Temporary files/cache - 6.2GB, fully replaceable)
 TIER3_TMP_ENABLED=true
 TIER3_TMP_SOURCE="/mnt/btrfs-pool/subvol6-tmp"
 TIER3_TMP_LOCAL_DIR="$LOCAL_POOL_SNAPSHOTS/subvol6-tmp"
 TIER3_TMP_EXTERNAL_DIR="$EXTERNAL_BACKUP_ROOT/subvol6-tmp"
-TIER3_TMP_LOCAL_RETENTION_WEEKLY=2  # Only 2 weeks (cache data)
-TIER3_TMP_EXTERNAL_RETENTION_MONTHLY=3  # Only 3 months (cache data)
-TIER3_TMP_SCHEDULE="weekly"
+TIER3_TMP_LOCAL_SCHEDULE="weekly"
+TIER3_TMP_EXTERNAL_SCHEDULE="monthly"
+TIER3_TMP_LOCAL_RETENTION=4              # Only 4 weeks (cache data)
+TIER3_TMP_EXTERNAL_RETENTION=3
+
+# Graduated local retention (Time Machine-style) for daily-schedule subvolumes
+# Tier 3 (weekly) uses simple count via _LOCAL_RETENTION instead
+GRADUATED_RETENTION_DAILY=14    # Keep all snapshots from last 14 days
+GRADUATED_RETENTION_WEEKLY=6    # Keep 1 per week for next ~6 weeks (days 15-60)
+GRADUATED_RETENTION_MONTHLY=3   # Keep 1 per month for next ~3 months (days 61-90)
 
 ################################################################################
 # END OF CONFIGURATION SECTION
@@ -345,20 +367,71 @@ check_external_space() {
     return 0
 }
 
+should_send_external() {
+    # Determine if external send should happen based on schedule
+    local schedule=$1  # "daily" | "weekly" | "monthly"
+    case "$schedule" in
+        daily)   return 0 ;;
+        weekly)  [[ $(date +%u) -eq 6 ]] ;;
+        monthly) [[ $(date +%d) == "01" ]] ;;
+        *)       return 1 ;;
+    esac
+}
+
 pin_parent() {
     local local_dir=$1
     local snapshot_name=$2
-    local pin_file="$local_dir/.last-external-parent"
-    echo "$snapshot_name" > "$pin_file"
-    log INFO "Pinned parent for incremental chain: $snapshot_name"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        log INFO "[DRY-RUN] Would pin parent: $snapshot_name (drive: ${EXTERNAL_DRIVE_LABEL:-unknown})"
+        return 0
+    fi
+
+    # Drive-specific pin file (supports offsite rotation with separate incremental chains)
+    if [[ -n "$EXTERNAL_DRIVE_LABEL" ]]; then
+        local pin_file="$local_dir/.last-external-parent-${EXTERNAL_DRIVE_LABEL}"
+        echo "$snapshot_name" > "$pin_file"
+        log INFO "Pinned parent for ${EXTERNAL_DRIVE_LABEL} incremental chain: $snapshot_name"
+    fi
+
+    # Also maintain legacy pin file for backwards compatibility during transition
+    echo "$snapshot_name" > "$local_dir/.last-external-parent"
 }
 
 get_pinned_parent() {
     local local_dir=$1
+
+    # Try drive-specific pin file first
+    if [[ -n "$EXTERNAL_DRIVE_LABEL" ]]; then
+        local pin_file="$local_dir/.last-external-parent-${EXTERNAL_DRIVE_LABEL}"
+        if [[ -f "$pin_file" ]]; then
+            cat "$pin_file"
+            return
+        fi
+    fi
+
+    # Fall back to legacy pin file
     local pin_file="$local_dir/.last-external-parent"
     if [[ -f "$pin_file" ]]; then
         cat "$pin_file"
     fi
+}
+
+get_all_pinned_parents() {
+    # Return all pinned parent names across all drives (for graduated cleanup protection)
+    local local_dir=$1
+    local pinned=()
+
+    for pin_file in "$local_dir"/.last-external-parent*; do
+        if [[ -f "$pin_file" ]]; then
+            local name
+            name=$(cat "$pin_file")
+            [[ -n "$name" ]] && pinned+=("$name")
+        fi
+    done
+
+    # Deduplicate and print
+    printf '%s\n' "${pinned[@]}" | sort -u
 }
 
 check_external_mounted() {
@@ -477,6 +550,7 @@ send_snapshot_incremental() {
 }
 
 cleanup_old_snapshots() {
+    # Simple count-based retention (used for external drives and Tier 3 local)
     local snapshot_dir=$1
     local retention_count=$2
     local pattern=$3  # e.g., "*-daily" or "*-weekly"
@@ -486,12 +560,14 @@ cleanup_old_snapshots() {
         return 0
     fi
 
-    # Check for pinned parent that must be preserved
-    local pinned_name
-    pinned_name=$(get_pinned_parent "$snapshot_dir")
+    # Collect ALL pinned parents across all drives
+    local -a pinned_names=()
+    while IFS= read -r name; do
+        [[ -n "$name" ]] && pinned_names+=("$name")
+    done < <(get_all_pinned_parents "$snapshot_dir")
 
     # Get list of snapshots matching pattern, sorted by modification time (oldest first)
-    local snapshots=($(find "$snapshot_dir" -maxdepth 1 -type d -name "$pattern" -printf '%T+ %p\n' | sort | awk '{print $2}'))
+    local snapshots=($(find "$snapshot_dir" -mindepth 1 -maxdepth 1 -type d -name "$pattern" -printf '%T+ %p\n' | sort | awk '{print $2}'))
 
     local count=${#snapshots[@]}
 
@@ -509,8 +585,16 @@ cleanup_old_snapshots() {
         local snap_basename
         snap_basename=$(basename "$snapshot")
 
-        # Never delete the pinned parent — it's the incremental chain anchor
-        if [[ -n "$pinned_name" ]] && [[ "$snap_basename" == "$pinned_name" ]]; then
+        # Never delete any pinned parent — they're incremental chain anchors
+        local is_pinned=false
+        for pinned_name in "${pinned_names[@]}"; do
+            if [[ "$snap_basename" == "$pinned_name" ]]; then
+                is_pinned=true
+                break
+            fi
+        done
+
+        if [[ "$is_pinned" == "true" ]]; then
             log WARNING "Preserving pinned parent snapshot (incremental chain anchor): $snapshot"
             continue
         fi
@@ -520,9 +604,145 @@ cleanup_old_snapshots() {
         ((deleted++))
     done
 
-    if [[ -n "$pinned_name" ]] && [[ $deleted -lt $to_delete ]]; then
+    if [[ $deleted -lt $to_delete ]]; then
         log INFO "Retained $(( to_delete - deleted )) snapshot(s) due to pinned parent protection"
     fi
+
+    return 0
+}
+
+cleanup_graduated() {
+    # Time Machine-style graduated retention for daily-schedule subvolumes
+    # Keeps: all from last N days, 1/week for M weeks, 1/month for P months
+    # Protects all pinned parents across all drives
+    local snapshot_dir=$1
+    local pattern=$2  # e.g., "*-htpc-home"
+
+    if [[ ! -d "$snapshot_dir" ]]; then
+        log WARNING "Snapshot directory does not exist: $snapshot_dir"
+        return 0
+    fi
+
+    # Collect ALL pinned parents across all drives
+    local -a pinned_names=()
+    while IFS= read -r name; do
+        [[ -n "$name" ]] && pinned_names+=("$name")
+    done < <(get_all_pinned_parents "$snapshot_dir")
+
+    # Get list of snapshots matching pattern, sorted newest first
+    local -a snapshots=()
+    while IFS= read -r snap; do
+        [[ -n "$snap" ]] && snapshots+=("$snap")
+    done < <(find "$snapshot_dir" -mindepth 1 -maxdepth 1 -type d -name "$pattern" -printf '%T@ %p\n' | sort -rn | awk '{print $2}')
+
+    local count=${#snapshots[@]}
+    if [[ $count -eq 0 ]]; then
+        return 0
+    fi
+
+    local now_epoch
+    now_epoch=$(date +%s)
+
+    # Track which weeks and months already have a keeper
+    local -A kept_weeks=()
+    local -A kept_months=()
+    local -a to_delete=()
+    local kept=0
+
+    for snapshot in "${snapshots[@]}"; do
+        local snap_basename
+        snap_basename=$(basename "$snapshot")
+
+        # Always protect pinned parents
+        local is_pinned=false
+        for pinned_name in "${pinned_names[@]}"; do
+            if [[ "$snap_basename" == "$pinned_name" ]]; then
+                is_pinned=true
+                break
+            fi
+        done
+        if [[ "$is_pinned" == "true" ]]; then
+            log INFO "Graduated cleanup: preserving pinned parent: $snap_basename"
+            ((kept++))
+            continue
+        fi
+
+        # Extract date from snapshot name (format: YYYYMMDD-*)
+        local snap_date="${snap_basename:0:8}"
+        if ! [[ "$snap_date" =~ ^[0-9]{8}$ ]]; then
+            log WARNING "Cannot parse date from snapshot name: $snap_basename — keeping"
+            ((kept++))
+            continue
+        fi
+
+        local snap_epoch
+        snap_epoch=$(date -d "${snap_date:0:4}-${snap_date:4:2}-${snap_date:6:2}" +%s 2>/dev/null || echo "0")
+        if [[ "$snap_epoch" == "0" ]]; then
+            log WARNING "Invalid date in snapshot name: $snap_basename — keeping"
+            ((kept++))
+            continue
+        fi
+
+        local age_days=$(( (now_epoch - snap_epoch) / 86400 ))
+
+        # Rule 1: Keep all from last GRADUATED_RETENTION_DAILY days
+        if [[ $age_days -le $GRADUATED_RETENTION_DAILY ]]; then
+            ((kept++))
+            continue
+        fi
+
+        # Rule 2: Keep 1 per ISO week for next GRADUATED_RETENTION_WEEKLY weeks
+        local weekly_limit=$(( GRADUATED_RETENTION_DAILY + (GRADUATED_RETENTION_WEEKLY * 7) ))
+        if [[ $age_days -le $weekly_limit ]]; then
+            local iso_week
+            iso_week=$(date -d "${snap_date:0:4}-${snap_date:4:2}-${snap_date:6:2}" +%G-W%V 2>/dev/null)
+            if [[ -z "${kept_weeks[$iso_week]:-}" ]]; then
+                kept_weeks["$iso_week"]=1
+                ((kept++))
+                continue
+            fi
+            # Already have a keeper for this week — delete
+            to_delete+=("$snapshot")
+            continue
+        fi
+
+        # Rule 3: Keep 1 per month for next GRADUATED_RETENTION_MONTHLY months
+        local monthly_limit=$(( weekly_limit + (GRADUATED_RETENTION_MONTHLY * 31) ))
+        if [[ $age_days -le $monthly_limit ]]; then
+            local month="${snap_date:0:6}"  # YYYYMM
+            if [[ -z "${kept_months[$month]:-}" ]]; then
+                kept_months["$month"]=1
+                ((kept++))
+                continue
+            fi
+            # Already have a keeper for this month — delete
+            to_delete+=("$snapshot")
+            continue
+        fi
+
+        # Rule 4: Older than all windows — delete
+        to_delete+=("$snapshot")
+    done
+
+    if [[ ${#to_delete[@]} -eq 0 ]]; then
+        log INFO "Graduated cleanup: no snapshots to delete in $snapshot_dir (keeping $kept)"
+        return 0
+    fi
+
+    log INFO "Graduated cleanup: deleting ${#to_delete[@]} snapshots from $snapshot_dir (keeping $kept)"
+
+    if [[ "$DRY_RUN" == "true" ]]; then
+        for snapshot in "${to_delete[@]}"; do
+            log INFO "[DRY-RUN] Would delete: $(basename "$snapshot")"
+        done
+        return 0
+    fi
+
+    for snapshot in "${to_delete[@]}"; do
+        log INFO "Deleting old snapshot: $(basename "$snapshot")"
+        sudo btrfs subvolume delete "$snapshot" 2>/dev/null || \
+            log ERROR "Failed to delete snapshot: $snapshot"
+    done
 
     return 0
 }
@@ -537,7 +757,7 @@ get_latest_snapshot() {
     fi
 
     # Find most recent snapshot matching pattern
-    local latest=$(find "$snapshot_dir" -maxdepth 1 -type d -name "$pattern" -printf '%T+ %p\n' | sort -r | head -1 | awk '{print $2}')
+    local latest=$(find "$snapshot_dir" -mindepth 1 -maxdepth 1 -type d -name "$pattern" -printf '%T+ %p\n' | sort -r | head -1 | awk '{print $2}')
 
     echo "$latest"
 }
@@ -552,7 +772,7 @@ get_second_latest_snapshot() {
     fi
 
     # Find second most recent snapshot matching pattern (for use as parent in incremental send)
-    local second=$(find "$snapshot_dir" -maxdepth 1 -type d -name "$pattern" -printf '%T+ %p\n' | sort -r | sed -n '2p' | awk '{print $2}')
+    local second=$(find "$snapshot_dir" -mindepth 1 -maxdepth 1 -type d -name "$pattern" -printf '%T+ %p\n' | sort -r | sed -n '2p' | awk '{print $2}')
 
     echo "$second"
 }
@@ -570,7 +790,7 @@ find_common_parent() {
     fi
 
     # Get local snapshots sorted by date (newest first), excluding the current one being sent
-    local local_snapshots=$(find "$local_dir" -maxdepth 1 -type d -name "$pattern" -printf '%f\n' | sort -r)
+    local local_snapshots=$(find "$local_dir" -mindepth 1 -maxdepth 1 -type d -name "$pattern" -printf '%f\n' | sort -r)
 
     # Check each local snapshot to see if it exists on external
     for snap in $local_snapshots; do
@@ -651,15 +871,9 @@ backup_tier1_home() {
         }
     fi
 
-    # Send to external (weekly)
-    if [[ "$LOCAL_ONLY" != "true" ]] && [[ "$TIER1_HOME_SCHEDULE" == "daily" ]]; then
-        if [[ $(date +%u) -eq 6 ]]; then  # Saturday
-            check_external_mounted || {
-                record_failure "$subvol_name" "External drive not mounted"
-                record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER1_HOME_LOCAL_DIR" "$TIER1_HOME_EXTERNAL_DIR" "*-htpc-home"
-                return 1
-            }
-
+    # Send to external (per schedule)
+    if [[ "$LOCAL_ONLY" != "true" ]] && should_send_external "$TIER1_HOME_EXTERNAL_SCHEDULE"; then
+        if check_external_mounted; then
             local parent=$(find_common_parent "$TIER1_HOME_LOCAL_DIR" "$TIER1_HOME_EXTERNAL_DIR" "*-htpc-home")
             send_snapshot_incremental "$parent" "$local_snapshot" "$TIER1_HOME_EXTERNAL_DIR" || {
                 record_failure "$subvol_name" "External send failed"
@@ -667,15 +881,16 @@ backup_tier1_home() {
                 return 1
             }
 
-            # Pin the snapshot we just sent as the incremental chain anchor
+            [[ -n "$parent" ]] && SEND_TYPE["$subvol_name"]="incremental" || SEND_TYPE["$subvol_name"]="full"
             pin_parent "$TIER1_HOME_LOCAL_DIR" "$snapshot_name"
-
-            cleanup_old_snapshots "$TIER1_HOME_EXTERNAL_DIR" "$TIER1_HOME_EXTERNAL_RETENTION_WEEKLY" "*-htpc-home"
+            cleanup_old_snapshots "$TIER1_HOME_EXTERNAL_DIR" "$TIER1_HOME_EXTERNAL_RETENTION" "*-htpc-home"
+        else
+            log INFO "No external drive mounted — skipping external send for $subvol_name"
         fi
     fi
 
-    # Cleanup local snapshots
-    cleanup_old_snapshots "$TIER1_HOME_LOCAL_DIR" "$TIER1_HOME_LOCAL_RETENTION_DAILY" "*-htpc-home"
+    # Cleanup local snapshots (graduated retention for daily subvolumes)
+    cleanup_graduated "$TIER1_HOME_LOCAL_DIR" "*-htpc-home"
 
     record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER1_HOME_LOCAL_DIR" "$TIER1_HOME_EXTERNAL_DIR" "*-htpc-home"
     mark_completed "$subvol_name"
@@ -710,25 +925,24 @@ backup_tier1_opptak() {
         }
     fi
 
-    if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%u) -eq 6 ]]; then
-        check_external_mounted || {
-            record_failure "$subvol_name" "External drive not mounted"
-            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER1_OPPTAK_LOCAL_DIR" "$TIER1_OPPTAK_EXTERNAL_DIR" "*-opptak"
-            return 1
-        }
+    if [[ "$LOCAL_ONLY" != "true" ]] && should_send_external "$TIER1_OPPTAK_EXTERNAL_SCHEDULE"; then
+        if check_external_mounted; then
+            local parent=$(find_common_parent "$TIER1_OPPTAK_LOCAL_DIR" "$TIER1_OPPTAK_EXTERNAL_DIR" "*-opptak")
+            send_snapshot_incremental "$parent" "$local_snapshot" "$TIER1_OPPTAK_EXTERNAL_DIR" || {
+                record_failure "$subvol_name" "External send failed"
+                record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER1_OPPTAK_LOCAL_DIR" "$TIER1_OPPTAK_EXTERNAL_DIR" "*-opptak"
+                return 1
+            }
 
-        local parent=$(find_common_parent "$TIER1_OPPTAK_LOCAL_DIR" "$TIER1_OPPTAK_EXTERNAL_DIR" "*-opptak")
-        send_snapshot_incremental "$parent" "$local_snapshot" "$TIER1_OPPTAK_EXTERNAL_DIR" || {
-            record_failure "$subvol_name" "External send failed"
-            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER1_OPPTAK_LOCAL_DIR" "$TIER1_OPPTAK_EXTERNAL_DIR" "*-opptak"
-            return 1
-        }
-
-        pin_parent "$TIER1_OPPTAK_LOCAL_DIR" "$snapshot_name"
-        cleanup_old_snapshots "$TIER1_OPPTAK_EXTERNAL_DIR" "$TIER1_OPPTAK_EXTERNAL_RETENTION_WEEKLY" "*-opptak"
+            [[ -n "$parent" ]] && SEND_TYPE["$subvol_name"]="incremental" || SEND_TYPE["$subvol_name"]="full"
+            pin_parent "$TIER1_OPPTAK_LOCAL_DIR" "$snapshot_name"
+            cleanup_old_snapshots "$TIER1_OPPTAK_EXTERNAL_DIR" "$TIER1_OPPTAK_EXTERNAL_RETENTION" "*-opptak"
+        else
+            log INFO "No external drive mounted — skipping external send for $subvol_name"
+        fi
     fi
 
-    cleanup_old_snapshots "$TIER1_OPPTAK_LOCAL_DIR" "$TIER1_OPPTAK_LOCAL_RETENTION_DAILY" "*-opptak"
+    cleanup_graduated "$TIER1_OPPTAK_LOCAL_DIR" "*-opptak"
 
     record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER1_OPPTAK_LOCAL_DIR" "$TIER1_OPPTAK_EXTERNAL_DIR" "*-opptak"
     mark_completed "$subvol_name"
@@ -763,25 +977,24 @@ backup_tier1_containers() {
         }
     fi
 
-    if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%u) -eq 6 ]]; then
-        check_external_mounted || {
-            record_failure "$subvol_name" "External drive not mounted"
-            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER1_CONTAINERS_LOCAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_DIR" "*-containers"
-            return 1
-        }
+    if [[ "$LOCAL_ONLY" != "true" ]] && should_send_external "$TIER1_CONTAINERS_EXTERNAL_SCHEDULE"; then
+        if check_external_mounted; then
+            local parent=$(find_common_parent "$TIER1_CONTAINERS_LOCAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_DIR" "*-containers")
+            send_snapshot_incremental "$parent" "$local_snapshot" "$TIER1_CONTAINERS_EXTERNAL_DIR" || {
+                record_failure "$subvol_name" "External send failed"
+                record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER1_CONTAINERS_LOCAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_DIR" "*-containers"
+                return 1
+            }
 
-        local parent=$(find_common_parent "$TIER1_CONTAINERS_LOCAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_DIR" "*-containers")
-        send_snapshot_incremental "$parent" "$local_snapshot" "$TIER1_CONTAINERS_EXTERNAL_DIR" || {
-            record_failure "$subvol_name" "External send failed"
-            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER1_CONTAINERS_LOCAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_DIR" "*-containers"
-            return 1
-        }
-
-        pin_parent "$TIER1_CONTAINERS_LOCAL_DIR" "$snapshot_name"
-        cleanup_old_snapshots "$TIER1_CONTAINERS_EXTERNAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_RETENTION_WEEKLY" "*-containers"
+            [[ -n "$parent" ]] && SEND_TYPE["$subvol_name"]="incremental" || SEND_TYPE["$subvol_name"]="full"
+            pin_parent "$TIER1_CONTAINERS_LOCAL_DIR" "$snapshot_name"
+            cleanup_old_snapshots "$TIER1_CONTAINERS_EXTERNAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_RETENTION" "*-containers"
+        else
+            log INFO "No external drive mounted — skipping external send for $subvol_name"
+        fi
     fi
 
-    cleanup_old_snapshots "$TIER1_CONTAINERS_LOCAL_DIR" "$TIER1_CONTAINERS_LOCAL_RETENTION_DAILY" "*-containers"
+    cleanup_graduated "$TIER1_CONTAINERS_LOCAL_DIR" "*-containers"
 
     record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER1_CONTAINERS_LOCAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_DIR" "*-containers"
     mark_completed "$subvol_name"
@@ -816,25 +1029,24 @@ backup_tier2_docs() {
         }
     fi
 
-    if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%u) -eq 6 ]]; then
-        check_external_mounted || {
-            record_failure "$subvol_name" "External drive not mounted"
-            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER2_DOCS_LOCAL_DIR" "$TIER2_DOCS_EXTERNAL_DIR" "*-docs"
-            return 1
-        }
+    if [[ "$LOCAL_ONLY" != "true" ]] && should_send_external "$TIER2_DOCS_EXTERNAL_SCHEDULE"; then
+        if check_external_mounted; then
+            local parent=$(find_common_parent "$TIER2_DOCS_LOCAL_DIR" "$TIER2_DOCS_EXTERNAL_DIR" "*-docs")
+            send_snapshot_incremental "$parent" "$local_snapshot" "$TIER2_DOCS_EXTERNAL_DIR" || {
+                record_failure "$subvol_name" "External send failed"
+                record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER2_DOCS_LOCAL_DIR" "$TIER2_DOCS_EXTERNAL_DIR" "*-docs"
+                return 1
+            }
 
-        local parent=$(find_common_parent "$TIER2_DOCS_LOCAL_DIR" "$TIER2_DOCS_EXTERNAL_DIR" "*-docs")
-        send_snapshot_incremental "$parent" "$local_snapshot" "$TIER2_DOCS_EXTERNAL_DIR" || {
-            record_failure "$subvol_name" "External send failed"
-            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER2_DOCS_LOCAL_DIR" "$TIER2_DOCS_EXTERNAL_DIR" "*-docs"
-            return 1
-        }
-
-        pin_parent "$TIER2_DOCS_LOCAL_DIR" "$snapshot_name"
-        cleanup_old_snapshots "$TIER2_DOCS_EXTERNAL_DIR" "$TIER2_DOCS_EXTERNAL_RETENTION_WEEKLY" "*-docs"
+            [[ -n "$parent" ]] && SEND_TYPE["$subvol_name"]="incremental" || SEND_TYPE["$subvol_name"]="full"
+            pin_parent "$TIER2_DOCS_LOCAL_DIR" "$snapshot_name"
+            cleanup_old_snapshots "$TIER2_DOCS_EXTERNAL_DIR" "$TIER2_DOCS_EXTERNAL_RETENTION" "*-docs"
+        else
+            log INFO "No external drive mounted — skipping external send for $subvol_name"
+        fi
     fi
 
-    cleanup_old_snapshots "$TIER2_DOCS_LOCAL_DIR" "$TIER2_DOCS_LOCAL_RETENTION_DAILY" "*-docs"
+    cleanup_graduated "$TIER2_DOCS_LOCAL_DIR" "*-docs"
 
     record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER2_DOCS_LOCAL_DIR" "$TIER2_DOCS_EXTERNAL_DIR" "*-docs"
     mark_completed "$subvol_name"
@@ -858,8 +1070,8 @@ backup_tier2_root() {
         return 0
     fi
 
-    # Root is monthly only
-    if [[ $(date +%d) -ne 01 ]]; then
+    # Root is monthly only (local schedule gate)
+    if ! should_send_external "$TIER2_ROOT_LOCAL_SCHEDULE"; then
         log INFO "$subvol_name backup runs on 1st of month only, skipping"
         record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root"
         return 0
@@ -876,25 +1088,24 @@ backup_tier2_root() {
         }
     fi
 
-    if [[ "$LOCAL_ONLY" != "true" ]]; then
-        check_external_mounted || {
-            record_failure "$subvol_name" "External drive not mounted"
-            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root"
-            return 1
-        }
+    if [[ "$LOCAL_ONLY" != "true" ]] && should_send_external "$TIER2_ROOT_EXTERNAL_SCHEDULE"; then
+        if check_external_mounted; then
+            local parent=$(find_common_parent "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root")
+            send_snapshot_incremental "$parent" "$local_snapshot" "$TIER2_ROOT_EXTERNAL_DIR" || {
+                record_failure "$subvol_name" "External send failed"
+                record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root"
+                return 1
+            }
 
-        local parent=$(find_common_parent "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root")
-        send_snapshot_incremental "$parent" "$local_snapshot" "$TIER2_ROOT_EXTERNAL_DIR" || {
-            record_failure "$subvol_name" "External send failed"
-            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root"
-            return 1
-        }
-
-        pin_parent "$TIER2_ROOT_LOCAL_DIR" "$snapshot_name"
-        cleanup_old_snapshots "$TIER2_ROOT_EXTERNAL_DIR" "$TIER2_ROOT_EXTERNAL_RETENTION_MONTHLY" "*-htpc-root"
+            [[ -n "$parent" ]] && SEND_TYPE["$subvol_name"]="incremental" || SEND_TYPE["$subvol_name"]="full"
+            pin_parent "$TIER2_ROOT_LOCAL_DIR" "$snapshot_name"
+            cleanup_old_snapshots "$TIER2_ROOT_EXTERNAL_DIR" "$TIER2_ROOT_EXTERNAL_RETENTION" "*-htpc-root"
+        else
+            log INFO "No external drive mounted — skipping external send for $subvol_name"
+        fi
     fi
 
-    cleanup_old_snapshots "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_LOCAL_RETENTION_MONTHLY" "*-htpc-root"
+    cleanup_old_snapshots "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_LOCAL_RETENTION" "*-htpc-root"
 
     record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root"
     mark_completed "$subvol_name"
@@ -918,7 +1129,8 @@ backup_tier3_pics() {
         return 0
     fi
 
-    if [[ $(date +%u) -ne 6 ]]; then
+    # Tier 3: weekly local snapshots only
+    if ! should_send_external "$TIER3_PICS_LOCAL_SCHEDULE"; then
         log INFO "$subvol_name local backup runs on Saturdays only, skipping"
         record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*"
         return 0
@@ -935,25 +1147,24 @@ backup_tier3_pics() {
         }
     fi
 
-    if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%d) -le 7 ]]; then
-        check_external_mounted || {
-            record_failure "$subvol_name" "External drive not mounted"
-            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*"
-            return 1
-        }
+    if [[ "$LOCAL_ONLY" != "true" ]] && should_send_external "$TIER3_PICS_EXTERNAL_SCHEDULE"; then
+        if check_external_mounted; then
+            local parent=$(find_common_parent "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*")
+            send_snapshot_incremental "$parent" "$local_snapshot" "$TIER3_PICS_EXTERNAL_DIR" || {
+                record_failure "$subvol_name" "External send failed"
+                record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*"
+                return 1
+            }
 
-        local parent=$(find_common_parent "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*")
-        send_snapshot_incremental "$parent" "$local_snapshot" "$TIER3_PICS_EXTERNAL_DIR" || {
-            record_failure "$subvol_name" "External send failed"
-            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*"
-            return 1
-        }
-
-        pin_parent "$TIER3_PICS_LOCAL_DIR" "$snapshot_name"
-        cleanup_old_snapshots "$TIER3_PICS_EXTERNAL_DIR" "$TIER3_PICS_EXTERNAL_RETENTION_MONTHLY" "*-pics*"
+            [[ -n "$parent" ]] && SEND_TYPE["$subvol_name"]="incremental" || SEND_TYPE["$subvol_name"]="full"
+            pin_parent "$TIER3_PICS_LOCAL_DIR" "$snapshot_name"
+            cleanup_old_snapshots "$TIER3_PICS_EXTERNAL_DIR" "$TIER3_PICS_EXTERNAL_RETENTION" "*-pics*"
+        else
+            log INFO "No external drive mounted — skipping external send for $subvol_name"
+        fi
     fi
 
-    cleanup_old_snapshots "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_LOCAL_RETENTION_WEEKLY" "*-pics*"
+    cleanup_old_snapshots "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_LOCAL_RETENTION" "*-pics*"
 
     record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*"
     mark_completed "$subvol_name"
@@ -977,7 +1188,8 @@ backup_tier3_multimedia() {
         return 0
     fi
 
-    if [[ $(date +%u) -ne 6 ]]; then
+    # Tier 3: weekly local snapshots only
+    if ! should_send_external "$TIER3_MULTIMEDIA_LOCAL_SCHEDULE"; then
         log INFO "$subvol_name local backup runs on Saturdays only, skipping"
         record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*"
         return 0
@@ -994,29 +1206,26 @@ backup_tier3_multimedia() {
         }
     fi
 
-    if [[ "$TIER3_MULTIMEDIA_EXTERNAL_ENABLED" == "true" ]] && [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%d) -le 7 ]]; then
-        log INFO "$subvol_name external backup enabled (5.8TB - may take ~27h for initial backup)"
-        check_external_mounted || {
-            record_failure "$subvol_name" "External drive not mounted"
-            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*"
-            return 1
-        }
+    if [[ "$TIER3_MULTIMEDIA_EXTERNAL_ENABLED" == "true" ]] && [[ "$LOCAL_ONLY" != "true" ]] && should_send_external "$TIER3_MULTIMEDIA_EXTERNAL_SCHEDULE"; then
+        if check_external_mounted; then
+            local parent=$(find_common_parent "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*")
+            send_snapshot_incremental "$parent" "$local_snapshot" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" || {
+                record_failure "$subvol_name" "External send failed"
+                record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*"
+                return 1
+            }
 
-        local parent=$(find_common_parent "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*")
-        send_snapshot_incremental "$parent" "$local_snapshot" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" || {
-            record_failure "$subvol_name" "External send failed"
-            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*"
-            return 1
-        }
-
-        pin_parent "$TIER3_MULTIMEDIA_LOCAL_DIR" "$snapshot_name"
-        cleanup_old_snapshots "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_RETENTION_MONTHLY" "*-multimedia*"
+            [[ -n "$parent" ]] && SEND_TYPE["$subvol_name"]="incremental" || SEND_TYPE["$subvol_name"]="full"
+            pin_parent "$TIER3_MULTIMEDIA_LOCAL_DIR" "$snapshot_name"
+            cleanup_old_snapshots "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_RETENTION" "*-multimedia*"
+        else
+            log INFO "No external drive mounted — skipping external send for $subvol_name"
+        fi
     elif [[ "$TIER3_MULTIMEDIA_EXTERNAL_ENABLED" != "true" ]]; then
         log WARNING "$subvol_name external backup is DISABLED (set TIER3_MULTIMEDIA_EXTERNAL_ENABLED=true to enable)"
-        log WARNING "Do initial manual backup first (see docs/20-operations/guides/tier3-initial-backup.md)"
     fi
 
-    cleanup_old_snapshots "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_LOCAL_RETENTION_WEEKLY" "*-multimedia*"
+    cleanup_old_snapshots "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_LOCAL_RETENTION" "*-multimedia*"
 
     record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*"
     mark_completed "$subvol_name"
@@ -1040,7 +1249,8 @@ backup_tier3_music() {
         return 0
     fi
 
-    if [[ $(date +%u) -ne 6 ]]; then
+    # Tier 3: weekly local snapshots only
+    if ! should_send_external "$TIER3_MUSIC_LOCAL_SCHEDULE"; then
         log INFO "$subvol_name local backup runs on Saturdays only, skipping"
         record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*"
         return 0
@@ -1057,25 +1267,24 @@ backup_tier3_music() {
         }
     fi
 
-    if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%d) -le 7 ]]; then
-        check_external_mounted || {
-            record_failure "$subvol_name" "External drive not mounted"
-            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*"
-            return 1
-        }
+    if [[ "$LOCAL_ONLY" != "true" ]] && should_send_external "$TIER3_MUSIC_EXTERNAL_SCHEDULE"; then
+        if check_external_mounted; then
+            local parent=$(find_common_parent "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*")
+            send_snapshot_incremental "$parent" "$local_snapshot" "$TIER3_MUSIC_EXTERNAL_DIR" || {
+                record_failure "$subvol_name" "External send failed"
+                record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*"
+                return 1
+            }
 
-        local parent=$(find_common_parent "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*")
-        send_snapshot_incremental "$parent" "$local_snapshot" "$TIER3_MUSIC_EXTERNAL_DIR" || {
-            record_failure "$subvol_name" "External send failed"
-            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*"
-            return 1
-        }
-
-        pin_parent "$TIER3_MUSIC_LOCAL_DIR" "$snapshot_name"
-        cleanup_old_snapshots "$TIER3_MUSIC_EXTERNAL_DIR" "$TIER3_MUSIC_EXTERNAL_RETENTION_MONTHLY" "*-music*"
+            [[ -n "$parent" ]] && SEND_TYPE["$subvol_name"]="incremental" || SEND_TYPE["$subvol_name"]="full"
+            pin_parent "$TIER3_MUSIC_LOCAL_DIR" "$snapshot_name"
+            cleanup_old_snapshots "$TIER3_MUSIC_EXTERNAL_DIR" "$TIER3_MUSIC_EXTERNAL_RETENTION" "*-music*"
+        else
+            log INFO "No external drive mounted — skipping external send for $subvol_name"
+        fi
     fi
 
-    cleanup_old_snapshots "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_LOCAL_RETENTION_WEEKLY" "*-music*"
+    cleanup_old_snapshots "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_LOCAL_RETENTION" "*-music*"
 
     record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*"
     mark_completed "$subvol_name"
@@ -1099,7 +1308,8 @@ backup_tier3_tmp() {
         return 0
     fi
 
-    if [[ $(date +%u) -ne 6 ]]; then
+    # Tier 3: weekly local snapshots only
+    if ! should_send_external "$TIER3_TMP_LOCAL_SCHEDULE"; then
         log INFO "$subvol_name local backup runs on Saturdays only, skipping"
         record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*"
         return 0
@@ -1116,25 +1326,24 @@ backup_tier3_tmp() {
         }
     fi
 
-    if [[ "$LOCAL_ONLY" != "true" ]] && [[ $(date +%d) -le 7 ]]; then
-        check_external_mounted || {
-            record_failure "$subvol_name" "External drive not mounted"
-            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*"
-            return 1
-        }
+    if [[ "$LOCAL_ONLY" != "true" ]] && should_send_external "$TIER3_TMP_EXTERNAL_SCHEDULE"; then
+        if check_external_mounted; then
+            local parent=$(find_common_parent "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*")
+            send_snapshot_incremental "$parent" "$local_snapshot" "$TIER3_TMP_EXTERNAL_DIR" || {
+                record_failure "$subvol_name" "External send failed"
+                record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*"
+                return 1
+            }
 
-        local parent=$(find_common_parent "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*")
-        send_snapshot_incremental "$parent" "$local_snapshot" "$TIER3_TMP_EXTERNAL_DIR" || {
-            record_failure "$subvol_name" "External send failed"
-            record_backup_metrics "$subvol_name" "$start_time" 0 "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*"
-            return 1
-        }
-
-        pin_parent "$TIER3_TMP_LOCAL_DIR" "$snapshot_name"
-        cleanup_old_snapshots "$TIER3_TMP_EXTERNAL_DIR" "$TIER3_TMP_EXTERNAL_RETENTION_MONTHLY" "*-tmp*"
+            [[ -n "$parent" ]] && SEND_TYPE["$subvol_name"]="incremental" || SEND_TYPE["$subvol_name"]="full"
+            pin_parent "$TIER3_TMP_LOCAL_DIR" "$snapshot_name"
+            cleanup_old_snapshots "$TIER3_TMP_EXTERNAL_DIR" "$TIER3_TMP_EXTERNAL_RETENTION" "*-tmp*"
+        else
+            log INFO "No external drive mounted — skipping external send for $subvol_name"
+        fi
     fi
 
-    cleanup_old_snapshots "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_LOCAL_RETENTION_WEEKLY" "*-tmp*"
+    cleanup_old_snapshots "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_LOCAL_RETENTION" "*-tmp*"
 
     record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*"
     mark_completed "$subvol_name"
@@ -1229,6 +1438,30 @@ export_prometheus_metrics() {
         for subvol in "${!SNAPSHOT_COUNT_EXTERNAL[@]}"; do
             echo "backup_snapshot_count{subvolume=\"$subvol\",location=\"external\"} ${SNAPSHOT_COUNT_EXTERNAL[$subvol]}"
         done
+
+        echo ""
+        echo "# HELP backup_send_type Whether last send was incremental (1) or full (0)"
+        echo "# TYPE backup_send_type gauge"
+
+        for subvol in "${!SEND_TYPE[@]}"; do
+            local type_val=0
+            [[ "${SEND_TYPE[$subvol]}" == "incremental" ]] && type_val=1
+            echo "backup_send_type{subvolume=\"$subvol\"} $type_val"
+        done
+
+        echo ""
+        echo "# HELP backup_external_drive_mounted Whether external drive was mounted during run (1=yes, 0=no)"
+        echo "# TYPE backup_external_drive_mounted gauge"
+        [[ "$EXTERNAL_DRIVE_MOUNTED" == "true" ]] && echo "backup_external_drive_mounted 1" || echo "backup_external_drive_mounted 0"
+
+        echo ""
+        echo "# HELP backup_external_free_bytes Free space on external drive in bytes"
+        echo "# TYPE backup_external_free_bytes gauge"
+        if [[ "$EXTERNAL_DRIVE_MOUNTED" == "true" ]] && [[ -d "$EXTERNAL_BACKUP_ROOT" ]]; then
+            local free_bytes
+            free_bytes=$(df --output=avail -B1 "$(dirname "$EXTERNAL_BACKUP_ROOT")" 2>/dev/null | tail -1 | tr -d ' ')
+            echo "backup_external_free_bytes ${free_bytes:-0}"
+        fi
 
         echo ""
         echo "# HELP backup_script_last_run_timestamp Unix timestamp when script last ran"

--- a/scripts/btrfs-snapshot-backup.sh
+++ b/scripts/btrfs-snapshot-backup.sh
@@ -209,7 +209,7 @@ TIER3_TMP_SOURCE="/mnt/btrfs-pool/subvol6-tmp"
 TIER3_TMP_LOCAL_DIR="$LOCAL_POOL_SNAPSHOTS/subvol6-tmp"
 TIER3_TMP_EXTERNAL_DIR="$EXTERNAL_BACKUP_ROOT/subvol6-tmp"
 TIER3_TMP_LOCAL_SCHEDULE="weekly"
-TIER3_TMP_EXTERNAL_SCHEDULE="first-saturday"
+TIER3_TMP_EXTERNAL_SCHEDULE="never"      # Cache data — fully replaceable, no external backup
 TIER3_TMP_LOCAL_RETENTION=4              # Only 4 weeks (cache data)
 TIER3_TMP_EXTERNAL_RETENTION=3
 
@@ -1480,10 +1480,11 @@ export_prometheus_metrics() {
         done
 
         echo ""
-        echo "# HELP backup_send_type Whether last send was incremental (1), full (0), or no send (-1)"
+        echo "# HELP backup_send_type Last send type: 2=no send this run, 1=incremental, 0=full"
         echo "# TYPE backup_send_type gauge"
 
         # Emit for all known subvolumes to avoid disappearing series in Prometheus
+        # Uses 2 for no-send (not -1) so alert rules on ==0 (full send) don't false-positive
         for subvol in "${!BACKUP_SUCCESS[@]}"; do
             if [[ -n "${SEND_TYPE[$subvol]:-}" ]]; then
                 if [[ "${SEND_TYPE[$subvol]}" == "incremental" ]]; then
@@ -1492,7 +1493,7 @@ export_prometheus_metrics() {
                     echo "backup_send_type{subvolume=\"$subvol\"} 0"
                 fi
             else
-                echo "backup_send_type{subvolume=\"$subvol\"} -1"
+                echo "backup_send_type{subvolume=\"$subvol\"} 2"
             fi
         done
 

--- a/scripts/btrfs-snapshot-backup.sh
+++ b/scripts/btrfs-snapshot-backup.sh
@@ -176,7 +176,7 @@ TIER3_PICS_SOURCE="/mnt/btrfs-pool/subvol2-pics"
 TIER3_PICS_LOCAL_DIR="$LOCAL_POOL_SNAPSHOTS/subvol2-pics"
 TIER3_PICS_EXTERNAL_DIR="$EXTERNAL_BACKUP_ROOT/subvol2-pics"
 TIER3_PICS_LOCAL_SCHEDULE="weekly"
-TIER3_PICS_EXTERNAL_SCHEDULE="monthly"
+TIER3_PICS_EXTERNAL_SCHEDULE="first-saturday"
 TIER3_PICS_LOCAL_RETENTION=8             # 8 weekly = 2 months
 TIER3_PICS_EXTERNAL_RETENTION=6
 
@@ -189,7 +189,7 @@ TIER3_MULTIMEDIA_LOCAL_DIR="$LOCAL_POOL_SNAPSHOTS/subvol4-multimedia"
 TIER3_MULTIMEDIA_EXTERNAL_DIR="$EXTERNAL_BACKUP_ROOT/subvol4-multimedia"
 TIER3_MULTIMEDIA_EXTERNAL_ENABLED=false  # Set to true after initial manual backup
 TIER3_MULTIMEDIA_LOCAL_SCHEDULE="weekly"
-TIER3_MULTIMEDIA_EXTERNAL_SCHEDULE="monthly"
+TIER3_MULTIMEDIA_EXTERNAL_SCHEDULE="first-saturday"
 TIER3_MULTIMEDIA_LOCAL_RETENTION=4
 TIER3_MULTIMEDIA_EXTERNAL_RETENTION=3
 
@@ -199,7 +199,7 @@ TIER3_MUSIC_SOURCE="/mnt/btrfs-pool/subvol5-music"
 TIER3_MUSIC_LOCAL_DIR="$LOCAL_POOL_SNAPSHOTS/subvol5-music"
 TIER3_MUSIC_EXTERNAL_DIR="$EXTERNAL_BACKUP_ROOT/subvol5-music"
 TIER3_MUSIC_LOCAL_SCHEDULE="weekly"
-TIER3_MUSIC_EXTERNAL_SCHEDULE="monthly"
+TIER3_MUSIC_EXTERNAL_SCHEDULE="first-saturday"
 TIER3_MUSIC_LOCAL_RETENTION=8            # 8 weekly = 2 months
 TIER3_MUSIC_EXTERNAL_RETENTION=6
 
@@ -209,15 +209,16 @@ TIER3_TMP_SOURCE="/mnt/btrfs-pool/subvol6-tmp"
 TIER3_TMP_LOCAL_DIR="$LOCAL_POOL_SNAPSHOTS/subvol6-tmp"
 TIER3_TMP_EXTERNAL_DIR="$EXTERNAL_BACKUP_ROOT/subvol6-tmp"
 TIER3_TMP_LOCAL_SCHEDULE="weekly"
-TIER3_TMP_EXTERNAL_SCHEDULE="monthly"
+TIER3_TMP_EXTERNAL_SCHEDULE="first-saturday"
 TIER3_TMP_LOCAL_RETENTION=4              # Only 4 weeks (cache data)
 TIER3_TMP_EXTERNAL_RETENTION=3
 
 # Graduated local retention (Time Machine-style) for daily-schedule subvolumes
 # Tier 3 (weekly) uses simple count via _LOCAL_RETENTION instead
+# Total coverage: 14 + (6*7) + (3*31) = ~149 days (~5 months)
 GRADUATED_RETENTION_DAILY=14    # Keep all snapshots from last 14 days
-GRADUATED_RETENTION_WEEKLY=6    # Keep 1 per week for next ~6 weeks (days 15-60)
-GRADUATED_RETENTION_MONTHLY=3   # Keep 1 per month for next ~3 months (days 61-90)
+GRADUATED_RETENTION_WEEKLY=6    # Keep 1 per week for next ~6 weeks (days 15-56)
+GRADUATED_RETENTION_MONTHLY=3   # Keep 1 per month for next ~3 months (days 57-149)
 
 ################################################################################
 # END OF CONFIGURATION SECTION
@@ -367,14 +368,16 @@ check_external_space() {
     return 0
 }
 
-should_send_external() {
-    # Determine if external send should happen based on schedule
-    local schedule=$1  # "daily" | "weekly" | "monthly"
+should_run_on_schedule() {
+    # Determine if an action should run based on schedule
+    # Used for both local snapshot gating and external send gating
+    local schedule=$1  # "daily" | "weekly" | "monthly" | "first-saturday"
     case "$schedule" in
-        daily)   return 0 ;;
-        weekly)  [[ $(date +%u) -eq 6 ]] ;;
-        monthly) [[ $(date +%d) == "01" ]] ;;
-        *)       return 1 ;;
+        daily)          return 0 ;;
+        weekly)         [[ $(date +%u) -eq 6 ]] ;;
+        monthly)        [[ $(date +%d) == "01" ]] ;;
+        first-saturday) [[ $(date +%u) -eq 6 ]] && [[ $(date +%d) -le 7 ]] ;;
+        *)              return 1 ;;
     esac
 }
 
@@ -394,7 +397,8 @@ pin_parent() {
         log INFO "Pinned parent for ${EXTERNAL_DRIVE_LABEL} incremental chain: $snapshot_name"
     fi
 
-    # Also maintain legacy pin file for backwards compatibility during transition
+    # Legacy pin file — remove after 2026-04-21 (1 month transition)
+    # Once both drives have drive-specific pin files, this is unused
     echo "$snapshot_name" > "$local_dir/.last-external-parent"
 }
 
@@ -872,7 +876,7 @@ backup_tier1_home() {
     fi
 
     # Send to external (per schedule)
-    if [[ "$LOCAL_ONLY" != "true" ]] && should_send_external "$TIER1_HOME_EXTERNAL_SCHEDULE"; then
+    if [[ "$LOCAL_ONLY" != "true" ]] && should_run_on_schedule "$TIER1_HOME_EXTERNAL_SCHEDULE"; then
         if check_external_mounted; then
             local parent=$(find_common_parent "$TIER1_HOME_LOCAL_DIR" "$TIER1_HOME_EXTERNAL_DIR" "*-htpc-home")
             send_snapshot_incremental "$parent" "$local_snapshot" "$TIER1_HOME_EXTERNAL_DIR" || {
@@ -881,7 +885,11 @@ backup_tier1_home() {
                 return 1
             }
 
-            [[ -n "$parent" ]] && SEND_TYPE["$subvol_name"]="incremental" || SEND_TYPE["$subvol_name"]="full"
+            if [[ -n "$parent" ]]; then
+                SEND_TYPE["$subvol_name"]="incremental"
+            else
+                SEND_TYPE["$subvol_name"]="full"
+            fi
             pin_parent "$TIER1_HOME_LOCAL_DIR" "$snapshot_name"
             cleanup_old_snapshots "$TIER1_HOME_EXTERNAL_DIR" "$TIER1_HOME_EXTERNAL_RETENTION" "*-htpc-home"
         else
@@ -925,7 +933,7 @@ backup_tier1_opptak() {
         }
     fi
 
-    if [[ "$LOCAL_ONLY" != "true" ]] && should_send_external "$TIER1_OPPTAK_EXTERNAL_SCHEDULE"; then
+    if [[ "$LOCAL_ONLY" != "true" ]] && should_run_on_schedule "$TIER1_OPPTAK_EXTERNAL_SCHEDULE"; then
         if check_external_mounted; then
             local parent=$(find_common_parent "$TIER1_OPPTAK_LOCAL_DIR" "$TIER1_OPPTAK_EXTERNAL_DIR" "*-opptak")
             send_snapshot_incremental "$parent" "$local_snapshot" "$TIER1_OPPTAK_EXTERNAL_DIR" || {
@@ -934,7 +942,11 @@ backup_tier1_opptak() {
                 return 1
             }
 
-            [[ -n "$parent" ]] && SEND_TYPE["$subvol_name"]="incremental" || SEND_TYPE["$subvol_name"]="full"
+            if [[ -n "$parent" ]]; then
+                SEND_TYPE["$subvol_name"]="incremental"
+            else
+                SEND_TYPE["$subvol_name"]="full"
+            fi
             pin_parent "$TIER1_OPPTAK_LOCAL_DIR" "$snapshot_name"
             cleanup_old_snapshots "$TIER1_OPPTAK_EXTERNAL_DIR" "$TIER1_OPPTAK_EXTERNAL_RETENTION" "*-opptak"
         else
@@ -977,7 +989,7 @@ backup_tier1_containers() {
         }
     fi
 
-    if [[ "$LOCAL_ONLY" != "true" ]] && should_send_external "$TIER1_CONTAINERS_EXTERNAL_SCHEDULE"; then
+    if [[ "$LOCAL_ONLY" != "true" ]] && should_run_on_schedule "$TIER1_CONTAINERS_EXTERNAL_SCHEDULE"; then
         if check_external_mounted; then
             local parent=$(find_common_parent "$TIER1_CONTAINERS_LOCAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_DIR" "*-containers")
             send_snapshot_incremental "$parent" "$local_snapshot" "$TIER1_CONTAINERS_EXTERNAL_DIR" || {
@@ -986,7 +998,11 @@ backup_tier1_containers() {
                 return 1
             }
 
-            [[ -n "$parent" ]] && SEND_TYPE["$subvol_name"]="incremental" || SEND_TYPE["$subvol_name"]="full"
+            if [[ -n "$parent" ]]; then
+                SEND_TYPE["$subvol_name"]="incremental"
+            else
+                SEND_TYPE["$subvol_name"]="full"
+            fi
             pin_parent "$TIER1_CONTAINERS_LOCAL_DIR" "$snapshot_name"
             cleanup_old_snapshots "$TIER1_CONTAINERS_EXTERNAL_DIR" "$TIER1_CONTAINERS_EXTERNAL_RETENTION" "*-containers"
         else
@@ -1029,7 +1045,7 @@ backup_tier2_docs() {
         }
     fi
 
-    if [[ "$LOCAL_ONLY" != "true" ]] && should_send_external "$TIER2_DOCS_EXTERNAL_SCHEDULE"; then
+    if [[ "$LOCAL_ONLY" != "true" ]] && should_run_on_schedule "$TIER2_DOCS_EXTERNAL_SCHEDULE"; then
         if check_external_mounted; then
             local parent=$(find_common_parent "$TIER2_DOCS_LOCAL_DIR" "$TIER2_DOCS_EXTERNAL_DIR" "*-docs")
             send_snapshot_incremental "$parent" "$local_snapshot" "$TIER2_DOCS_EXTERNAL_DIR" || {
@@ -1038,7 +1054,11 @@ backup_tier2_docs() {
                 return 1
             }
 
-            [[ -n "$parent" ]] && SEND_TYPE["$subvol_name"]="incremental" || SEND_TYPE["$subvol_name"]="full"
+            if [[ -n "$parent" ]]; then
+                SEND_TYPE["$subvol_name"]="incremental"
+            else
+                SEND_TYPE["$subvol_name"]="full"
+            fi
             pin_parent "$TIER2_DOCS_LOCAL_DIR" "$snapshot_name"
             cleanup_old_snapshots "$TIER2_DOCS_EXTERNAL_DIR" "$TIER2_DOCS_EXTERNAL_RETENTION" "*-docs"
         else
@@ -1071,7 +1091,7 @@ backup_tier2_root() {
     fi
 
     # Root is monthly only (local schedule gate)
-    if ! should_send_external "$TIER2_ROOT_LOCAL_SCHEDULE"; then
+    if ! should_run_on_schedule "$TIER2_ROOT_LOCAL_SCHEDULE"; then
         log INFO "$subvol_name backup runs on 1st of month only, skipping"
         record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root"
         return 0
@@ -1088,7 +1108,7 @@ backup_tier2_root() {
         }
     fi
 
-    if [[ "$LOCAL_ONLY" != "true" ]] && should_send_external "$TIER2_ROOT_EXTERNAL_SCHEDULE"; then
+    if [[ "$LOCAL_ONLY" != "true" ]] && should_run_on_schedule "$TIER2_ROOT_EXTERNAL_SCHEDULE"; then
         if check_external_mounted; then
             local parent=$(find_common_parent "$TIER2_ROOT_LOCAL_DIR" "$TIER2_ROOT_EXTERNAL_DIR" "*-htpc-root")
             send_snapshot_incremental "$parent" "$local_snapshot" "$TIER2_ROOT_EXTERNAL_DIR" || {
@@ -1097,7 +1117,11 @@ backup_tier2_root() {
                 return 1
             }
 
-            [[ -n "$parent" ]] && SEND_TYPE["$subvol_name"]="incremental" || SEND_TYPE["$subvol_name"]="full"
+            if [[ -n "$parent" ]]; then
+                SEND_TYPE["$subvol_name"]="incremental"
+            else
+                SEND_TYPE["$subvol_name"]="full"
+            fi
             pin_parent "$TIER2_ROOT_LOCAL_DIR" "$snapshot_name"
             cleanup_old_snapshots "$TIER2_ROOT_EXTERNAL_DIR" "$TIER2_ROOT_EXTERNAL_RETENTION" "*-htpc-root"
         else
@@ -1130,7 +1154,7 @@ backup_tier3_pics() {
     fi
 
     # Tier 3: weekly local snapshots only
-    if ! should_send_external "$TIER3_PICS_LOCAL_SCHEDULE"; then
+    if ! should_run_on_schedule "$TIER3_PICS_LOCAL_SCHEDULE"; then
         log INFO "$subvol_name local backup runs on Saturdays only, skipping"
         record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*"
         return 0
@@ -1147,7 +1171,7 @@ backup_tier3_pics() {
         }
     fi
 
-    if [[ "$LOCAL_ONLY" != "true" ]] && should_send_external "$TIER3_PICS_EXTERNAL_SCHEDULE"; then
+    if [[ "$LOCAL_ONLY" != "true" ]] && should_run_on_schedule "$TIER3_PICS_EXTERNAL_SCHEDULE"; then
         if check_external_mounted; then
             local parent=$(find_common_parent "$TIER3_PICS_LOCAL_DIR" "$TIER3_PICS_EXTERNAL_DIR" "*-pics*")
             send_snapshot_incremental "$parent" "$local_snapshot" "$TIER3_PICS_EXTERNAL_DIR" || {
@@ -1156,7 +1180,11 @@ backup_tier3_pics() {
                 return 1
             }
 
-            [[ -n "$parent" ]] && SEND_TYPE["$subvol_name"]="incremental" || SEND_TYPE["$subvol_name"]="full"
+            if [[ -n "$parent" ]]; then
+                SEND_TYPE["$subvol_name"]="incremental"
+            else
+                SEND_TYPE["$subvol_name"]="full"
+            fi
             pin_parent "$TIER3_PICS_LOCAL_DIR" "$snapshot_name"
             cleanup_old_snapshots "$TIER3_PICS_EXTERNAL_DIR" "$TIER3_PICS_EXTERNAL_RETENTION" "*-pics*"
         else
@@ -1189,7 +1217,7 @@ backup_tier3_multimedia() {
     fi
 
     # Tier 3: weekly local snapshots only
-    if ! should_send_external "$TIER3_MULTIMEDIA_LOCAL_SCHEDULE"; then
+    if ! should_run_on_schedule "$TIER3_MULTIMEDIA_LOCAL_SCHEDULE"; then
         log INFO "$subvol_name local backup runs on Saturdays only, skipping"
         record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*"
         return 0
@@ -1206,7 +1234,7 @@ backup_tier3_multimedia() {
         }
     fi
 
-    if [[ "$TIER3_MULTIMEDIA_EXTERNAL_ENABLED" == "true" ]] && [[ "$LOCAL_ONLY" != "true" ]] && should_send_external "$TIER3_MULTIMEDIA_EXTERNAL_SCHEDULE"; then
+    if [[ "$TIER3_MULTIMEDIA_EXTERNAL_ENABLED" == "true" ]] && [[ "$LOCAL_ONLY" != "true" ]] && should_run_on_schedule "$TIER3_MULTIMEDIA_EXTERNAL_SCHEDULE"; then
         if check_external_mounted; then
             local parent=$(find_common_parent "$TIER3_MULTIMEDIA_LOCAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "*-multimedia*")
             send_snapshot_incremental "$parent" "$local_snapshot" "$TIER3_MULTIMEDIA_EXTERNAL_DIR" || {
@@ -1215,7 +1243,11 @@ backup_tier3_multimedia() {
                 return 1
             }
 
-            [[ -n "$parent" ]] && SEND_TYPE["$subvol_name"]="incremental" || SEND_TYPE["$subvol_name"]="full"
+            if [[ -n "$parent" ]]; then
+                SEND_TYPE["$subvol_name"]="incremental"
+            else
+                SEND_TYPE["$subvol_name"]="full"
+            fi
             pin_parent "$TIER3_MULTIMEDIA_LOCAL_DIR" "$snapshot_name"
             cleanup_old_snapshots "$TIER3_MULTIMEDIA_EXTERNAL_DIR" "$TIER3_MULTIMEDIA_EXTERNAL_RETENTION" "*-multimedia*"
         else
@@ -1250,7 +1282,7 @@ backup_tier3_music() {
     fi
 
     # Tier 3: weekly local snapshots only
-    if ! should_send_external "$TIER3_MUSIC_LOCAL_SCHEDULE"; then
+    if ! should_run_on_schedule "$TIER3_MUSIC_LOCAL_SCHEDULE"; then
         log INFO "$subvol_name local backup runs on Saturdays only, skipping"
         record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*"
         return 0
@@ -1267,7 +1299,7 @@ backup_tier3_music() {
         }
     fi
 
-    if [[ "$LOCAL_ONLY" != "true" ]] && should_send_external "$TIER3_MUSIC_EXTERNAL_SCHEDULE"; then
+    if [[ "$LOCAL_ONLY" != "true" ]] && should_run_on_schedule "$TIER3_MUSIC_EXTERNAL_SCHEDULE"; then
         if check_external_mounted; then
             local parent=$(find_common_parent "$TIER3_MUSIC_LOCAL_DIR" "$TIER3_MUSIC_EXTERNAL_DIR" "*-music*")
             send_snapshot_incremental "$parent" "$local_snapshot" "$TIER3_MUSIC_EXTERNAL_DIR" || {
@@ -1276,7 +1308,11 @@ backup_tier3_music() {
                 return 1
             }
 
-            [[ -n "$parent" ]] && SEND_TYPE["$subvol_name"]="incremental" || SEND_TYPE["$subvol_name"]="full"
+            if [[ -n "$parent" ]]; then
+                SEND_TYPE["$subvol_name"]="incremental"
+            else
+                SEND_TYPE["$subvol_name"]="full"
+            fi
             pin_parent "$TIER3_MUSIC_LOCAL_DIR" "$snapshot_name"
             cleanup_old_snapshots "$TIER3_MUSIC_EXTERNAL_DIR" "$TIER3_MUSIC_EXTERNAL_RETENTION" "*-music*"
         else
@@ -1309,7 +1345,7 @@ backup_tier3_tmp() {
     fi
 
     # Tier 3: weekly local snapshots only
-    if ! should_send_external "$TIER3_TMP_LOCAL_SCHEDULE"; then
+    if ! should_run_on_schedule "$TIER3_TMP_LOCAL_SCHEDULE"; then
         log INFO "$subvol_name local backup runs on Saturdays only, skipping"
         record_backup_metrics "$subvol_name" "$start_time" 1 "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*"
         return 0
@@ -1326,7 +1362,7 @@ backup_tier3_tmp() {
         }
     fi
 
-    if [[ "$LOCAL_ONLY" != "true" ]] && should_send_external "$TIER3_TMP_EXTERNAL_SCHEDULE"; then
+    if [[ "$LOCAL_ONLY" != "true" ]] && should_run_on_schedule "$TIER3_TMP_EXTERNAL_SCHEDULE"; then
         if check_external_mounted; then
             local parent=$(find_common_parent "$TIER3_TMP_LOCAL_DIR" "$TIER3_TMP_EXTERNAL_DIR" "*-tmp*")
             send_snapshot_incremental "$parent" "$local_snapshot" "$TIER3_TMP_EXTERNAL_DIR" || {
@@ -1335,7 +1371,11 @@ backup_tier3_tmp() {
                 return 1
             }
 
-            [[ -n "$parent" ]] && SEND_TYPE["$subvol_name"]="incremental" || SEND_TYPE["$subvol_name"]="full"
+            if [[ -n "$parent" ]]; then
+                SEND_TYPE["$subvol_name"]="incremental"
+            else
+                SEND_TYPE["$subvol_name"]="full"
+            fi
             pin_parent "$TIER3_TMP_LOCAL_DIR" "$snapshot_name"
             cleanup_old_snapshots "$TIER3_TMP_EXTERNAL_DIR" "$TIER3_TMP_EXTERNAL_RETENTION" "*-tmp*"
         else
@@ -1440,13 +1480,20 @@ export_prometheus_metrics() {
         done
 
         echo ""
-        echo "# HELP backup_send_type Whether last send was incremental (1) or full (0)"
+        echo "# HELP backup_send_type Whether last send was incremental (1), full (0), or no send (-1)"
         echo "# TYPE backup_send_type gauge"
 
-        for subvol in "${!SEND_TYPE[@]}"; do
-            local type_val=0
-            [[ "${SEND_TYPE[$subvol]}" == "incremental" ]] && type_val=1
-            echo "backup_send_type{subvolume=\"$subvol\"} $type_val"
+        # Emit for all known subvolumes to avoid disappearing series in Prometheus
+        for subvol in "${!BACKUP_SUCCESS[@]}"; do
+            if [[ -n "${SEND_TYPE[$subvol]:-}" ]]; then
+                if [[ "${SEND_TYPE[$subvol]}" == "incremental" ]]; then
+                    echo "backup_send_type{subvolume=\"$subvol\"} 1"
+                else
+                    echo "backup_send_type{subvolume=\"$subvol\"} 0"
+                fi
+            else
+                echo "backup_send_type{subvolume=\"$subvol\"} -1"
+            fi
         done
 
         echo ""
@@ -1455,12 +1502,14 @@ export_prometheus_metrics() {
         [[ "$EXTERNAL_DRIVE_MOUNTED" == "true" ]] && echo "backup_external_drive_mounted 1" || echo "backup_external_drive_mounted 0"
 
         echo ""
-        echo "# HELP backup_external_free_bytes Free space on external drive in bytes"
+        echo "# HELP backup_external_free_bytes Free space on external drive in bytes (0 when unmounted)"
         echo "# TYPE backup_external_free_bytes gauge"
         if [[ "$EXTERNAL_DRIVE_MOUNTED" == "true" ]] && [[ -d "$EXTERNAL_BACKUP_ROOT" ]]; then
             local free_bytes
             free_bytes=$(df --output=avail -B1 "$(dirname "$EXTERNAL_BACKUP_ROOT")" 2>/dev/null | tail -1 | tr -d ' ')
             echo "backup_external_free_bytes ${free_bytes:-0}"
+        else
+            echo "backup_external_free_bytes 0"
         fi
 
         echo ""


### PR DESCRIPTION
## Summary

- **Daily external sends for Tier 1/2** — RPO reduced from 7 days to ~1 day. Per-subvolume `EXTERNAL_SCHEDULE` config replaces hardcoded Saturday checks.
- **Time Machine-style graduated local retention** — 14 daily + 6 weekly + 3 monthly (~21 snapshots, 90-day coverage). Supports quarterly offsite drive rotation.
- **Dual pin files per drive** — `.last-external-parent-WD-18TB` and `.last-external-parent-WD-18TB1` maintain independent incremental chains for offsite rotation.
- **Single nightly timer** replaces daily+weekly pair. Weekly timer disabled.
- **Graceful drive absence** — no Discord alerts when external drive is unmounted.
- **New Prometheus metrics** — `backup_send_type`, `backup_external_drive_mounted`, `backup_external_free_bytes`

## Context

The BTRFS pool runs Single profile (no RAID) — external backups are the only protection against disk failure. The weekly-only schedule was designed when every send was a multi-hour full send. Now that incremental sends work reliably (March 2026 operational excellence work: pinned parents, space pre-checks, stderr capture), incremental sends complete in minutes.

The offsite drive (WD-18TB1) will be stored at a friend's location and cycled ~quarterly. The graduated retention ensures the offsite pinned parent survives the 90-day window.

See ADR-020 for full architectural decision record.

## Test Plan

- [x] `bash -n` syntax check passes
- [x] `--dry-run --verbose` full run: Tier 1/2 external sends attempted, Tier 3 skips (correct)
- [x] `--dry-run --subvolume containers`: targeted test passes
- [x] Graduated cleanup: parses dates, preserves pinned parents, respects all retention windows
- [x] Drive-specific pin files: "Pinned parent for WD-18TB1 incremental chain"
- [x] `pin_parent` respects `--dry-run`
- [x] Weekly timer disabled, daily timer active
- [ ] Verify first nightly run at 02:00 (check `journalctl --user -u btrfs-backup-daily.service -n 100`)
- [ ] Verify incremental chains building correctly after 3 nights

🤖 Generated with [Claude Code](https://claude.com/claude-code)