### PR TITLE
fix: monitoring rshared propagation — drive-swap zombie LUKS mapper (ADR-023)

### DIFF
--- a/docs/00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md
+++ b/docs/00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md
@@ -41,6 +41,10 @@ The backup *strategy* from ADR-020 is unchanged — Urd implements the same mode
 
 These are the touchpoints between Urd and the homelab infrastructure. **Update this ADR when any of these change.**
 
+### Drive-swap safety (ADR-023)
+
+Urd's drive-rotation pattern (swapping LUKS-encrypted BTRFS drives in the IcyBox dock) was pinning `/dev/mapper/luks-<UUID>` via recursive bind mounts in the monitoring stack. ADR-023 resolves this by putting `cadvisor` and `node_exporter` on `rshared` propagation so host unmounts propagate into the containers. Any future container that bind-mounts host paths reaching `/run/media` must follow the same pattern.
+
 ### Systemd units
 
 | Unit | Schedule | Description |

--- a/docs/00-foundation/decisions/2026-04-21-ADR-023-monitoring-bind-propagation.md
+++ b/docs/00-foundation/decisions/2026-04-21-ADR-023-monitoring-bind-propagation.md
@@ -1,0 +1,87 @@
+# ADR-023: Shared Mount Propagation for Monitoring Containers
+
+**Date:** 2026-04-21
+**Status:** Accepted
+**Related:** ADR-021 (Urd backup integration — the downstream victim)
+
+## Context
+
+Urd uses removable LUKS-encrypted BTRFS drives in an IcyBox dock as offsite backup targets. Every time the user swaps drives (e.g. WD-18TB ↔ WD-18TB1), the next unlock fails:
+
+```
+Error unlocking /dev/sdX: Failed to activate device: File exists
+```
+
+The `/dev/mapper/luks-<UUID>` node stays ACTIVE with Open count ≥ 1 after the host unmounts. `cryptsetup close` and `dmsetup remove --force` both fail with "Device or resource busy". `lsof`/`fuser` on the host show nothing. Symptom recurs on every swap; the only working workaround is restarting the monitoring containers.
+
+### Root cause
+
+Both monitoring containers recursively bind-mount host `/`:
+
+- `cadvisor.container` — `Volume=/:/rootfs:ro`
+- `node_exporter.container` — `Volume=/:/host:ro,rslave`
+
+Podman 5.8 performs this as a recursive bind regardless of quadlet wording. Any drive mounted at `/run/media/patriark/<LABEL>` at container start time (e.g. after `AutoUpdate=registry` restarts the container while a drive is attached, or after a reboot with the drive present) gets captured as a submount inside the container's mount namespace, pinning the LUKS dm-mapper.
+
+Propagation flags should unstick this, but don't:
+
+- **`rslave`** — the kernel requires CAP_SYS_ADMIN in the user namespace that owns the source mount to establish a slave relation. Rootless Podman creates a new user namespace, and host `/` is owned by the initial userns, so `rslave` is silently downgraded to `private`. Host unmount events never propagate into the container. Verified live: `/proc/<pid>/mountinfo` showed the node_exporter `/host` bind with no `master:X` field despite the quadlet requesting rslave.
+- **`rprivate`** / default — same problem: no propagation.
+- **`nsenter -t <pid> -m -- umount`** inside the container's mount namespace — fails with `Permission denied` because the rootless container lacks mount caps in its userns. Not a viable recovery path.
+
+### Why not scope down the bind
+
+Non-recursive bind (`--mount type=bind,bind-nonrecursive=true`) fails with `mount "/": Invalid argument` when the source is `/` in rootless mode — crun's `open_tree()` without `AT_RECURSIVE` is rejected on a host-owned root mount. Verified by direct test. Works for sub-paths like `/etc` but not `/`.
+
+Replacing the `/` bind with a hand-picked list of directories loses filesystem-collector visibility for any mountpoint not explicitly bound in. We'd have to re-declare every filesystem we want metrics on, and re-add new ones as they appear.
+
+## Decision
+
+Use **`rshared`** propagation on the root bind for both monitoring containers. This puts the container's bind into the same peer group as the host mount, so host unmount events propagate into the container and release the LUKS dm-mapper reference automatically on drive removal.
+
+**Symmetry concern — irrelevant here.** `rshared` is bidirectional in general, but in rootless Podman the container lacks CAP_SYS_ADMIN in its userns, so it cannot initiate umount/mount operations that would propagate back to the host. Propagation is effectively one-way (host → container) for us, matching the `rslave` semantics we wanted.
+
+**Filesystem metrics filter.** In parallel, `node_exporter` is configured with `--collector.filesystem.mount-points-exclude` extended to skip `/run/media/.+` — so removable backup drives don't clutter Prometheus with per-drive filesystem series that come and go.
+
+## Configuration
+
+**`quadlets/cadvisor.container`:**
+```
+Volume=/:/rootfs:ro,rshared
+```
+
+**`quadlets/node_exporter.container`:**
+```
+Volume=/:/host:ro,rshared
+Exec=--path.rootfs=/host --collector.textfile.directory=/textfile-metrics \
+     --collector.filesystem.mount-points-exclude=^/(dev|proc|run/(credentials/.+|media/.+)|sys|var/lib/(docker|containers)/.+|sysroot)($|/)
+```
+
+## Consequences
+
+**Positive:**
+- Drive swaps no longer leave zombie dm-mappers. No more post-swap restart of monitoring stack.
+- Host `umount` events (periodic or drive-swap triggered) propagate into both containers cleanly.
+- `/run/media` no longer emits filesystem metrics for drives that come and go.
+
+**Neutral:**
+- Mount propagation now runs in both directions at the kernel level. Cannot be exploited by the rootless container (no mount caps), and both containers are trusted components of the monitoring stack.
+- `cadvisor` continues to use the systemd cgroup factory (not the podman socket factory — pre-existing behavior independent of this change).
+
+**Negative:**
+- None measured. Metrics coverage unchanged for `/`, `/boot`, `/boot/efi`, `/home`, `/mnt` (verified post-deployment).
+
+## Constraint for future monitoring containers
+
+Any future container that bind-mounts host paths which contain dynamic/removable mountpoints (e.g. `/run/media`, `/mnt/*` for USB devices) MUST use `rshared` propagation on the root bind — OR limit the bind to a non-recursive scope that cannot reach those paths — to avoid recreating the zombie-mapper failure mode.
+
+## Verification
+
+Deployed 2026-04-21. Post-deployment checks:
+
+1. `grep -E " /host | /rootfs " /proc/<pid>/mountinfo` now shows `shared:<N>` (was absent).
+2. `node_filesystem_size_bytes` still reports `/`, `/boot`, `/boot/efi`, `/home`, `/mnt`; no `/run/media/*` series.
+3. `cadvisor` reports 80+ cgroup entries under `/user.slice/.../container.slice/*.service` (unchanged).
+4. Both services `active (running)` with passing healthchecks.
+
+End-to-end drive-swap validation pending next Urd offsite rotation.

