### PR TITLE
fix: dependency health check recognizes socket/timer units

### DIFF
--- a/scripts/export-dependency-metrics.sh
+++ b/scripts/export-dependency-metrics.sh
@@ -151,8 +151,15 @@ check_dependency_health() {
         return
     fi
 
-    # Check if it's a real systemd service
-    if systemctl --user is-active "$dep.service" >/dev/null 2>&1; then
+    # If target already carries a systemd unit suffix (e.g. https.socket, backup.timer),
+    # query it verbatim. Otherwise default to the .service unit.
+    local unit
+    if [[ "$dep" =~ \.(service|socket|timer|target|mount|path|device|scope|slice)$ ]]; then
+        unit="$dep"
+    else
+        unit="$dep.service"
+    fi
+    if systemctl --user is-active "$unit" >/dev/null 2>&1; then
         echo "1"
         return
     fi


### PR DESCRIPTION
## Summary

- `check_dependency_health()` in `scripts/export-dependency-metrics.sh` hardcoded a `.service` suffix when calling `systemctl is-active`.
- After ADR-022 (#135, merged 2026-04-18) added `http.socket` and `https.socket` as Traefik runtime dependencies, the checker queried the non-existent `https.socket.service` and reported `0` — firing `CriticalServiceDependencyUnhealthy` alerts daily despite both sockets and Traefik being healthy.
- Fix: detect existing systemd unit suffix (`.service|.socket|.timer|.target|.mount|.path|.device|.scope|.slice`) and query the unit verbatim; otherwise append `.service` as before.

## Root cause

```
systemctl --user is-active https.socket           # active
systemctl --user is-active https.socket.service   # inactive  ← what the script checked
```

Graph entry (from `.claude/context/dependency-graph.json`):

```json
{"target": "https.socket", "type": "runtime", "strength": "hard", "source": "quadlet"}
```

## Verification

Pre-fix metric:
```
homelab_dependency_health{dependency="https.socket",homelab_service="traefik",...} 0
```

Post-fix metric (after running `./scripts/export-dependency-metrics.sh`):
```
homelab_dependency_health{dependency="http.socket",...}  1
homelab_dependency_health{dependency="https.socket",...} 1
```

Alert will clear within the 5-minute `for:` window once Prometheus re-scrapes the node_exporter textfile collector.

## Test plan

- [ ] Wait for next `dependency-metrics-export.timer` run (~15 min) and confirm Prometheus scrape shows `homelab_dependency_health{dependency="https.socket"} 1`
- [ ] Confirm `CriticalServiceDependencyUnhealthy` alert resolves in Alertmanager (Discord "resolved" notification expected)
- [ ] Regression check: existing `.service` dependencies still evaluate correctly (no behavior change for non-suffixed targets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)