### PR TITLE
fix: Boot race condition — network dependencies fail 6 services on reboot

### DIFF
--- a/config/traefik/dynamic/middleware.yml
+++ b/config/traefik/dynamic/middleware.yml
@@ -117,6 +117,17 @@ http:
           ipStrategy:
             depth: 1
 
+    # qBittorrent (WebUI loads 500+ resources on first page load: JS, HTML views, images, API calls)
+    # Already behind Authelia SSO — only authenticated users reach this service
+    rate-limit-qbittorrent:
+      rateLimit:
+        average: 300      # Generous sustained rate for authenticated WebUI
+        burst: 600        # Support initial page load (~500 resources: JS, HTML, images, API)
+        period: 1m
+        sourceCriterion:
+          ipStrategy:
+            depth: 1
+
     # Immich (photo management - high capacity for thumbnail loading)
     rate-limit-immich:
       rateLimit:

--- a/config/traefik/dynamic/routers.yml
+++ b/config/traefik/dynamic/routers.yml
@@ -266,7 +266,7 @@ http:
         - websecure
       middlewares:
         - crowdsec-bouncer@file
-        - rate-limit@file
+        - rate-limit-qbittorrent@file
         - authelia@file
         - security-headers@file
       tls:

--- a/docs/AUTO-DEPENDENCY-GRAPH.md
+++ b/docs/AUTO-DEPENDENCY-GRAPH.md
@@ -1,6 +1,6 @@
 # Service Dependency Graph (Auto-Generated)
 
-**Generated:** 2026-03-09 06:02:55 UTC
+**Generated:** 2026-03-24 06:01:52 UTC
 **System:** fedora-htpc
 
 ---
@@ -82,15 +82,6 @@ graph TB
     traefik -.-> vaultwarden
 
     %% Monitoring (Prometheus scrapes via monitoring network)
-    prometheus -.->|scrapes| gathio
-    prometheus -.->|scrapes| home_assistant
-    prometheus -.->|scrapes| immich_server
-    prometheus -.->|scrapes| jellyfin
-    prometheus -.->|scrapes| navidrome
-    prometheus -.->|scrapes| nextcloud
-    prometheus -.->|scrapes| nextcloud_db
-    prometheus -.->|scrapes| nextcloud_redis
-    prometheus -.->|scrapes| traefik
 
     %% Styling
     style traefik fill:#f9f,stroke:#333,stroke-width:4px
@@ -203,7 +194,7 @@ Derived from `After=` directives in quadlet files. systemd handles this automati
 
 Services on the same network can communicate:
 
-**auth_services:** authelia,redis-authelia,traefik
+**auth_services:** authelia,redis-authelia
 
 **gathio:** gathio,gathio-db
 
@@ -211,7 +202,7 @@ Services on the same network can communicate:
 
 **media_services:** jellyfin
 
-**monitoring:** alert-discord-relay,alertmanager,cadvisor,gathio,grafana,home-assistant,immich-server,jellyfin,loki,navidrome,nextcloud,nextcloud-db,nextcloud-redis,node_exporter,prometheus,promtail,traefik,unpoller
+**monitoring:** alert-discord-relay,alertmanager,cadvisor,grafana,loki,node_exporter,prometheus,promtail,unpoller
 
 **nextcloud:** nextcloud,nextcloud-db,nextcloud-redis
 

--- a/docs/AUTO-DOCUMENTATION-INDEX.md
+++ b/docs/AUTO-DOCUMENTATION-INDEX.md
@@ -1,7 +1,7 @@
 # Documentation Index (Auto-Generated)
 
-**Generated:** 2026-03-09 06:02:55 UTC
-**Total Documents:** 405
+**Generated:** 2026-03-24 06:01:53 UTC
+**Total Documents:** 419
 
 ---
 
@@ -22,7 +22,7 @@
 
 ## Documentation by Category
 
-### 00-foundation/ (13 documents)
+### 00-foundation/ (14 documents)
 
 **Fundamentals and core concepts**
 