--- a/docs/98-journals/2026-04-21-monitoring-bind-propagation.md
+++ b/docs/98-journals/2026-04-21-monitoring-bind-propagation.md
@@ -1,0 +1,61 @@
+# Monitoring Bind Propagation — ADR-023
+
+**Date:** 2026-04-21
+**PR:** _pending_
+**ADR:** [ADR-023](../00-foundation/decisions/2026-04-21-ADR-023-monitoring-bind-propagation.md)
+**Context:** Cross-project fallout investigation. Urd's drive-swap workflow (LUKS-encrypted BTRFS rotation between WD-18TB and WD-18TB1) was consistently failing the next unlock with `Error unlocking /dev/sdX: Failed to activate device: File exists`. Root cause diagnosed from the Urd side: the monitoring containers were holding the `/run/media/patriark/<LABEL>` mount in their namespace, pinning the LUKS dm-mapper refcount above zero. Restarting the containers was the recurring workaround. This journal is about landing the permanent fix on the homelab side.
+
+---
+
+## What shipped
+
+| File | Change |
+|---|---|
+| `quadlets/cadvisor.container` | `Volume=/:/rootfs:ro` → `Volume=/:/rootfs:ro,rshared` |
+| `quadlets/node_exporter.container` | `Volume=/:/host:ro,rslave` → `Volume=/:/host:ro,rshared`; `--collector.filesystem.mount-points-exclude` extended with `run/media/.+` |
+| `docs/00-foundation/decisions/2026-04-21-ADR-023-monitoring-bind-propagation.md` | New ADR |
+| `docs/00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md` | Added "Drive-swap safety" cross-reference at top of Integration Contract |
+
+Post-deploy: both containers `active`, healthchecks pass, `shared:N` present on `/rootfs` and `/host` (was absent), filesystem metrics still cover `/`, `/boot`, `/boot/efi`, `/home`, `/mnt` — `/run/media/*` filtered out.
+
+---
+
+## Three things worth writing down
+
+### `rslave` silently downgrades to `private` in rootless podman
+
+node_exporter already carried `Volume=/:/host:ro,rslave` in its quadlet and had for a long time. Live `/proc/<pid>/mountinfo` showed no `master:X` field — the bind was effectively `private`. That's why host unmounts never propagated in.
+
+The reason is a kernel permission check. To establish a slave relation, the caller must have CAP_SYS_ADMIN in the user namespace that owns the source mount. Rootless podman creates a new userns, host `/` is owned by the initial userns, and crun doesn't have the cap over that. The kernel silently falls back to `private` rather than erroring. The quadlet looks correct; the running mount does something different. Worth remembering whenever a rootless container is supposed to "receive" host mount events.
+
+### `bind-nonrecursive=true` doesn't work on `/`
+
+First attempt was `--mount type=bind,source=/,destination=/host,ro=true,bind-nonrecursive=true` — the clean "never see /run/media at all" path. Both containers failed to start with:
+
+```
+mount `/` to `host`: Invalid argument
+```
+
+Not a quadlet issue. Reproduced with a one-shot `podman run` against alpine. `bind-nonrecursive=true` works fine for `/etc` and other sub-paths, but fails specifically when source is `/`. crun's `open_tree()` without `AT_RECURSIVE` against the host root mount is rejected in rootless mode. This is kernel/crun, not podman or quadlet syntax — no workaround at the container layer short of binding specific subdirectories instead of `/`, which loses filesystem-collector coverage for anything not pre-declared.
+
+### `rshared` is the working alternative — and it's safe here
+
+Once slave was out and non-recursive was out, the remaining lever was `rshared`. `rshared` is bidirectional by kernel design: an unmount on either side propagates to peers. That's usually the reason to avoid it — a container could unmount something and affect the host.
+
+Here it's fine. Rootless containers lack CAP_SYS_ADMIN in their userns, so they cannot initiate umount/mount in the first place. The "bidirectional" property is de facto one-way (host → container). Verified in `/proc/<pid>/mountinfo`: both containers now show `shared:N` on the root bind and all inherited submounts (including `/run/media/patriark/WD-18TB`). Host unmount of the drive will propagate in and release the reference.
+
+---
+
+## Validation status
+
+- ✅ Containers start clean, healthchecks pass.
+- ✅ `/proc/<pid>/mountinfo` shows `shared:N` on root bind for both containers.
+- ✅ node_exporter metrics cover `/`, `/boot`, `/boot/efi`, `/home`, `/mnt`; no `/run/media/*` series.
+- ✅ cAdvisor continues to report container cgroups (unchanged — pre-existing systemd-factory fallback).
+- ⏳ End-to-end drive-swap validation: the next Urd offsite rotation will prove host unmount actually drops the container's mount reference. Until that happens in production, ADR-023 is accepted-but-unvalidated on the drive-swap outcome specifically.
+
+---
+
+## Cross-project note
+
+Documented the integration contract on both sides. ADR-021's Integration Contract now opens with a "Drive-swap safety" paragraph pointing at ADR-023, so future contributors touching monitoring binds see the constraint before they break it. Urd's side will keep its own memory entry for the symptom.

