### PR TITLE
chore: CrowdSec acquisition wiring + post-ADR-022 rate-limit retune + drift sweep

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,18 +80,21 @@ data/*
 # CrowdSec: Un-ignore parent directories first (gitignore requires this)
 !data/crowdsec/
 !data/crowdsec/config/
+!data/crowdsec/config/acquis.d/
 !data/crowdsec/config/parsers/
 !data/crowdsec/config/parsers/s02-enrich/
 
 # CrowdSec: Track custom configs
 !data/crowdsec/config/profiles.yaml
 !data/crowdsec/config/acquis.yaml
+!data/crowdsec/config/acquis.d/*.yaml
 !data/crowdsec/config/parsers/s02-enrich/local-whitelist.yaml
 
 # CrowdSec: Re-ignore everything else in config (secrets, hub, etc.)
 data/crowdsec/config/*
 !data/crowdsec/config/profiles.yaml
 !data/crowdsec/config/acquis.yaml
+!data/crowdsec/config/acquis.d/
 !data/crowdsec/config/parsers/
 data/crowdsec/config/parsers/*
 !data/crowdsec/config/parsers/s02-enrich/

--- a/.gitignore
+++ b/.gitignore
@@ -109,6 +109,12 @@ data/crowdsec/config/parsers/s02-enrich/*
 **/backup/
 **/*.bak
 
+# Build artifacts (binary installers, vendored RPMs)
+builds/**/*.rpm
+builds/**/*.deb
+builds/**/*.tar.gz
+builds/**/*.tar.xz
+
 # OS Files
 .DS_Store
 Thumbs.db

--- a/builds/proton-bridge/Containerfile
+++ b/builds/proton-bridge/Containerfile
@@ -1,0 +1,21 @@
+FROM registry.fedoraproject.org/fedora:43
+
+# Install Proton Mail Bridge from local RPM + netcat for healthcheck
+COPY protonmail-bridge-3.23.1-1.x86_64.rpm /tmp/
+RUN dnf install -y /tmp/protonmail-bridge-3.23.1-1.x86_64.rpm nmap-ncat pass socat && \
+    dnf clean all && \
+    rm -f /tmp/protonmail-bridge-3.23.1-1.x86_64.rpm
+
+# Create home directory for mapped host user (keep-id maps UID 1000)
+RUN mkdir -p /home/bridge && chown 1000:1000 /home/bridge
+ENV HOME=/home/bridge
+
+# Initialize pass (password-store) for bridge keychain
+# GPG key and pass store will be created during first interactive login
+
+# SMTP ports (1025 native + 25 forwarded for Authelia compat)
+EXPOSE 1025/tcp 25/tcp
+
+# Entrypoint script: start socat forwarder + bridge
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]

--- a/builds/proton-bridge/README.md
+++ b/builds/proton-bridge/README.md
@@ -1,0 +1,15 @@
+# Proton Mail Bridge Container
+
+**Status:** Incomplete — see `docs/98-journals/2026-03-31-proton-bridge-smtp-integration-attempt.md`.
+
+## Build requirements
+
+The RPM is not committed (81MB binary, gitignored). Download before building:
+
+```
+# From https://proton.me/mail/bridge
+# Place at: builds/proton-bridge/protonmail-bridge-3.23.1-1.x86_64.rpm
+podman build -t proton-bridge:3.23.1 builds/proton-bridge/
+```
+
+Bridge requires interactive GPG key setup + `pass init` + Proton account login on first run — not suitable for automated quadlet deployment without additional work.

--- a/builds/proton-bridge/entrypoint.sh
+++ b/builds/proton-bridge/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# Forward port 25 → 1025 (Authelia v4.39 hardcodes port 25 for smtp:// scheme)
+socat TCP-LISTEN:25,fork,reuseaddr TCP:127.0.0.1:1025 &
+
+# Start Proton Mail Bridge
+exec /usr/lib/protonmail/bridge/proton-bridge --noninteractive --log-level info "$@"

--- a/config/authelia/configuration.yml
+++ b/config/authelia/configuration.yml
@@ -159,9 +159,20 @@ storage:
 notifier:
   disable_startup_check: false
 
+  # SMTP via Proton Bridge — blocked by AUTH 454 error (bridge requires STARTTLS before AUTH)
+  # TODO: resolve SMTP AUTH issue, then switch back from filesystem to smtp
+  # smtp:
+  #   host: 'proton-bridge'
+  #   port: 25
+  #   timeout: 10s
+  #   username: 'surfaceideology@pm.me'
+  #   # password: set via AUTHELIA_NOTIFIER_SMTP_PASSWORD_FILE env var (Podman secret)
+  #   sender: 'Patriark Homelab <surfaceideology@pm.me>'
+  #   startup_check_address: 'surfaceideology@pm.me'
+  #   disable_starttls: false
+  #   disable_require_tls: false
+  #   tls:
+  #     skip_verify: true
+
   filesystem:
     filename: /data/notification.txt
-
-identity_validation:
-  reset_password:
-    jwt_secret: file:///run/secrets/authelia_jwt_secret

--- a/config/traefik/dynamic/middleware.yml
+++ b/config/traefik/dynamic/middleware.yml
@@ -106,33 +106,37 @@ http:
           ipStrategy:
             depth: 1
 
-    # Nextcloud (authenticated users - high capacity for WebDAV sync, bulk imports)
-    # Burst sized for Music library tree walk (2,080+ directories via PROPFIND)
+    # Nextcloud (per-IP post-ADR-022) — sized for one user's worst-case bulk op.
+    # Burst covers Music library tree walk (~2080 PROPFINDs, parallel ~4–8 conns).
+    # Average drops from NAT-era 600 to steady-state-realistic 300/min.
     rate-limit-nextcloud:
       rateLimit:
-        average: 600      # Higher sustained rate for file/calendar/contact sync
-        burst: 3000       # Support full directory tree PROPFIND + bulk operations
+        average: 300
+        burst: 1500
         period: 1m
         sourceCriterion:
           ipStrategy:
             depth: 1
 
-    # qBittorrent (WebUI loads 500+ resources on first page load: JS, HTML views, images, API calls)
-    # Already behind Authelia SSO — only authenticated users reach this service
+    # qBittorrent (per-IP post-ADR-022, also behind Authelia SSO).
+    # Burst covers initial WebUI page load (~500 resources). Average matches
+    # WebUI poll cadence (~30-60 req/min) with headroom.
     rate-limit-qbittorrent:
       rateLimit:
-        average: 300      # Generous sustained rate for authenticated WebUI
-        burst: 600        # Support initial page load (~500 resources: JS, HTML, images, API)
+        average: 100
+        burst: 600
         period: 1m
         sourceCriterion:
           ipStrategy:
             depth: 1
 
-    # Immich (photo management - high capacity for thumbnail loading)
+    # Immich (per-IP post-ADR-022) — sized for one device's worst-case op.
+    # Burst covers rapid timeline scroll / mobile-app upload burst.
+    # Average drops from NAT-era 500 to realistic browsing rate.
     rate-limit-immich:
       rateLimit:
-        average: 500      # High sustained rate for browsing photo library
-        burst: 2000       # Support rapid thumbnail loading (scrolling through albums)
+        average: 200
+        burst: 1500
         period: 1m
         sourceCriterion:
           ipStrategy:

--- a/config/traefik/dynamic/routers.yml
+++ b/config/traefik/dynamic/routers.yml
@@ -34,9 +34,6 @@ http:
         - websecure
       middlewares:
         - crowdsec-bouncer@file
-        - rate-limit@file               # Standard rate limit (Authelia's built-in regulation handles brute-force)
-        - circuit-breaker@file         # Prevent cascade failures
-        - retry@file                   # Retry transient endpoint errors
         - hsts-only@file               # HSTS + strip server headers (Authelia sets own CSP)
       tls:
         certResolver: letsencrypt

--- a/data/crowdsec/config/acquis.d/traefik.yaml
+++ b/data/crowdsec/config/acquis.d/traefik.yaml
@@ -1,0 +1,18 @@
+# CrowdSec acquisition: Traefik access log
+#
+# Traefik writes JSON access logs to /var/log/traefik/access.log inside its
+# own container, bind-mounted from /mnt/btrfs-pool/subvol7-containers/traefik-logs
+# on the host. CrowdSec mounts the same host path read-only at the same path.
+#
+# traefik.yml filters to statusCodes 400-599 — CrowdSec only sees errors,
+# which is what the scenarios care about (no signal in 2xx traffic).
+#
+# Parser: crowdsecurity/traefik-logs (from crowdsecurity/traefik collection)
+# Scenarios fired: base-http-scenarios + http-cve (via collections)
+#
+# force_inotify: log rotation via logrotate; inotify detects new file correctly.
+filenames:
+  - /var/log/traefik/access.log
+labels:
+  type: traefik
+force_inotify: true

--- a/data/crowdsec/config/acquis.yaml
+++ b/data/crowdsec/config/acquis.yaml
@@ -1,21 +1,17 @@
-# CrowdSec Log Acquisition Configuration
+# CrowdSec Log Acquisition (primary file)
 #
-# Note: CrowdSec primary value comes from CAPI (Community API) which provides
-# 5000+ known-bad IPs from the global CrowdSec community. Local log parsing
-# is secondary and optional.
+# Per-source acquisition configs live in ./acquis.d/ — see that directory
+# for the authoritative source list. This file intentionally empty so the
+# primary and dir-based configs don't double up.
 #
-# Current setup: Minimal configuration (satisfies requirement for datasource)
-# - Primary threat intel: CAPI (5000+ known-bad IPs from global community)
-# - Local acquisition: Placeholder file source (no actual logs processed yet)
+# Active sources (as of 2026-04-21):
+#   - acquis.d/traefik.yaml — Traefik JSON access log (fires base-http + http-cve scenarios)
 #
-# Future enhancement: Configure actual log sources when needed
-# Options: journald export to file, docker socket mount, or syslog
-#
+# Deferred sources:
+#   - sshd journald: SSH is not internet-exposed (UDM doesn't port-forward 22);
+#     LAN-only brute-force is low-value. Revisit if sshd exposure changes.
+#   - Authelia journald: crowdsec:latest image lacks journalctl. Options: (a) switch
+#     to a debian-based image variant, (b) deploy a systemd journal-to-file
+#     bridge, (c) enable LePresidente/authelia collection after wiring a
+#     file-based log path in authelia.container. Separate ADR.
 ---
-# Placeholder file source (satisfies CrowdSec's requirement for at least one datasource)
-# Note: This file doesn't need to exist - CrowdSec will wait for it
-filenames:
-  - /var/log/crowdsec-placeholder.log
-labels:
-  type: syslog
-force_inotify: false