@@ -42,6 +42,7 @@
 - ADR-017: [2026-01-05-ADR-017-slash-commands-and-subagents](00-foundation/decisions/2026-01-05-ADR-017-slash-commands-and-subagents.md)
 - ADR-018: [2026-02-04-ADR-018-static-ip-multi-network-services](00-foundation/decisions/2026-02-04-ADR-018-static-ip-multi-network-services.md)
 - ADR-019: [2026-02-22-ADR-019-filesystem-permission-model](00-foundation/decisions/2026-02-22-ADR-019-filesystem-permission-model.md)
+- ADR-020: [2026-03-21-ADR-020-daily-external-backups](00-foundation/decisions/2026-03-21-ADR-020-daily-external-backups.md)
 
 ---
 
@@ -166,7 +167,7 @@
 
 ---
 
-### 97-plans/ (27 documents)
+### 97-plans/ (30 documents)
 
 **Strategic plans and forward-looking projects**
 - 📋 [2025-01-08-unpoller-with-advanced-networks-monitoring-plan.md](97-plans/2025-01-08-unpoller-with-advanced-networks-monitoring-plan.md)
@@ -178,6 +179,9 @@
 - 📋 [2025-12-30-nextcloud-security-performance-observability-plan.md](97-plans/2025-12-30-nextcloud-security-performance-observability-plan.md)
 - 📋 [2026-01-04-workflow-improvements-plan.md](97-plans/2026-01-04-workflow-improvements-plan.md)
 - ✅ [2026-01-22-monthly-review-matter-hybrid-approach.md](97-plans/2026-01-22-monthly-review-matter-hybrid-approach.md)
+- 📋 [2026-03-19-fedora-coreos-rebuild-plan.md](97-plans/2026-03-19-fedora-coreos-rebuild-plan.md)
+- 📋 [2026-03-19-nixos-homelab-rebuild-plan.md](97-plans/2026-03-19-nixos-homelab-rebuild-plan.md)
+- 📋 [2026-03-22-urd-btrfs-time-machine-plan.md](97-plans/2026-03-22-urd-btrfs-time-machine-plan.md)
 - 📋 [ADR-REORGANIZATION-PLAN.md](97-plans/ADR-REORGANIZATION-PLAN.md)
 - 📋 [MIGRATION-PLAN-FINAL.md](97-plans/MIGRATION-PLAN-FINAL.md)
 - ✅ [PLAN-1-AUTO-UPDATE-SAFETY-NET.md](97-plans/PLAN-1-AUTO-UPDATE-SAFETY-NET.md)
@@ -199,7 +203,7 @@
 
 ---
 
-### 98-journals/ (179 documents)
+### 98-journals/ (188 documents)
 
 **Chronological project history (append-only log)**
 
@@ -207,7 +211,7 @@ Complete dated entries documenting the homelab journey. See directory for full c
 
 ---
 
-### 99-reports/ (32 documents)
+### 99-reports/ (34 documents)
 
 **Automated system reports and point-in-time snapshots**
 
@@ -217,16 +221,22 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 
 ## Recently Updated (Last 7 Days)
 