--- a/quadlets/cadvisor.container
+++ b/quadlets/cadvisor.container
@@ -10,8 +10,8 @@ HostName=cadvisor
 AutoUpdate=registry
 Network=systemd-monitoring
 
-# cAdvisor needs access to host resources
-Volume=/:/rootfs:ro
+# rshared propagation on / so removable-drive unmounts propagate in — see ADR-023.
+Volume=/:/rootfs:ro,rshared
 Volume=/run/user/1000/podman/podman.sock:/var/run/docker.sock:ro
 Volume=/sys:/sys:rw
 Volume=%h/.local/share/containers:/var/lib/containers:ro

--- a/quadlets/node_exporter.container
+++ b/quadlets/node_exporter.container
@@ -9,9 +9,8 @@ ContainerName=node_exporter
 HostName=node_exporter
 Network=systemd-monitoring
 
-# Node exporter needs access to host filesystem for accurate metrics
-# Mount host paths as read-only
-Volume=/:/host:ro,rslave
+# rshared propagation on / so removable-drive unmounts propagate in — see ADR-023.
+Volume=/:/host:ro,rshared
 Volume=/sys:/host/sys:ro,rslave
 Volume=/proc:/host/proc:ro,rslave
 
@@ -22,7 +21,8 @@ Volume=%h/containers/data/backup-metrics:/textfile-metrics:ro,Z
 Environment=PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
 # Node exporter command line arguments
