### PR TITLE
fix: harden network ingress/egress on media + home_automation (#141, #142)

### DIFF
--- a/quadlets/home-assistant.container
+++ b/quadlets/home-assistant.container
@@ -24,8 +24,8 @@ DNSSearch=lokal
 Volume=%h/containers/config/home-assistant:/config:Z
 Volume=%h/containers/data/home-assistant:/data:Z
 
-# Ports (published for local access)
-PublishPort=8123:8123
+# Ports (bound to LAN interface only - see GH #142)
+PublishPort=192.168.1.70:8123:8123
 
 # Health Check
 HealthCmd=curl -f http://localhost:8123/manifest.json || exit 1

--- a/quadlets/home_automation.network
+++ b/quadlets/home_automation.network
@@ -6,3 +6,7 @@ Subnet=10.89.6.0/24
 Gateway=10.89.6.1
 IPRange=10.89.6.2-10.89.6.68
 DNS=192.168.1.69
+# Internal network - no outbound internet access
+# home-assistant has reverse_proxy as secondary network for cloud integrations
+# matter-server is LAN-only (Matter multicast) and needs no egress
+Internal=true

--- a/quadlets/jellyfin.container
+++ b/quadlets/jellyfin.container
@@ -35,9 +35,9 @@ Volume=/mnt/btrfs-pool/subvol6-tmp/jellyfin-cache:/cache:Z
 Volume=/mnt/btrfs-pool/subvol4-multimedia:/media/multimedia:ro,z
 Volume=/mnt/btrfs-pool/subvol5-music:/media/music:ro,z
 
-# Ports
-PublishPort=8096:8096
-PublishPort=7359:7359/udp
+# Ports (bound to LAN interface only - see GH #142)
+PublishPort=192.168.1.70:8096:8096
+PublishPort=192.168.1.70:7359:7359/udp
 
 # Health Check
 HealthCmd=curl -f http://localhost:8096/health || exit 1

--- a/quadlets/media_services.network
+++ b/quadlets/media_services.network
@@ -6,3 +6,6 @@ Subnet=10.89.1.0/24
 Gateway=10.89.1.1
 IPRange=10.89.1.2-10.89.1.68
 DNS=192.168.1.69
+# Internal network - no outbound internet access
+# Jellyfin has reverse_proxy as secondary network for metadata fetches
+Internal=true


### PR DESCRIPTION
## Summary
Bundled two related config hardening issues from the 2026-04-17 config review (§4 MEDIUM-6 and MEDIUM-7). Same quadlet files touched, same restart surface, one maintenance window.

- **Closes #141** — Set `Internal=true` on `media_services` and `home_automation` networks. Neither needs direct egress: jellyfin and home-assistant both have `reverse_proxy` as a secondary network for external calls, and matter-server is LAN-multicast only. Only `reverse_proxy.network` legitimately needs egress now.
- **Closes #142** — Bind `PublishPort` to the LAN interface (`192.168.1.70`) on jellyfin (`8096/tcp`, `7359/udp`) and home-assistant (`8123/tcp`). A firewalld misstep can no longer expose these services without the Traefik fail-fast chain (CrowdSec → rate-limit → security headers).

### Correction from issue body
Issue #142 suggested binding to `192.168.1.69`, but that's the Pi-hole DNS referenced across every quadlet. The actual LAN IP on `enp3s0` is **`192.168.1.70`** — used here.

## Changes
| File | Change |
|---|---|
| `quadlets/media_services.network` | `+ Internal=true` |
| `quadlets/home_automation.network` | `+ Internal=true` |
| `quadlets/jellyfin.container` | `8096:8096` → `192.168.1.70:8096:8096`; `7359:7359/udp` → `192.168.1.70:7359:7359/udp` |
| `quadlets/home-assistant.container` | `8123:8123` → `192.168.1.70:8123:8123` |

12 insertions, 5 deletions.

## Applied sequence
Adding `Internal=true` requires network recreation (podman's generated unit uses `network create --ignore`, so restart alone is a no-op once the net exists):
1. Stopped jellyfin, home-assistant, matter-server
2. `systemctl --user daemon-reload`
3. `podman network rm systemd-media_services systemd-home_automation`
4. Restarted the two network services (recreated with `--internal`)
5. Started the three containers

## Test plan
- [x] `ss -tlnp | grep -E '8096\|8123'` shows `192.168.1.70:...` (was `*:...`)
- [x] `ss -ulnp | grep 7359` shows `192.168.1.70:7359`
- [x] `podman network inspect systemd-{media_services,home_automation} --format '{{.Internal}}'` → `true` on both
- [x] `podman exec matter-server python3 -c "socket.gethostbyname('google.com')"` → `gaierror` (egress blocked)
- [x] `podman exec home-assistant curl https://www.home-assistant.io/` → `HTTP 200` (egress via reverse_proxy preserved)
- [x] `podman exec jellyfin curl https://api.themoviedb.org/` → `HTTP 301` (metadata egress preserved)
- [x] `curl -I https://home.patriark.org/` → `HTTP/2 302` (Traefik unaffected)
- [x] `curl -I https://jellyfin.patriark.org/` → `HTTP/2 302` (Traefik unaffected)
- [x] `curl -I http://192.168.1.70:{8123,8096}/` → reachable from LAN
- [x] Loopback (`http://127.0.0.1:8123/`) no longer reachable — expected consequence of the `host-ip:` form
- [x] All three containers `(healthy)` post-restart
- [x] HA → matter-server WebSocket port (5580) still reachable internally

## Follow-ups
None expected. Both `reverse_proxy.network` retaining egress is intentional (Traefik → Let's Encrypt, Cloudflare DNS-01).

🤖 Generated with [Claude Code](https://claude.com/claude-code)