-- 2026-03-08: [automation-reference.md](20-operations/guides/automation-reference.md)
-- 2026-03-08: [security-audit.md](30-security/guides/security-audit.md)
-- 2026-03-09: [2026-03-08-security-auditor-skill-evaluation.md](98-journals/2026-03-08-security-auditor-skill-evaluation.md)
-- 2026-03-08: [2026-03-08-security-audit-investigated.md](99-reports/2026-03-08-security-audit-investigated.md)
-- 2026-03-09: [remediation-monthly-202602.md](99-reports/remediation-monthly-202602.md)
-- 2026-03-08: [security-audit-2026-03-08.md](99-reports/security-audit-2026-03-08.md)
-- 2026-03-09: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
-- 2026-03-09: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
-- 2026-03-09: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
-- 2026-03-09: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
+- 2026-03-18: [2025-12-31-ADR-016-configuration-design-principles.md](00-foundation/decisions/2025-12-31-ADR-016-configuration-design-principles.md)
+- 2026-03-18: [2026-02-04-ADR-018-static-ip-multi-network-services.md](00-foundation/decisions/2026-02-04-ADR-018-static-ip-multi-network-services.md)
+- 2026-03-22: [2026-03-21-ADR-020-daily-external-backups.md](00-foundation/decisions/2026-03-21-ADR-020-daily-external-backups.md)
+- 2026-03-22: [backup-strategy.md](20-operations/guides/backup-strategy.md)
+- 2026-03-20: [2026-03-19-fedora-coreos-rebuild-plan.md](97-plans/2026-03-19-fedora-coreos-rebuild-plan.md)
+- 2026-03-20: [2026-03-19-nixos-homelab-rebuild-plan.md](97-plans/2026-03-19-nixos-homelab-rebuild-plan.md)
+- 2026-03-22: [2026-03-22-urd-btrfs-time-machine-plan.md](97-plans/2026-03-22-urd-btrfs-time-machine-plan.md)
+- 2026-03-17: [2026-03-17-pasta-source-nat-investigation.md](98-journals/2026-03-17-pasta-source-nat-investigation.md)
+- 2026-03-19: [2026-03-17-traefik-network-attack-surface-reduction.md](98-journals/2026-03-17-traefik-network-attack-surface-reduction.md)
+- 2026-03-22: [2026-03-21-backup-script-operational-excellence.md](98-journals/2026-03-21-backup-script-operational-excellence.md)
+- 2026-03-22: [2026-03-22-backup-system-audit-and-architecture-exploration.md](98-journals/2026-03-22-backup-system-audit-and-architecture-exploration.md)
+- 2026-03-23: [2026-03-23-cadvisor-oom-death-spiral-postmortem.md](98-journals/2026-03-23-cadvisor-oom-death-spiral-postmortem.md)
+- 2026-03-24: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
+- 2026-03-24: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
+- 2026-03-24: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
+- 2026-03-24: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
 
 ---
 

--- a/docs/AUTO-NETWORK-TOPOLOGY.md
+++ b/docs/AUTO-NETWORK-TOPOLOGY.md
@@ -1,6 +1,6 @@
 # Network Topology (Auto-Generated)
 
-**Generated:** 2026-03-09 06:02:51 UTC
+**Generated:** 2026-03-24 06:01:49 UTC
 **System:** fedora-htpc | **Networks:** 8 | **Containers:** 30
 
 ---
@@ -62,7 +62,6 @@ graph TB
         direction LR
         auth_services_authelia[authelia]
         auth_services_redis_authelia[redis-authelia]
-        auth_services_traefik[traefik]
     end
 
     subgraph gathio["gathio<br/>10.89.0.0/24"]
@@ -87,20 +86,11 @@ graph TB
         monitoring_alert_discord_relay[alert-discord-relay]
         monitoring_alertmanager[alertmanager]
         monitoring_cadvisor[cadvisor]
-        monitoring_gathio[gathio]
         monitoring_grafana[grafana]
-        monitoring_home_assistant[home-assistant]
-        monitoring_immich_server[immich-server]
-        monitoring_jellyfin[jellyfin]
         monitoring_loki[loki]
-        monitoring_navidrome[navidrome]
-        monitoring_nextcloud[nextcloud]
-        monitoring_nextcloud_db[nextcloud-db]
-        monitoring_nextcloud_redis[nextcloud-redis]
         monitoring_node_exporter[node_exporter]
         monitoring_prometheus[prometheus]
         monitoring_promtail[promtail]
-        monitoring_traefik[traefik]
         monitoring_unpoller[unpoller]
     end
 
@@ -164,17 +154,17 @@ Shows which services belong to which networks. Dynamically generated from runnin
 | authelia | ✅ | - | - | - | - | - | - | ✅ |
 | crowdsec | - | - | - | - | - | - | - | ✅ |
 | redis-authelia | ✅ | - | - | - | - | - | - | - |
-| traefik | ✅ | - | - | - | ✅ | - | - | ✅ |
+| traefik | - | - | - | - | - | - | - | ✅ |
 | **Public Services** |
 | alert-discord-relay | - | - | - | - | ✅ | - | - | ✅ |
 | audiobookshelf | - | - | - | - | - | - | - | ✅ |