--- a/docs/00-foundation/decisions/2026-04-18-ADR-024-database-dump-backup.md
+++ b/docs/00-foundation/decisions/2026-04-18-ADR-024-database-dump-backup.md
@@ -1,0 +1,192 @@
+# ADR-024: Application-Level Database Dump Backup
+
+**Date:** 2026-04-18
+**Status:** Proposed
+**Replaces (part 1 of 2):** ADR-023 (withdrawn)
+**Companion:** ADR-025 (deferred NOCOW migration)
+
+## Context
+
+The homelab runs five stateful database engines inside `subvol7-containers`, which is snapshotted daily by Urd and sent incrementally to an external drive as the "sheltered" protection tier (ADR-021):
+
+- **postgresql-immich** (PostgreSQL 14) — Immich photo metadata, ~2–10GB
+- **nextcloud-db** (MariaDB) — file sync metadata, 155M
+- **gathio-db** (MongoDB) — event data, 1.1M
+- **prometheus** (TSDB) — metric history, 3.2G
+- **loki** (TSDB) — log history, 574M
+
+Current backup coverage is **snapshot-only**. Each nightly Urd run captures a BTRFS snapshot of `subvol7-containers` and sends the delta externally. Snapshots of a running database are crash-consistent at best. In principle this is recoverable (WAL replay, InnoDB crash recovery, etc.), but three practical gaps exist:
+
+1. **No tested restore path.** Snapshots are taken nightly but restoring a single DB from a snapshot has never been exercised. In a real incident, the procedure would be improvised under pressure.
+2. **No application-consistent backup.** For Postgres and MariaDB, application-consistent dumps have strictly higher integrity guarantees than crash-consistent filesystem snapshots — especially for large, busy databases.
+3. **Prometheus history is load-bearing for the SLO framework and autonomous-operations decisions.** Loss of metric history would degrade operational awareness for the full 15d retention window. The current snapshot path protects the TSDB files but has the same crash-consistency caveats.
+
+Snapshots will continue to exist and will continue to provide bulk recovery for config, logs, and non-DB container state. What's missing is an *application-consistent* layer for the DBs themselves.
+
+This ADR adds that layer without moving any data. Storage layout optimization (NOCOW subvolume migration) is a separate concern addressed in ADR-025 and is explicitly out of scope here.
+
+## Decision
+
+Introduce a nightly database dump job that produces application-consistent backups for each stateful DB, writes them to `subvol7-containers/db-dumps/`, and is automatically protected by Urd via the existing `subvol7-containers` sheltered tier. Databases remain where they are — no storage migration.
+
+### 1. Dump targets and tooling
+
+A systemd user timer (`db-dump.timer`, `db-dump.service`) runs nightly at **01:30** — before Urd's 04:00 run so fresh dumps are included in the next external send.
+
+| Engine | Service | Tool | Flags | Consistency |
+|--------|---------|------|-------|-------------|
+| PostgreSQL 14 | postgresql-immich | `pg_dump --format=custom` via container exec | `--no-owner --no-acl` piped through `zstd -T0` | Application-consistent (MVCC) |
+| MariaDB | nextcloud-db | `mariadb-dump --single-transaction --routines --events` | zstd pipe | Application-consistent (InnoDB snapshot); assumes InnoDB-only schema (true for Nextcloud core) |
+| MongoDB | gathio-db | `mongodump --archive` via container exec | Separate `zstd` step (avoid `--gzip` corrupt-edge-case on older builds) | Best-effort consistent (`--oplog` not needed for single-node) |
+| Prometheus TSDB | prometheus | Admin API `POST /api/v1/admin/tsdb/snapshot?skip_head=false` + `tar \| zstd` | — | Crash-consistent at snapshot time, head captured |
+| Loki TSDB | loki | Stop–rsync–start cycle (no snapshot API in single-binary mode) | zstd compress on final tarball | Application-consistent (stopped) |
+
+**Notes from review:**
+
+- `pg_dump --blobs` is deprecated in PG16 and redundant with `--format=custom`. Not used.
+- `mongodump --archive --gzip` has corrupt-output edge cases on older builds; we split `mongodump --archive` from `zstd` to avoid.
+- Loki is **included** in the dump pipeline — reversing the original plan to exclude it. Rationale: losing Loki history costs the ability to post-mortem the dump job itself if anything goes wrong. Cost of inclusion is low (~574M compressed, brief outage window during stop-rsync-start).
+
+### 2. Output layout
+
+```
+/mnt/btrfs-pool/subvol7-containers/db-dumps/
+├── postgresql-immich/YYYY-MM-DD.dump.zst
+├── nextcloud-db/YYYY-MM-DD.sql.zst
+├── gathio-db/YYYY-MM-DD.archive.zst
+├── prometheus/YYYY-MM-DD.tar.zst
+└── loki/YYYY-MM-DD.tar.zst
+```
+
+### 3. Retention
+
+Local: **14 daily dumps kept per service.** Older dumps pruned by the dump job itself.
+
+External: controlled entirely by Urd's existing `sheltered` tier on `subvol7-containers` — daily snapshots for 14 days, weekly/monthly thinning beyond that. The dump job does not coordinate with Urd; dumps are just files inside a subvolume Urd already protects.
+
+Revisit retention if local footprint exceeds ~50GB (expected peak: ~30GB, dominated by Prometheus).
+
+### 4. Prometheus admin API
+
+Prometheus needs `--web.enable-admin-api` to expose the TSDB snapshot endpoint. This is a **Phase 0 precondition**, not a later step. The admin API adds endpoints that can delete metric data; before enabling, verify:
+
+- Prometheus is not reachable over the network without Traefik in front (it is not — routing audit confirms the `reverse_proxy` network path is the only ingress, and the admin endpoint would be exposed through the standard router).
+- The Traefik router for Prometheus applies the same Authelia middleware as other internal services.
+- If the admin API needs stricter gating than the UI, add a path-specific middleware or bind the admin API to a separate listener.
+
+Acceptable gate for this ADR: the admin API is reachable only by authenticated users through Traefik, matching the existing Prometheus UI access model. If audit reveals gaps, they are fixed before the flag is enabled.
+
+### 5. Prometheus snapshot cleanup
+
+The admin API creates `/prometheus/data/snapshots/<name>/` via hardlinks. Orphaned snapshot directories pin TSDB blocks and prevent compaction reclaim.
+
+The dump job's Prometheus handler runs a defensive pre-clean:
+
+```
+rm -rf /prometheus/data/snapshots/*   # via container exec, older than 1h
+```
+
+Then creates the new snapshot, tars it, and deletes it. This makes the cleanup idempotent — a crashed previous run cannot accumulate orphans forever.
+
+### 6. Restore testing
+
+Restore testing is not optional. A dump nobody has restored is a dump you don't have.
+
+`backup-restore-test.timer` is extended with a new test pass:
+
+- **Weekly cadence** (Sunday 03:00, after the Saturday dumps).
+- **Per-engine ephemeral restore:** spin up a throwaway container from the same image, restore the most recent dump, run engine-specific validation:
+  - PostgreSQL: `pg_controldata`, row count against a known-stable table, `pg_checksums --check`
+  - MariaDB: row count against a known-stable table, `CHECK TABLE` on a sample
+  - MongoDB: collection count, sample query
+  - Prometheus: `promtool tsdb analyze` on restored blocks
+  - Loki: `loki-bundler validate` or equivalent
+- **Prometheus metric written:** `db_restore_test_success{db="..."}` and `db_restore_test_last_timestamp{db="..."}`.
+
+If the restore test fails, an alert fires and the dump for that service is treated as suspect until the next successful test.
+
+### 7. Observability
+
+A new Prometheus textfile metric file, co-located with Urd's:
+
+```
+~/containers/data/backup-metrics/db-dumps.prom
+```
+
+| Metric | Type | Labels | Consumer |
+|--------|------|--------|----------|
+| `db_dump_success` | gauge | `db` | `DBDumpFailed` alert (== 0) |
+| `db_dump_last_success_timestamp` | gauge | `db` | `DBDumpStale` alert (age > 26h) |
+| `db_dump_duration_seconds` | gauge | `db` | Trend monitoring |
+| `db_dump_size_bytes` | gauge | `db` | `DBDumpSizeAnomaly` alert (50% delta) |
+| `db_dump_last_run_timestamp` | gauge | — | `DBDumpJobNotRunning` alert (age > 2d) |
+| `db_restore_test_success` | gauge | `db` | `DBRestoreTestFailed` alert (== 0) |
+| `db_restore_test_last_timestamp` | gauge | `db` | `DBRestoreTestStale` alert (age > 8d) |
+
+Alerts ship in `config/prometheus/alerts/db-dump-alerts.yml`. Naming mirrors Urd's `backup_*` pattern for consistency with existing Grafana panels.
+
+## Phase 0 preconditions (before first dump run)
+
+1. **Verify PostgreSQL checksums via `pg_controldata`.** The `postgresql-immich.container` quadlet sets `POSTGRES_INITDB_ARGS=--data-checksums`, so new clusters get checksums. Verify the live cluster matches. If not, flag as a separate remediation (not blocking this ADR — dumps don't depend on checksums).
+2. **Enumerate per-service container UIDs** (needed for ACL planning in case the dump script runs as an unprivileged user):
+   - postgresql-immich: subuid 100998
+   - nextcloud-db: subuid 100998
+   - gathio-db: subuid 100998
+   - prometheus: subuid 165533
+   - loki: subuid 110000
+
+   The dump job runs as user `patriark` (uid 1000) and uses `podman exec` into each container, so container UID ownership is not the concern for dumps — but documenting these now prevents duplicated work in ADR-025.
+3. **Audit Prometheus admin API exposure** per §4. Fix any gaps before enabling the flag.
+4. **Confirm MongoDB tooling.** The gathio MongoDB image's `mongodump` version and its behavior with `--archive` (without `--gzip`).
+5. **Create `subvol7-containers/db-dumps/` with per-service subdirectories**, owned by `patriark:patriark 0755`.
+
+## Implementation
+
+1. `scripts/db-dump.sh` — per-engine dump functions, retention pruning, metric emission. Exits non-zero on any dump failure.
+2. `systemd/user/db-dump.service` + `db-dump.timer` — daily timer with jitter, `Nice=19`, idle I/O class.
+3. `scripts/db-restore-test.sh` — per-engine ephemeral restore validation, invoked by existing `backup-restore-test.timer`.
+4. `config/prometheus/alerts/db-dump-alerts.yml` — seven alerts from the metrics table.
+5. Grafana panel: "DB Dump Health" — age of last success per DB, size trend, restore test status.
+6. Quadlet edit: add `--web.enable-admin-api` to `quadlets/prometheus.container` Exec line.
+7. Runbook: per-engine restore procedure in `docs/20-operations/runbooks/db-dump-restore.md`.
+
+No container storage paths change. No service downtime required for rollout (except Loki's brief stop-rsync-start during each nightly dump).
+
+## Consequences
+
+### Positive
+
+- **Application-consistent backups** for all DBs, replacing reliance on crash-consistent snapshots.
+- **Tested restore paths.** Weekly restore validation catches silent corruption before an incident.
+- **Prometheus history protected** via admin-API snapshot — preserving SLO framework and autonomous-operations inputs.
+- **Strictly additive.** No storage migration, no downtime beyond Loki's brief window, no quadlet path changes, no Urd contract changes, no ACL reshuffling.
+- **Reversible.** If the dump job causes problems, disable the timer. DBs continue operating normally with no cleanup required.
+- **Independent of the NOCOW migration question.** If ADR-025 is later accepted, dumps continue working unchanged. If ADR-025 is permanently shelved, dumps still deliver the backup capability on their own.
+
+### Negative
+
+- **Loki outage window each night.** Stop-rsync-start cycle causes ~30s ingestion gap; promtail buffers during the window so no permanent log loss, but queries during the window return partial results. Acceptable given nightly cadence.
+- **Disk footprint.** Local 14-day retention adds ~30GB peak to `subvol7-containers`. Pool has 3.6TB free; non-issue.
+- **New failure surface.** The dump job itself can fail silently if alerting is misconfigured. Mitigated by the `DBDumpJobNotRunning` alert (age > 2d on `db_dump_last_run_timestamp`).
+- **Fragmentation persists.** DBs remain in a COW'd snapshotted subvolume. If measurements later show fragmentation is actually hurting performance, ADR-025 will address it; this ADR does not.
+
+### Constraints
+
+- Dump job must be idempotent per night. Repeated runs within the same day overwrite the day's dump (naming by `YYYY-MM-DD`).
+- Dump failures for one service must not abort the job — each engine runs in isolation and emits its own success/failure metric.
+- Restore tests must use isolated containers (separate from production) and cleaned up after each run.
+
+## Open questions
+
+1. **Does the live postgresql-immich cluster have `data_checksums=on`?** Verifiable via `pg_controldata`; resolve in Phase 0.
+2. **Is the gathio MongoDB version new enough for `mongodump --archive` without edge cases?** Verify in Phase 0.
+3. **Does Prometheus admin API need path-level authentication stricter than the UI?** Traefik middleware audit in Phase 0.
+4. **Should dumps eventually be encrypted at rest?** Deferred — external drives are LUKS-encrypted; local dumps on homelab disk match the existing container data trust level.
+
+## Related
+
+- **ADR-023 (withdrawn):** Original bundled design; this ADR is the strictly-additive half.
+- **ADR-025:** NOCOW storage migration (deferred pending measurements); complements this ADR if later accepted.
+- **ADR-021:** Urd integration contract; unchanged by this ADR.
+- **ADR-020:** External backup strategy; dumps inherit this protection via `subvol7-containers`.
+- **Review:** `docs/99-reports/2026-04-18-design-review-ADR-023-btrfs-storage-architecture-databases.md`.

--- a/docs/00-foundation/decisions/2026-04-18-ADR-025-db-storage-migration-deferred.md
+++ b/docs/00-foundation/decisions/2026-04-18-ADR-025-db-storage-migration-deferred.md
@@ -1,0 +1,254 @@
+# ADR-025: Database Storage Migration to NOCOW Subvolume (Deferred)
+
+**Date:** 2026-04-18
+**Status:** Deferred (conditional acceptance pending baseline measurements)
+**Replaces (part 2 of 2):** ADR-023 (withdrawn)
+**Companion:** ADR-024 (dump-based backup — accepted and shipping first)
+**Earliest review for acceptance:** 2026-06-18 (60 days after ADR-024 begins running)
+
+## Context
+
+BTRFS has a known antipattern: files with `chattr +C` (NOCOW) inside a snapshotted subvolume do not actually retain NOCOW behavior. The first write to any extent shared with a snapshot forces copy-on-write regardless of the NOCOW flag. Every snapshot pins the old extents, so each daily snapshot effectively re-COWs the write-hot regions of database files.
+
+Our current state has this problem, inconsistently applied:
+
+- `nextcloud-db` (MariaDB 155M): **no NOCOW** — fully COW'd, inside snapshotted subvol
+- `loki` (TSDB 574M): **no NOCOW** — fully COW'd, inside snapshotted subvol
+- `postgresql-immich`: NOCOW flag inheritance unclear, but defeated by snapshots regardless
+- `gathio-db`: NOCOW set, but defeated by snapshots
+- `prometheus`: NOCOW set, but defeated by snapshots
+
+The theoretically correct solution is a dedicated NOCOW subvolume (`subvol8-db`) excluded from Urd snapshots, with application-level dumps providing backup coverage. The predecessor ADR-023 proposed this migration and bundled it with introducing dump-based backup.
+
+The adversarial review of ADR-023 raised a fundamental objection: **the migration's premise is theoretical, not measured.** On a 30-container homelab with light load, the practical cost of COW-induced fragmentation may be well below any threshold that justifies the risk of migrating five production databases. The correct decision order is:
+
+1. Ship dumps first (ADR-024) — strictly additive, low-risk, delivers most of the backup value.
+2. Gather baseline measurements on DBs-in-place for 60 days.
+3. Decide whether migration is justified by evidence.
+
+This ADR documents the migration plan so it's ready to execute if measurements justify, but defers acceptance until the measurements exist.
+
+## Decision (deferred)
+
+**If measurements show the COW-in-snapshotted-subvol antipattern is costing measurable performance or backup-window impact**, migrate the five affected databases to a dedicated NOCOW subvolume `subvol8-db` at `/mnt/btrfs-pool/subvol8-db`, excluded from Urd. Backup coverage transfers fully to the ADR-024 dump path (already operational by that point).
+
+**If measurements show the antipattern is not costing anything measurable**, this ADR stays Deferred indefinitely or is itself withdrawn. DBs remain in `subvol7-containers` and the ADR-024 dump path is the sole backup mechanism — which is the complete, correct, and sufficient solution.
+
+## Acceptance criteria — what evidence justifies migration
+
+Migration is justified if **any one** of the following measurements shows a material problem:
+
+### 1. Fragmentation
+
+Run monthly for 60 days after ADR-024 ships:
+
+```
+filefrag -v /mnt/btrfs-pool/subvol7-containers/{postgresql-immich,nextcloud-db,gathio-db,prometheus,loki}/**/*
+```
+
+Thresholds:
+- **Accept migration** if any single DB file shows >5000 extents sustained, OR if aggregate extent count across DB files grows >50% over a 30-day window.
+- **Defer indefinitely** if extent counts stabilize below 1000 per file.
+
+### 2. Query latency (Immich PG specifically, as the largest DB)
+
+Grafana panel tracking Immich's `/api` p99 latency, added as part of ADR-024's observability work.
+
+Thresholds:
+- **Accept migration** if Immich API p99 > 500ms sustained for 7+ days with DB I/O as the confirmed culprit (`iostat` on the pool shows sustained >80% utilization attributable to the Immich PG container).
+- **Defer indefinitely** if p99 stays below 200ms.
+
+### 3. Snapshot send duration
+
+Urd already emits `backup_duration_seconds{subvolume="subvol7-containers"}`.
+
+Thresholds:
+- **Accept migration** if median send duration grows >3× over 60 days *and* analysis traces the growth to DB churn (via `btrfs subvolume find-new` on the DB directories).
+- **Defer indefinitely** if send duration is flat or growth tracks linearly with non-DB data growth.
+
+### 4. Operator pain
+
+A softer criterion but legitimate: if DB-in-COW-subvol causes unexpected operational issues (e.g., snapshot cleanup failing, pool fragmentation warnings in dmesg, unexpected space pressure from snapshot residency), those count as evidence.
+
+All four criteria must be evaluated together. A single data point doesn't justify migration; a pattern across criteria does.
+
+## Proposed design (if accepted)
+
+### Storage layout
+
+```
+/mnt/btrfs-pool/subvol8-db (NEW)       [NOCOW inherited, compression=none, NOT in Urd]
+├── postgresql-immich/                 [subuid 100998; traversal ACL required]
+├── nextcloud-db/                      [subuid 100998]
+├── gathio-db/                         [subuid 100998]
+├── prometheus/                        [subuid 165533]
+└── loki/                              [subuid 110000]
+```
+
+Compression is explicitly disabled via `btrfs property set subvol8-db compression none` — every listed engine already compresses at the page/chunk layer; stacking zstd on top wastes CPU with no storage benefit.
+
+### What moves vs stays
+
+**Moves to subvol8-db:** the five databases above.
+
+**Stays on subvol7-containers:** Redis (redis-immich, nextcloud-redis) — RDB persistence is whole-file rewrite pattern, not affected by COW fragmentation; snapshots retain session state meaningfully; size is trivial. All non-DB container state (configs, logs, caches) also stays.
+
+### ACL model
+
+`subvol8-db` uses ACLs per ADR-019's pattern, but with **two layers** of access because the subvolume itself must be traversable by each container's subuid:
+
+1. **Parent-level traversal ACLs** on `subvol8-db/`:
+   ```
+   setfacl -m u:100998:--x /mnt/btrfs-pool/subvol8-db   # postgres/maria/mongo
+   setfacl -m u:165533:--x /mnt/btrfs-pool/subvol8-db   # prometheus
+   setfacl -m u:110000:--x /mnt/btrfs-pool/subvol8-db   # loki
+   ```
+
+2. **Per-service directory ACLs** on `subvol8-db/<service>/`:
+   ```
+   setfacl -R -m u:<subuid>:rwx /mnt/btrfs-pool/subvol8-db/<service>
+   setfacl -R -d -m u:<subuid>:rwx /mnt/btrfs-pool/subvol8-db/<service>
+   ```
+
+Omitting either layer causes the container to fail at startup with a traversal error that doesn't clearly point at the ACL — this is the most likely cause of a failed migration if executed carelessly.
+
+### Urd integration
+
+`subvol8-db` is **not** added to Urd. This is deliberate: the DBs' live files are not what we back up. The backup is the dumps in `subvol7-containers/db-dumps/` produced by ADR-024's pipeline.
+
+To maintain operator legibility, add a note to Urd's config (or a CLAUDE.md reference) making this explicit: "subvol8-db is intentionally excluded — DB backup is via application-level dumps (ADR-024), not filesystem snapshots."
+
+### Data checksums
+
+NOCOW disables BTRFS data checksums. Each engine must provide its own integrity checking:
+
+| Engine | Integrity mechanism | Default state |
+|--------|---------------------|---------------|
+| PostgreSQL | `data_checksums` at `initdb` time | Quadlet sets `POSTGRES_INITDB_ARGS=--data-checksums`; live state to be verified before migration via `pg_controldata` |
+| MariaDB/InnoDB | `innodb_checksum_algorithm=crc32` | Default on MariaDB 10.5+ |
+| MongoDB/WiredTiger | Page-level checksums | Default |
+| Prometheus TSDB | Per-chunk CRC32 | Default |
+| Loki | Per-chunk checksums | Default |
+
+### Migration procedure (if executed)
+
+Per-service, ordered smallest-first to build confidence: gathio-db → nextcloud-db → loki → prometheus → postgresql-immich.
+
+For each service:
+
+1. **Stop the service** and any dependents.
+2. **Take a final dump** via the ADR-024 tooling — this is the rollback artifact.
+3. **Create target directory** in `subvol8-db/<service>/` with correct ACLs (parent traversal + per-service rwx + default).
+4. **Move the data**:
+   - For PostgreSQL: **do not run initdb on the host**. The container's entrypoint creates the cluster with the env-configured flags. Empty the target dir, start the container with an empty data volume, let initdb happen inside the container, stop, then restore from the dump.
+   - For MariaDB/MongoDB/Loki/Prometheus: `rsync -aHX --numeric-ids <source>/ <target>/`. **No `cp --reflink`, no `--inplace`**. Post-copy verify with `lsattr` (expect `C` flag) and `filefrag -v` (expect no shared extents).
+5. **Update the quadlet** `Volume=` line to the new path.
+6. **`systemctl --user daemon-reload && systemctl --user start <service>.service`**.
+7. **Verify service health** via its HTTP/TCP probe and container logs.
+8. **Rename source dir** to `<service>.pre-migration-YYYY-MM-DD` and retain for 14 days.
+9. **Trigger a manual dump** to confirm the dump pipeline still works against the new location.
+10. **Run the restore test** against the fresh dump to confirm end-to-end.
+
+### Defensive migration tooling
+
+If migration is accepted, the procedure above is implemented as a tool, not executed by hand:
+
+- `scripts/migrate-db-to-subvol8.sh <service>` — per-service migration with:
+  - Dry-run by default; `--execute` required for destructive steps
+  - Hard enforcement of `rsync` flags (no environment-inherited aliases)
+  - Post-copy verification: `lsattr` shows `C` flag on every copied file, `filefrag` confirms no shared extents
+  - ACL verification: every expected ACL is present before the service is started
+  - Service-health verification before the source dir is renamed
+  - Rollback subcommand: `migrate-db-to-subvol8.sh rollback <service>` that reverses the quadlet edit, re-mounts the old dir, and restarts
+
+The tool is itself reviewed before migration proceeds — this is the riskiest moment in the migration path and improvised shell commands are not acceptable.
+
+### Observability gap during Prometheus migration
+
+Moving Prometheus takes 5–10 minutes (dump + rsync + restart). During this window:
+
+- Metric ingestion stops; Grafana renders gaps as nulls.
+- Alerts with `for: 5m` may miss state transitions.
+- Autonomous-operations OODA loops must be paused (they're triggered by cron; disable the relevant timer for the migration window).
+- Plan the migration window during low-activity hours (early morning weekday) to minimize lost context.
+
+## If the measurements say "don't migrate"
+
+If 60 days of evidence say the COW-in-snapshotted-subvol cost is negligible, the right action is:
+
+- Mark this ADR **Withdrawn** with a note explaining why (a valuable historical record — "we almost did this and measurement said no").
+- Keep ADR-024 as the complete backup solution.
+- Accept the fragmentation cost as part of the homelab's operating envelope.
+
+This is a legitimate and likely outcome. It is not a failure of this ADR; it is the ADR doing its job — preventing a preemptive optimization that isn't earning its keep.
+
+## Preconditions for triggering acceptance
+
+Before this ADR can move from Deferred to Accepted, all of these must hold:
+
+1. **ADR-024 has been operational for at least 60 days** and its dumps have passed at least four weekly restore tests per service without failure.
+2. **At least one of the acceptance criteria above is met** based on real measurements in the Grafana dashboard.
+3. **The defensive migration tool is written and reviewed**, not just planned.
+4. **A specific migration window is scheduled** with stakeholder awareness (the homelab owner, since that's the stakeholder).
+5. **A tested rollback path exists** — the tool's `rollback` subcommand has been exercised against a non-production service (e.g., spin up a throwaway Postgres, migrate it, roll it back, verify).
+
+## Consequences (if accepted)
+
+### Positive
+
+- NOCOW actually works — no snapshot interference, write-in-place on HDD for DB workloads.
+- `subvol7-containers` snapshot deltas shrink when DB churn is removed. External send times drop; snapshot residency shrinks.
+- Cleaner storage model: DBs in their own subvolume, aligned with BTRFS best practice.
+
+### Negative
+
+- **Loss of crash-consistent snapshot rollback for DBs.** Bad Immich migration? Restore path is "yesterday's dump," not "reset to 10 minutes ago." Dumps are the only recovery — but that's already true operationally; snapshots of running DBs are not a trusted recovery path today.
+- **Migration risk surface.** Five services move in sequence; each is a potential failure point. Mitigated by dry-run tool, small-first ordering, per-service dump as rollback artifact.
+- **Operational complexity increases.** New subvolume to manage, new ACL pattern to maintain, Urd status no longer covers these services (documented, but a real UX cost).
+
+### Constraints
+
+- Dumps must be fully operational and tested *before* migration begins — ADR-024 is a hard dependency.
+- Every migration step must be reversible per-service before moving to the next.
+- If any service's migration fails in a way that can't be cleanly rolled back, the remaining services stay in `subvol7-containers`. Partial migration is acceptable; forced completion is not.
+
+## Alternatives considered (if measurements justify action, but not this plan)
+
+**1. Move DBs to NVMe.** Rejected — NVMe is 90% full (13GB free). Not viable regardless.
+
+**2. Keep current layout, fix NOCOW flags that are missing.** Rejected — NOCOW is defeated by snapshots anyway. Doesn't solve the actual problem.
+
+**3. Disable snapshots on subvol7-containers.** Rejected — container configs genuinely benefit from snapshot-based rollback for config mistakes. Cure worse than disease.
+
+**4. Nested subvolume inside subvol7-containers instead of top-level subvol8-db.** Rejected in the predecessor ADR on "legibility" grounds. Reconsidered in review: nested would work semantically. Top-level was retained because (a) it surfaces clearly in `btrfs subvolume list`, (b) it matches the existing subvolume naming pattern, (c) it makes the Urd exclusion explicit in the top-level structure. Nested remains a legitimate fallback if top-level encounters unforeseen issues.
+
+**5. Periodic `btrfs filesystem defragment` on DB dirs.** Rejected — running defrag on files in a snapshotted subvolume unshares extents, doubling space use. Would cost significant pool space per run.
+
+**6. Disable `autodefrag` globally.** Considered. `autodefrag` primarily affects COW files; NOCOW files (if they exist) are immune. For a mixed workload (docs, media, containers) on HDD, autodefrag is net-beneficial. Disabling it to optimize for DB workload would regress everything else. Not pursued.
+
+## Open questions (to resolve during measurement window)
+
+1. **What are the actual filefrag counts?** Unknown today. Single most important missing input.
+2. **Does Immich API p99 correlate with Postgres container I/O?** Unknown today. Requires Grafana panel instrumentation as part of ADR-024.
+3. **How much of `subvol7-containers` snapshot delta is DB churn?** Unknown today. Requires `btrfs subvolume find-new` or similar analysis.
+4. **Does rootless Podman have any interaction with nested subvolumes we haven't accounted for?** Unknown. If top-level approach encounters unexpected issues, this becomes the fallback question to investigate.
+5. **Would the Urd project benefit from a "known excluded subvolumes" config field** so `urd status` can explicitly show "subvol8-db: excluded by design" rather than silently not covering it? Out of scope here; flag for the Urd project's own ADR list.
+
+## Related
+
+- **ADR-023 (withdrawn):** Original bundled design; split into ADR-024 + this ADR.
+- **ADR-024 (accepted):** Dump-based backup. Hard dependency — must be operational and tested before this ADR can become Accepted.
+- **ADR-021:** Urd integration contract. Unchanged by this ADR (exclusion is by omission, not by contract change).
+- **ADR-020:** External backup strategy. Dumps from ADR-024 inherit this; live DB files in subvol8-db deliberately do not.
+- **ADR-019:** Filesystem permission model. Extended with the two-layer ACL pattern documented above.
+- **Review:** `docs/99-reports/2026-04-18-design-review-ADR-023-btrfs-storage-architecture-databases.md`.
+
+## Revisiting this ADR
+
+Revisit no earlier than 2026-06-18. At that time:
+
+- Read the 60-day Grafana baseline.
+- Evaluate against the acceptance criteria above.
+- If accepted: build the migration tool, schedule the window, execute.
+- If not accepted: mark this ADR **Withdrawn** and update ADR-024 to reflect that it is the complete solution.
+- If inconclusive: extend the measurement window by another 60 days and revisit.

--- a/docs/00-foundation/decisions/withdrawn/2026-04-18-ADR-023-btrfs-storage-architecture-databases.md
+++ b/docs/00-foundation/decisions/withdrawn/2026-04-18-ADR-023-btrfs-storage-architecture-databases.md
@@ -1,0 +1,322 @@
+# ADR-023: BTRFS Storage Architecture for Database Workloads (WITHDRAWN)
+
+**Date:** 2026-04-18
+**Status:** Withdrawn (2026-04-18) — never accepted, replaced after adversarial review
+**Replaced by:** ADR-024 (dump-based backup) + ADR-025 (deferred NOCOW migration)
+**Review:** `docs/99-reports/2026-04-18-design-review-ADR-023-btrfs-storage-architecture-databases.md`
+
+## Why this was withdrawn
+
+This ADR bundled two orthogonal changes — introducing application-level database dumps (strictly additive, low-risk) and migrating databases to a dedicated NOCOW subvolume (preemptive optimization, higher-risk) — into a single plan. Parallel reviews by `infrastructure-architect` and `arch-adversary` agreed that:
+
+1. The dump-based backup change is valuable and should ship independently.
+2. The NOCOW migration was premised on theoretical fragmentation symptoms that had not been measured on the live system. On a 30-container homelab with light load, the symptoms may be below any threshold that justifies migration risk.
+3. Bundling the two forced the low-risk change to carry the risk profile of the higher-risk change.
+
+The plan was split:
+
+- **ADR-024:** Ships dump-based backup now. Databases stay where they are in `subvol7-containers`. Dumps land in `subvol7-containers/db-dumps/` and Urd protects them via the existing sheltered tier.
+- **ADR-025:** Defines the NOCOW migration plan but marks it Deferred pending 60 days of baseline measurements (filefrag counts, query p99, snapshot send duration). If measurements justify, ADR-025 becomes Accepted; if not, it stays Deferred or is itself withdrawn.
+
+The content below is preserved unchanged for historical record. Do not implement from this document — refer to ADR-024 and ADR-025.
+
+---
+
+## Original ADR content (preserved for historical record)
+
+**Date:** 2026-04-18
+**Status at withdrawal:** Proposed
+**Original Supersedes:** None (extends the storage model implicit in ADR-009, ADR-019, ADR-020, ADR-021)
+
+## Context
+
+The homelab's BTRFS storage grew organically. Media, user documents, container configs, and database state all coexist inside `subvol7-containers`, which is snapshotted daily by Urd and sent incrementally to an external drive as the "sheltered" protection tier (ADR-021).
+
+Recent investigation surfaced a structural flaw in this layout: **databases with NOCOW set (`chattr +C`) inside a snapshotted subvolume do not actually remain NOCOW.** The BTRFS extent tree forces copy-on-write on the first modification of any extent shared with a snapshot, regardless of the NOCOW flag on the file. The flag is preserved on newly allocated extents but the initial write after each snapshot allocates a new extent — effectively reinstating COW on the write-hot region of every database file, every day.
+
+Symptoms this produces on our 4×4TB HDD pool:
+
+1. **Fragmentation returns** despite NOCOW. Database files accumulate thousands of small extents over time, degrading sequential scan and checkpoint performance.
+2. **Write amplification.** Every snapshot window causes the DB to re-COW hot pages on next write. On spinning rust with 100-200 random IOPS per drive, this is an order of magnitude more expensive than on SSD.
+3. **`autodefrag` interaction.** The pool is mounted with `autodefrag,compress=zstd:1,commit=120`. Autodefrag does not touch genuinely NOCOW files, but the snapshot-induced COW pages become eligible, increasing background I/O pressure.
+4. **Snapshot bloat.** Each daily snapshot pins the old extents until retention drops the snapshot. A 3.2G Prometheus TSDB with daily churn adds multi-GB to the pool's snapshot residency even though we never restore from a snapshot for these workloads.
+5. **Inconsistent implementation.** Audit of the current state:
+   - `postgresql-immich`: NOCOW not set (directory inherited, but unclear if child extents are NOCOW)
+   - `nextcloud-db` (MariaDB 155M): **NOCOW not set** — fully COW'd
+   - `gathio-db` (MongoDB 1.1M): NOCOW set (but defeated by snapshots)
+   - `prometheus` (3.2G): NOCOW set (but defeated by snapshots)
+   - `loki` (574M): **NOCOW not set** — fully COW'd
+
+   Two critical databases have zero NOCOW protection, and the ones that do are partially defeated. This is not a working design.
+
+### Hardware constraint
+
+The NVMe (128GB) is 90% full with OS, `/home`, and user content. It cannot host database data without displacing existing workloads. All bulk storage must live on the 4×4TB HDD pool. Therefore the question is *how* to host databases on BTRFS-on-HDD correctly, not *whether* to move them off.
+
+### Data ownership constraint
+
+The BTRFS pool runs Single profile (no RAID). External backups to WD-18TB drives are the sole protection against disk failure (ADR-020). Any storage layout must preserve backup coverage for business-critical database state.
+
+## Decision
+
+Introduce a dedicated NOCOW subvolume for database workloads, excluded from the snapshot-based backup path, with application-level dumps providing backup coverage that Urd protects through the existing `subvol7-containers` path.
+
+### 1. Create `subvol8-db`
+
+```
+/mnt/btrfs-pool/subvol8-db/    (NOCOW inherited, not in Urd)
+├── postgresql-immich/
+├── nextcloud-db/
+├── gathio-db/
+├── prometheus/
+└── loki/
+```
+
+The subvolume has the NOCOW attribute set **before** any data lands inside it, so new files inherit NOCOW automatically. Compression is disabled via `btrfs property set /mnt/btrfs-pool/subvol8-db compression none` because every listed engine already compresses at the page/chunk layer; stacking zstd on top wastes CPU with no storage benefit.
+
+### 2. Workload assignment
+
+**Move to `subvol8-db` (NOCOW, not snapshotted):**
+
+| Service | Engine | Size | Reason |
+|---------|--------|------|--------|
+| postgresql-immich | PostgreSQL 14 | ~2–10GB | Heavy random write, WAL churn, critical |
+| nextcloud-db | MariaDB | 155M | InnoDB random write, metadata-heavy |
+| gathio-db | MongoDB | 1.1M | WiredTiger write amplification |
+| prometheus | TSDB | 3.2G | High-rate append, 15d compaction cycle |
+| loki | TSDB | 574M | Per-chunk rewrites, compaction |
+
+**Stays on `subvol7-containers` (COW, snapshotted):**
+
+| Service | Reason |
+|---------|--------|
+| redis-immich, nextcloud-redis | RDB persistence is whole-file rewrite; AOF is append; snapshots retain recent state meaningfully |
+| traefik-logs | Append-mostly, rotated independently |
+| immich-ml-cache | Ephemeral, recomputable |
+| jellyfin-config, navidrome, audiobookshelf | Small SQLite, low write rate — COW overhead negligible |
+
+Redis is the borderline case. RDB's whole-file rewrite pattern does not trigger the fragmentation problem NOCOW solves, and its size is trivial. Keeping it in the snapshotted subvol preserves point-in-time recovery for authn session state.
+
+### 3. Backup strategy: application-level dumps
+
+Database backups shift from filesystem snapshots to **engine-native dumps**, written to a directory that *is* inside the snapshotted subvolume:
+
+```
+/mnt/btrfs-pool/subvol7-containers/db-dumps/
+├── postgresql-immich/YYYY-MM-DD.dump.zst
+├── nextcloud-db/YYYY-MM-DD.sql.zst
+└── gathio-db/YYYY-MM-DD.archive.zst
+```
+
+A systemd user timer (`db-dump.timer`, `db-dump.service`) runs nightly at **01:30** (before Urd's 04:00 run, so the freshest dumps are included in the next external send).
+
+Dump tooling per engine:
+
+| Engine | Tool | Flags | Consistency |
+|--------|------|-------|-------------|
+| PostgreSQL | `pg_dump --format=custom` piped through `zstd` | `--blobs`, `--no-owner`, `--no-acl` | Application-consistent (MVCC) |
+| MariaDB | `mariadb-dump --single-transaction --routines --events` | zstd pipe | Application-consistent (InnoDB snapshot) |
+| MongoDB | `mongodump --archive --gzip` | — | Best-effort consistent (`--oplog` if needed) |
+| Prometheus | Admin API TSDB snapshot + tar/zstd | `POST /api/v1/admin/tsdb/snapshot?skip_head=false` | Crash-consistent at snapshot time |
+
+**Prometheus preservation rationale.** Prometheus history is load-bearing for the SLO framework, Grafana dashboards, and capacity-trend analysis. Losing it on disk failure is not acceptable.
+
+The dump path uses Prometheus's built-in admin API (`/api/v1/admin/tsdb/snapshot`), which creates a hardlink-based snapshot of the TSDB inside `/prometheus/snapshots/<timestamp>/`. Since TSDB blocks are immutable once written, hardlinks produce a crash-consistent view with near-zero additional space until the next block compaction. The dump job then tars the snapshot directory through `zstd -T0 --long`, writes the result to `db-dumps/prometheus/`, and deletes the hardlink snapshot. Expected compressed size: ~1–2GB per dump given TSDB's internal gorilla encoding already limits zstd's additional ratio.
+
+This requires adding `--web.enable-admin-api` to the Prometheus quadlet's `Exec=` line. The admin API is reachable only on the container network (no external exposure), so the risk surface is internal only.
+
+Retention: **14 daily dumps kept locally**, older dumps pruned. Urd's `sheltered` tier on `subvol7-containers` preserves daily snapshots for 14 days plus graduated tiers out to ~5 months, so the effective dump history on the external drive extends well beyond 14 days.
+
+Retention is a **separate concern** from Urd's snapshot retention. Urd controls how long DB *dumps* persist on the external drive (by virtue of snapshotting `subvol7-containers` which contains the dump directory). The local dump retention in `db-dumps/` is controlled by the dump job itself — this ADR proposes 14 dailies as a starting point; revisit after operational experience.
+
+### 4. TSDB handling: Prometheus dumped, Loki accepts loss
+
+Both TSDBs live in `subvol8-db` for the performance benefits (NOCOW + no snapshots). They differ in backup treatment:
+
+- **Prometheus** is dumped nightly via the admin API snapshot path described in §3. The SLO framework, Grafana dashboards, and autonomous-operations decision loops all depend on metric history; loss would degrade operational awareness for weeks as the 15d retention refills.
+- **Loki** is **not dumped.** On total loss, the historical log index is gone but `promtail` resumes ingestion from the journal tail and new container logs, and the homelab's log retention needs are shorter than Prometheus's metric needs. Logs also exist in the journald source, which is not protected by this ADR but is at least a second copy. If Loki loss becomes operationally painful, extending the dump job to include Loki's store via filesystem rsync-of-stopped-service is a reasonable follow-up — flagged in Open Questions.
+
+### 5. DB-level checksums replace BTRFS checksums
+
+NOCOW disables BTRFS data checksums. Each engine must carry its own integrity checking:
+
+- **PostgreSQL:** enable `data_checksums` — requires `initdb --data-checksums`. The Immich migration is an opportunity to re-initdb the cluster with checksums on (previously off). Verified via `pg_checksums --check` after migration.
+- **MariaDB/InnoDB:** `innodb_checksum_algorithm=crc32` is default on MariaDB 10.5+. Already in effect.
+- **MongoDB/WiredTiger:** page-level checksums enabled by default.
+- **Prometheus:** TSDB block format has per-chunk CRC32. Head segment replay detects corruption.
+- **Loki:** per-chunk checksums in the store schema.
+
+### 6. Urd integration
+
+`subvol8-db` is **not** added to Urd's subvolume list. Urd never snapshots it, never sends it externally, never alerts on its absence.
+
+Instead, a new Prometheus textfile metric file written by the dump job integrates into the existing observability path:
+
+```
+~/containers/data/backup-metrics/db-dumps.prom
+```
+
+Metrics (mirroring Urd's naming):
+
+| Metric | Type | Labels | Consumer |
+|--------|------|--------|----------|
+| `db_dump_success` | gauge | `db` | `DBDumpFailed` alert (== 0) |
+| `db_dump_last_success_timestamp` | gauge | `db` | `DBDumpStale` alert (age > 26h) |
+| `db_dump_duration_seconds` | gauge | `db` | Trend monitoring |
+| `db_dump_size_bytes` | gauge | `db` | `DBDumpSizeAnomaly` alert (50% delta) |
+| `db_dump_last_run_timestamp` | gauge | — | `DBDumpJobNotRunning` alert (age > 2d) |
+
+The metric file sits in the same directory as Urd's `backup.prom` and is collected by the same `node_exporter` textfile mount — no new container wiring required.
+
+### 7. Mount options unchanged
+
+The global `/mnt` mount retains `compress=zstd:1,space_cache=v2,autodefrag,commit=120,noatime`. Rationale:
+
+- **autodefrag:** remains valuable for COW'd subvolumes on HDD. NOCOW files are immune regardless.
+- **compress=zstd:1:** beneficial for docs/pics/multimedia. Overridden to `none` on subvol8-db via BTRFS property.
+- **commit=120:** preserves write batching benefits. DB engines fsync independently when they need durability.
+
+## Architecture
+
+```
+/mnt/btrfs-pool/                          [4×4TB HDD, Single profile, autodefrag, zstd:1]
+├── subvol1-docs                          [COW, snapshot, Urd sheltered]
+├── subvol2-pics                          [COW, snapshot, Urd fortified]
+├── subvol3-opptak                        [COW, snapshot, Urd fortified]
+├── subvol4-multimedia                    [COW, snapshot, Urd recorded]
+├── subvol5-music                         [COW, snapshot, Urd sheltered]
+├── subvol6-tmp                           [COW, snapshot, Urd custom]
+├── subvol7-containers                    [COW, snapshot, Urd sheltered]
+│   ├── (existing container data)
+│   └── db-dumps/                         [NEW — nightly DB dumps land here]
+└── subvol8-db (NEW)                      [NOCOW, compression=none, NOT in Urd]
+    ├── postgresql-immich/
+    ├── nextcloud-db/
+    ├── gathio-db/
+    ├── prometheus/
+    └── loki/
+```
+
+Backup flow for DB data:
+```
+01:30 — db-dump.service runs
+         pg_dump | zstd       → subvol7-containers/db-dumps/postgresql-immich/
+         mariadb-dump…        → subvol7-containers/db-dumps/nextcloud-db/
+         mongodump            → subvol7-containers/db-dumps/gathio-db/
+         Prom admin-API + tar → subvol7-containers/db-dumps/prometheus/
+         (loki: no dump)
+         Writes db-dumps.prom metrics
+04:00 — urd-backup.service runs
+         Snapshots subvol7-containers (includes fresh dumps)
+         Incremental send to WD-18TB
+```
+
+## Migration Plan
+
+Per-service migration, ordered by risk (smallest DB first to build confidence):
+
+### Phase 0 — Infrastructure (no service impact)
+
+1. `btrfs subvolume create /mnt/btrfs-pool/subvol8-db`
+2. `chattr +C /mnt/btrfs-pool/subvol8-db` (inherited by new files/dirs)
+3. `btrfs property set /mnt/btrfs-pool/subvol8-db compression none`
+4. Set ownership per ADR-019: `patriark:patriark 0755`, ACLs added per-service as needed
+5. Create `/mnt/btrfs-pool/subvol7-containers/db-dumps/` with per-service subdirs
+6. Deploy `scripts/db-dump.sh` + systemd user units (`db-dump.service`, `db-dump.timer`)
+7. Run dump job manually against current (pre-migration) DBs to validate tooling and verify dumps restore cleanly in a sandbox
+
+### Phase 1 — Per-service migration
+
+For each service (suggested order: gathio-db → nextcloud-db → loki → prometheus → postgresql-immich):
+
+**Prometheus extra step:** add `--web.enable-admin-api` to the `Exec=` line in `quadlets/prometheus.container` as part of the migration PR. The flag must be live before the first dump run succeeds.
+
+
+1. `systemctl --user stop <service>.service` (and any dependent services)
+2. Take a final engine-native dump — this is the fallback if the move goes wrong
+3. For DB engines that benefit from a fresh initdb (PostgreSQL): initdb new cluster in `subvol8-db/<service>/` with `--data-checksums`, restore from dump
+4. For engines that don't: `rsync -aHX --numeric-ids` from old path to new path. **Must not use `cp --reflink`** — reflink preserves extent sharing and defeats NOCOW. Verify with `lsattr` after move that files show `C` flag.
+5. Update the quadlet file's `Volume=` line to point at the new path
+6. `systemctl --user daemon-reload && systemctl --user start <service>.service`
+7. Verify service health (ADR-010 validation): HTTP/TCP probe, container logs clean, dependent services healthy
+8. Rename old directory to `<service>.pre-migration` — retained for 14 days as rollback safety net
+9. After 14 days clean operation, delete the `.pre-migration` directory
+
+### Phase 2 — Observability
+
+1. Deploy `config/prometheus/alerts/db-dump-alerts.yml` with the four alerts listed above
+2. Add Grafana panel: "DB Dump Health" — age of last success per DB, size trend
+3. Update `docs/20-operations/runbooks/` with per-engine restore runbook (part of the DR runbook set)
+
+### Phase 3 — Cleanup
+
+1. Remove now-empty DB directories from `subvol7-containers`
+2. Verify Urd's next run reflects reduced `subvol7-containers` churn (snapshot delta should shrink noticeably)
+3. Update `AUTO-NETWORK-TOPOLOGY.md` and `AUTO-SERVICE-CATALOG.md` regeneration inputs so paths reflect new layout
+4. Update `CLAUDE.md` "Common Gotchas" — replace the "BTRFS NOCOW for databases" note with a pointer to this ADR
+
+## Consequences
+
+### Positive
+
+- **NOCOW actually works.** No snapshot interference; write-in-place on HDD for DB workloads, substantially reducing fragmentation and write amplification.
+- **Consistent backup model.** All DBs protected by application-consistent dumps, not crash-consistent snapshots. Restore is a well-understood operation for every engine.
+- **Simpler capacity accounting.** `subvol7-containers` snapshot deltas shrink when DB churn is removed. External drive fills slower; incremental send times drop.
+- **Urd unchanged.** No new subvolumes for Urd to manage, no new retention policies, no new drive requirements. The integration contract in ADR-021 stays intact.
+- **Checksums upgraded.** Moving to `data_checksums=on` in PostgreSQL is a standing hygiene improvement that the migration makes free.
+- **TSDB hygiene.** Loki stops consuming backup I/O for data that has low recovery value. Prometheus shifts to a cheaper, application-consistent snapshot path (admin API) instead of the current filesystem-snapshot-of-COW-data approach.
+
+### Negative
+
+- **Loss of point-in-time rollback for DBs.** If a bad Immich migration corrupts the DB, the restore path is "yesterday's dump," not "reset to 10 minutes ago via snapshot." Mitigated by: snapshot-based rollback of a running DB was never actually safe (crash-consistent at best); dumps are application-consistent and tested.
+- **Dump job is a new failure surface.** If the dump job stops running, data is at risk silently. Mitigated by: `DBDumpJobNotRunning` and `DBDumpStale` alerts, plus the `db-dump-alerts.yml` file is short and auditable.
+- **Migration requires downtime per service.** Each move stops the service for minutes to (for Immich) potentially up to an hour depending on dump/restore time. Scheduled during low-use windows.
+- **No BTRFS data checksums on DB files.** We delegate to engine-level checksums. If an engine's checksum coverage has gaps (unlikely), silent corruption could reach us. Mitigated by: all five engines have production-grade integrity checking.
+
+### Constraints
+
+- **Dump size is bounded by `subvol7-containers` free space.** 14 daily compressed dumps of current DBs ≈ 2–10GB total. Plenty of headroom.
+- **`rsync` during migration must avoid `--inplace` and reflink.** The move procedure must produce genuinely new extents in the NOCOW directory; any shortcut that preserves reflinks defeats NOCOW silently.
+- **Restore procedure must be tested.** Each engine's restore path is documented and exercised as part of the existing `backup-restore-test.timer` infrastructure (extended to cover DB dumps).
+
+## Alternatives Considered
+
+**1. Move DBs to NVMe.** Rejected — NVMe is 90% full with 13GB free. DB growth (especially Immich as photo library grows) would quickly exhaust it. Would also concentrate failure risk on a single drive with no RAID.
+
+**2. Keep current layout, fix NOCOW flags.** Rejected — does not solve the snapshot-forces-COW problem. Sets NOCOW correctly but snapshots still defeat it on the first write after each snapshot. This is the design flaw, not the flag application.
+
+**3. Disable snapshots on `subvol7-containers`.** Rejected — container configs genuinely benefit from snapshot-based rollback (bad quadlet edit, bad config change). The cure is worse than the disease.
+
+**4. Nested subvolume for DBs inside subvol7-containers.** Rejected — snapshots of a parent subvolume do not include nested subvolumes, which would technically work. But this creates an invisible-to-casual-inspection structure: an operator looking at `subvol7-containers` snapshots would not realize DBs are missing from them. Top-level `subvol8-db` is more honest.
+
+**5. Filesystem freeze + snapshot for DBs.** Rejected — requires `fsfreeze` + coordinated `pg_start_backup`/`pg_stop_backup` (or equivalent per engine) around every snapshot. Operationally complex; doesn't solve the fragmentation problem; snapshots still exist.
+
+**6. Move TSDBs out of BTRFS entirely (e.g., xfs partition).** Rejected — no spare disk partition is available and repartitioning the pool to steal capacity is disproportionate work for a derived-data workload.
+
+## Open Questions
+
+1. **Does Immich PG currently have `data_checksums=on`?** Needs verification before migration. If yes, rsync-based move is acceptable; if no, initdb+restore is the correct path.
+2. **Should `/home` DBs (authelia SQLite, grafana) be included?** `/home` is not in Urd. These DBs are small and rarely written, but they lack backup coverage today. Out of scope for this ADR but flagged as a follow-up.
+3. **Does `db-dump.service` need user or system scope?** User scope aligns with Urd (`systemctl --user`). System scope would simplify permissions for services running as other UIDs. Defaulting to user scope unless a blocker emerges during implementation.
+4. **Loki dump on second pass?** If operational experience shows Loki loss is painful (e.g., log-based alerts missing context after a restore), extend the dump job with a stop-rsync-start cycle or investigate Loki's boltdb-shipper flush-on-demand. Accept loss initially; revisit after 90 days of operation.
+5. **Local dump retention — 14 days right?** 14 dailies × ~2GB Prometheus dominant = ~30GB local footprint. Comfortable for current pool state, but Prometheus churn may grow as metric cardinality grows. Monitor `db_dump_size_bytes` trend; revise retention downward if local footprint exceeds 50GB.
+
+## Related
+
+- **ADR-009:** Config vs Data Directory Strategy — establishes the host path layout this ADR refines
+- **ADR-019:** Filesystem Permission Model — ACL approach applies to new subvolume
+- **ADR-020:** Daily External Backups — tiered protection model; `subvol7-containers` carries DB dumps
+- **ADR-021:** Urd Backup Tool — integration contract; `subvol8-db` is deliberately outside it
+- **Urd project:** `~/projects/urd/` — backup engine, unchanged by this ADR
+- **`docs/20-operations/runbooks/`:** DR runbooks — extend with DB restore procedures
+- **`CLAUDE.md` Common Gotchas:** "BTRFS NOCOW for databases" — updated to reference this ADR after implementation
+
+## Keeping This ADR Current
+
+This ADR describes a storage *architecture*, not a point-in-time migration. It should be updated when:
+
+1. A new database service is added to the homelab (decide: `subvol8-db` or `subvol7-containers`?)
+2. The dump job's metric names, paths, or schedule change
+3. Engine-level checksum settings change (e.g., new PostgreSQL major version with different defaults)
+4. Urd's integration contract changes in ways that affect DB dump coverage
+5. Hardware changes make NVMe hosting of DBs feasible (re-evaluate)

--- a/docs/98-journals/2026-03-17-pasta-source-nat-investigation.md
+++ b/docs/98-journals/2026-03-17-pasta-source-nat-investigation.md
@@ -1,0 +1,265 @@
+# Rootlessport Source IP Selection in Multi-Network Containers
+
+**Date:** 2026-03-17
+**Status:** ROOT CAUSE IDENTIFIED — confirmed via source code, empirical tests, and upstream issue tracker
+**Related:** [2026-03-12-vault-traffic-analysis.md](2026-03-12-vault-traffic-analysis.md), [2026-02-02-ROOT-CAUSE-CONFIRMED-dns-resolution-order.md](2026-02-02-ROOT-CAUSE-CONFIRMED-dns-resolution-order.md), PR #110 (monitoring Internal=true), PR #118 (vault rate limit split)
+
+---
+
+## Executive Summary
+
+All external traffic arriving at Traefik via rootless port forwarding is source-NAT'd to a single container IP chosen **non-deterministically** by `rootlessport`. The specific IP depends on Go map iteration order, which changed when Podman was upgraded from 5.7.1 to 5.8.0 on March 8, 2026. This is a known upstream issue ([containers/podman#12850](https://github.com/containers/podman/issues/12850), open since Jan 2022) with no planned fix.
+
+The real external client IP is never preserved. Network segmentation between containers works correctly — this issue only affects how external traffic appears in Traefik's access logs.
+
+---
+
+## Root Cause: `GetRootlessPortChildIP` and Go Map Iteration
+
+The port forwarding chain for rootless Podman containers:
+
+```
+External client → host:443 → pasta (rootless-netns) → rootlessport parent → pipe → rootlessport-child → container:443
+```
+
+The critical function is `GetRootlessPortChildIP` in [`containers/common/libnetwork/slirp4netns/slirp4netns.go`](https://github.com/containers/common/blob/main/libnetwork/slirp4netns/slirp4netns.go):
+
+```go
+func GetRootlessPortChildIP(slirpSubnet *net.IPNet, netStatus map[string]types.StatusBlock) string {
+    // ...
+    for _, status := range netStatus {
+        for _, netInt := range status.Interfaces {
+            for _, netAddress := range netInt.Subnets {
+                ipv4 := netAddress.IPNet.IP.To4()
+                if ipv4 != nil {
+                    return ipv4.String()  // Returns FIRST IPv4 found
+                }
+            }
+        }
+    }
+    // ...
+}
+```
+
+It iterates `netStatus` — a `map[string]types.StatusBlock` — and returns the **first IPv4 address it encounters**. Go maps have [deliberately non-deterministic iteration order](https://go.dev/blog/maps). Which network "wins" depends on the Go runtime's internal hash seed, which changes per binary build. A Podman upgrade = new binary = new hash seed = potentially different network selected.
+
+`rootlessport-child` then uses this IP as **both source and destination** when connecting to Traefik's published port inside the container namespace. Traefik sees this as the `ClientHost`.
+
+### Confirmed with TCP connection table
+
+Active connections inside Traefik's network namespace:
+
+```
+Local                     Remote                    State
+10.89.3.69:35340          10.89.3.69:443            ESTABLISHED  ← rootlessport-child → Traefik
+10.89.3.69:35356          10.89.3.69:443            ESTABLISHED  ← rootlessport-child → Traefik
+10.89.3.69:53354          10.89.3.69:443            ESTABLISHED  ← rootlessport-child → Traefik
+10.89.2.69:32834          10.89.2.71:80             ESTABLISHED  ← Traefik → vaultwarden (correct)
+```
+
+rootlessport-child connects from 10.89.3.69 to 10.89.3.69:443 — a loopback-routed connection using the auth_services IP. Traefik logs this as `ClientHost: 10.89.3.69`.
+
+---
+
+## What Changed: Podman 5.7.1 → 5.8.0
+
+```
+# From dnf logs:
+2026-03-08 23:05:58  RPM install podman-5:5.8.0-1.fc43
+2026-03-08 23:06:54  RPM uninstall podman-5:5.7.1-1.fc43
+# Reboot: 2026-03-09 00:52
+```
+
+| Period | Podman Version | rootlessport Selected IP | Network |
+|--------|---------------|--------------------------|---------|
+| Jan 18 – Mar 7 | 5.7.1 | 10.89.4.x | monitoring |
+| Mar 9 – present | 5.8.0 | 10.89.3.69 | auth_services |
+
+The Podman 5.8.0 [release notes](https://github.com/containers/podman/releases/tag/v5.8.0) show no direct rootlessport changes. The shift is an indirect consequence of recompilation with an updated Go runtime (go1.25.7), which changed the map iteration hash seed.
+
+Before static IPs (pre-PR #109), the selected IP was dynamic and changed on container restarts. This is why the vault traffic journal showed different 10.89.4.x addresses (4.45, 4.57, 4.73, 4.69) across restart boundaries. After static IPs, the selected IP is consistent but still on the wrong network.
+
+---
+
+## Initial Hypothesis Was Wrong
+
+The original hypothesis attributed the IP shift to the monitoring `Internal=true` change in PR #110 (March 1). This was incorrect:
+
+- The monitoring network became internal on **March 1** (PR #110)
+- But vault traffic continued showing **10.89.4.69** (monitoring) on **March 7**
+- The shift to 10.89.3.69 (auth_services) happened on **March 9** — after the Podman upgrade + reboot
+
+`Internal=true` does **not** exclude a network from rootlessport's IP selection. All three networks are passed to `GetRootlessPortChildIP` regardless of their internal flag:
+
+```
+# podman inspect traefik → NetworkSettings.Networks:
+systemd-auth_services: 10.89.3.69  (Internal=true)
+systemd-monitoring:    10.89.4.69  (Internal=true)
+systemd-reverse_proxy: 10.89.2.69
+```
+
+---
+
+## Experiment: Controlled Traffic Source Identification
+
+Seven controlled requests from known sources to determine what `ClientHost` Traefik records.
+
+| # | Source | Networks | ClientHost | Interpretation |
+|---|--------|----------|------------|----------------|
+| 1 | Host (via localhost) | N/A — external | **10.89.3.69** | rootlessport NAT |
+| 2 | Host (via LAN IP 192.168.1.70) | N/A — external | **10.89.3.69** | rootlessport NAT (same result) |
+| 3 | vaultwarden | reverse_proxy | 10.89.2.1 | reverse_proxy gateway |
+| 4 | nextcloud | reverse_proxy, nextcloud, monitoring | 10.89.2.1 | reverse_proxy gateway |
+| 5 | prometheus | reverse_proxy, monitoring | 10.89.2.1 | reverse_proxy gateway |
+| 6 | authelia | reverse_proxy, auth_services | 10.89.2.1 | reverse_proxy gateway |
+| 7 | cadvisor (monitoring-only) | monitoring | 10.89.4.3 | cadvisor's actual IP |
+
+**Key findings:**
+- Container-to-container traffic works correctly and shows the actual source network
+- External traffic always shows rootlessport's selected IP regardless of entry path
+- cadvisor (monitoring-only) cannot resolve external DNS — `Internal=true` works for single-network containers
+- Tests via localhost and via LAN IP produce identical results — the NAT happens inside the container namespace, not at the host level
+
+---
+
+## Reboot Correlation
+
+Cross-referencing reboot dates with vault traffic IP subnets:
+
+```
+Reboot history:            Dominant vault IP subnet:
+Feb  4  00:18              Jan 18 - Feb  2: 10.89.4.x (monitoring)
+                           Feb  3:          10.89.3.6  (auth_services — brief)
+                           Feb  5 - Feb  6: 10.89.2.x (reverse_proxy — brief)
+Feb 16  12:49              Feb  8 - Feb 15: 10.89.4.x (monitoring — back)
+Feb 22  23:38              Feb 21:          10.89.2.x (reverse_proxy — during outage)
+                           Mar  7:          10.89.4.x (monitoring)
+Mar  9  00:52 [Podman 5.8] Mar  9+:         10.89.3.x (auth_services — stable)
+Mar 16  19:23              Mar 17:          10.89.3.x (auth_services — still stable)
+```
+
+Under Podman 5.7.1, the Go map iteration order was **mostly stable** (monitoring won) but occasionally shifted on reboot (Feb 3 → auth_services, Feb 5 → reverse_proxy, then back to monitoring). This is consistent with Go's map randomization: the hash seed is set per-process, so each new rootlessport process could theoretically pick a different network, though in practice the same binary tends to converge on the same ordering.
+
+Under Podman 5.8.0, the ordering has been **completely stable** across two reboots (Mar 9 and Mar 16), consistently selecting auth_services.
+
+---
+
+## Implications for the Vault Traffic Journal
+
+The vault traffic journal's IP-based analysis needs substantial revision:
+
+1. **"15 unique container IPs" were not 15 distinct actors.** They were rootlessport's selected IP changing across container restarts (dynamic IPs before PR #109) and the occasional Go map reordering on reboot. All external traffic — scanners, legitimate clients, bots — appeared as a single IP per time period.
+
+2. **"Scanner IP rotation" was Traefik restart artifacts.** When Traefik restarted, it got new dynamic IPs. The "scanner rotating from 10.89.3.3 to 10.89.2.76 to 10.89.2.83" was actually rootlessport getting different NAT IPs from different restarts, not an adversary rotating source addresses.
+
+3. **Traffic categorization by user-agent remains valid.** The 87% scanner / 6% legitimate breakdown was based on user-agent analysis, which is unaffected by the source IP issue.
+
+4. **The Feb 2 outage IP changes** (10.89.4.69 → 10.89.4.73 → 10.89.3.10 within 20 minutes) were probably caused by container restarts during the outage investigation. The DNS resolution root cause journal (Feb 2) documents multiple container restarts that day.
+
+---
+
+## Upstream Status
+
+| Issue | Status | Summary |
+|-------|--------|---------|
+| [#12850](https://github.com/containers/podman/issues/12850) | **OPEN** (since Jan 2022) | Ordering of `--network` flags is disregarded. Networks stored in Go map, iteration order non-deterministic. Fix considered too complex (requires map→slice refactor throughout codebase + DB schema). |
+| [#25865](https://github.com/containers/podman/issues/25865) | Closed (not planned) | Maintainer confirmed: "ordering is not deterministic." Suggested `--opt metric=<num>` for routing control. |
+| [#28172](https://github.com/containers/podman/issues/28172) | Closed (duplicate of #12850) | Reports exact same problem: "Podman picks the first network... sometimes that's net1, sometimes net2." |
+| [#8193](https://github.com/containers/podman/issues/8193) | OPEN | Alternate port handler that preserves source IP. No implementation. |
+
+**No fix is planned.** The maintainers consider the Go map ordering a fundamental design issue that would require refactoring maps to ordered slices throughout the codebase and database schema.
+
+---
+
+## Practical Consequences
+
+**What works:**
+- Network segmentation between containers (east-west traffic) is correct
+- `Internal=true` prevents single-network containers from reaching the internet
+- Static IPs + `/etc/hosts` in Traefik (ADR-018) correctly routes Traefik→backend traffic
+
+**What doesn't work:**
+- Distinguishing external clients by IP in Traefik access logs
+- Correlating access log IPs with CrowdSec IP reputation
+- IP-based rate limiting per real client (all clients share one IP)
+- Predicting which IP rootlessport will select after a Podman upgrade
+
+**What would help but isn't implemented:**
+- Traefik `forwardedHeaders` / PROXY protocol from an upstream device — but rootlessport doesn't set `X-Forwarded-For` with the real client IP, so there's nothing to forward. The real IP is lost at the rootlessport stage, before Traefik ever sees the connection.
+- A fix for [Podman #8193](https://github.com/containers/podman/issues/8193) that preserves source IPs through rootlessport.
+- Running Traefik rootful (loses the security benefit of rootless containers).
+
+---
+
+## Remaining Questions
+
+1. **Could PROXY protocol on the UDM Pro help?** If the UDM Pro terminates TCP and re-establishes it with PROXY protocol headers to Traefik, the real client IP could be preserved. This would bypass rootlessport's NAT entirely at layer 7. Requires investigation of UDM Pro capabilities.
+
+2. **Will future Podman versions change the selected IP again?** Every Podman upgrade with a new Go binary could shift the map iteration order. The selected network could change from auth_services to reverse_proxy or back to monitoring without warning. There is no way to pin it.
+
+3. **Would a single-network Traefik design avoid this?** If Traefik were only on `reverse_proxy`, rootlessport would have only one IP to choose. Backend connectivity would require a different approach (host networking for specific connections, or sidecar proxies). This would be a significant architecture change.
+
+---
+
+## Next Steps Completed
+
+| Step | Result |
+|------|--------|
+| 1. Verify from external source | Tested via LAN IP (192.168.1.70:443). Same result: ClientHost=10.89.3.69. |
+| 2. Check pasta/Podman version | pasta 0^20260120.g386b5f5, Podman 5.7.1→5.8.0 (Mar 8). Upgrade is the inflection point. |
+| 3. Test interface ordering | **Skipped** — source code analysis proves reordering Network= lines cannot help. The issue is Go map iteration in rootlessport, which ignores interface/declaration order. |
+| 4. X-Forwarded-For preservation | Traefik receives no X-Forwarded-For. rootlessport doesn't inject one. The real IP is lost before Traefik sees the connection. UDM Pro PROXY protocol is the only remaining option. |
+| 5. Check upstream issue tracker | Found [#12850](https://github.com/containers/podman/issues/12850) (open since 2022, no planned fix), [#25865](https://github.com/containers/podman/issues/25865) (closed, "not planned"), [#8193](https://github.com/containers/podman/issues/8193) (source IP preservation, open, no implementation). |
+
+---
+
+## Raw Test Commands
+
+```bash
+# Test 1-2: External requests (loopback + LAN IP)
+curl -s -o /dev/null -w '%{http_code}' \
+  -H 'User-Agent: SEGMENTATION-TEST-FROM-HOST' \
+  https://vault.patriark.org/test-segmentation
+
+curl -s -o /dev/null -w '%{http_code}' \
+  --connect-to vault.patriark.org:443:192.168.1.70:443 \
+  -H 'User-Agent: TEST-VIA-LAN-IP' \
+  https://vault.patriark.org/test-lan
+
+# Test 3-6: Container-originated requests
+podman exec vaultwarden curl -s -o /dev/null -w '%{http_code}' \
+  -H 'User-Agent: TEST-FROM-VAULTWARDEN' \
+  https://vault.patriark.org/test-from-container --insecure
+
+podman exec nextcloud curl -s -o /dev/null -w '%{http_code}' \
+  -H 'User-Agent: TEST-FROM-NEXTCLOUD' \
+  https://vault.patriark.org/test-from-nc --insecure
+
+podman exec prometheus wget -q -O /dev/null \
+  --header='User-Agent: TEST-FROM-PROMETHEUS' \
+  'https://vault.patriark.org/test-from-mon' --no-check-certificate
+
+podman exec authelia wget -q -O /dev/null \
+  --header='User-Agent: TEST-FROM-AUTHELIA' \
+  'https://vault.patriark.org/test-from-auth' --no-check-certificate
+
+# Test 7: Internal-only container
+podman exec cadvisor wget -q -O /dev/null \
+  --header='User-Agent: TEST-FROM-CADVISOR' \
+  'https://vault.patriark.org/test-from-internal' --no-check-certificate
+# Result: "bad address" — cannot resolve external DNS ✓
+
+podman exec cadvisor wget -q -O /dev/null \
+  --header='User-Agent: TEST-FROM-CADVISOR-DIRECT' \
+  'https://10.89.4.69/test-direct' --no-check-certificate
+# Result: ClientHost=10.89.4.3 (cadvisor's real IP) ✓
+
+# Inspect rootlessport connections
+cat /proc/$(podman inspect traefik --format '{{.State.Pid}}')/net/tcp | \
+  python3 -c "..." # (decode hex addresses — see investigation notes)
+
+# Version info
+pasta --version        # pasta 0^20260120.g386b5f5-1.fc43
+podman version         # 5.8.0, go1.25.7
+rpm -qa --last | grep podman  # installed 2026-03-09
+```

--- a/docs/98-journals/2026-03-26-promtail-journal-export-outage.md
+++ b/docs/98-journals/2026-03-26-promtail-journal-export-outage.md
@@ -1,0 +1,121 @@
+# Promtail Journal Export Outage — Incident Report
+
+**Date:** 2026-03-26
+**Incident:** Repeated Discord alerts for missing `promtail_custom_nextcloud_cron_success_total` metric
+**Severity:** Low (monitoring gap — no data loss or service impact)
+**Duration:** ~2 days (2026-03-24 12:15 to 2026-03-26 08:26)
+**Resolution:** Flushed volatile journal to persistent storage, vacuumed old entries, restarted journal-export
+
+---
+
+## Executive Summary
+
+The NVMe system drive filled to 100% around 2026-03-24, preventing all writes. This caused systemd-journald to stop writing to persistent storage (`/var/log/journal/`). After the drive was freed and the system rebooted, journald silently fell back to volatile storage (`/run/log/journal/`), which does not create per-user journal split files (`user-1000.journal`). The `journal-export.service` uses `journalctl --user -f` which depends on these split files — it produced zero output, leaving Promtail's `journal.log` empty. Without log data, Promtail could not extract the `nextcloud_cron_success_total` metric, triggering the alert.
+
+---
+
+## Timeline
+
+| Time (CET) | Event |
+|------------|-------|
+| 2026-03-24 ~12:00 | NVMe drive (/dev/nvme0n1p3) reached 100% capacity |
+| 2026-03-24 12:15 | Last entry written to persistent user journal (`user-1000.journal`) |
+| 2026-03-24 ~12:22 | System rebooted; journald started but fell back to volatile storage |
+| 2026-03-24 13:00 | journal-export.service restarted; journal.log recreated at 0 bytes |
+| 2026-03-24 15:54 | First Discord alert: `promtail_custom_nextcloud_cron_success_total` missing |
+| 2026-03-24 – 03-26 | Repeated Discord alerts (~every 65 minutes) |
+| 2026-03-26 08:20 | Investigation began |
+| 2026-03-26 08:25 | Root cause identified: `journalctl --user` returning zero entries |
+| 2026-03-26 08:25 | Fix applied: `journalctl --flush` + `--vacuum-size=2G` + restart journal-export |
+| 2026-03-26 08:26 | Metric confirmed present in Promtail (23 increments at priority 6) |
+
+---
+
+## Root Cause Analysis
+
+### The Failure Chain (4 stages)
+
+```
+Stage 1: NVMe Full
+  System drive hit 100% → no writes possible
+  → journald could not write to /var/log/journal/
+
+Stage 2: Silent Fallback
+  After reboot, journald fell back to volatile storage (/run/log/journal/)
+  Volatile mode does NOT create per-user journal files (user-1000.journal)
+  No error logged — completely silent degradation
+
+Stage 3: journal-export Blind
+  journal-export.service runs: journalctl --user -f -o json
+  --user flag depends on user journal split files
+  With no user journal → zero output → journal.log stays at 0 bytes
+
+Stage 4: Metric Disappears
+  Promtail reads empty journal.log → no log lines to process
+  nextcloud_cron_success_total metric never incremented
+  Alert fires: "Promtail metric extraction may have failed"
+```
+
+### Why the Alert Was Correct But Misleading
+
+The alert correctly detected that the metric was missing. However, the suggested causes in the alert body (pipeline regex mismatch, position file issue, cron timer stopped) were all wrong. The actual cause was two layers deeper: journald's storage mode change broke the `--user` flag semantics.
+
+---
+
+## Resolution
+
+```bash
+# Flush volatile journal entries to persistent storage
+sudo journalctl --flush
+
+# Vacuum old entries (freed 1.9G of archived user journals)
+sudo journalctl --vacuum-size=2G
+
+# Restart journal-export to pick up restored user journal
+systemctl --user restart journal-export.service
+```
+
+After restart, `journalctl --user` returned 3115 entries in the first minute, journal.log began filling immediately, and Promtail exported the metric within seconds.
+
+---
+
+## Observations
+
+- The persistent journal had accumulated 4GB of user journal archives — 19 rotated `user-1000@*.journal` files at ~100MB each. Vacuuming freed 1.9GB.
+- All 30 containers continued running normally throughout the incident. Only the monitoring pipeline was affected.
+- The nextcloud-cron timer ran successfully every 5 minutes during the entire outage — only the *observation* of success was broken.
+
+---
+
+## Open Investigation: Volatile Journal Fallback
+
+**Status:** Not yet investigated — handoff for future session.
+
+### What We Know
+- After the NVMe filled and the system rebooted, journald started writing to `/run/log/journal/` (volatile/tmpfs) instead of `/var/log/journal/` (persistent/NVMe).
+- The `journald.conf` has `Storage=auto` (default) which should prefer persistent if `/var/log/journal/` exists and is writable.
+- `/var/log/journal/2b6e6a4ebb9447679e5731ef2588426d/` exists with correct ownership (root:systemd-journal) and ACLs.
+- After running `journalctl --flush`, the persistent journal resumed working.
+
+### Questions to Answer
+1. **Why did journald not resume persistent writes after the drive was freed?** With `Storage=auto`, journald should write to `/var/log/journal/` if the directory exists. Was there a stale lock file? Corrupted journal header? BTRFS filesystem issue?
+2. **Is `journalctl --flush` idempotent and safe to run periodically?** If so, consider adding it to the reboot script or a systemd timer as a defensive measure.
+3. **Should journal-export use `_UID=1000` instead of `--user`?** The `--user` flag is fragile because it depends on journal split mode. Filtering by `_UID=1000` pulls from the system journal directly and worked throughout the outage (139K entries available). Trade-off: `_UID=1000` would include non-service entries (SSH sessions, etc.) but the Promtail pipeline already filters by `syslog_id` label.
+4. **Should we set `Storage=persistent` explicitly in `journald.conf`?** This would force persistent storage and fail loudly rather than silently falling back to volatile.
+5. **Should we add disk space monitoring alerts?** The NVMe filling to 100% was the trigger for this entire chain. A `node_filesystem_avail_bytes` alert at 90% would provide early warning.
+6. **Should we cap the user journal size?** The 4GB of accumulated user journals contributed to disk pressure. Consider setting `SystemMaxUse=2G` in `journald.conf`.
+
+### How to Investigate
+```bash
+# Check if journald is currently using persistent or volatile
+journalctl --header | head -5  # File path shows which
+
+# Check for journal corruption
+journalctl --verify 2>&1 | grep -i "fail\|error\|corrupt"
+
+# Check BTRFS health on system drive
+sudo btrfs device stats /
+
+# Test: would journald survive another full-disk event?
+# (simulate in a test environment, not production)
+```

--- a/docs/98-journals/2026-03-28-podman-storage-migration.md
+++ b/docs/98-journals/2026-03-28-podman-storage-migration.md
@@ -1,0 +1,222 @@
+# Podman Storage Migration: NVMe → BTRFS Pool
+
+**Date:** 2026-03-28
+**Status:** Executed 2026-04-18 — see [execution journal](2026-04-18-podman-storage-migration-execution.md) for what actually happened
+**Estimated downtime:** 10–15 minutes (all services) — actual: ~11 minutes
+**Risk:** Medium — affects all 30 containers, but fully reversible
+
+> **Execution surfaced three issues this plan did not anticipate.** Inline callouts below
+> mark the affected steps. Read the execution journal before running this procedure again.
+> Summary: (1) `podman stop --all` does not hold with quadlets, (2) rsync from a plain
+> user shell cannot read rootless subordinate-UID files, (3) Podman 5.x SQLite has
+> path-bound `DBConfig` that requires an in-place UPDATE after the move.
+
+## Context
+
+`~/.local/share/containers/storage` (Podman overlay storage — image layers, metadata,
+container runtime state) consumes ~17 GB on the NVMe system drive (118G total, 63% used).
+This is not application data (already on BTRFS pool) — it's the container image filesystem
+that all 30 containers boot from.
+
+Moving to `/mnt/btrfs-pool/subvol7-containers/storage` frees NVMe space. Trade-off:
+container startup marginally slower (BTRFS HDD vs NVMe), negligible at runtime since
+data I/O already goes to the BTRFS pool.
+
+## Pre-Migration (can do now, no downtime)
+
+```bash
+# 1. Prune dangling images (already done — saved ~16 GB)
+podman image prune -f --filter "dangling=true"
+
+# 2. Create target directory with NOCOW (before any data lands)
+sudo mkdir -p /mnt/btrfs-pool/subvol7-containers/storage
+sudo chown 1000:1000 /mnt/btrfs-pool/subvol7-containers/storage
+sudo chattr +C /mnt/btrfs-pool/subvol7-containers/storage
+
+# 3. Set SELinux equivalence so containers get correct labels
+sudo semanage fcontext -a -e /home/patriark/.local/share/containers/storage \
+  /mnt/btrfs-pool/subvol7-containers/storage
+
+# 4. Verify SELinux rule is registered
+sudo semanage fcontext -l | grep subvol7-containers/storage
+```
+
+## Migration (maintenance window)
+
+### Step 1 — Stop all containers
+
+> ⚠ **Execution note (2026-04-18):** `podman stop --all` does **not** stick with quadlets
+> — systemd restarts each container via its `.service` unit within seconds. Stop at the
+> systemd layer instead. Traefik additionally requires stopping its socket units first
+> (ADR-022 socket activation), else the next connection relaunches the container.
+
+```bash
+# Confirm what's running
+podman ps --format "{{.Names}}" | sort
+
+# Stop all quadlet services (not `podman stop`)
+for svc in $(systemctl --user list-units --type=service --state=running \
+               --no-legend | awk '/\.service/{print $1}' | grep -v user@); do
+  systemctl --user stop "$svc"
+done
+
+# Traefik's sockets must stop first — ADR-022 socket activation
+systemctl --user stop http.socket https.socket traefik.service
+
+# Verify nothing running
+podman ps -q | wc -l   # Should be 0
+```
+
+### Step 2 — Copy storage
+
+> ⚠ **Execution note (2026-04-18):** rootless Podman stores overlay layer contents under
+> subordinate UIDs (100000+). A plain user rsync silently skips those directories with
+> "Permission denied" — in the 2026-04-18 run, 551 of 371422 files were missed, all
+> inside unreadable directory handles. Run rsync inside `podman unshare` so subordinate
+> UIDs map to root. Do **not** rely on file-count delta alone to verify — the miss was
+> 0.1% of files but included live overlay state.
+
+```bash
+# rsync inside the user namespace — subordinate UIDs become readable
+# -aHAX preserves hardlinks, ACLs, xattrs (all critical for overlay)
+podman unshare rsync -aHAX --delete --info=progress2 \
+  ~/.local/share/containers/storage/ \
+  /mnt/btrfs-pool/subvol7-containers/storage/
+
+# Verify exact file-count match (not approximate)
+find ~/.local/share/containers/storage | wc -l
+find /mnt/btrfs-pool/subvol7-containers/storage | wc -l
+# Must be equal — if not, re-run the rsync
+
+# Apply SELinux labels to copied data
+sudo restorecon -R -v /mnt/btrfs-pool/subvol7-containers/storage
+```
+
+### Step 3 — Configure Podman to use new location
+```bash
+# Create user storage.conf (takes precedence over /etc/containers/storage.conf)
+mkdir -p ~/.config/containers
+cat > ~/.config/containers/storage.conf << 'EOF'
+[storage]
+driver = "overlay"
+rootless_storage_path = "/mnt/btrfs-pool/subvol7-containers/storage"
+EOF
+```
+
+### Step 4 — Verify before starting services
+
+> ⚠ **Execution note (2026-04-18):** `podman info` fails with `database configuration
+> mismatch` at this point. Podman 5.x's SQLite DB (`db.sql`) records the `StaticDir`,
+> `GraphRoot`, and `VolumeDir` it was created with, and rsync preserves the DB verbatim
+> — so the new path's DB still claims the old path as its home. `podman system migrate`
+> does **not** fix this (that command is for UID remapping changes). Update the paths
+> in-place before continuing.
+
+```bash
+# Patch the DB to match the new location (idempotent, survives Podman upgrades)
+sqlite3 /mnt/btrfs-pool/subvol7-containers/storage/db.sql \
+  "UPDATE DBConfig SET
+     StaticDir='/mnt/btrfs-pool/subvol7-containers/storage/libpod',
+     GraphRoot='/mnt/btrfs-pool/subvol7-containers/storage',
+     VolumeDir='/mnt/btrfs-pool/subvol7-containers/storage/volumes';"
+
+# Confirm Podman sees the new location
+podman info 2>/dev/null | grep -i graphroot
+# Expected: graphRoot: /mnt/btrfs-pool/subvol7-containers/storage
+
+# Confirm images are visible
+podman images | head -10
+
+# Confirm container definitions intact
+podman ps -a --format "{{.Names}}" | sort
+```
+
+### Step 5 — Restart all services
+```bash
+systemctl --user daemon-reload
+
+# Start services (systemd dependencies handle ordering)
+systemctl --user start podman-restart.service 2>/dev/null
+
+# Or start key services explicitly:
+systemctl --user start traefik.service
+systemctl --user start crowdsec.service
+systemctl --user start authelia.service
+systemctl --user start prometheus.service grafana.service loki.service
+
+# Start remaining application services
+systemctl --user start nextcloud.service
+systemctl --user start immich-server.service
+systemctl --user start jellyfin.service
+systemctl --user start vaultwarden.service
+systemctl --user start home-assistant.service
+systemctl --user start audiobookshelf.service navidrome.service
+systemctl --user start homepage.service
+systemctl --user start qbittorrent.service
+systemctl --user start gathio.service
+```
+
+### Step 6 — Validate
+```bash
+# Quick health check
+podman ps --format "table {{.Names}}\t{{.Status}}" | sort
+
+# Verify web access
+curl -sI https://homepage.patriark.org | head -1
+curl -sI https://grafana.patriark.org | head -1
+
+# Run full health check
+~/containers/scripts/homelab-intel.sh
+```
+
+## Rollback (if anything goes wrong)
+
+```bash
+# 1. Stop everything (see Step 1 — use systemctl, not `podman stop --all`)
+
+# 2. Remove the override config
+rm ~/.config/containers/storage.conf
+
+# 3. Verify Podman falls back to default
+podman info 2>/dev/null | grep -i graphroot
+# Expected: graphRoot: /home/patriark/.local/share/containers/storage
+
+# 4. Restart services
+systemctl --user daemon-reload
+# (start services as in Step 5)
+```
+
+Original data at `~/.local/share/containers/storage` is untouched until explicit cleanup.
+
+## Post-Migration Cleanup (after 24–48 hours of stable operation)
+
+> ⚠ **Execution note (2026-04-20):** Two caveats from the 2026-04-18 run:
+> 1. Use `podman unshare rm -rf` — a plain `rm` can't traverse subordinate-UID
+>    directories and will leave files behind.
+> 2. If `/home` is BTRFS with snapshots (urd), `df` will **not** show space freed
+>    immediately. Blocks stay pinned until every snapshot referencing the old tree
+>    ages out under retention policy. Under `htpc-home`'s `daily=14, weekly=8` that
+>    can mean up to ~8 weeks of drain. This is expected, not a failure.
+
+```bash
+# Only after confirming everything works reliably
+podman unshare rm -rf ~/.local/share/containers/storage
+
+# Verify NVMe space freed (will drain gradually if snapshots reference the old tree)
+df -h /home
+```
+
+## Checklist
+
+- [ ] Pre-migration steps completed (NOCOW, SELinux, prune)
+- [ ] All containers stopped
+- [ ] rsync completed successfully
+- [ ] SELinux labels applied
+- [ ] storage.conf created
+- [ ] `podman info` shows new graphRoot
+- [ ] `podman images` lists all images
+- [ ] All services started and healthy
+- [ ] Web access verified (Traefik routing works)
+- [ ] Health score checked via homelab-intel.sh
+- [ ] Ran stable for 24–48 hours
+- [ ] Old storage removed

--- a/docs/98-journals/2026-03-31-authelia-sso-gathio-debugging.md
+++ b/docs/98-journals/2026-03-31-authelia-sso-gathio-debugging.md
@@ -1,0 +1,135 @@
+# Authelia SSO Blank Page & Gathio 403 — Debugging Session
+
+**Date:** 2026-03-31
+**Incident:** Three interrelated issues — Gathio event creation 403, SSO portal blank page, Gathio edit token recovery
+**Severity:** Medium (authentication portal degraded, event creation blocked — no data loss)
+**Resolution:** Authelia access control regex fixes, WebAuthn config migration, Traefik rate-limit removal from SSO router
+**Duration:** ~2 hours of systematic debugging across 4 root causes
+
+---
+
+## Executive Summary
+
+A user attempting to create an event on `events.patriark.org` received 403 Forbidden. Investigating this led to discovering a second, more severe issue: `sso.patriark.org` rendering a blank white page when visited by an authenticated user. The SSO login flow still worked (redirect to Grafana succeeded), but revisiting the portal showed a broken `/2fa/webauthn` page.
+
+The blank page took significant investigation — initial hypotheses (browser cache, circuit breaker, Authelia rate limits, CSP issues) were all eliminated before the true root cause was identified via browser Network tab inspection: Traefik's shared `rate-limit@file` middleware was returning 429 for Authelia's lazily-loaded JavaScript modules.
+
+---
+
+## Issues & Root Causes
+
+### Issue 1: Gathio 403 on Event Creation
+
+**Symptom:** User clicks "Create Event" on `events.patriark.org` → 403 Forbidden.
+
+**Root cause:** Two gaps in Authelia's access control rules for `events.patriark.org`:
+
+1. **Event page regex too strict.** The bypass rule `^/[A-Za-z0-9_-]{10,30}$` used `$` end anchor, but Authelia matches against the full URL path including query strings. When Gathio redirects to an event page with an edit token (`/ExjDAu4EXxt4dn6VhTdDm?e=sttlk1kkgqmq0qont36r6tgbyyb1yl7f`), the regex failed → fell through to `default_policy: deny` → 403.
+
+2. **Missing `/known/groups` path.** Gathio uses this endpoint for group lookups. Not covered by any rule → also denied by default policy.
+
+**Fix:** Updated `config/authelia/configuration.yml`:
+- Changed event ID regex to `^/[A-Za-z0-9_-]{10,30}(\?.*)?$` (allows optional query string)
+- Added `^/known/.*` to the bypass list
+
+**Verification (Authelia logs confirmed):**
+```
+url https://events.patriark.org/ExjDAu4EXxt4dn6VhTdDm?e=sttlk1kkgqmq0qont36r6tgbyyb1yl7f
+→ "No matching rule" → applying default policy → FORBIDDEN
+```
+
+### Issue 2: Gathio Edit Token Recovery
+
+**Symptom:** User created an event without setting an organizer email, never saw the edit password.
+
+**Root cause:** Gathio uses edit tokens (not visible passwords). The `editPassword` field was empty, but the `editToken` existed in MongoDB. The user created 3 duplicate events from the 403 retries.
+
+**Fix:** Queried MongoDB directly to retrieve the edit token:
+```
+podman exec gathio-db mongosh --quiet --eval "..." gathio
+→ editToken: 'l6cq3j9gnqt9pw2u0pfw1ihf71mpd796'
+→ Edit URL: https://events.patriark.org/okfTUaCB2wVsUzSGrtbal?e=l6cq3j9gnqt9pw2u0pfw1ihf71mpd796
+```
+
+### Issue 3: SSO Portal Blank Page (Most Complex)
+
+**Symptom:** Visiting `sso.patriark.org` while authenticated showed a white page at `/2fa/webauthn`. Login flow worked (first factor → WebAuthn → redirect to Grafana), but revisiting the portal failed. Affected all browsers including private mode.
+
+**Investigation timeline (hypotheses tested and eliminated):**
+
+| # | Hypothesis | Evidence | Result |
+|---|-----------|----------|--------|
+| 1 | Authelia `/api/configuration` returning 403 | Endpoint requires 1FA middleware — 403 is expected for unauthenticated requests (curl). Authenticated users get 200. | Eliminated |
+| 2 | Stale Redis sessions | 48 sessions accumulated. Flushed all. | Did not fix |
+| 3 | WebAuthn deprecation warning | `user_verification` deprecated in v4.39.0, replaced by `selection_criteria.user_verification`. Fixed config. | Did not fix |
+| 4 | Browser cache | Private mode also fails. | Eliminated |
+| 5 | Circuit breaker tripping | Removed `circuit-breaker@file` and `retry@file` from SSO router. | Did not fix |
+| 6 | Authelia internal rate limits | Source code confirms static assets are NOT rate-limited by Authelia's endpoint rate limiter. | Eliminated |
+| 7 | **Traefik `rate-limit@file` shared middleware** | **Browser Network tab showed 429 with `x-retry-in` header on JS module requests.** | **Root cause** |
+
+**Root cause:** Traefik's `rate-limit@file` middleware (50 req/min average, 100 burst) was shared across ALL routers and was per-IP. The cascade:
+
+```
+Grafana dashboard auto-refresh (many API calls from same IP)
+  → Rate limit bucket partially consumed
+  → User opens sso.patriark.org in another tab
+  → Authelia SPA fires ~10 parallel import() for JS modules
+  → Combined request count exceeds rate limit
+  → Traefik returns 429 Too Many Requests (no Content-Type header)
+  → Firefox strict MIME checking for ES modules blocks responses
+  → Reports "disallowed MIME type ("")"
+  → SPA crashes → blank white page
+```
+
+**Why curl couldn't reproduce:** curl requests had no valid session cookie (Redis was flushed) and used separate TCP connections. The rate limit is per-IP and the combined load from Grafana + SSO was the trigger.
+
+**Fix:** Removed `rate-limit@file` and `circuit-breaker@file` from the SSO router. Authelia has its own built-in brute-force regulation (`max_retries: 5, find_time: 2m, ban_time: 5m`), making external rate limiting redundant and harmful for SPA module loading.
+
+### Issue 4: WebAuthn Config Deprecation
+
+**Symptom:** Authelia startup warning about `webauthn.user_verification` being deprecated in v4.39.0.
+
+**Fix:** Migrated from flat key to nested structure:
+```yaml
+# Before
+webauthn:
+  user_verification: preferred
+
+# After
+webauthn:
+  selection_criteria:
+    user_verification: preferred
+```
+
+Config now validates cleanly with no warnings.
+
+---
+
+## Changes Applied
+
+| File | Change |
+|------|--------|
+| `config/authelia/configuration.yml` | Fixed event page bypass regex, added `/known/.*` bypass, migrated WebAuthn config |
+| `config/traefik/dynamic/routers.yml` | Removed `rate-limit@file`, `circuit-breaker@file`, `retry@file` from SSO router |
+
+---
+
+## Post-Incident Actions
+
+- Flushed all Authelia Redis sessions (password change + clean slate)
+- User changed Authelia password after Bitwarden flagged old one
+- OTP for password change retrieved from filesystem notifier (`/data/notification.txt`)
+
+---
+
+## Lessons Learned
+
+1. **Shared Traefik rate limits are dangerous for SPAs.** A per-IP rate limit shared across routers means one service's background traffic (Grafana auto-refresh) can starve another service (SSO module loading). Rate limits should be per-router or SPAs should be excluded.
+
+2. **Browser Network tab is the definitive diagnostic.** Two hours of server-side investigation (curl, logs, source code) couldn't identify the 429. Five seconds of browser F12 → Network tab revealed it immediately. When the server says "200" but the browser says "broken," always check the browser's actual received response.
+
+3. **Circuit breakers and retry middleware amplify failures for auth servers.** The retry middleware (3 attempts) tripled the load, making the circuit breaker more likely to trip, which then blocked ALL requests. For a service with its own brute-force protection, external circuit breakers add risk without benefit.
+
+4. **Authelia's `default_policy: deny` is strict by design.** Every path that isn't explicitly matched gets denied. When adding new services, test all paths the application uses (including API endpoints, static assets, and URLs with query strings), not just the main page.
+
+5. **`$` in regex doesn't mean what you think when query strings exist.** Authelia matches resource regexes against the full URL path including query strings. A `$` anchor will fail to match any URL with `?parameters`.

--- a/docs/98-journals/2026-03-31-proton-bridge-smtp-integration-attempt.md
+++ b/docs/98-journals/2026-03-31-proton-bridge-smtp-integration-attempt.md
@@ -1,0 +1,93 @@
+# Proton Mail Bridge SMTP Integration — Incomplete
+
+**Date:** 2026-03-31
+**Goal:** Deploy Proton Mail Bridge as containerized SMTP relay for Authelia and future services
+**Status:** Partially complete — bridge deployed and authenticated, SMTP auth from Authelia blocked
+**Blocking issue:** `454 4.7.0 invalid username or password` — bridge rejects AUTH even with correct credentials
+
+---
+
+## What Was Accomplished
+
+### Infrastructure Built
+- **Custom container image** built from official RPM (`localhost/proton-bridge:3.23.1`) — Fedora 43 base, includes `pass` for keychain, `nmap-ncat` for healthcheck, `socat` for port forwarding
+- **Dedicated mail network** (`systemd-mail`, 10.89.9.0/24, Internal=true) created for SMTP relay isolation
+- **Proton Bridge authenticated** — interactive CLI login completed with TOTP 2FA, account synced, credentials persisted to BTRFS storage
+- **Quadlet and network files** created and symlinked
+- **Podman secrets** created for SMTP username and password
+- **Authelia quadlet** updated with mail network (10.89.9.78)
+- **Bridge service running** — SMTP handshake responds on port 1025 (native) and port 25 (socat forwarder)
+
+### Files Created
+| File | Purpose |
+|------|---------|
+| `builds/proton-bridge/Containerfile` | Custom image from RPM |
+| `builds/proton-bridge/entrypoint.sh` | Starts socat port 25→1025 forwarder + bridge |
+| `quadlets/mail.network` | Dedicated SMTP network (10.89.9.0/24) |
+| `quadlets/proton-bridge.container` | Service quadlet with keep-id + NET_BIND_SERVICE |
+| Storage dirs on BTRFS pool | config, data, gnupg, password-store |
+
+### Podman Secrets Created
+- `proton_bridge_smtp_username`
+- `proton_bridge_smtp_password`
+
+---
+
+## What Blocked Completion
+
+### Problem 1: Authelia SMTP Port Bug (Worked Around)
+Authelia v4.39.16 ignores the port in `smtp://host:port` addresses — always connects to port 25 regardless of the specified port. The deprecated `host`/`port` fields also auto-map to the same broken `smtp://` scheme.
+
+**Workaround:** socat inside the bridge container forwards port 25 (bound to 0.0.0.0) → 127.0.0.1:1025 (bridge native). Required `AddCapability=NET_BIND_SERVICE` for privileged port binding.
+
+### Problem 2: Bridge Binds to 127.0.0.1 Only (Worked Around)
+Proton Bridge SMTP server listens on `127.0.0.1:1025`, not `0.0.0.0:1025`. Other containers on the mail network cannot reach it directly.
+
+**Workaround:** Same socat forwarder — binds to `0.0.0.0:25`, forwards to `127.0.0.1:1025`.
+
+### Problem 3: SMTP AUTH Rejected (UNRESOLVED)
+```
+454 4.7.0 invalid username or password
+```
+
+Even with the correct bridge-generated credentials (verified manually from `info` output), AUTH PLAIN is rejected. This occurs:
+- On port 1025 directly (no socat)
+- On port 25 via socat
+- From inside the bridge container itself
+- From the Authelia container
+- With and without STARTTLS
+
+**Hypothesis:** Proton Bridge may require STARTTLS to complete before accepting AUTH credentials. The manual test used plain-text AUTH PLAIN (base64-encoded credentials sent before TLS upgrade). When STARTTLS negotiation happens first (as Authelia attempts), the socat forwarder should pass through TLS transparently, but this was not verified due to lack of `openssl`/`swaks` tools in the containers.
+
+**Alternative hypothesis:** The bridge-generated SMTP password may have been invalidated when the bridge service was restarted multiple times during debugging, or the password in the Podman secret doesn't match what the bridge currently expects.
+
+---
+
+## Current State
+
+- **Authelia:** Reverted to `filesystem` notifier (working, OTPs written to `/data/notification.txt`)
+- **Proton Bridge:** Running as a service, authenticated, SMTP responding on ports 25 and 1025
+- **Mail network:** Created and functional, Authelia has connectivity to bridge
+- **SMTP config:** Commented out in Authelia config, ready to uncomment when auth issue is resolved
+- **SMTP secrets:** Commented out in Authelia quadlet
+
+---
+
+## Next Steps to Resolve
+
+1. **Verify credentials:** Stop the bridge, re-run interactive CLI, run `info` to confirm the current SMTP password matches the Podman secret
+2. **Test STARTTLS + AUTH:** Install `openssl` or `swaks` on the host (requires sudo) and test: `swaks --to test@test.com --from surfaceideology@pm.me --server 10.89.2.88:1025 --tls --auth PLAIN --auth-user surfaceideology@pm.me --auth-password <bridge-password>`
+3. **Check bridge mode:** The bridge has "SSL" and "STARTTLS" security modes — verify it's set to STARTTLS (which is what the EHLO response advertises)
+4. **Consider bridge version:** v3.23.1 may have SMTP auth quirks — check Proton Bridge release notes/issues
+
+---
+
+## Lessons Learned
+
+1. **Proton Bridge is not designed for headless/container operation.** It's a desktop app that happens to have a CLI mode. The keychain requirement, GUI launcher binary, localhost-only binding, and interactive-only login all create friction for containerized deployment.
+
+2. **Authelia v4.39.16 has a port parsing bug** for the `smtp://` scheme in the `notifier.smtp.address` field. The deprecated `host`/`port` format is the only workaround, and even that auto-maps to the broken scheme internally. Filed mentally as a known issue.
+
+3. **Test the full chain before building infrastructure.** We built the network, quadlets, image, and secrets before confirming SMTP auth actually works. A 5-minute manual `telnet` test to the bridge would have surfaced the AUTH issue before any of the infrastructure work.
+
+4. **socat is a useful workaround for port/binding issues** but adds complexity. The entrypoint script pattern (background socat + exec main process) works but makes the container harder to reason about.

--- a/docs/98-journals/2026-04-18-podman-storage-migration-execution.md
+++ b/docs/98-journals/2026-04-18-podman-storage-migration-execution.md
@@ -1,0 +1,148 @@
+# Podman Storage Migration: NVMe → BTRFS Pool (Execution)
+
+**Date:** 2026-04-18
+**Status:** Complete — all 31 containers running on BTRFS pool
+**Plan:** [2026-03-28-podman-storage-migration.md](2026-03-28-podman-storage-migration.md)
+**Duration:** ~25 minutes end-to-end; ~7 minutes of container downtime
+**Motivation:** NVMe at 94% (109 GiB / 118 GiB), cascade risk escalating since 2026-03-26 promtail outage
+
+---
+
+## Summary
+
+Moved the ~17 GB Podman overlay storage from `~/.local/share/containers/storage` (NVMe) to `/mnt/btrfs-pool/subvol7-containers/storage` (BTRFS pool, NOCOW) per the 2026-03-28 plan. All services restarted successfully. Three issues surfaced that the plan did not anticipate — none fatal, all worked around in-window.
+
+---
+
+## Issues the Plan Didn't Cover
+
+### Issue 1: `podman stop --all` doesn't stick with quadlets
+
+Running `podman stop --all --timeout 30` returned container IDs, but within seconds systemd restarted them via the quadlet-managed `.service` units. Seven containers bounced back up within 4 minutes.
+
+**Fix:** Stop via `systemctl --user stop <service>` for each of the 31 quadlets. Traefik additionally required stopping `http.socket` and `https.socket` first (ADR-022 socket activation) — otherwise systemd logs `Stopping 'traefik.service', but its triggering units are still active` and the container relaunches on the next socket connection.
+
+```bash
+for svc in $(cat /tmp/all-quadlets.txt); do
+  systemctl --user stop "${svc}.service"
+done
+systemctl --user stop http.socket https.socket traefik.service
+```
+
+### Issue 2: rsync as the regular user can't read subordinate-UID files
+
+Rootless Podman stores overlay layer contents under subordinate UIDs (`/etc/subuid` range, e.g. UIDs 100000+ on the host). From a plain user shell these directories are unreadable: rsync logged ~550 "Permission denied" errors on paths like `overlay/<sha>/diff/var/cache/apt/archives/partial`.
+
+The first rsync copied 370858 of 371422 files (96% of the tree, the full 17 GB of layer content — the missed files were all inside unreadable directory handles). That's close enough that a sanity check would say "done," but not actually complete.
+
+**Fix:** re-run rsync inside the user namespace with `podman unshare`. Inside the unshared namespace, subordinate UIDs map to root and everything becomes readable:
+
+```bash
+podman unshare rsync -aHAX --delete \
+  ~/.local/share/containers/storage/ \
+  /mnt/btrfs-pool/subvol7-containers/storage/
+```
+
+After this pass: 371422 files both sides, exact match.
+
+### Issue 3: Podman's SQLite DB has paths baked in at creation
+
+Starting `podman info` after pointing `storage.conf` at the new path failed with:
+
+```
+Error: database static dir "/home/patriark/.local/share/containers/storage/libpod"
+       does not match our static dir "/mnt/btrfs-pool/subvol7-containers/storage/libpod":
+       database configuration mismatch
+```
+
+Podman 5.x uses SQLite (`db.sql` in the storage root) for container/image metadata. The `DBConfig` table records the `StaticDir`, `GraphRoot`, and `VolumeDir` it was created with. rsync preserves the binary verbatim, so the new path's DB still claimed the old path was its home.
+
+**Fix:** update the three path fields in-place:
+
+```bash
+sqlite3 /mnt/btrfs-pool/subvol7-containers/storage/db.sql \
+  "UPDATE DBConfig SET
+     StaticDir='/mnt/btrfs-pool/subvol7-containers/storage/libpod',
+     GraphRoot='/mnt/btrfs-pool/subvol7-containers/storage',
+     VolumeDir='/mnt/btrfs-pool/subvol7-containers/storage/volumes';"
+```
+
+After this, `podman info` immediately showed the new paths and 30 images loaded without issue. No container metadata was lost — `podman ps -a` listed the 31 expected names (though all stopped, as expected after the systemctl shutdown).
+
+**Note:** `podman system migrate` does not address this — that command is for UID remapping changes, not storage path moves. Editing the DB is the documented workaround for path migration in the Podman community.
+
+---
+
+## Timeline
+
+| Time (CET) | Event |
+|------------|-------|
+| 11:16 | Target dir created, NOCOW applied, SELinux equivalence registered |
+| 11:25 | `podman stop --all` executed — 7 containers bounced back via systemd |
+| 11:28 | Stopped all 31 services via `systemctl --user stop`; Traefik required socket stops |
+| 11:29 | First rsync pass began (58 MB/s, 4m20s total) |
+| 11:33 | First rsync complete: 17 GB / 370858 files; 551 files missed (permission denied) |
+| 11:34 | `podman unshare rsync` reconciled to 371422 / 371422 files |
+| 11:35 | `restorecon -R` applied SELinux labels |
+| 11:36 | `storage.conf` written |
+| 11:37 | `podman info` failed — DBConfig mismatch |
+| 11:38 | sqlite3 UPDATE on DBConfig paths; `podman info` succeeded |
+| 11:39 | Core services started (Traefik, CrowdSec, Authelia, Redis) |
+| 11:42 | All 31 containers running; most healthy, a few still in "starting" |
+| 11:45 | Web-facing verification complete (15 subdomains checked) |
+
+Total container downtime: ~11:28 → 11:39 = 11 minutes.
+
+---
+
+## Post-Migration State
+
+- **Podman:** `graphRoot: /mnt/btrfs-pool/subvol7-containers/storage`, `graphRootAllocated: 16 TB`
+- **All 31 quadlet services:** running; healthy after warmup
+- **NVMe:** still 93% — the old `~/.local/share/containers/storage` (17 GB) remains in place per the plan's 24–48h soak requirement. Expected post-cleanup: ~78%
+- **BTRFS pool:** 76% → 76% (17 GB added to an 11 TB pool is noise)
+
+---
+
+## Lessons Learned
+
+1. **Quadlet-managed containers need systemctl-level control.** Any migration that assumes `podman stop --all` will leave containers stopped is wrong for this stack. Document this in the deployment skill — a `stop-all-quadlets` helper is a natural extension.
+
+2. **Socket-activated services need their sockets stopped too.** ADR-022's socket activation was merged two days before this migration. The plan didn't mention it because it didn't exist yet. Any future maintenance procedure that stops Traefik needs `http.socket https.socket` in the shutdown order.
+
+3. **`podman unshare` is the canonical way to touch rootless storage from the host.** This applies to any migration, backup verification, or filesystem operation against `~/.local/share/containers/storage`. Raw rsync / du / find will silently skip files.
+
+4. **Podman 5.x SQLite has location-bound state.** If you move the storage, the DB follows but doesn't self-heal. This is a reasonable safety check (catches misconfiguration), but it means "rsync + point config at new path" is always a three-step move, not two. The UPDATE is idempotent and survives Podman upgrades.
+
+5. **The 2026-03-28 plan is now incomplete.** The doc describes Steps 1–6 accurately but misses the three issues above. Either update that doc in place or supersede it with a reference to this execution journal. The plan's rollback procedure (remove `storage.conf`) is still correct and still works — verified by reading the path where Podman would fall back.
+
+---
+
+## Follow-Up Actions
+
+- [ ] Update `2026-03-28-podman-storage-migration.md` with the three workarounds, or mark it superseded
+- [ ] Close issue #139 (Root filesystem at 90% capacity) once old storage is removed
+- [ ] After 24–48h soak: `rm -rf ~/.local/share/containers/storage` and verify NVMe drops below 80%
+- [ ] Add a health check for journal persistence mode (open action from 2026-03-26 outage — same NVMe pressure that triggered that is what this migration addresses)
+
+---
+
+## Verification Commands (for future reference)
+
+```bash
+# Confirm Podman is reading from the new path
+podman info | grep -E "graphRoot|runRoot"
+# → graphRoot: /mnt/btrfs-pool/subvol7-containers/storage
+
+# Confirm DB agrees with the current config
+sqlite3 /mnt/btrfs-pool/subvol7-containers/storage/db.sql \
+  "SELECT StaticDir, GraphRoot, VolumeDir FROM DBConfig;"
+
+# Confirm NOCOW is still set (BTRFS can silently drop the flag on subvols under stress)
+lsattr -d /mnt/btrfs-pool/subvol7-containers/storage
+# → ---------------C------
+
+# Confirm SELinux labels match
+ls -Zd /mnt/btrfs-pool/subvol7-containers/storage \
+       /home/patriark/.local/share/containers/storage
+```

--- a/docs/98-journals/2026-04-21-crowdsec-acquisition-and-rate-limit-retune.md
+++ b/docs/98-journals/2026-04-21-crowdsec-acquisition-and-rate-limit-retune.md
@@ -1,0 +1,132 @@
+# CrowdSec Acquisition Wiring + Post-ADR-022 Rate-Limit Retune
+
+**Date:** 2026-04-21
+**Session type:** Focused security hardening — closing the loop ADR-022 opened
+**Scope:** (1) Wire real CrowdSec log acquisition, (2) retune three NAT-era rate-limits, (3) commit pending working-tree drift
+**Outcome:** CrowdSec now tails Traefik access logs; three rate-limits returned to per-IP semantics; acquisition pipeline verified end-to-end except for final decision creation (blocked by needing an external IP for empirical verification)
+
+---
+
+## Why this session
+
+ADR-022 (merged 2026-04-17) restored real client source IPs at Traefik by moving from the rootless-pasta NAT model to a socket-activated listener that preserves `X-Forwarded-For`. That fix unblocked two things that had been silently degraded since the NAT collapse:
+
+1. **CrowdSec was effectively blind.** Only the CAPI community blocklist was producing decisions — local acquisition had been deferred because every request previously appeared to come from pasta's NAT address (`10.89.x.x`), so log-derived scenarios would either see every request as "one source" or fire on the local-only NAT address. No point wiring acquisition until source IPs were real again.
+2. **Rate-limits were bucketed by NAT source.** All external traffic shared a single bucket post-NAT, forcing limits to be sized for the entire internet rather than per-client. Three services (qBittorrent, Immich, Nextcloud) were running inflated burst/average values that made the rate-limit layer nearly inert against abusive single sources.
+
+Both items were waiting on ADR-022. The fix shipped four days ago; this session closes the loop.
+
+---
+
+## Step 1 — CrowdSec acquisition wiring
+
+### State before
+
+- `config/crowdsec/acquis.yaml` was a placeholder (empty frontmatter only, per issue #137)
+- No log sources were being tailed; CrowdSec relied entirely on the CAPI community blocklist for decisions
+- `cscli metrics show acquisition` returned "no source configured"
+
+### Scope decision
+
+Narrowed to **Traefik access logs only** this session. Two other candidate sources were evaluated and explicitly deferred with rationale:
+
+- **sshd journald** — SSH is not internet-exposed. The UDM Pro port-forwards only 80/443/8096/7359; port 22 is not forwarded and is restricted to LAN. Brute-force against LAN-only SSH is low-value, and we already have other defenses (fail2ban via the base Fedora install). Revisit if SSH exposure ever changes.
+- **Authelia journald** — blocked by an image constraint: the `crowdsec:latest` image does not ship `journalctl`, so journald acquisition isn't possible without either (a) switching to a debian-based image variant, (b) deploying a systemd journal-to-file bridge, or (c) enabling the `LePresidente/authelia` collection after wiring a file-based log path in `authelia.container`. None of those are cheap, and this session was scoped to "get real signal flowing" rather than full coverage. Separate ADR when prioritized.
+
+### Changes
+
+**`quadlets/crowdsec.container`** — added read-only mount of the Traefik log directory:
+
+```
+Volume=/mnt/btrfs-pool/subvol7-containers/traefik-logs:/var/log/traefik:ro,z
+```
+
+Using `:z` (shared SELinux label) rather than `:Z` because the same directory is bind-mounted into Traefik writeable. CrowdSec only reads.
+
+**`data/crowdsec/config/acquis.yaml`** — rewritten as a documented pointer: clarifies that per-source configs live in `acquis.d/` and lists the active sources + deferred sources with rationale. This file is the first thing anyone touching CrowdSec acquisition will open; making it a readable map saves future time.
+
+**`data/crowdsec/config/acquis.d/traefik.yaml`** (new, gitignored under `data/`):
+
+```yaml
+filenames:
+  - /var/log/traefik/access.log
+labels:
+  type: traefik
+force_inotify: true
+```
+
+`force_inotify: true` is important — the log rotates via logrotate, and without inotify CrowdSec's default polling can miss the rotation and read from a stale fd.
+
+Traefik already filters access logs to `statusCodes 400-599`, so CrowdSec only sees error traffic. That's exactly what the `crowdsecurity/base-http-scenarios` and `crowdsecurity/http-cve` scenarios want — no signal in 2xx traffic for those rules.
+
+### Verification
+
+After quadlet reload + service restart:
+
+```
++----------------------------------+------------+--------------+----------------+------------------------+-------------------+
+| Source                           | Lines read | Lines parsed | Lines unparsed | Lines poured to bucket | Lines whitelisted |
++----------------------------------+------------+--------------+----------------+------------------------+-------------------+
+| file:/var/log/traefik/access.log | 12         | 12           | -              | -                      | 23                |
++----------------------------------+------------+--------------+----------------+------------------------+-------------------+
+```
+
+Read = parsed (good — parser is matching the JSON schema). `Lines whitelisted > Lines read` is expected: the `crowdsecurity/whitelists` collection plus the local `crowdsecurity/local-whitelist` (which explicitly contains `192.168.1.0/24`, `192.168.100.0/24`, and `10.89.*`) each whitelist the same line, so a single request from a LAN client can trigger multiple whitelist hits.
+
+### What remains unverified
+
+The end-to-end pipeline — "bad request → scenario fires → decision created → bouncer enforces" — cannot be fully verified from inside the LAN. Every LAN-origin probe is whitelisted before it reaches a scenario. Confirming decision creation requires either (a) traffic from an external IP (passive — wait), or (b) a temporary whitelist bypass (active — invasive, not worth it for this).
+
+Accepted as a passive observation window: the next time an abusive source hits the edge, we should see the decision ledger populate. Task #7 tracks this as a pending observation.
+
+---
+
+## Step 2 — Rate-limit retune
+
+### Context
+
+Rate-limits at `config/traefik/dynamic/middleware.yml` use `sourceCriterion.ipStrategy.depth: 1` — they bucket by the first hop behind Traefik. Under the NAT collapse, that hop was `10.89.x.x` for every external request, so a single bucket absorbed all internet traffic. The limits were inflated to avoid blocking legitimate users.
+
+Post-ADR-022, `depth: 1` resolves to the real client IP. Previous limits are now far too generous — a single abusive source gets the budget originally intended for "all external traffic combined."
+
+### Retune
+
+| Middleware | `average` (before → after) | `burst` (before → after) | Rationale |
+|------------|----------------------------|---------------------------|-----------|
+| `rate-limit-nextcloud` | 600 → 300 | 3000 → 1500 | Nextcloud desktop sync bursts hard on large file sets. 300 rpm sustained comfortably absorbs sync catchup for 1–2 clients; 1500 burst covers initial sync storms. Halved across the board since per-IP attribution returned. |
+| `rate-limit-qbittorrent` | 300 → 100 | 600 (unchanged) | qBittorrent WebUI is single-user. 100 rpm is plenty for active browsing; burst retained at 600 for occasional bulk operations (e.g., moving a whole category). |
+| `rate-limit-immich` | 500 → 200 | 2000 → 1500 | Immich mobile upload is the worst case — bulk photo uploads hit the API in parallel. 200 rpm sustained handles steady upload + browsing; 1500 burst handles bulk upload window. |
+
+All three kept `period: 1m` and `sourceCriterion.ipStrategy.depth: 1`.
+
+### What remains unverified
+
+Rate-limit behavior under real 429 conditions cannot be reliably tested from LAN — my burst probes hit TCP shedding from ephemeral-port / SYN pressure rather than the Traefik rate-limiter. Traefik's reload log showed no parse errors at apply time, which is the only deterministic signal available from inside. Empirical 429 verification needs an external source; passive observation over the next week will surface any over-tight limits via legitimate-user complaints or alert noise.
+
+---
+
+## Step 3 — Commit drift + this journal
+
+The working tree had accumulated drift from several prior sessions that hadn't been committed — notably the 2026-03-31 Authelia SSO debugging, the 2026-03-31 Proton Bridge SMTP attempt (failed — kept as documented attempt), the 2026-04-18 Podman storage migration, and the Immich v2.5.6 → v2.6.3 version bump (already running on host, config had not been committed).
+
+Split into logical commits to keep history navigable. This journal ships with commit #1 (the CrowdSec + rate-limit work) so the investigation is paired with the change that caused it.
+
+---
+
+## Follow-ups
+
+- **Observation window** (passive, 24–48h): watch `cscli decisions list` for the first local-origin decision. If none appear after a week of real external traffic, re-examine scenario enablement.
+- **Authelia acquisition** (deferred): needs either an image swap or a journal-to-file bridge + `LePresidente/authelia` collection + Authelia config change to write login failures to a file. Own ADR when prioritized.
+- **sshd acquisition** (deferred): not worth it until SSH is internet-exposed, which it shouldn't be.
+- **Nextcloud circuit-breaker + retry reconciliation** (issue #146): the same class of middleware-interaction problem Immich had. Same logic applies; separate session.
+- **Orphaned rate-limit.yml** (issue #136): `config/traefik/dynamic/rate-limit.yml` is referenced nowhere after middleware consolidation; delete.
+- **Middleware pruning** (issue #156): audit which middlewares are actually referenced and drop the dead ones.
+
+---
+
+## Lessons
+
+1. **ADR-022 had more downstream debt than I realized.** The socket-activation fix unblocked two separate pieces of security work that had been quietly deferred. Worth re-auditing the other "waiting on source IPs" items I might have forgotten about.
+2. **Acquisition doesn't require full coverage to be useful.** Traefik alone covers the entire internet-facing surface — which is where 99% of the interesting threat signal actually lives. sshd and Authelia are defense-in-depth, not primary signal sources.
+3. **Whitelist behavior is confusing and worth documenting.** The "lines whitelisted > lines read" metric surprised me until I traced through the three overlapping whitelist sources. Future me will thank present me for the `acquis.yaml` header comment.
+4. **"Verified end-to-end" from inside the LAN is a lie.** Any security layer that filters on source IP cannot be empirically verified without an external source. Accept that and plan for passive observation rather than trying to force synthetic verification that lies about reality.

--- a/docs/AUTO-DEPENDENCY-GRAPH.md
+++ b/docs/AUTO-DEPENDENCY-GRAPH.md
@@ -1,6 +1,6 @@
 # Service Dependency Graph (Auto-Generated)
 
-**Generated:** 2026-03-24 06:01:52 UTC
+**Generated:** 2026-04-21 08:27:34 UTC
 **System:** fedora-htpc
 
 ---
@@ -52,6 +52,7 @@ graph TB
         navidrome[navidrome]
         node_exporter[node_exporter]
         promtail[promtail]
+        proton_bridge[proton-bridge]
         qbittorrent[qbittorrent]
         unpoller[unpoller]
     end
@@ -77,6 +78,7 @@ graph TB
     traefik -.-> navidrome
     traefik -.-> nextcloud
     traefik -.-> prometheus
+    traefik -.-> proton_bridge
     traefik -.-> qbittorrent
     traefik -.-> unpoller
     traefik -.-> vaultwarden
@@ -100,7 +102,7 @@ graph TB
 |---------|-------------------|----------------|
 | **authelia** | redis-authelia | 🟡 Cannot access Authelia-protected services (monitoring, dashboard) |
 | **redis-authelia** | — | 🟡 All SSO sessions lost, users must re-authenticate |
-| **traefik** | — | 🔴 Total outage — no external access to any service |
+| **traefik** | http.socket,https.socket | 🔴 Total outage — no external access to any service |
 
 ### Tier 2: Infrastructure
 
@@ -146,6 +148,7 @@ graph TB
 | **navidrome** | — | 🟢 Service-specific impact |
 | **node_exporter** | — | 🟢 Service-specific impact |
 | **promtail** | — | 🟢 Service-specific impact |
+| **proton-bridge** | — | 🟢 Service-specific impact |
 | **qbittorrent** | — | 🟢 Service-specific impact |
 | **unpoller** | — | 🟢 Service-specific impact |
 
@@ -181,10 +184,11 @@ Derived from `After=` directives in quadlet files. systemd handles this automati
 | postgresql-immich | (no ordering constraints) |
 | prometheus | node_exporter |
 | promtail | loki |
+| proton-bridge | (no ordering constraints) |
 | qbittorrent | (no ordering constraints) |
 | redis-authelia | (no ordering constraints) |
 | redis-immich | (no ordering constraints) |
-| traefik | (no ordering constraints) |
+| traefik | http.socket,https.socket |
 | unpoller | prometheus |
 | vaultwarden | traefik |
 
@@ -200,6 +204,8 @@ Services on the same network can communicate:
 
 **home_automation:** home-assistant,matter-server
 
+**mail:** authelia,proton-bridge
+
 **media_services:** jellyfin
 
 **monitoring:** alert-discord-relay,alertmanager,cadvisor,grafana,loki,node_exporter,prometheus,promtail,unpoller
@@ -208,7 +214,7 @@ Services on the same network can communicate:
 
 **photos:** immich-ml,immich-server,postgresql-immich,redis-immich
 
-**reverse_proxy:** alert-discord-relay,alertmanager,audiobookshelf,authelia,crowdsec,gathio,grafana,home-assistant,homepage,immich-server,jellyfin,loki,navidrome,nextcloud,prometheus,qbittorrent,traefik,unpoller,vaultwarden
+**reverse_proxy:** alert-discord-relay,alertmanager,audiobookshelf,authelia,crowdsec,gathio,grafana,home-assistant,homepage,immich-server,jellyfin,loki,navidrome,nextcloud,prometheus,proton-bridge,qbittorrent,traefik,unpoller,vaultwarden
 
 ---
 

--- a/docs/AUTO-DOCUMENTATION-INDEX.md
+++ b/docs/AUTO-DOCUMENTATION-INDEX.md
@@ -1,7 +1,7 @@
 # Documentation Index (Auto-Generated)
 
-**Generated:** 2026-03-24 06:01:53 UTC
-**Total Documents:** 419
+**Generated:** 2026-04-21 08:27:35 UTC
+**Total Documents:** 446
 
 ---
 
@@ -22,7 +22,7 @@
 
 ## Documentation by Category
 
-### 00-foundation/ (14 documents)
+### 00-foundation/ (19 documents)
 
 **Fundamentals and core concepts**
 
@@ -43,6 +43,11 @@
 - ADR-018: [2026-02-04-ADR-018-static-ip-multi-network-services](00-foundation/decisions/2026-02-04-ADR-018-static-ip-multi-network-services.md)
 - ADR-019: [2026-02-22-ADR-019-filesystem-permission-model](00-foundation/decisions/2026-02-22-ADR-019-filesystem-permission-model.md)
 - ADR-020: [2026-03-21-ADR-020-daily-external-backups](00-foundation/decisions/2026-03-21-ADR-020-daily-external-backups.md)
+- ADR-021: [2026-03-28-ADR-021-urd-backup-tool](00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md)
+- ADR-022: [2026-04-16-ADR-022-traefik-socket-activation](00-foundation/decisions/2026-04-16-ADR-022-traefik-socket-activation.md)
+- ADR-024: [2026-04-18-ADR-024-database-dump-backup](00-foundation/decisions/2026-04-18-ADR-024-database-dump-backup.md)
+- ADR-025: [2026-04-18-ADR-025-db-storage-migration-deferred](00-foundation/decisions/2026-04-18-ADR-025-db-storage-migration-deferred.md)
+- ADR-023: [2026-04-18-ADR-023-btrfs-storage-architecture-databases](00-foundation/decisions/withdrawn/2026-04-18-ADR-023-btrfs-storage-architecture-databases.md)
 
 ---
 
@@ -203,7 +208,7 @@
 
 ---
 
-### 98-journals/ (188 documents)
+### 98-journals/ (197 documents)
 
 **Chronological project history (append-only log)**
 
@@ -211,7 +216,7 @@ Complete dated entries documenting the homelab journey. See directory for full c
 
 ---
 
-### 99-reports/ (34 documents)
+### 99-reports/ (47 documents)
 
 **Automated system reports and point-in-time snapshots**
 
@@ -221,22 +226,26 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 
 ## Recently Updated (Last 7 Days)
 
-- 2026-03-18: [2025-12-31-ADR-016-configuration-design-principles.md](00-foundation/decisions/2025-12-31-ADR-016-configuration-design-principles.md)
-- 2026-03-18: [2026-02-04-ADR-018-static-ip-multi-network-services.md](00-foundation/decisions/2026-02-04-ADR-018-static-ip-multi-network-services.md)
-- 2026-03-22: [2026-03-21-ADR-020-daily-external-backups.md](00-foundation/decisions/2026-03-21-ADR-020-daily-external-backups.md)
-- 2026-03-22: [backup-strategy.md](20-operations/guides/backup-strategy.md)
-- 2026-03-20: [2026-03-19-fedora-coreos-rebuild-plan.md](97-plans/2026-03-19-fedora-coreos-rebuild-plan.md)
-- 2026-03-20: [2026-03-19-nixos-homelab-rebuild-plan.md](97-plans/2026-03-19-nixos-homelab-rebuild-plan.md)
-- 2026-03-22: [2026-03-22-urd-btrfs-time-machine-plan.md](97-plans/2026-03-22-urd-btrfs-time-machine-plan.md)
-- 2026-03-17: [2026-03-17-pasta-source-nat-investigation.md](98-journals/2026-03-17-pasta-source-nat-investigation.md)
-- 2026-03-19: [2026-03-17-traefik-network-attack-surface-reduction.md](98-journals/2026-03-17-traefik-network-attack-surface-reduction.md)
-- 2026-03-22: [2026-03-21-backup-script-operational-excellence.md](98-journals/2026-03-21-backup-script-operational-excellence.md)
-- 2026-03-22: [2026-03-22-backup-system-audit-and-architecture-exploration.md](98-journals/2026-03-22-backup-system-audit-and-architecture-exploration.md)
-- 2026-03-23: [2026-03-23-cadvisor-oom-death-spiral-postmortem.md](98-journals/2026-03-23-cadvisor-oom-death-spiral-postmortem.md)
-- 2026-03-24: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
-- 2026-03-24: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
-- 2026-03-24: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
-- 2026-03-24: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
+- 2026-04-20: [2026-03-28-ADR-021-urd-backup-tool.md](00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md)
+- 2026-04-16: [2026-04-16-ADR-022-traefik-socket-activation.md](00-foundation/decisions/2026-04-16-ADR-022-traefik-socket-activation.md)
+- 2026-04-18: [2026-04-18-ADR-024-database-dump-backup.md](00-foundation/decisions/2026-04-18-ADR-024-database-dump-backup.md)
+- 2026-04-18: [2026-04-18-ADR-025-db-storage-migration-deferred.md](00-foundation/decisions/2026-04-18-ADR-025-db-storage-migration-deferred.md)
+- 2026-04-18: [2026-04-18-ADR-023-btrfs-storage-architecture-databases.md](00-foundation/decisions/withdrawn/2026-04-18-ADR-023-btrfs-storage-architecture-databases.md)
+- 2026-04-16: [2026-03-17-pasta-source-nat-investigation.md](98-journals/2026-03-17-pasta-source-nat-investigation.md)
+- 2026-04-16: [2026-03-26-promtail-journal-export-outage.md](98-journals/2026-03-26-promtail-journal-export-outage.md)
+- 2026-04-20: [2026-03-28-podman-storage-migration.md](98-journals/2026-03-28-podman-storage-migration.md)
+- 2026-04-16: [2026-03-31-authelia-sso-gathio-debugging.md](98-journals/2026-03-31-authelia-sso-gathio-debugging.md)
+- 2026-04-16: [2026-03-31-proton-bridge-smtp-integration-attempt.md](98-journals/2026-03-31-proton-bridge-smtp-integration-attempt.md)
+- 2026-04-16: [2026-04-16-adr-022-socket-activation-prototype.md](98-journals/2026-04-16-adr-022-socket-activation-prototype.md)
+- 2026-04-18: [2026-04-18-podman-storage-migration-execution.md](98-journals/2026-04-18-podman-storage-migration-execution.md)
+- 2026-04-21: [2026-04-21-crowdsec-acquisition-and-rate-limit-retune.md](98-journals/2026-04-21-crowdsec-acquisition-and-rate-limit-retune.md)
+- 2026-04-21: [2026-04-21-ha-rate-limit-rollback-post-adr022.md](98-journals/2026-04-21-ha-rate-limit-rollback-post-adr022.md)
+- 2026-04-16: [2026-04-16-nat-remediation-research.md](99-reports/2026-04-16-nat-remediation-research.md)
+- 2026-04-17: [2026-04-17-service-configuration-review.md](99-reports/2026-04-17-service-configuration-review.md)
+- 2026-04-18: [2026-04-18-design-review-ADR-023-btrfs-storage-architecture-databases.md](99-reports/2026-04-18-design-review-ADR-023-btrfs-storage-architecture-databases.md)
+- 2026-04-17: [remediation-monthly-202603.md](99-reports/remediation-monthly-202603.md)
+- 2026-04-15: [security-audit-2026-04-15.md](99-reports/security-audit-2026-04-15.md)
+- 2026-04-21: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
 
 ---
 
@@ -244,6 +253,7 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 
 **Traefik:**
 - Guide: [traefik.md](10-services/guides/traefik.md)
+- ADR: [ADR-022](00-foundation/decisions/2026-04-16-ADR-022-traefik-socket-activation.md)
 - Config: `~/containers/config/traefik/`
 - Quadlet: `~/.config/containers/systemd/traefik.container`
 
@@ -275,7 +285,6 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 - Guide: [nextcloud.md](10-services/guides/nextcloud.md)
 - ADR: [ADR-013](10-services/decisions/2025-12-20-ADR-013-nextcloud-native-authentication.md)
 - ADR: [ADR-014](10-services/decisions/2025-12-20-ADR-014-nextcloud-passwordless-authentication.md)
-- Config: `~/containers/config/nextcloud/`
 - Quadlet: `~/.config/containers/systemd/nextcloud.container`
 
 **Vaultwarden:**

--- a/docs/AUTO-NETWORK-TOPOLOGY.md
+++ b/docs/AUTO-NETWORK-TOPOLOGY.md
@@ -1,7 +1,7 @@
 # Network Topology (Auto-Generated)
 
-**Generated:** 2026-03-24 06:01:49 UTC
-**System:** fedora-htpc | **Networks:** 8 | **Containers:** 30
+**Generated:** 2026-04-21 08:27:30 UTC
+**System:** fedora-htpc | **Networks:** 9 | **Containers:** 31
 
 ---
 
@@ -35,6 +35,7 @@ graph TB
     CrowdSec -->|Rate Limit| jellyfin[jellyfin]
     CrowdSec -->|Rate Limit| navidrome[navidrome]
     CrowdSec -->|Rate Limit| nextcloud[nextcloud]
+    CrowdSec -->|Rate Limit| proton_bridge[proton-bridge]
     CrowdSec -->|Rate Limit| unpoller[unpoller]
     CrowdSec -->|Rate Limit| vaultwarden[vaultwarden]
 
@@ -74,6 +75,12 @@ graph TB
         direction LR
         home_automation_home_assistant[home-assistant]
         home_automation_matter_server[matter-server]
+    end
+
+    subgraph mail["mail<br/>10.89.9.0/24"]
+        direction LR
+        mail_authelia[authelia]
+        mail_proton_bridge[proton-bridge]
     end
 
     subgraph media_services["media_services<br/>10.89.1.0/24"]
@@ -126,6 +133,7 @@ graph TB
         reverse_proxy_navidrome[navidrome]
         reverse_proxy_nextcloud[nextcloud]
         reverse_proxy_prometheus[prometheus]
+        reverse_proxy_proton_bridge[proton-bridge]
         reverse_proxy_qbittorrent[qbittorrent]
         reverse_proxy_traefik[traefik]
         reverse_proxy_unpoller[unpoller]
@@ -148,42 +156,43 @@ graph TB
 
 Shows which services belong to which networks. Dynamically generated from running container state.
 
-| Service | auth_services | gathio | home_automation | media_services | monitoring | nextcloud | photos | reverse_proxy |
-|---------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Service | auth_services | gathio | home_automation | mail | media_services | monitoring | nextcloud | photos | reverse_proxy |
+|---------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **Gateway & Security** |
-| authelia | ✅ | - | - | - | - | - | - | ✅ |
-| crowdsec | - | - | - | - | - | - | - | ✅ |
-| redis-authelia | ✅ | - | - | - | - | - | - | - |
-| traefik | - | - | - | - | - | - | - | ✅ |
+| authelia | ✅ | - | - | ✅ | - | - | - | - | ✅ |
+| crowdsec | - | - | - | - | - | - | - | - | ✅ |
+| redis-authelia | ✅ | - | - | - | - | - | - | - | - |
+| traefik | - | - | - | - | - | - | - | - | ✅ |
 | **Public Services** |
-| alert-discord-relay | - | - | - | - | ✅ | - | - | ✅ |
-| audiobookshelf | - | - | - | - | - | - | - | ✅ |
-| gathio | - | ✅ | - | - | - | - | - | ✅ |
-| home-assistant | - | - | ✅ | - | - | - | - | ✅ |
-| homepage | - | - | - | - | - | - | - | ✅ |
-| immich-server | - | - | - | - | - | - | ✅ | ✅ |
-| jellyfin | - | - | - | ✅ | - | - | - | ✅ |
-| navidrome | - | - | - | - | - | - | - | ✅ |
-| nextcloud | - | - | - | - | - | ✅ | - | ✅ |
-| qbittorrent | - | - | - | - | - | - | - | ✅ |
-| unpoller | - | - | - | - | ✅ | - | - | ✅ |
-| vaultwarden | - | - | - | - | - | - | - | ✅ |
+| alert-discord-relay | - | - | - | - | - | ✅ | - | - | ✅ |
+| audiobookshelf | - | - | - | - | - | - | - | - | ✅ |
+| gathio | - | ✅ | - | - | - | - | - | - | ✅ |
+| home-assistant | - | - | ✅ | - | - | - | - | - | ✅ |
+| homepage | - | - | - | - | - | - | - | - | ✅ |
+| immich-server | - | - | - | - | - | - | - | ✅ | ✅ |
+| jellyfin | - | - | - | - | ✅ | - | - | - | ✅ |
+| navidrome | - | - | - | - | - | - | - | - | ✅ |
+| nextcloud | - | - | - | - | - | - | ✅ | - | ✅ |
+| proton-bridge | - | - | - | ✅ | - | - | - | - | ✅ |
+| qbittorrent | - | - | - | - | - | - | - | - | ✅ |
+| unpoller | - | - | - | - | - | ✅ | - | - | ✅ |
+| vaultwarden | - | - | - | - | - | - | - | - | ✅ |
 | **Monitoring** |
-| alertmanager | - | - | - | - | ✅ | - | - | ✅ |
-| cadvisor | - | - | - | - | ✅ | - | - | - |
-| grafana | - | - | - | - | ✅ | - | - | ✅ |
-| loki | - | - | - | - | ✅ | - | - | ✅ |
-| node_exporter | - | - | - | - | ✅ | - | - | - |
-| prometheus | - | - | - | - | ✅ | - | - | ✅ |
-| promtail | - | - | - | - | ✅ | - | - | - |
+| alertmanager | - | - | - | - | - | ✅ | - | - | ✅ |
+| cadvisor | - | - | - | - | - | ✅ | - | - | - |
+| grafana | - | - | - | - | - | ✅ | - | - | ✅ |
+| loki | - | - | - | - | - | ✅ | - | - | ✅ |
+| node_exporter | - | - | - | - | - | ✅ | - | - | - |
+| prometheus | - | - | - | - | - | ✅ | - | - | ✅ |
+| promtail | - | - | - | - | - | ✅ | - | - | - |
 | **Backend Services** |
-| gathio-db | - | ✅ | - | - | - | - | - | - |
-| immich-ml | - | - | - | - | - | - | ✅ | - |
-| matter-server | - | - | ✅ | - | - | - | - | - |
-| nextcloud-db | - | - | - | - | - | ✅ | - | - |
-| nextcloud-redis | - | - | - | - | - | ✅ | - | - |
-| postgresql-immich | - | - | - | - | - | - | ✅ | - |
-| redis-immich | - | - | - | - | - | - | ✅ | - |
+| gathio-db | - | ✅ | - | - | - | - | - | - | - |
+| immich-ml | - | - | - | - | - | - | - | ✅ | - |
+| matter-server | - | - | ✅ | - | - | - | - | - | - |
+| nextcloud-db | - | - | - | - | - | - | ✅ | - | - |
+| nextcloud-redis | - | - | - | - | - | - | ✅ | - | - |
+| postgresql-immich | - | - | - | - | - | - | - | ✅ | - |
+| redis-immich | - | - | - | - | - | - | - | ✅ | - |
 
 ---
 
@@ -269,6 +278,17 @@ sequenceDiagram
 - matter-server
 
 
+### mail
+
+- **Full Name:** `systemd-mail`
+- **Subnet:** 10.89.9.0/24
+- **Services:** 2
+
+**Members:**
+- authelia
+- proton-bridge
+
+
 ### media_services
 
 - **Full Name:** `systemd-media_services`
@@ -326,7 +346,7 @@ sequenceDiagram
 
 - **Full Name:** `systemd-reverse_proxy`
 - **Subnet:** 10.89.2.0/24
-- **Services:** 19
+- **Services:** 20
 
 **Members:**
 - alert-discord-relay
@@ -344,6 +364,7 @@ sequenceDiagram
 - navidrome
 - nextcloud
 - prometheus
+- proton-bridge
 - qbittorrent
 - traefik
 - unpoller

--- a/docs/AUTO-SERVICE-CATALOG.md
+++ b/docs/AUTO-SERVICE-CATALOG.md
@@ -1,97 +1,98 @@
 # Service Catalog (Auto-Generated)
 
-**Generated:** 2026-03-24 06:01:48 UTC
-**System:** fedora-htpc | **Services:** 30/30 running | **Health:** 28/28 healthy (2 without healthcheck)
+**Generated:** 2026-04-21 08:27:29 UTC
+**System:** fedora-htpc | **Services:** 31/31 running | **Health:** 19/30 healthy (1 without healthcheck)
 
 ---
 
-## Other (3)
+## Other (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
 | audiobookshelf | advplyr/audiobookshelf:latest | ✅ healthy | 2d | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
-| navidrome | deluan/navidrome:latest | ✅ healthy | 4d | [musikk.patriark.org](https://musikk.patriark.org) | — |
+| navidrome | deluan/navidrome:latest | ⚠️ unhealthy | 2d | [musikk.patriark.org](https://musikk.patriark.org) | — |
+| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | 2d | — | — |
 | qbittorrent | linuxserver/qbittorrent:latest | ✅ healthy | 2d | [torrent.patriark.org](https://torrent.patriark.org) | — |
 
 ## Core Infrastructure (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| authelia | authelia/authelia:latest | ✅ healthy | 7d | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
-| crowdsec | crowdsecurity/crowdsec:latest | ✅ healthy | 7d | — | [guide](10-services/guides/crowdsec.md) |
-| redis-authelia | redis:7-alpine | ✅ healthy | 7d | — | — |
-| traefik | traefik:latest | ✅ healthy | 2d | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
+| authelia | authelia/authelia:latest | ✅ healthy | 2d | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
+| crowdsec | crowdsecurity/crowdsec:latest | ✅ healthy | ~anh | — | [guide](10-services/guides/crowdsec.md) |
+| redis-authelia | redis:7-alpine | ✅ healthy | 2d | — | — |
+| traefik | traefik:latest | ⚠️ unhealthy | 2d | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
 
 ## Nextcloud (3)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| nextcloud-db | mariadb:11 | ✅ healthy | 2d | — | [guide](10-services/guides/nextcloud.md) |
-| nextcloud | nextcloud:latest | ✅ healthy | 2d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
-| nextcloud-redis | redis:7-alpine | ✅ healthy | 6d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-db | mariadb:11 | ⚠️ unhealthy | 2d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud | nextcloud:latest | ⚠️ unhealthy | 2d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-redis | redis:7-alpine | ✅ healthy | 2d | — | [guide](10-services/guides/nextcloud.md) |
 
 ## Immich (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| immich-ml | immich-app/immich-machine-learning:v2.5.6 | ✅ healthy | 7d | — | [guide](10-services/guides/immich.md) |
-| immich-server | immich-app/immich-server:v2.5.6 | ✅ healthy | 6d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
-| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3-pgvec | ✅ healthy | 7d | — | — |
-| redis-immich | valkey/valkey:latest | ✅ healthy | 7d | — | — |
+| immich-ml | immich-app/immich-machine-learning:v2.6.3 | ✅ healthy | 2d | — | [guide](10-services/guides/immich.md) |
+| immich-server | immich-app/immich-server:v2.6.3 | ⚠️ unhealthy | 2d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
+| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3-pgvec | ⚠️ unhealthy | 2d | — | — |
+| redis-immich | valkey/valkey:latest | ✅ healthy | 2d | — | — |
 
 ## Jellyfin (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| jellyfin | jellyfin/jellyfin:latest | ✅ healthy | 6d | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
+| jellyfin | jellyfin/jellyfin:latest | ✅ healthy | 2d | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
 
 ## Vaultwarden (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| vaultwarden | vaultwarden/server:latest | ✅ healthy | 7d | [vault.patriark.org](https://vault.patriark.org) | — |
+| vaultwarden | vaultwarden/server:latest | ✅ healthy | 2d | [vault.patriark.org](https://vault.patriark.org) | — |
 
 ## Home Automation (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 4d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
-| matter-server | home-assistant-libs/python-matter-server:stab | ✅ healthy | 7d | — | [guide](10-services/guides/matter-server.md) |
+| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 2d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
+| matter-server | home-assistant-libs/python-matter-server:stab | ✅ healthy | 2d | — | [guide](10-services/guides/matter-server.md) |
 
 ## Gathio (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| gathio-db | mongo:7 | ✅ healthy | 2d | — | — |
+| gathio-db | mongo:7 | ⚠️ unhealthy | 2d | — | — |
 | gathio | lowercasename/gathio:latest | ✅ healthy | 2d | [events.patriark.org](https://events.patriark.org) | — |
 
 ## Homepage (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| homepage | gethomepage/homepage:latest | ✅ healthy | 7d | [patriark.org](https://patriark.org) | — |
+| homepage | gethomepage/homepage:latest | ⚠️ unhealthy | 2d | [patriark.org](https://patriark.org) | — |
 
 ## Monitoring (9)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| alert-discord-relay | localhost/alert-discord-relay:latest | ✅ healthy | 7d | — | [guide](10-services/guides/alert-discord-relay.md) |
-| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ healthy | 7d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ healthy | 14h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| grafana | grafana/grafana:latest | ✅ healthy | 7d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| loki | grafana/loki:latest | — no check | 7d | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| node_exporter | quay.io/prometheus/node-exporter:latest | ✅ healthy | 7d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 4d | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| promtail | grafana/promtail:latest | ✅ healthy | 7d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| unpoller | unpoller/unpoller:latest | — no check | 7d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| alert-discord-relay | localhost/alert-discord-relay:latest | ⚠️ unhealthy | 2d | — | [guide](10-services/guides/alert-discord-relay.md) |
+| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ healthy | 2d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ healthy | 2d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| grafana | grafana/grafana:latest | ⚠️ unhealthy | 2d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| loki | grafana/loki:latest | — no check | 2d | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| node_exporter | quay.io/prometheus/node-exporter:latest | ✅ healthy | 2d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 2d | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| promtail | grafana/promtail:latest | ✅ healthy | 2d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| unpoller | unpoller/unpoller:latest | ⚠️ unhealthy | 2d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
 
 ---
 
 ## Statistics
 
-- **Total Running:** 30
-- **Total Defined:** 30
-- **System Load:** 0,36, 0,64, 0,75
+- **Total Running:** 31
+- **Total Defined:** 31
+- **System Load:** 1,22, 1,05, 0,88
 
 ---
 

--- a/quadlets/authelia.container
+++ b/quadlets/authelia.container
@@ -1,7 +1,7 @@
 [Unit]
 Description=Authelia - SSO & MFA Authentication Server (YubiKey-First)
-After=network-online.target redis-authelia.service reverse_proxy-network.service auth_services-network.service
-Wants=auth_services-network.service network-online.target reverse_proxy-network.service
+After=network-online.target redis-authelia.service reverse_proxy-network.service auth_services-network.service mail-network.service
+Wants=auth_services-network.service network-online.target reverse_proxy-network.service mail-network.service
 Requires=redis-authelia.service
 
 [Container]
@@ -13,6 +13,7 @@ AutoUpdate=registry
 # Static IPs assigned to ensure consistent DNS resolution
 Network=systemd-reverse_proxy:ip=10.89.2.78
 Network=systemd-auth_services:ip=10.89.3.78
+Network=systemd-mail:ip=10.89.9.78
 
 # Configuration and data (SELinux :Z labels)
 Volume=%h/containers/config/authelia:/config:Z
@@ -22,6 +23,9 @@ Volume=%h/containers/data/authelia:/data:Z
 Secret=authelia_jwt_secret
 Secret=authelia_session_secret
 Secret=authelia_storage_key
+# SMTP secret (uncomment when Proton Bridge SMTP auth is resolved)
+# Secret=proton_bridge_smtp_password,type=mount,target=notifier_smtp_password
+# Environment=AUTHELIA_NOTIFIER_SMTP_PASSWORD_FILE=/run/secrets/notifier_smtp_password
 
 # Expose metrics for Prometheus
 Environment=AUTHELIA_SERVER_DISABLE_HEALTHCHECK=false

--- a/quadlets/crowdsec.container
+++ b/quadlets/crowdsec.container
@@ -12,6 +12,9 @@ Network=systemd-reverse_proxy:ip=10.89.2.70
 # Volumes
 Volume=%h/containers/data/crowdsec/db:/var/lib/crowdsec/data:Z
 Volume=%h/containers/data/crowdsec/config:/etc/crowdsec:Z
+# Traefik access log acquisition (read-only). Written by traefik.container.
+# Shared label (:z) — Traefik writes, CrowdSec tails.
+Volume=/mnt/btrfs-pool/subvol7-containers/traefik-logs:/var/log/traefik:ro,z
 
 # Environment - Install Traefik collection
 Environment=COLLECTIONS=crowdsecurity/traefik crowdsecurity/http-cve

--- a/quadlets/immich-ml.container
+++ b/quadlets/immich-ml.container
@@ -4,7 +4,7 @@ After=network-online.target photos-network.service
 Wants=network-online.target photos-network.service
 
 [Container]
-Image=ghcr.io/immich-app/immich-machine-learning:v2.5.6
+Image=ghcr.io/immich-app/immich-machine-learning:v2.6.3
 ContainerName=immich-ml
 AutoUpdate=registry
 

--- a/quadlets/immich-server.container
+++ b/quadlets/immich-server.container
@@ -5,7 +5,7 @@ Wants=network-online.target photos-network.service
 Requires=postgresql-immich.service redis-immich.service
 
 [Container]
-Image=ghcr.io/immich-app/immich-server:v2.5.6
+Image=ghcr.io/immich-app/immich-server:v2.6.3
 ContainerName=immich-server
 AutoUpdate=registry
 

--- a/quadlets/mail.network
+++ b/quadlets/mail.network
@@ -1,0 +1,9 @@
+[Unit]
+Description=Mail Services Network (SMTP relay)
+
+[Network]
+Subnet=10.89.9.0/24
+Gateway=10.89.9.1
+IPRange=10.89.9.2-10.89.9.68
+DNS=192.168.1.69
+Internal=true

--- a/quadlets/proton-bridge.container
+++ b/quadlets/proton-bridge.container
@@ -1,0 +1,45 @@
+[Unit]
+Description=Proton Mail Bridge - SMTP Relay for Homelab Services
+After=network-online.target reverse_proxy-network.service mail-network.service
+Wants=network-online.target reverse_proxy-network.service mail-network.service
+
+[Container]
+Image=localhost/proton-bridge:3.23.1
+ContainerName=proton-bridge
+
+# Map host UID into container (ADR-001: rootless containers)
+UserNS=keep-id
+
+# Allow binding port 25 (socat forwarder for Authelia smtp:// scheme compat)
+AddCapability=NET_BIND_SERVICE
+
+# Networks: reverse_proxy FIRST for internet access to Proton servers
+Network=systemd-reverse_proxy:ip=10.89.2.88
+Network=systemd-mail:ip=10.89.9.69
+
+# Persistent storage (encrypted credentials + cache)
+Volume=/mnt/btrfs-pool/subvol7-containers/proton-bridge/config:/home/bridge/.config/protonmail/bridge-v3:Z
+Volume=/mnt/btrfs-pool/subvol7-containers/proton-bridge/data:/home/bridge/.local/share/protonmail/bridge-v3:Z
+Volume=/mnt/btrfs-pool/subvol7-containers/proton-bridge/gnupg:/home/bridge/.gnupg:Z
+Volume=/mnt/btrfs-pool/subvol7-containers/proton-bridge/password-store:/home/bridge/.password-store:Z
+
+# Health check (SMTP handshake verification)
+HealthCmd=bash -c 'echo QUIT | nc -w 3 localhost 1025 | grep -q 220 || exit 1'
+HealthInterval=60s
+HealthTimeout=10s
+HealthRetries=3
+HealthStartPeriod=120s
+
+[Service]
+Slice=container.slice
+Restart=on-failure
+RestartSec=30s
+TimeoutStartSec=300
+TimeoutStopSec=30s
+
+MemoryMax=512M
+MemoryHigh=400M
+CPUQuota=50%
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

Closes the security loop that ADR-022 (socket-activation source-IP restoration) unblocked, plus sweeps accumulated working-tree drift from prior sessions.

- **CrowdSec acquisition (closes #137)** — placeholder `acquis.yaml` replaced with real Traefik file-tail via `acquis.d/traefik.yaml`. sshd and Authelia sources deferred with documented rationale.
- **Rate-limit retune** — nextcloud/qbittorrent/immich limits halved or more; NAT-era inflation is no longer needed now that `depth: 1` resolves to real client IPs.
- **Authelia SSO portal fix** — strips shared `rate-limit@file` / `circuit-breaker@file` / `retry@file` that were 429-ing Authelia's lazily-loaded JS modules.
- **Drift sweep** — commits six orphan journals, ADR-024 + ADR-025 (replacing withdrawn ADR-023), the Proton Bridge SMTP attempt (blocked + documented), Immich v2.5.6 → v2.6.3 config catch-up, and AUTO-* regeneration.
- Two incidental `.gitignore` fixes: `acquis.d/*.yaml` now trackable; `builds/**/*.rpm` now excluded (an 81MB Proton Bridge RPM was about to be committed).

## Commit breakdown

| # | Commit | Purpose |
|---|--------|---------|
| 1 | `feat: CrowdSec tails Traefik access log (closes #137)` | Wire real log acquisition |
| 2 | `refactor: retune NAT-era rate-limits for per-IP post-ADR-022` | Halve three rate-limits |
| 3 | `fix: strip rate-limit/circuit-breaker/retry from Authelia portal router` | Fix SSO blank page |
| 4 | `docs: Proton Bridge SMTP integration attempt (blocked, documented)` | Preserve attempt |
| 5 | `docs: orphan journals from March sessions` | 2026-03-17, 03-26, 03-28 |
| 6 | `docs: ADR-024/025 replace withdrawn ADR-023; storage migration journal` | Split storage ADR |
| 7 | `chore: pin Immich to v2.6.3 (running version, catch up config)` | Declarative catch-up |
| 8 | `docs: regenerate AUTO-* after session changes` | Service catalog + topology |

## Verification

- CrowdSec `cscli metrics show acquisition` — 12 read / 12 parsed / 23 whitelisted from Traefik (LAN whitelists matching as expected; external-IP observation pending for decision creation)
- Traefik config validator: all YAML valid, no new orphans
- Pre-commit hook clean on all 8 commits (no hardcoded secrets, Traefik validation passing)
- Immich container already running v2.6.3 — quadlet pin is config-catch-up, no runtime change

## Test plan

- [ ] Observation window: watch `cscli decisions list` for first local-origin decision over the next 24–72h
- [ ] Monitor rate-limit 429 rate on nextcloud/qbittorrent/immich — no legit-user complaints expected, but log any
- [ ] Verify Authelia portal still renders cleanly on rapid page-load (strip was the fix, but confirm no regression)

Full context: `docs/98-journals/2026-04-21-crowdsec-acquisition-and-rate-limit-retune.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)