-Exec=--path.rootfs=/host --collector.textfile.directory=/textfile-metrics
+# mount-points-exclude extends the upstream default with run/media/ for removable backup drives (ADR-023)
+Exec=--path.rootfs=/host --collector.textfile.directory=/textfile-metrics --collector.filesystem.mount-points-exclude=^/(dev|proc|run/(credentials/.+|media/.+)|sys|var/lib/(docker|containers)/.+|sysroot)($|/)
 
 DNS=192.168.1.69
 


### PR DESCRIPTION
## Summary

- **Fix:** cAdvisor and node_exporter now use `rshared` propagation on the root bind so host unmounts of `/run/media/patriark/<DRIVE>` propagate into the containers, releasing the LUKS dm-mapper on Urd drive swaps.
- **Side-fix:** node_exporter `--collector.filesystem.mount-points-exclude` extended with `run/media/.+` so removable backup drives don't generate per-drive Prometheus series.
- **Docs:** ADR-023 captures the decision, ADR-021 (Urd integration) cross-references it, journal explains the three non-obvious findings that shaped the solution.

## Root cause recap

Urd's quarterly drive rotation (WD-18TB ↔ WD-18TB1 in the IcyBox dock) was consistently failing the next unlock with `Error unlocking /dev/sdX: Failed to activate device: File exists`. The dm-mapper was being pinned by recursive bind mounts inside cAdvisor and node_exporter — when a drive was mounted at container start (e.g. via `AutoUpdate=registry` restart), the container captured `/run/media/patriark/<LABEL>` as a submount. Host unmount didn't propagate back because propagation was effectively `private`. Workaround was restart-the-containers, recurring every swap.

## Why `rshared` and not the alternatives

Investigated and ruled out:
- **`rslave`** — node_exporter already had this in quadlet. Kernel silently downgrades to `private` in rootless podman because the userns doesn't own host `/`. Verified via `/proc/<pid>/mountinfo` (no `master:` field).
- **`bind-nonrecursive=true`** — fails with `mount '/': Invalid argument` in rootless mode. crun's `open_tree()` without `AT_RECURSIVE` against host `/` is rejected. Works for sub-paths but not root.
- **systemd path-unit restart hook** — workaround, racy, monitoring gap on every swap.

`rshared` works because rootless containers lack CAP_SYS_ADMIN in their userns, so the bidirectional property is de facto one-way (host → container). Full reasoning in [ADR-023](docs/00-foundation/decisions/2026-04-21-ADR-023-monitoring-bind-propagation.md).

## Files changed

| File | Change |
|---|---|
| `quadlets/cadvisor.container` | `Volume=/:/rootfs:ro` → `Volume=/:/rootfs:ro,rshared` |
| `quadlets/node_exporter.container` | `Volume=/:/host:ro,rslave` → `Volume=/:/host:ro,rshared`; mount-points-exclude extended |
| `docs/00-foundation/decisions/2026-04-21-ADR-023-monitoring-bind-propagation.md` | New ADR |
| `docs/00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md` | Drive-swap safety cross-reference |
| `docs/98-journals/2026-04-21-monitoring-bind-propagation.md` | Journal |

## Verification (already done locally)

- [x] Both services `active (running)`, healthchecks pass
- [x] `/proc/<pid>/mountinfo` shows `shared:N` on `/rootfs` and `/host` (was absent before)
- [x] `node_filesystem_*` metrics cover `/`, `/boot`, `/boot/efi`, `/home`, `/mnt`
- [x] No `/run/media/*` series in node_exporter metrics
- [x] cAdvisor still reports cgroups via systemd factory (unchanged)
- [ ] End-to-end: host unmount of WD-18TB drops the container's mount reference — validates on next Urd offsite rotation

🤖 Generated with [Claude Code](https://claude.com/claude-code)