-| gathio | - | ✅ | - | - | ✅ | - | - | ✅ |
-| home-assistant | - | - | ✅ | - | ✅ | - | - | ✅ |
+| gathio | - | ✅ | - | - | - | - | - | ✅ |
+| home-assistant | - | - | ✅ | - | - | - | - | ✅ |
 | homepage | - | - | - | - | - | - | - | ✅ |
-| immich-server | - | - | - | - | ✅ | - | ✅ | ✅ |
-| jellyfin | - | - | - | ✅ | ✅ | - | - | ✅ |
-| navidrome | - | - | - | - | ✅ | - | - | ✅ |
-| nextcloud | - | - | - | - | ✅ | ✅ | - | ✅ |
+| immich-server | - | - | - | - | - | - | ✅ | ✅ |
+| jellyfin | - | - | - | ✅ | - | - | - | ✅ |
+| navidrome | - | - | - | - | - | - | - | ✅ |
+| nextcloud | - | - | - | - | - | ✅ | - | ✅ |
 | qbittorrent | - | - | - | - | - | - | - | ✅ |
 | unpoller | - | - | - | - | ✅ | - | - | ✅ |
 | vaultwarden | - | - | - | - | - | - | - | ✅ |
@@ -190,8 +180,8 @@ Shows which services belong to which networks. Dynamically generated from runnin
 | gathio-db | - | ✅ | - | - | - | - | - | - |
 | immich-ml | - | - | - | - | - | - | ✅ | - |
 | matter-server | - | - | ✅ | - | - | - | - | - |
-| nextcloud-db | - | - | - | - | ✅ | ✅ | - | - |
-| nextcloud-redis | - | - | - | - | ✅ | ✅ | - | - |
+| nextcloud-db | - | - | - | - | - | ✅ | - | - |
+| nextcloud-redis | - | - | - | - | - | ✅ | - | - |
 | postgresql-immich | - | - | - | - | - | - | ✅ | - |
 | redis-immich | - | - | - | - | - | - | ✅ | - |
 
@@ -250,12 +240,11 @@ sequenceDiagram
 
 - **Full Name:** `systemd-auth_services`
 - **Subnet:** 10.89.3.0/24
-- **Services:** 3
+- **Services:** 2
 
 **Members:**
 - authelia
 - redis-authelia
-- traefik
 
 
 ### gathio
@@ -294,26 +283,17 @@ sequenceDiagram
 
 - **Full Name:** `systemd-monitoring`
 - **Subnet:** 10.89.4.0/24
-- **Services:** 18
+- **Services:** 9
 
 **Members:**
 - alert-discord-relay
 - alertmanager
 - cadvisor
-- gathio
 - grafana
-- home-assistant
-- immich-server
-- jellyfin
 - loki
-- navidrome
-- nextcloud
-- nextcloud-db
-- nextcloud-redis
 - node_exporter
 - prometheus
 - promtail
-- traefik
 - unpoller
 
 

--- a/docs/AUTO-SERVICE-CATALOG.md
+++ b/docs/AUTO-SERVICE-CATALOG.md
@@ -1,6 +1,6 @@
 # Service Catalog (Auto-Generated)
 
-**Generated:** 2026-03-09 06:02:50 UTC
+**Generated:** 2026-03-24 06:01:48 UTC
 **System:** fedora-htpc | **Services:** 30/30 running | **Health:** 28/28 healthy (2 without healthcheck)
 
 ---
