### PR TITLE
docs: HA rate-limit rollback journal (ADR-022 follow-up)

### DIFF
--- a/docs/98-journals/2026-04-21-ha-rate-limit-rollback-post-adr022.md
+++ b/docs/98-journals/2026-04-21-ha-rate-limit-rollback-post-adr022.md
@@ -1,0 +1,60 @@
+# HA Rate-Limit Rollback — Closing Out ADR-022
+
+**Date:** 2026-04-21
+**Status:** Live config re-aligned with `main` HEAD; follow-up rate-limit work identified
+**Related:** ADR-022 (socket activation, merged PR #135)
+
+## Context
+
+ADR-022 restored real client source IPs at Traefik on 2026-04-16 by moving to
+systemd socket activation, bypassing the `rootlessport` SNAT. The ADR explicitly
+flagged rate-limit retuning as follow-up work — values like
+`rate-limit-home-assistant: burst=600` were sized for "all external users share
+one bucket" and stopped making sense once per-IP buckets became real again.
+
+## What actually happened
+
+The `rate-limit-home-assistant` middleware was introduced on 2026-04-12 as a
+hot-fix for the iOS HA cold-start bursting through the standard 100/50 bucket
+(launchpad — `docs/99-reports/2026-04-12-nat-security-model-violation.md`). Its
+own comment cited the shared NAT IP as the sizing rationale.
+
+**Drift surfaced during the rollback:** the 2026-04-12 hot-fix was deployed live
+(Traefik autoloaded it via bind-mounted `config/`) but **never committed to git**.
+`main` HEAD never carried `rate-limit-home-assistant` — only the working tree
+did. Editing `middleware.yml` to remove it and `routers.yml` to route HA back to
+`rate-limit@file` produced zero net diff against HEAD, because HEAD already
+reflected the intended post-ADR-022 state. The rollback was de-facto a
+drift correction, not a schema change.
+
+Transient `ERR error="middleware rate-limit-home-assistant@file does not exist"`
+appeared once at the file-reload boundary (middleware.yml reloaded before
+routers.yml in that cycle), resolved on the next poll. HA confirmed live at
+HTTP 200.
+
+## What's now live
+
+- HA router middleware chain: `crowdsec-bouncer@file → rate-limit@file → security-headers-ha@file`
+- Rate limit per client: 100 avg / 50 burst / 1 min — generous headroom for the
+  ~80 parallel JS chunks on a cold iOS app launch, per real client.
+- `rate-limit-home-assistant` middleware: gone from both git and disk.
+
+## Follow-up (out of scope for this session)
+
+- **Still oversized, still NAT-era:** `rate-limit-qbittorrent` (300/600),
+  `rate-limit-immich` (500/2000), `rate-limit-nextcloud` (600/3000). Each was
+  sized for legitimate bulk ops (thumbnail grids, PROPFIND tree walks) so the
+  retune needs per-service reasoning rather than a blanket cut.
+- **ADR-022 environmental verifications** — confirm organic CrowdSec drops on
+  real external IPs and independent per-IP rate-limit buckets under load.
+  Passive observation, needs a sampling window.
+- **Vaultwarden event log** — `EVENTS_DAYS_RETAIN` still unset; forensic gap.
+- **authelia-portal middleware stripped** — working tree has `rate-limit@file`,
+  `circuit-breaker@file`, `retry@file` removed from `sso.patriark.org`,
+  uncommitted. Not touched this session — separate decision.
+
+## Lesson
+
+Traefik autoreload from a bind-mounted config directory means **live config can
+silently drift from git**. Hot-fixes under pressure need a "did you commit this?"
+step or the drift is invisible until something else pulls the files.


### PR DESCRIPTION
## Summary

- Post-ADR-022 closing work: the \`rate-limit-home-assistant\` middleware (a NAT-era workaround from the 2026-04-12 hot-fix) is removed from both git and the live Traefik config.
- HA router now uses the standard \`rate-limit@file\` tier (100 avg / 50 burst). Per-client buckets are meaningful again post-socket-activation; ~80 parallel JS chunks on an iOS cold-start fit with headroom.
- Surfaces a drift finding: the 2026-04-12 hot-fix was deployed live via bind-mounted config but never committed. Today's edits re-aligned the live config with \`main\` HEAD (net zero diff).

## Lesson

Traefik autoreloads from a bind-mounted config directory, so live config can silently drift from git. Hot-fixes under pressure need a follow-through commit or the drift is invisible.

## Not in this PR (follow-ups)

- Other NAT-era oversized limits: \`rate-limit-qbittorrent\`, \`rate-limit-immich\`, \`rate-limit-nextcloud\`. Each was sized for legitimate bulk ops (thumbnails, PROPFIND walks) and needs per-service reasoning.
- ADR-022 environmental verifications (organic CrowdSec drops, independent per-IP buckets under load).
- Vaultwarden \`EVENTS_DAYS_RETAIN\` still unset.

## Test plan

- [x] HA serves HTTP 200 after edit (\`curl -sL https://ha.patriark.org/\`)
- [x] Traefik log confirms single transient error at file-reload boundary, clean after next poll
- [x] \`git diff HEAD\` confirms net-zero change in config files (live re-aligned with HEAD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)