@@ -9,81 +9,81 @@
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| audiobookshelf | advplyr/audiobookshelf:latest | ✅ healthy | 6h | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
-| navidrome | deluan/navidrome:latest | ✅ healthy | 6h | [musikk.patriark.org](https://musikk.patriark.org) | — |
-| qbittorrent | linuxserver/qbittorrent:latest | ✅ healthy | 6h | [torrent.patriark.org](https://torrent.patriark.org) | — |
+| audiobookshelf | advplyr/audiobookshelf:latest | ✅ healthy | 2d | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
+| navidrome | deluan/navidrome:latest | ✅ healthy | 4d | [musikk.patriark.org](https://musikk.patriark.org) | — |
+| qbittorrent | linuxserver/qbittorrent:latest | ✅ healthy | 2d | [torrent.patriark.org](https://torrent.patriark.org) | — |
 
 ## Core Infrastructure (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| authelia | authelia/authelia:latest | ✅ healthy | 6h | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
-| crowdsec | crowdsecurity/crowdsec:latest | ✅ healthy | 6h | — | [guide](10-services/guides/crowdsec.md) |
-| redis-authelia | redis:7-alpine | ✅ healthy | 6h | — | — |
-| traefik | traefik:latest | ✅ healthy | 6h | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
+| authelia | authelia/authelia:latest | ✅ healthy | 7d | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
+| crowdsec | crowdsecurity/crowdsec:latest | ✅ healthy | 7d | — | [guide](10-services/guides/crowdsec.md) |
+| redis-authelia | redis:7-alpine | ✅ healthy | 7d | — | — |
+| traefik | traefik:latest | ✅ healthy | 2d | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
 
 ## Nextcloud (3)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| nextcloud-db | mariadb:11 | ✅ healthy | 6h | — | [guide](10-services/guides/nextcloud.md) |
-| nextcloud | nextcloud:latest | ✅ healthy | 6h | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
-| nextcloud-redis | redis:7-alpine | ✅ healthy | 6h | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-db | mariadb:11 | ✅ healthy | 2d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud | nextcloud:latest | ✅ healthy | 2d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-redis | redis:7-alpine | ✅ healthy | 6d | — | [guide](10-services/guides/nextcloud.md) |
 
 ## Immich (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| immich-ml | immich-app/immich-machine-learning:v2.5.6 | ✅ healthy | 6h | — | [guide](10-services/guides/immich.md) |
-| immich-server | immich-app/immich-server:v2.5.6 | ✅ healthy | 6h | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
-| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3-pgvec | ✅ healthy | 6h | — | — |
-| redis-immich | valkey/valkey:latest | ✅ healthy | 6h | — | — |
+| immich-ml | immich-app/immich-machine-learning:v2.5.6 | ✅ healthy | 7d | — | [guide](10-services/guides/immich.md) |
+| immich-server | immich-app/immich-server:v2.5.6 | ✅ healthy | 6d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
+| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3-pgvec | ✅ healthy | 7d | — | — |
+| redis-immich | valkey/valkey:latest | ✅ healthy | 7d | — | — |
 
 ## Jellyfin (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| jellyfin | jellyfin/jellyfin:latest | ✅ healthy | 6h | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
+| jellyfin | jellyfin/jellyfin:latest | ✅ healthy | 6d | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
 
 ## Vaultwarden (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| vaultwarden | vaultwarden/server:latest | ✅ healthy | 6h | [vault.patriark.org](https://vault.patriark.org) | — |
+| vaultwarden | vaultwarden/server:latest | ✅ healthy | 7d | [vault.patriark.org](https://vault.patriark.org) | — |
 
 ## Home Automation (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 6h | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
-| matter-server | home-assistant-libs/python-matter-server:stab | ✅ healthy | 6h | — | [guide](10-services/guides/matter-server.md) |
+| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 4d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
+| matter-server | home-assistant-libs/python-matter-server:stab | ✅ healthy | 7d | — | [guide](10-services/guides/matter-server.md) |
 
 ## Gathio (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| gathio-db | mongo:7 | ✅ healthy | 6h | — | — |
-| gathio | lowercasename/gathio:latest | ✅ healthy | 6h | [events.patriark.org](https://events.patriark.org) | — |
+| gathio-db | mongo:7 | ✅ healthy | 2d | — | — |
+| gathio | lowercasename/gathio:latest | ✅ healthy | 2d | [events.patriark.org](https://events.patriark.org) | — |
 
 ## Homepage (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| homepage | gethomepage/homepage:latest | ✅ healthy | 6h | [patriark.org](https://patriark.org) | — |
+| homepage | gethomepage/homepage:latest | ✅ healthy | 7d | [patriark.org](https://patriark.org) | — |
 
 ## Monitoring (9)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| alert-discord-relay | localhost/alert-discord-relay:latest | ✅ healthy | 6h | — | [guide](10-services/guides/alert-discord-relay.md) |
-| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ healthy | 6h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ healthy | 6h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| grafana | grafana/grafana:latest | ✅ healthy | 6h | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| loki | grafana/loki:latest | — no check | 6h | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| node_exporter | quay.io/prometheus/node-exporter:latest | ✅ healthy | 6h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 6h | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| promtail | grafana/promtail:latest | ✅ healthy | 6h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| unpoller | unpoller/unpoller:latest | — no check | 6h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| alert-discord-relay | localhost/alert-discord-relay:latest | ✅ healthy | 7d | — | [guide](10-services/guides/alert-discord-relay.md) |
+| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ healthy | 7d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ healthy | 14h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| grafana | grafana/grafana:latest | ✅ healthy | 7d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| loki | grafana/loki:latest | — no check | 7d | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| node_exporter | quay.io/prometheus/node-exporter:latest | ✅ healthy | 7d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 4d | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| promtail | grafana/promtail:latest | ✅ healthy | 7d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| unpoller | unpoller/unpoller:latest | — no check | 7d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
 
 ---
 
@@ -91,7 +91,7 @@
 
 - **Total Running:** 30
 - **Total Defined:** 30
-- **System Load:** 0,44, 0,94, 1,04
+- **System Load:** 0,36, 0,64, 0,75
 
 ---
 

--- a/quadlets/alert-discord-relay.container
+++ b/quadlets/alert-discord-relay.container
@@ -1,8 +1,7 @@
 [Unit]
 Description=Alert Discord Relay - Alertmanager to Discord Webhook Bridge
 After=network-online.target reverse_proxy-network.service monitoring-network.service
-Wants=network-online.target
-Requires=reverse_proxy-network.service monitoring-network.service
+Wants=monitoring-network.service network-online.target reverse_proxy-network.service
 
 [Container]
 Image=localhost/alert-discord-relay:latest

--- a/quadlets/alertmanager.container
+++ b/quadlets/alertmanager.container
@@ -1,8 +1,7 @@
 [Unit]
 Description=Alertmanager - Alert Routing and Notification
 After=network-online.target monitoring-network.service
-Wants=network-online.target
-Requires=monitoring-network.service
+Wants=monitoring-network.service network-online.target
 
 [Container]
 Image=quay.io/prometheus/alertmanager:latest

--- a/quadlets/authelia.container
+++ b/quadlets/authelia.container
@@ -1,8 +1,8 @@
 [Unit]
 Description=Authelia - SSO & MFA Authentication Server (YubiKey-First)
 After=network-online.target redis-authelia.service reverse_proxy-network.service auth_services-network.service
-Wants=network-online.target
-Requires=redis-authelia.service reverse_proxy-network.service auth_services-network.service
+Wants=auth_services-network.service network-online.target reverse_proxy-network.service
+Requires=redis-authelia.service
 
 [Container]
 Image=docker.io/authelia/authelia:latest

--- a/quadlets/cadvisor.container
+++ b/quadlets/cadvisor.container
@@ -1,8 +1,7 @@
 [Unit]
 Description=cAdvisor - Container Metrics Exporter
 After=network-online.target monitoring-network.service
-Wants=network-online.target
-Requires=monitoring-network.service
+Wants=monitoring-network.service network-online.target
 
 [Container]
 Image=gcr.io/cadvisor/cadvisor:latest

--- a/quadlets/gathio-db.container
+++ b/quadlets/gathio-db.container
@@ -1,8 +1,7 @@
 [Unit]
 Description=MongoDB Database for Gathio
 After=network-online.target gathio-network.service
-Wants=network-online.target
-Requires=gathio-network.service
+Wants=gathio-network.service network-online.target
 
 [Container]
 Image=docker.io/library/mongo:7

--- a/quadlets/grafana.container
+++ b/quadlets/grafana.container
@@ -1,8 +1,7 @@
 [Unit]
 Description=Grafana Monitoring Dashboard
 After=network-online.target monitoring-network.service
-Wants=network-online.target
-Requires=monitoring-network.service
+Wants=monitoring-network.service network-online.target
 
 [Container]
 Image=docker.io/grafana/grafana:latest

--- a/quadlets/home-assistant.container
+++ b/quadlets/home-assistant.container
@@ -1,8 +1,7 @@
 [Unit]
 Description=Home Assistant - Home Automation Hub
 After=network-online.target reverse_proxy-network.service home_automation-network.service
-Wants=network-online.target
-Requires=reverse_proxy-network.service home_automation-network.service
+Wants=home_automation-network.service network-online.target reverse_proxy-network.service
 
 [Container]
 Image=ghcr.io/home-assistant/home-assistant:stable

--- a/quadlets/homepage.container
+++ b/quadlets/homepage.container
@@ -1,8 +1,7 @@
 [Unit]
 Description=Homepage - Homelab Dashboard
 After=network-online.target reverse_proxy-network.service
-Wants=network-online.target
-Requires=reverse_proxy-network.service
+Wants=network-online.target reverse_proxy-network.service
 
 [Container]
 Image=ghcr.io/gethomepage/homepage:latest

--- a/quadlets/immich-ml.container
+++ b/quadlets/immich-ml.container
@@ -1,8 +1,7 @@
 [Unit]
 Description=Immich Machine Learning
 After=network-online.target photos-network.service
-Wants=network-online.target
-Requires=photos-network.service
+Wants=network-online.target photos-network.service
 
 [Container]
 Image=ghcr.io/immich-app/immich-machine-learning:v2.5.6

--- a/quadlets/immich-server.container
+++ b/quadlets/immich-server.container
@@ -1,8 +1,8 @@
 [Unit]
 Description=Immich Server
 After=network-online.target photos-network.service postgresql-immich.service redis-immich.service
-Wants=network-online.target
-Requires=photos-network.service postgresql-immich.service redis-immich.service
+Wants=network-online.target photos-network.service
+Requires=postgresql-immich.service redis-immich.service
 
 [Container]
 Image=ghcr.io/immich-app/immich-server:v2.5.6

--- a/quadlets/jellyfin.container
+++ b/quadlets/jellyfin.container
@@ -1,8 +1,7 @@
 [Unit]
 Description=Jellyfin Media Server
 After=network-online.target reverse_proxy-network.service media_services-network.service
-Wants=network-online.target
-Requires=reverse_proxy-network.service media_services-network.service
+Wants=media_services-network.service network-online.target reverse_proxy-network.service
 
 [Container]
 Image=docker.io/jellyfin/jellyfin:latest

--- a/quadlets/loki.container
+++ b/quadlets/loki.container
@@ -1,8 +1,7 @@
 [Unit]
 Description=Loki Log Aggregation System
 After=network-online.target monitoring-network.service
-Wants=network-online.target
-Requires=monitoring-network.service
+Wants=monitoring-network.service network-online.target
 
 [Container]
 Image=docker.io/grafana/loki:latest

--- a/quadlets/matter-server.container
+++ b/quadlets/matter-server.container
@@ -1,8 +1,7 @@
 [Unit]
 Description=Matter Server (python-matter-server)
 After=network-online.target home_automation-network.service
-Wants=network-online.target
-Requires=home_automation-network.service
+Wants=home_automation-network.service network-online.target
 
 [Container]
 Image=ghcr.io/home-assistant-libs/python-matter-server:stable

--- a/quadlets/node_exporter.container
+++ b/quadlets/node_exporter.container
@@ -1,8 +1,7 @@
 [Unit]
 Description=Node Exporter - System Metrics Collector
 After=network-online.target monitoring-network.service
-Wants=network-online.target
-Requires=monitoring-network.service
+Wants=monitoring-network.service network-online.target
 
 [Container]
 Image=quay.io/prometheus/node-exporter:latest

--- a/quadlets/postgresql-immich.container
+++ b/quadlets/postgresql-immich.container
@@ -1,8 +1,7 @@
 [Unit]
 Description=PostgreSQL for Immich
 After=network-online.target photos-network.service
-Wants=network-online.target
-Requires=photos-network.service
+Wants=network-online.target photos-network.service
 
 [Container]
 Image=ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0

--- a/quadlets/prometheus.container
+++ b/quadlets/prometheus.container
@@ -1,8 +1,7 @@
 [Unit]
 Description=Prometheus Metrics Database
 After=network-online.target monitoring-network.service node_exporter.service
-Wants=network-online.target node_exporter.service
-Requires=monitoring-network.service
+Wants=monitoring-network.service network-online.target node_exporter.service
 
 [Container]
 Image=quay.io/prometheus/prometheus:latest

--- a/quadlets/promtail.container
+++ b/quadlets/promtail.container
@@ -1,8 +1,7 @@
 [Unit]
 Description=Promtail - Log Collector for Loki
 After=network-online.target monitoring-network.service loki.service
-Wants=network-online.target loki.service
-Requires=monitoring-network.service
+Wants=loki.service monitoring-network.service network-online.target
 
 [Container]
 Image=docker.io/grafana/promtail:latest

--- a/quadlets/qbittorrent.container
+++ b/quadlets/qbittorrent.container
@@ -1,8 +1,7 @@
 [Unit]
 Description=qBittorrent - BitTorrent Client (Headless)
 After=network-online.target reverse_proxy-network.service
-Wants=network-online.target
-Requires=reverse_proxy-network.service
+Wants=network-online.target reverse_proxy-network.service
 
 [Container]
 Image=docker.io/linuxserver/qbittorrent:latest

--- a/quadlets/redis-authelia.container
+++ b/quadlets/redis-authelia.container
@@ -1,8 +1,7 @@
 [Unit]
 Description=Redis - Authelia Session Storage
 After=network-online.target auth_services-network.service
-Wants=network-online.target
-Requires=auth_services-network.service
+Wants=auth_services-network.service network-online.target
 
 [Container]
 Image=docker.io/library/redis:7-alpine

--- a/quadlets/redis-immich.container
+++ b/quadlets/redis-immich.container
@@ -1,8 +1,7 @@
 [Unit]
 Description=Redis for Immich
 After=network-online.target photos-network.service
-Wants=network-online.target
-Requires=photos-network.service
+Wants=network-online.target photos-network.service
 
 [Container]
 Image=docker.io/valkey/valkey:latest

--- a/quadlets/traefik.container
+++ b/quadlets/traefik.container
@@ -1,8 +1,7 @@
 [Unit]
 Description=Traefik Reverse Proxy
 After=network-online.target reverse_proxy-network.service
-Wants=network-online.target
-Requires=reverse_proxy-network.service
+Wants=network-online.target reverse_proxy-network.service
 
 [Container]
 Image=docker.io/library/traefik:latest

--- a/quadlets/unpoller.container
+++ b/quadlets/unpoller.container
@@ -2,8 +2,7 @@
 Description=Unpoller - UniFi Metrics Exporter for Prometheus
 Documentation=https://unpoller.com/docs/
 After=network-online.target reverse_proxy-network.service prometheus.service
-Wants=network-online.target
-Requires=reverse_proxy-network.service
+Wants=network-online.target reverse_proxy-network.service
 
 [Container]
 Image=ghcr.io/unpoller/unpoller:latest


### PR DESCRIPTION
## Summary

- Changed `Requires=` to `Wants=` for network dependencies across all 22 quadlets to prevent boot race condition where slow network creation causes cascading service failures
- Service dependencies (redis, postgresql) remain as `Requires=` — true hard deps
- Added custom qBittorrent rate limit (300/min sustained, 600 burst) to handle WebUI's ~500 resource initial page load

## Root Cause

On 2026-03-24 reboot, `reverse_proxy-network.service` took ~10 minutes to start. With `Requires=`, systemd immediately failed all dependent services (qBittorrent, Jellyfin, Homepage, Home Assistant, alert-discord-relay, UnPoller). `Restart=on-failure` doesn't cover dependency failures, so services stayed dead.

## Fix

`Wants=` + `After=` preserves boot ordering while allowing `Restart=on-failure` to handle transient delays. If a container starts before its network is ready, it fails at runtime — which `Restart=on-failure` does handle.

## Test Plan

- [x] All 22 quadlets updated and daemon-reloaded
- [x] Verified `systemctl --user show qbittorrent.service` shows network under `Wants=` not `Requires=`
- [x] All previously-failed services manually started and confirmed running
- [ ] Verify on next reboot that services start without intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)