### PR TITLE
feat: UDM Pro SIEM syslog pipeline + ADR-027 forward-NOCOW policy

### DIFF
--- a/config/grafana/provisioning/dashboards/json/unifi-syslog.json
+++ b/config/grafana/provisioning/dashboards/json/unifi-syslog.json
@@ -1,0 +1,590 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "description": "UDM Pro SIEM syslog — firewall, IDS/IPS, and system events forwarded via syslog-ng receiver. Receiver pipeline: UDM Pro → UDP 1514 → unifi-syslog container → udm.log → Promtail → Loki. See docs/98-journals/2026-04-22-udm-pro-siem-syslog-pipeline.md.",
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 0},
+      "id": 100,
+      "panels": [],
+      "title": "Pipeline Health",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "Promtail lines read from udm.log in the last 5 minutes. Zero = receiver is silent (either UDM stopped forwarding, firewalld is dropping, or syslog-ng is not writing).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "red", "value": null},
+              {"color": "yellow", "value": 1},
+              {"color": "green", "value": 5}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 0, "y": 1},
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "sum(increase(promtail_read_lines_total{path=~\".*udm.log\"}[5m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Events Read (5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "prometheus", "uid": "prometheus"},
+      "description": "Promtail send errors to Loki in the last 5 minutes. Any value > 0 = ingestion is losing events.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "red", "value": 1}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 6, "y": 1},
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {"type": "prometheus", "uid": "prometheus"},
+          "expr": "sum(increase(promtail_dropped_entries_total[5m])) + sum(increase(promtail_sent_batches_total{status_code!~\"2..\"}[5m]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Ingestion Errors (5m)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "loki"},
+      "description": "Total UDM events in the last 1 hour.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "blue", "value": null}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 12, "y": 1},
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {"type": "loki", "uid": "loki"},
+          "expr": "sum(count_over_time({job=\"unifi-syslog\"}[1h]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Events (1h)",
+      "type": "stat"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "loki"},
+      "description": "UDM events flagged as warning or higher severity (warning, err, crit, alert, emerg) in the last 1 hour. These are the events operators typically care about during incident review.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {"color": "green", "value": null},
+              {"color": "yellow", "value": 10},
+              {"color": "red", "value": 100}
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 4, "w": 6, "x": 18, "y": 1},
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {"type": "loki", "uid": "loki"},
+          "expr": "sum(count_over_time({job=\"unifi-syslog\", priority=~\"warning|err|crit|alert|emerg\"}[1h]))",
+          "refId": "A"
+        }
+      ],
+      "title": "Warning+ Events (1h)",
+      "type": "stat"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 5},
+      "id": 101,
+      "panels": [],
+      "title": "Event Rate",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "loki"},
+      "description": "UDM event rate stacked by program (ubios-udapi-server, kernel, etc.). Spikes indicate bursts from a specific subsystem; flat lines are steady-state chatter.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "events/sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {"tooltip": false, "viz": false, "legend": false},
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {"group": "A", "mode": "normal"},
+            "thresholdsStyle": {"mode": "off"}
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{"color": "green", "value": null}]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 6},
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "lastNotNull", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {"type": "loki", "uid": "loki"},
+          "expr": "sum by (program) (rate({job=\"unifi-syslog\"}[5m]))",
+          "legendFormat": "{{program}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Event Rate by Program",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "loki"},
+      "description": "UDM event rate stacked by syslog priority level. A rising proportion of warning/err/crit is a signal worth investigating.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "palette-classic"},
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "events/sec",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 30,
+            "gradientMode": "none",
+            "hideFrom": {"tooltip": false, "viz": false, "legend": false},
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {"type": "linear"},
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {"group": "A", "mode": "normal"},
+            "thresholdsStyle": {"mode": "off"}
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{"color": "green", "value": null}]
+          },
+          "unit": "short"
+        },
+        "overrides": [
+          {
+            "matcher": {"id": "byName", "options": "emerg"},
+            "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "dark-red"}}]
+          },
+          {
+            "matcher": {"id": "byName", "options": "alert"},
+            "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "red"}}]
+          },
+          {
+            "matcher": {"id": "byName", "options": "crit"},
+            "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "orange"}}]
+          },
+          {
+            "matcher": {"id": "byName", "options": "err"},
+            "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "yellow"}}]
+          },
+          {
+            "matcher": {"id": "byName", "options": "warning"},
+            "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "super-light-yellow"}}]
+          },
+          {
+            "matcher": {"id": "byName", "options": "notice"},
+            "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "blue"}}]
+          },
+          {
+            "matcher": {"id": "byName", "options": "info"},
+            "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "light-blue"}}]
+          },
+          {
+            "matcher": {"id": "byName", "options": "debug"},
+            "properties": [{"id": "color", "value": {"mode": "fixed", "fixedColor": "text"}}]
+          }
+        ]
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 6},
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": ["mean", "lastNotNull", "max"],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {"mode": "multi", "sort": "desc"}
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {"type": "loki", "uid": "loki"},
+          "expr": "sum by (priority) (rate({job=\"unifi-syslog\"}[5m]))",
+          "legendFormat": "{{priority}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Event Rate by Priority",
+      "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 14},
+      "id": 102,
+      "panels": [],
+      "title": "Distribution",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "loki"},
+      "description": "Top 10 programs by event volume over the dashboard time range. Useful for baselining what's chatty vs. quiet before tuning syslog-ng filters.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "custom": {
+            "align": "auto",
+            "cellOptions": {"type": "auto"},
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{"color": "green", "value": null}]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 0, "y": 15},
+      "id": 7,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [{"desc": true, "displayName": "Value"}]
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {"type": "loki", "uid": "loki"},
+          "expr": "topk(10, sum by (program) (count_over_time({job=\"unifi-syslog\"}[$__range])))",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Top Programs (by volume)",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {"Time": true},
+            "indexByName": {},
+            "renameByName": {"Value": "Events", "program": "Program"}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "loki"},
+      "description": "Event counts by syslog facility over the dashboard time range. Kernel/auth/daemon/local0–7 — useful to see whether traffic is from the UDM kernel (firewall/IDS) vs. userspace services.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {"mode": "thresholds"},
+          "custom": {
+            "align": "auto",
+            "cellOptions": {"type": "auto"},
+            "inspect": false
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [{"color": "green", "value": null}]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {"h": 8, "w": 12, "x": 12, "y": 15},
+      "id": 8,
+      "options": {
+        "cellHeight": "sm",
+        "footer": {
+          "countRows": false,
+          "fields": "",
+          "reducer": ["sum"],
+          "show": false
+        },
+        "showHeader": true,
+        "sortBy": [{"desc": true, "displayName": "Value"}]
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {"type": "loki", "uid": "loki"},
+          "expr": "sum by (facility) (count_over_time({job=\"unifi-syslog\"}[$__range]))",
+          "format": "table",
+          "instant": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Events by Facility",
+      "transformations": [
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {"Time": true},
+            "indexByName": {},
+            "renameByName": {"Value": "Events", "facility": "Facility"}
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 23},
+      "id": 103,
+      "panels": [],
+      "title": "Security-Relevant Events",
+      "type": "row"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "loki"},
+      "description": "Events matching common intrusion/block/scan keywords. Bootstrap filter — tighten once 24–48h of real traffic reveals which keywords map to actual UDM IDS/IPS matches.",
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 24},
+      "id": 9,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {"type": "loki", "uid": "loki"},
+          "expr": "{job=\"unifi-syslog\"} |~ \"(?i)intrusion|attack|blocked|denied|threat|scan|signature|ids|ips|firewall.*drop\"",
+          "refId": "A"
+        }
+      ],
+      "title": "Security Keyword Matches",
+      "type": "logs"
+    },
+    {
+      "datasource": {"type": "loki", "uid": "loki"},
+      "description": "All UDM events at priority warning or higher. Useful during incident review — complements the keyword filter above.",
+      "gridPos": {"h": 10, "w": 24, "x": 0, "y": 34},
+      "id": 10,
+      "options": {
+        "dedupStrategy": "none",
+        "enableLogDetails": true,
+        "prettifyLogMessage": false,
+        "showCommonLabels": false,
+        "showLabels": true,
+        "showTime": true,
+        "sortOrder": "Descending",
+        "wrapLogMessage": true
+      },
+      "pluginVersion": "10.0.0",
+      "targets": [
+        {
+          "datasource": {"type": "loki", "uid": "loki"},
+          "expr": "{job=\"unifi-syslog\", priority=~\"warning|err|crit|alert|emerg\"}",
+          "refId": "A"
+        }
+      ],
+      "title": "Warning+ Events",
+      "type": "logs"
+    },
+    {
+      "collapsed": true,
+      "gridPos": {"h": 1, "w": 24, "x": 0, "y": 44},
+      "id": 104,
+      "panels": [
+        {
+          "datasource": {"type": "loki", "uid": "loki"},
+          "description": "Unfiltered UDM event stream. Expensive to render over long time ranges — use for last-5-minute spot checks.",
+          "gridPos": {"h": 12, "w": 24, "x": 0, "y": 45},
+          "id": 11,
+          "options": {
+            "dedupStrategy": "none",
+            "enableLogDetails": true,
+            "prettifyLogMessage": false,
+            "showCommonLabels": false,
+            "showLabels": true,
+            "showTime": true,
+            "sortOrder": "Descending",
+            "wrapLogMessage": true
+          },
+          "pluginVersion": "10.0.0",
+          "targets": [
+            {
+              "datasource": {"type": "loki", "uid": "loki"},
+              "expr": "{job=\"unifi-syslog\"}",
+              "refId": "A"
+            }
+          ],
+          "title": "All UDM Events (raw stream)",
+          "type": "logs"
+        }
+      ],
+      "title": "Raw Stream (expand to view)",
+      "type": "row"
+    }
+  ],
+  "refresh": "30s",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": ["security", "unifi", "syslog", "udm-pro"],
+  "templating": {"list": []},
+  "time": {"from": "now-6h", "to": "now"},
+  "timepicker": {},
+  "timezone": "",
+  "title": "UniFi UDM Pro SIEM",
+  "uid": "unifi-syslog",
+  "version": 1,
+  "weekStart": ""
+}

--- a/config/logrotate/unifi-syslog
+++ b/config/logrotate/unifi-syslog
@@ -1,0 +1,24 @@
+# UniFi UDM Pro Syslog Rotation
+# Purpose: Bound growth of /var/log/unifi-syslog/udm.log (forensic log from UDM SIEM Server)
+#
+# Installation:
+#   sudo cp ~/containers/config/logrotate/unifi-syslog /etc/logrotate.d/unifi-syslog
+#   sudo chmod 644 /etc/logrotate.d/unifi-syslog
+#
+# Testing:
+#   sudo logrotate -d /etc/logrotate.d/unifi-syslog
+
+/mnt/btrfs-pool/subvol8-db/unifi-syslog/*.log {
+    daily
+    rotate 14
+    compress
+    delaycompress
+    missingok
+    notifempty
+    # copytruncate avoids cross-user podman signaling (logrotate runs as root,
+    # unifi-syslog is rootless under uid 1000). syslog-ng keeps its file
+    # descriptor open and continues writing; we accept a tiny rotation-window
+    # data gap for forensic logs.
+    copytruncate
+    minsize 1k
+}

--- a/config/promtail/promtail-config.yml
+++ b/config/promtail/promtail-config.yml
@@ -165,6 +165,31 @@ scrape_configs:
       - output:
           source: stdout_preview
 
+  # UniFi UDM Pro SIEM syslog (firewall + IDS/IPS + system events)
+  # Receiver pipeline: UDM Pro -> UDP 1514 -> syslog-ng container -> udm.log
+  # Template written by syslog-ng:
+  #   ISODATE src=SOURCEIP host=HOST prog=PROGRAM pid=PID pri=PRIORITY fac=FACILITY msg=MESSAGE
+  - job_name: unifi-syslog
+    static_configs:
+      - targets:
+          - localhost
+        labels:
+          job: unifi-syslog
+          host: udm-pro
+          __path__: /var/log/unifi-syslog/udm.log
+    pipeline_stages:
+      - regex:
+          expression: '^(?P<time>\S+)\s+src=(?P<src_ip>\S+)\s+host=(?P<src_host>\S+)\s+prog=(?P<program>\S+)\s+pid=(?P<pid>\S+)\s+pri=(?P<priority>\S+)\s+fac=(?P<facility>\S+)\s+msg=(?P<msg>.*)$'
+      - timestamp:
+          source: time
+          format: RFC3339
+      - labels:
+          program:
+          facility:
+          priority:
+      - output:
+          source: msg
+
   # Traefik access logs (errors only)
   - job_name: traefik-access
     static_configs:

--- a/config/unifi-syslog/syslog-ng.conf
+++ b/config/unifi-syslog/syslog-ng.conf
@@ -1,0 +1,48 @@
+@version: 4.5
+@include "scl.conf"
+
+# UniFi UDM Pro SIEM syslog receiver.
+#
+# Source restriction is enforced by firewalld on the host (rich rule: src=192.168.1.1/32).
+# Rootless Podman NAT may rewrite source IPs for UDP, so internal netmask() filtering is
+# unreliable - the host firewall is the authoritative trust boundary.
+#
+# Bootstrap policy: accept everything the UDM sends, write to one file. Tune filters after
+# observing 24-48h of real event patterns.
+
+options {
+  keep_hostname(yes);
+  use_dns(no);
+  use_fqdn(no);
+  chain_hostnames(off);
+  flush_lines(0);
+  stats(freq(3600));
+  # owner/group/perm intentionally omitted: rootless Podman + SELinux :Z relabeling
+  # makes cross-userns chown during file creation fail with a misleading ENOENT.
+  # Files are created with syslog-ng's default (root:root 0600 inside container =
+  # patriark:patriark on host), which is what we want.
+};
+
+source s_udm {
+  network(
+    transport("udp")
+    ip("0.0.0.0")
+    port(1514)
+    so-rcvbuf(1048576)
+    log-iw-size(10000)
+    log-fetch-limit(1000)
+  );
+};
+
+destination d_udm {
+  file(
+    "/var/log/unifi-syslog/udm.log"
+    template("${ISODATE} src=${SOURCEIP} host=${HOST} prog=${PROGRAM} pid=${PID} pri=${PRIORITY} fac=${FACILITY} msg=${MESSAGE}\n")
+    template-escape(no)
+  );
+};
+
+log {
+  source(s_udm);
+  destination(d_udm);
+};

--- a/docs/00-foundation/decisions/2026-04-22-ADR-027-forward-nocow-workloads-subvol8-db.md
+++ b/docs/00-foundation/decisions/2026-04-22-ADR-027-forward-nocow-workloads-subvol8-db.md
@@ -1,0 +1,98 @@
+# ADR-027: Forward-Only NOCOW Placement on subvol8-db (Policy)
+
+**Date:** 2026-04-22
+**Status:** Accepted
+**Companion:** ADR-025 (deferred DB migration — unchanged)
+**First tenant:** `unifi-syslog` (UDM Pro SIEM forensic log receiver)
+
+## Context
+
+ADR-025 designs a dedicated NOCOW subvolume (`/mnt/btrfs-pool/subvol8-db`) for write-hot, snapshot-hostile workloads, and defers the migration of five existing databases pending 60 days of measurements (earliest review 2026-06-18). That ADR remains in force for the deferred question it scopes.
+
+During deployment of the UDM Pro SIEM syslog pipeline (2026-04-22), a net-new write-hot workload needed a storage home:
+
+- `unifi-syslog` writes append-only log files at UDM event rate (tens to hundreds of entries per minute under normal load, higher under incidents).
+- Keeping the write in `subvol7-containers` would inherit the same COW-in-snapshotted-subvol antipattern ADR-025 describes — growing extent counts on every write, every daily snapshot pinning more old extents.
+- Placing it on `subvol8-db` is additive: the subvolume was already created as part of ADR-025's preparation work, and adding a greenfield tenant incurs none of the migration risk ADR-025 correctly insists on quantifying first.
+
+The open ADR-025 question is about **migrating existing DBs** — risk-laden, reversibility-sensitive, measurement-gated. The placement question for **new workloads** is different: a greenfield write has no migration, no rollback artifact to protect, no service to stop. Deferring new NOCOW-candidate workloads to `subvol7-containers` "until ADR-025 resolves" would actively create more migration debt, not less.
+
+This ADR separates the two questions and establishes a forward-only placement policy.
+
+## Decision
+
+**All new write-hot or snapshot-hostile workloads land on `/mnt/btrfs-pool/subvol8-db` from day one.** Existing workloads remain where they are; their migration remains the deferred question ADR-025 owns.
+
+A workload qualifies as NOCOW-candidate if any of the following apply:
+
+- **Append-only log streams** with sustained write rate (syslog receivers, audit trails, metric scrape targets not covered by a dedicated TSDB engine).
+- **Database engines with built-in integrity checksumming** (PostgreSQL `data_checksums`, MariaDB/InnoDB, MongoDB/WiredTiger, Prometheus TSDB, Loki chunks).
+- **Random-write patterns that fragment under COW** (B-tree rewrites, page updates, write-ahead logs).
+
+A workload does **not** qualify and stays on `subvol7-containers` if:
+
+- Writes are whole-file rewrites (Redis RDB snapshots, config files, image caches).
+- Snapshot-based rollback is genuinely valuable (container configs, application state an operator wants to revert with `btrfs subvolume snapshot`).
+- It's not meaningfully write-hot (low-rate, small-file workloads below any fragmentation threshold).
+
+For the ambiguous middle, err toward `subvol7-containers` — the cost of "wrong" placement there is fragmentation only, which is exactly what ADR-025 is measuring anyway. The cost of "wrong" placement on `subvol8-db` is loss of snapshot rollback, which is harder to retrofit.
+
+## Scope boundary with ADR-025
+
+| Question | Owner |
+|---|---|
+| New workloads that meet NOCOW criteria | **This ADR** — land on `subvol8-db` |
+| Existing DBs in `subvol7-containers` (5 services enumerated in ADR-025) | **ADR-025** — deferred until 2026-06-18 measurement review |
+| Redis, Gathio redis, container configs, caches | Neither — stays on `subvol7-containers` by design |
+
+ADR-025's acceptance criteria, migration procedure, and defensive tooling requirements are **unchanged**. If measurements on 2026-06-18 say "migrate," ADR-025's plan executes exactly as written. If they say "don't migrate," ADR-025 is withdrawn and the existing DBs stay on `subvol7-containers` — this ADR's forward-placement policy is unaffected either way.
+
+## Baseline storage layout (after this ADR)
+
+```
+/mnt/btrfs-pool/subvol8-db/            [NOT in Urd snapshot set]
+└── unifi-syslog/                      [root:root 0755; container uid 0 = host uid 1000]
+    └── udm.log                        [syslog-ng output; rotated daily × 14 by logrotate]
+```
+
+Compression on the subvolume root: `btrfs property set ... compression none`. NOCOW via `chattr +C` was attempted and returned EINVAL on kernel 6.19 for reasons not yet traced; for the `unifi-syslog` tenant this is accepted because (a) the subvolume is not snapshotted, so there's no COW-amplification fight to win, and (b) append-only log writes are not the fragmentation-sensitive pattern NOCOW is most valuable for. Future DB tenants (if ADR-025 accepts migration) will need the flag to work; that's on ADR-025 to resolve.
+
+## Integration requirements per new tenant
+
+When adding a tenant to `subvol8-db`, the deploying change must:
+
+1. **Create the per-service directory** under `/mnt/btrfs-pool/subvol8-db/<service>/` with ownership matching the container's effective host UID (typically `patriark:patriark` for rootless root-in-container; container subuid for LSIO PUID-mapped services).
+2. **Bind-mount with `:Z`** in the quadlet per ADR-001.
+3. **Not add the path to Urd's backup set.** `subvol8-db` is intentionally excluded from snapshots. If the tenant's data is operationally valuable (e.g., DBs), backup coverage is through application-level dumps (ADR-024 for DBs, tenant-specific for others). If the data is reconstructible (log streams, caches), no backup is needed — document that in the tenant's runbook.
+4. **Document the tenant** in this ADR's first-tenant list below, with a one-liner on why it qualified and how backup (if any) is handled.
+
+## Tenants
+
+| Tenant | Added | Workload class | Backup |
+|---|---|---|---|
+| `unifi-syslog` | 2026-04-22 | Append-only UDP syslog receiver | None — forensic logs are replayable from UDM retention; 14-day logrotate locally |
+
+This table is the living record. New tenants add a row; it does not require a new ADR unless the placement policy itself changes.
+
+## Consequences
+
+**Positive:**
+- New write-hot workloads avoid the COW-in-snapshotted-subvol antipattern from day one, regardless of what ADR-025's measurements say for existing DBs.
+- `subvol8-db` earns incremental load, giving real-world data on the subvolume's behavior before the (hypothetical) DB migration event needs to rely on it.
+- The ADR boundary is clean: greenfield placement vs. migration of live services are distinct decisions with distinct risk profiles, handled by distinct ADRs.
+
+**Negative:**
+- `subvol8-db` now has live operational dependencies before ADR-025's measurement window closes. If ADR-025 is ultimately withdrawn ("don't migrate"), `subvol8-db` still persists — it has tenants. That's fine, but worth naming: ADR-027 locks in the subvolume as a permanent fixture independent of ADR-025's outcome.
+- Tenants on `subvol8-db` have no filesystem-snapshot rollback path. The tenant table's "Backup" column must be explicit for every entry; "None" is an acceptable answer only when the data is genuinely reconstructible.
+
+**Constraints:**
+- No tenant may rely on snapshot rollback for recovery. If one needs it, it belongs on `subvol7-containers` and the write-hotness cost is accepted, not hidden.
+- Adding a tenant does not require a new ADR, but does require updating the tenant table in this document and referencing the ADR in the tenant's deployment journal.
+
+## Related
+
+- **ADR-001:** Rootless containers and `:Z` SELinux labeling — unchanged.
+- **ADR-019:** Filesystem permission model — the two-layer ACL pattern ADR-025 describes applies when DB tenants (with container subuid ownership) move in. For `unifi-syslog` (host-uid-owned), the simpler single-owner pattern suffices.
+- **ADR-024:** Dump-based backup — not directly invoked by `unifi-syslog`, but the mechanism DB tenants will use when/if they migrate.
+- **ADR-025:** Deferred DB migration — this ADR does **not** change its deferral. That ADR's measurement window and 2026-06-18 review date stand.
+- **Journal:** `docs/98-journals/2026-04-22-udm-pro-siem-syslog-pipeline.md` — first deployment to exercise this policy.

--- a/docs/98-journals/2026-04-22-udm-pro-siem-syslog-pipeline.md
+++ b/docs/98-journals/2026-04-22-udm-pro-siem-syslog-pipeline.md
@@ -1,0 +1,89 @@
+# UDM Pro SIEM Syslog Pipeline — Build Retrospective
+
+**Date:** 2026-04-22
+**PR:** _pending_
+**ADR:** [ADR-027](../00-foundation/decisions/2026-04-22-ADR-027-forward-nocow-workloads-subvol8-db.md)
+**Context:** UDM Pro frequently surfaces "network intrusion attempt" notifications (both LAN-local flows and external scans hitting `192.168.1.70`). None of those events landed in Loki, so there was no way to correlate UDM IDS signals with Traefik access logs during incident review. The SIEM Server setting on UDM forwards raw syslog over UDP. This build wires that stream into the existing Promtail → Loki pipeline.
+
+---
+
+## What shipped
+
+| File | Change |
+|---|---|
+| `quadlets/syslog.network` | NEW — dedicated `Internal=true` network (`10.89.7.0/24`) for the syslog ingestion tier |
+| `quadlets/unifi-syslog.container` | NEW — linuxserver/syslog-ng, UDP 1514 bound to LAN IP only, static IP `10.89.7.69` |
+| `config/unifi-syslog/syslog-ng.conf` | NEW — receive UDP on `0.0.0.0:1514`, write parseable template to `udm.log` |
+| `config/promtail/promtail-config.yml` | `+ job_name: unifi-syslog` — tails `udm.log`, regex-parses, labels `program/facility/priority` |
+| `quadlets/promtail.container` | `+ Volume=/mnt/btrfs-pool/subvol8-db/unifi-syslog:/var/log/unifi-syslog:ro,z` |
+| `config/logrotate/unifi-syslog` | NEW — daily × 14, `copytruncate` to avoid cross-user podman signaling |
+| `docs/00-foundation/decisions/2026-04-22-ADR-027-forward-nocow-workloads-subvol8-db.md` | NEW — forward-only NOCOW placement policy |
+
+Defense-in-depth on ingress:
+1. **firewalld rich rule** — `source address="192.168.1.1/32" port=1514 proto=udp accept` (authoritative source filter; runs before Podman's NAT layer).
+2. **LAN-IP-bound PublishPort** — `192.168.1.70:1514:1514/udp`, not `0.0.0.0`.
+3. **Dedicated `Internal=true` network** — the syslog receiver has no path to internet egress.
+4. **File-based ingestion into Loki** — Promtail tails `udm.log` via a read-only bind mount, no network coupling between the receiver and the monitoring stack.
+
+End-to-end verification: UDM ubios-udapi-server DHCP renewals on eth8 (public WAN) land in Loki via `{job="unifi-syslog"}`. Promtail metrics: `promtail_read_lines_total{path=".../udm.log"} 33`, `promtail_sent_entries_total{host="loki:3100"} 5215`, zero send errors.
+
+---
+
+## Lessons
+
+### LSIO + bind mount + rootless Podman: run the container as root
+
+syslog-ng refused to create `udm.log`, reporting `Error opening file for writing ... error='No such file or directory (2)'` against a directory that existed, was writable, and had the expected SELinux label. Spent real debugging time on this before the right frame clicked.
+
+The frame that was wrong: "ENOENT means the path doesn't exist — something about the bind mount or SELinux is hiding it." Every hypothesis along that axis (`:U`, `:Z`, MCS labels, subvol8-db traversal ACLs, rootless userns mount visibility) was a dead end. The frame that was right: LSIO containers run the service as `abc` (uid 1000 inside container), the bind mount was owned by `root` inside container (uid 1000 on host = `patriark`), and a non-root process cannot create files in a 0755 root-owned directory. syslog-ng reports the permission failure as ENOENT in this path — misleading, not malicious.
+
+Fix: `Environment=PUID=0` + `Environment=PGID=0`. In rootless Podman, container uid 0 maps to host uid 1000, which matches the bind mount owner. No subuid dance, no `:U` flag, no host-side chown — the idiomatic rootless Podman pattern when the workload is write-only and unprivileged work-inside-the-container is acceptable.
+
+**Lesson:** when an LSIO container hits "can't open file" on a bind mount, the first hypothesis should be "who is the container process, and who owns the mount host-side." In rootless Podman, `PUID=0 PGID=0` is often the cleanest answer for write-only sidecars. The `:U` flag looks attractive but plays badly with `:Z` (SELinux relabel happens at mount time, then `:U` tries to chown the relabeled dir, and LSIO's s6-overlay re-chowns on top — it's a three-way race that rarely ends well).
+
+### `chattr +C` on kernel 6.19 returned EINVAL; NOCOW wasn't needed here anyway
+
+After `btrfs subvolume create /mnt/btrfs-pool/subvol8-db` and `btrfs property set subvol8-db compression none`, the next step per ADR-025's design was `chattr +C` to inherit NOCOW on new files. The command returned `chattr: Invalid argument while setting flags on /mnt/btrfs-pool/subvol8-db`, both on the subvolume root and on the first subdirectory. Didn't trace the kernel-level reason — there's a known interaction between `btrfs property set compression none` and NOCOW flag manipulation in some kernel versions, and the failure was surfaced early enough to re-evaluate whether NOCOW was load-bearing for this tenant at all.
+
+It wasn't. `unifi-syslog` writes append-only logs, rotated daily, on a subvolume that isn't in the Urd snapshot set. The specific failure mode NOCOW prevents — COW amplification on random writes to files pinned by snapshots — does not apply to any of those three conditions for this workload. Skipping NOCOW here is correct, not a compromise.
+
+The ADR-025 deferred question (five existing DBs in `subvol7-containers`) is different. Those workloads *do* need NOCOW, and the `chattr +C` failure is a blocker for that migration. But `unifi-syslog` doesn't carry that constraint, so the blocker doesn't transfer.
+
+**Lesson:** when a platform primitive fails, re-derive whether you actually need it for this workload before investing in a workaround. The NOCOW reflex is correct for DB migrations; it's overhead for a log-receiver on an unsnapshotted subvolume. ADR-027 documents this so the next person adding a tenant doesn't waste the same cycles.
+
+### Separating "new placement" from "migrate existing" — the cleanest ADR decision of the build
+
+The `subvol8-db` subvolume was created as part of ADR-025's preparation work, but ADR-025 explicitly defers the migration of existing DBs pending 60 days of measurements. When `unifi-syslog` needed a write-hot storage home, the instinct was to either (a) wait for ADR-025 to resolve, or (b) drop the workload in `subvol7-containers` and carry migration debt.
+
+Both were wrong answers. The right answer is that "place new greenfield workloads" and "migrate five live production DBs" are different decisions with different risk profiles. Greenfield placement has no migration step, no rollback artifact to protect, no service to restart carefully — it's a pure write of new data to a chosen location. The measurement-gated caution ADR-025 correctly insists on for existing DBs doesn't transfer.
+
+Splitting the decision into ADR-027 took about 20 minutes and produced a cleaner invariant: new NOCOW-candidates go on `subvol8-db`, forward only. ADR-025 is untouched; its 2026-06-18 review date stands. Future tenants add a row to ADR-027's tenant table, not a new ADR.
+
+**Lesson:** when a deferred ADR blocks an unrelated new decision, check whether the deferral's premises actually apply to the new case. Often they don't, and the right move is a companion ADR that carves out the narrower forward-looking question cleanly. Don't paper over the distinction by retrofitting the deferred ADR's scope — that loads its measurement gate with work it wasn't designed to arbitrate.
+
+### Rootless Podman UDP NAT rewrites source IPs — rely on host-side filtering
+
+UDM packets arrive at `unifi-syslog` with `src=10.89.7.69` (the container's gateway), not `192.168.1.1`. Rootless Podman's pasta networking NATs UDP sources, so any in-container source-based filtering (syslog-ng `netmask()`) is operating on rewritten addresses and is not a trust boundary. The authoritative trust boundary is the firewalld rich rule on the host — it runs before NAT, sees the real source, and rejects non-UDM packets at the earliest possible point.
+
+This is why the syslog-ng config has no `netmask()` filter and the comment explicitly names firewalld as authoritative. Two layers that look similar are not always redundant — one of them is actually doing the work. Writing that down in the config file itself (not just the ADR) was worth the three extra lines; the next person editing this config shouldn't have to re-derive why the obvious filter is missing.
+
+**Lesson:** in-container network filters are application-layer conveniences, not security controls, whenever the container runtime NATs its inputs. The rule lives at the runtime boundary (firewalld, nftables, or the provider network), not inside the container.
+
+### Quadlet-generated units cannot be `enable`d
+
+Tried `systemctl --user enable unifi-syslog.service` out of muscle memory; it failed with "Unit is transient or generated." The `[Install] WantedBy=default.target` block in the `.container` file handles auto-wiring at quadlet-generation time — the correct deploy sequence is `daemon-reload` + `start`, never `enable`. Well-documented in podman's docs, but a reflex to unlearn coming from non-quadlet systemd.
+
+---
+
+## Follow-ups
+
+- **Prometheus alert:** "no UDM events in 10 min" — UDM Pro is a primary security signal; silent receiver failure is a real blind spot.
+- **Grafana dashboard panel:** UDM event rate by `program` label, with IDS/IPS facility highlighted. Makes the "is the UDM actually talking to us" question a glance-level check.
+- **Filter tuning after 24–48h of real traffic:** the bootstrap config writes everything to one file. Once real event patterns are visible in Loki, split noisy programs (DHCP renewals, link-state churn) from security-relevant ones (IDS matches, firewall drops) into separate destinations or separate log-level filters.
+- **ADR-025 unchanged:** measurement window continues. The `chattr +C` EINVAL finding is a known unknown for the DB migration day, but not a blocker to resolve now.
+
+---
+
+## Scope note
+
+This build touched the syslog ingestion pipeline only. Did not alter Traefik routing, did not open any new internet-facing ports, did not change the monitoring stack's existing scrape targets. The `subvol8-db` tenant count went from zero to one; ADR-027 documents the forward-placement policy so the second tenant can land without re-litigating the placement question.

--- a/docs/AUTO-DEPENDENCY-GRAPH.md
+++ b/docs/AUTO-DEPENDENCY-GRAPH.md
@@ -1,6 +1,6 @@
 # Service Dependency Graph (Auto-Generated)
 
-**Generated:** 2026-04-21 08:27:34 UTC
+**Generated:** 2026-04-22 05:02:53 UTC
 **System:** fedora-htpc
 
 ---

--- a/docs/AUTO-DOCUMENTATION-INDEX.md
+++ b/docs/AUTO-DOCUMENTATION-INDEX.md
@@ -1,7 +1,7 @@
 # Documentation Index (Auto-Generated)
 
-**Generated:** 2026-04-21 08:27:35 UTC
-**Total Documents:** 446
+**Generated:** 2026-04-22 05:02:54 UTC
+**Total Documents:** 390
 
 ---
 
@@ -22,7 +22,7 @@
 
 ## Documentation by Category
 
-### 00-foundation/ (19 documents)
+### 00-foundation/ (21 documents)
 
 **Fundamentals and core concepts**
 
@@ -47,6 +47,8 @@
 - ADR-022: [2026-04-16-ADR-022-traefik-socket-activation](00-foundation/decisions/2026-04-16-ADR-022-traefik-socket-activation.md)
 - ADR-024: [2026-04-18-ADR-024-database-dump-backup](00-foundation/decisions/2026-04-18-ADR-024-database-dump-backup.md)
 - ADR-025: [2026-04-18-ADR-025-db-storage-migration-deferred](00-foundation/decisions/2026-04-18-ADR-025-db-storage-migration-deferred.md)
+- ADR-023: [2026-04-21-ADR-023-monitoring-bind-propagation](00-foundation/decisions/2026-04-21-ADR-023-monitoring-bind-propagation.md)
+- ADR-026: [2026-04-21-ADR-026-nextcloud-pinned-major-version](00-foundation/decisions/2026-04-21-ADR-026-nextcloud-pinned-major-version.md)
 - ADR-023: [2026-04-18-ADR-023-btrfs-storage-architecture-databases](00-foundation/decisions/withdrawn/2026-04-18-ADR-023-btrfs-storage-architecture-databases.md)
 
 ---
@@ -208,7 +210,7 @@
 
 ---
 
-### 98-journals/ (197 documents)
+### 98-journals/ (200 documents)
 
 **Chronological project history (append-only log)**
 
@@ -226,26 +228,26 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 
 ## Recently Updated (Last 7 Days)
 
-- 2026-04-20: [2026-03-28-ADR-021-urd-backup-tool.md](00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md)
+- 2026-04-22: [2026-03-28-ADR-021-urd-backup-tool.md](00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md)
 - 2026-04-16: [2026-04-16-ADR-022-traefik-socket-activation.md](00-foundation/decisions/2026-04-16-ADR-022-traefik-socket-activation.md)
-- 2026-04-18: [2026-04-18-ADR-024-database-dump-backup.md](00-foundation/decisions/2026-04-18-ADR-024-database-dump-backup.md)
-- 2026-04-18: [2026-04-18-ADR-025-db-storage-migration-deferred.md](00-foundation/decisions/2026-04-18-ADR-025-db-storage-migration-deferred.md)
-- 2026-04-18: [2026-04-18-ADR-023-btrfs-storage-architecture-databases.md](00-foundation/decisions/withdrawn/2026-04-18-ADR-023-btrfs-storage-architecture-databases.md)
-- 2026-04-16: [2026-03-17-pasta-source-nat-investigation.md](98-journals/2026-03-17-pasta-source-nat-investigation.md)
-- 2026-04-16: [2026-03-26-promtail-journal-export-outage.md](98-journals/2026-03-26-promtail-journal-export-outage.md)
-- 2026-04-20: [2026-03-28-podman-storage-migration.md](98-journals/2026-03-28-podman-storage-migration.md)
-- 2026-04-16: [2026-03-31-authelia-sso-gathio-debugging.md](98-journals/2026-03-31-authelia-sso-gathio-debugging.md)
-- 2026-04-16: [2026-03-31-proton-bridge-smtp-integration-attempt.md](98-journals/2026-03-31-proton-bridge-smtp-integration-attempt.md)
+- 2026-04-21: [2026-04-18-ADR-024-database-dump-backup.md](00-foundation/decisions/2026-04-18-ADR-024-database-dump-backup.md)
+- 2026-04-21: [2026-04-18-ADR-025-db-storage-migration-deferred.md](00-foundation/decisions/2026-04-18-ADR-025-db-storage-migration-deferred.md)
+- 2026-04-22: [2026-04-21-ADR-023-monitoring-bind-propagation.md](00-foundation/decisions/2026-04-21-ADR-023-monitoring-bind-propagation.md)
+- 2026-04-21: [2026-04-21-ADR-026-nextcloud-pinned-major-version.md](00-foundation/decisions/2026-04-21-ADR-026-nextcloud-pinned-major-version.md)
+- 2026-04-21: [2026-04-18-ADR-023-btrfs-storage-architecture-databases.md](00-foundation/decisions/withdrawn/2026-04-18-ADR-023-btrfs-storage-architecture-databases.md)
+- 2026-04-21: [2026-04-21-nextcloud-slo-collapse-postmortem.md](90-archive/2026-04-21-nextcloud-slo-collapse-postmortem.md)
+- 2026-04-21: [2026-03-17-pasta-source-nat-investigation.md](98-journals/2026-03-17-pasta-source-nat-investigation.md)
+- 2026-04-21: [2026-03-26-promtail-journal-export-outage.md](98-journals/2026-03-26-promtail-journal-export-outage.md)
+- 2026-04-21: [2026-03-28-podman-storage-migration.md](98-journals/2026-03-28-podman-storage-migration.md)
+- 2026-04-21: [2026-03-31-authelia-sso-gathio-debugging.md](98-journals/2026-03-31-authelia-sso-gathio-debugging.md)
+- 2026-04-21: [2026-03-31-proton-bridge-smtp-integration-attempt.md](98-journals/2026-03-31-proton-bridge-smtp-integration-attempt.md)
 - 2026-04-16: [2026-04-16-adr-022-socket-activation-prototype.md](98-journals/2026-04-16-adr-022-socket-activation-prototype.md)
-- 2026-04-18: [2026-04-18-podman-storage-migration-execution.md](98-journals/2026-04-18-podman-storage-migration-execution.md)
+- 2026-04-21: [2026-04-18-podman-storage-migration-execution.md](98-journals/2026-04-18-podman-storage-migration-execution.md)
 - 2026-04-21: [2026-04-21-crowdsec-acquisition-and-rate-limit-retune.md](98-journals/2026-04-21-crowdsec-acquisition-and-rate-limit-retune.md)
 - 2026-04-21: [2026-04-21-ha-rate-limit-rollback-post-adr022.md](98-journals/2026-04-21-ha-rate-limit-rollback-post-adr022.md)
-- 2026-04-16: [2026-04-16-nat-remediation-research.md](99-reports/2026-04-16-nat-remediation-research.md)
-- 2026-04-17: [2026-04-17-service-configuration-review.md](99-reports/2026-04-17-service-configuration-review.md)
-- 2026-04-18: [2026-04-18-design-review-ADR-023-btrfs-storage-architecture-databases.md](99-reports/2026-04-18-design-review-ADR-023-btrfs-storage-architecture-databases.md)
-- 2026-04-17: [remediation-monthly-202603.md](99-reports/remediation-monthly-202603.md)
-- 2026-04-15: [security-audit-2026-04-15.md](99-reports/security-audit-2026-04-15.md)
-- 2026-04-21: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
+- 2026-04-22: [2026-04-21-monitoring-bind-propagation.md](98-journals/2026-04-21-monitoring-bind-propagation.md)
+- 2026-04-21: [2026-04-21-network-ingress-egress-hardening.md](98-journals/2026-04-21-network-ingress-egress-hardening.md)
+- 2026-04-21: [2026-04-21-nextcloud-postmortem-followups.md](98-journals/2026-04-21-nextcloud-postmortem-followups.md)
 
 ---
 
@@ -283,6 +285,7 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 
 **Nextcloud:**
 - Guide: [nextcloud.md](10-services/guides/nextcloud.md)
+- ADR: [ADR-026](00-foundation/decisions/2026-04-21-ADR-026-nextcloud-pinned-major-version.md)
 - ADR: [ADR-013](10-services/decisions/2025-12-20-ADR-013-nextcloud-native-authentication.md)
 - ADR: [ADR-014](10-services/decisions/2025-12-20-ADR-014-nextcloud-passwordless-authentication.md)
 - Quadlet: `~/.config/containers/systemd/nextcloud.container`

--- a/docs/AUTO-NETWORK-TOPOLOGY.md
+++ b/docs/AUTO-NETWORK-TOPOLOGY.md
@@ -1,6 +1,6 @@
 # Network Topology (Auto-Generated)
 
-**Generated:** 2026-04-21 08:27:30 UTC
+**Generated:** 2026-04-22 05:02:50 UTC
 **System:** fedora-htpc | **Networks:** 9 | **Containers:** 31
 
 ---

--- a/docs/AUTO-SERVICE-CATALOG.md
+++ b/docs/AUTO-SERVICE-CATALOG.md
@@ -1,6 +1,6 @@
 # Service Catalog (Auto-Generated)
 
-**Generated:** 2026-04-21 08:27:29 UTC
+**Generated:** 2026-04-22 05:02:49 UTC
 **System:** fedora-htpc | **Services:** 31/31 running | **Health:** 19/30 healthy (1 without healthcheck)
 
 ---
@@ -9,82 +9,82 @@
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| audiobookshelf | advplyr/audiobookshelf:latest | ✅ healthy | 2d | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
-| navidrome | deluan/navidrome:latest | ⚠️ unhealthy | 2d | [musikk.patriark.org](https://musikk.patriark.org) | — |
-| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | 2d | — | — |
-| qbittorrent | linuxserver/qbittorrent:latest | ✅ healthy | 2d | [torrent.patriark.org](https://torrent.patriark.org) | — |
+| audiobookshelf | advplyr/audiobookshelf:latest | ✅ healthy | 3d | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
+| navidrome | deluan/navidrome:latest | ⚠️ unhealthy | 3d | [musikk.patriark.org](https://musikk.patriark.org) | — |
+| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | 3d | — | — |
+| qbittorrent | linuxserver/qbittorrent:latest | ✅ healthy | 3d | [torrent.patriark.org](https://torrent.patriark.org) | — |
 
 ## Core Infrastructure (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| authelia | authelia/authelia:latest | ✅ healthy | 2d | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
-| crowdsec | crowdsecurity/crowdsec:latest | ✅ healthy | ~anh | — | [guide](10-services/guides/crowdsec.md) |
-| redis-authelia | redis:7-alpine | ✅ healthy | 2d | — | — |
-| traefik | traefik:latest | ⚠️ unhealthy | 2d | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
+| authelia | authelia/authelia:latest | ✅ healthy | 3d | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
+| crowdsec | crowdsecurity/crowdsec:latest | ✅ healthy | 22h | — | [guide](10-services/guides/crowdsec.md) |
+| redis-authelia | redis:7-alpine | ✅ healthy | 3d | — | — |
+| traefik | traefik:latest | ⚠️ unhealthy | 3d | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
 
 ## Nextcloud (3)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| nextcloud-db | mariadb:11 | ⚠️ unhealthy | 2d | — | [guide](10-services/guides/nextcloud.md) |
-| nextcloud | nextcloud:latest | ⚠️ unhealthy | 2d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
-| nextcloud-redis | redis:7-alpine | ✅ healthy | 2d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-db | mariadb:11 | ⚠️ unhealthy | 3d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud | nextcloud:latest | ⚠️ unhealthy | 3d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-redis | redis:7-alpine | ✅ healthy | 3d | — | [guide](10-services/guides/nextcloud.md) |
 
 ## Immich (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| immich-ml | immich-app/immich-machine-learning:v2.6.3 | ✅ healthy | 2d | — | [guide](10-services/guides/immich.md) |
-| immich-server | immich-app/immich-server:v2.6.3 | ⚠️ unhealthy | 2d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
-| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3-pgvec | ⚠️ unhealthy | 2d | — | — |
-| redis-immich | valkey/valkey:latest | ✅ healthy | 2d | — | — |
+| immich-ml | immich-app/immich-machine-learning:v2.6.3 | ✅ healthy | 3d | — | [guide](10-services/guides/immich.md) |
+| immich-server | immich-app/immich-server:v2.6.3 | ⚠️ unhealthy | 3d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
+| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3-pgvec | ⚠️ unhealthy | 3d | — | — |
+| redis-immich | valkey/valkey:latest | ✅ healthy | 3d | — | — |
 
 ## Jellyfin (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| jellyfin | jellyfin/jellyfin:latest | ✅ healthy | 2d | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
+| jellyfin | jellyfin/jellyfin:latest | ✅ healthy | 11h | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
 
 ## Vaultwarden (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| vaultwarden | vaultwarden/server:latest | ✅ healthy | 2d | [vault.patriark.org](https://vault.patriark.org) | — |
+| vaultwarden | vaultwarden/server:latest | ✅ healthy | 3d | [vault.patriark.org](https://vault.patriark.org) | — |
 
 ## Home Automation (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 2d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
-| matter-server | home-assistant-libs/python-matter-server:stab | ✅ healthy | 2d | — | [guide](10-services/guides/matter-server.md) |
+| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 11h | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
+| matter-server | home-assistant-libs/python-matter-server:stab | ✅ healthy | 11h | — | [guide](10-services/guides/matter-server.md) |
 
 ## Gathio (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| gathio-db | mongo:7 | ⚠️ unhealthy | 2d | — | — |
-| gathio | lowercasename/gathio:latest | ✅ healthy | 2d | [events.patriark.org](https://events.patriark.org) | — |
+| gathio-db | mongo:7 | ⚠️ unhealthy | 3d | — | — |
+| gathio | lowercasename/gathio:latest | ✅ healthy | 3d | [events.patriark.org](https://events.patriark.org) | — |
 
 ## Homepage (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| homepage | gethomepage/homepage:latest | ⚠️ unhealthy | 2d | [patriark.org](https://patriark.org) | — |
+| homepage | gethomepage/homepage:latest | ⚠️ unhealthy | 3d | [patriark.org](https://patriark.org) | — |
 
 ## Monitoring (9)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| alert-discord-relay | localhost/alert-discord-relay:latest | ⚠️ unhealthy | 2d | — | [guide](10-services/guides/alert-discord-relay.md) |
-| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ healthy | 2d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ healthy | 2d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| grafana | grafana/grafana:latest | ⚠️ unhealthy | 2d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| loki | grafana/loki:latest | — no check | 2d | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| node_exporter | quay.io/prometheus/node-exporter:latest | ✅ healthy | 2d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 2d | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| promtail | grafana/promtail:latest | ✅ healthy | 2d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| unpoller | unpoller/unpoller:latest | ⚠️ unhealthy | 2d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| alert-discord-relay | localhost/alert-discord-relay:latest | ⚠️ unhealthy | 3d | — | [guide](10-services/guides/alert-discord-relay.md) |
+| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ healthy | 3d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ healthy | 7h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| grafana | grafana/grafana:latest | ⚠️ unhealthy | 3d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| loki | grafana/loki:latest | — no check | 3d | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| node_exporter | quay.io/prometheus/node-exporter:latest | ✅ healthy | 7h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 3d | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| promtail | grafana/promtail:latest | ✅ healthy | 3d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| unpoller | unpoller/unpoller:latest | ⚠️ unhealthy | 3d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
 
 ---
 
@@ -92,7 +92,7 @@
 
 - **Total Running:** 31
 - **Total Defined:** 31
-- **System Load:** 1,22, 1,05, 0,88
+- **System Load:** 0,40, 0,49, 0,43
 
 ---
 

--- a/quadlets/promtail.container
+++ b/quadlets/promtail.container
@@ -21,6 +21,9 @@ Volume=%h/containers/.claude/context/decision-log.jsonl:/var/log/remediation/dec
 # Traefik access logs
 Volume=/mnt/btrfs-pool/subvol7-containers/traefik-logs:/var/log/traefik:ro,z
 
+# UniFi UDM Pro syslog (written by unifi-syslog container)
+Volume=/mnt/btrfs-pool/subvol8-db/unifi-syslog:/var/log/unifi-syslog:ro,z
+
 # Promtail command line arguments
 Exec=-config.file=/etc/promtail/promtail-config.yml
 

--- a/quadlets/syslog.network
+++ b/quadlets/syslog.network
@@ -1,0 +1,11 @@
+[Unit]
+Description=Syslog Ingestion Network
+
+[Network]
+Subnet=10.89.7.0/24
+Gateway=10.89.7.1
+IPRange=10.89.7.2-10.89.7.68
+DNS=192.168.1.69
+# Internal network - syslog receiver has no outbound internet.
+# Data flow is one-way: UDM Pro -> syslog-ng -> file -> Promtail (separate container).
+Internal=true

--- a/quadlets/unifi-syslog.container
+++ b/quadlets/unifi-syslog.container
@@ -1,0 +1,46 @@
+[Unit]
+Description=UniFi UDM Pro Syslog Receiver (syslog-ng)
+After=network-online.target syslog-network.service
+Wants=syslog-network.service network-online.target
+
+[Container]
+Image=docker.io/linuxserver/syslog-ng:latest
+ContainerName=unifi-syslog
+HostName=unifi-syslog
+AutoUpdate=registry
+Network=systemd-syslog:ip=10.89.7.69
+
+# Bind to LAN interface only - NOT 0.0.0.0. Defense in depth alongside firewalld rule.
+PublishPort=192.168.1.70:1514:1514/udp
+
+# Rootless Podman maps container-uid-0 to host-uid-1000 (patriark), which owns the bind
+# mount. Running syslog-ng as container-root keeps write semantics simple and avoids the
+# LSIO abc-user subuid shuffle that requires either a :U volume flag (unreliable with :Z)
+# or host-side subuid chown. For a write-only forensic-log receiver this is the cleaner
+# pattern.
+Environment=PUID=0
+Environment=PGID=0
+Environment=TZ=Europe/Oslo
+
+Volume=%h/containers/config/unifi-syslog/syslog-ng.conf:/config/syslog-ng.conf:ro,Z
+Volume=/mnt/btrfs-pool/subvol8-db/unifi-syslog:/var/log/unifi-syslog:Z
+
+DNS=192.168.1.69
+
+HealthCmd=pgrep -x syslog-ng
+HealthInterval=60s
+HealthRetries=3
+HealthStartPeriod=30s
+HealthTimeout=5s
+
+[Service]
+Slice=container.slice
+Restart=on-failure
+TimeoutStartSec=60
+
+# Resource Limits
+MemoryMax=128M
+MemoryHigh=110M
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

- **New service:** `unifi-syslog` (syslog-ng) receives UDM Pro SIEM syslog on UDP 1514 and writes to `udm.log`; Promtail tails the file into Loki for forensic correlation with Traefik access logs and other sources.
- **New storage policy:** ADR-027 establishes a forward-only NOCOW placement rule on `subvol8-db`. First tenant is `unifi-syslog`. ADR-025's deferred DB migration question is untouched.
- **New dashboard:** "UniFi UDM Pro SIEM" — pipeline health, rate by program/priority, security keyword filter, raw stream (collapsed).

## Why

UDM Pro surfaces intrusion/block notifications constantly (internal flows + external scans on `192.168.1.70`), and none of them landed in Loki before this PR. No path for incident review to correlate UDM IDS/IPS events with what the Traefik chain actually saw.

## Defense-in-depth on ingress

| Layer | Control |
|---|---|
| 1 | `firewalld` rich rule `source=192.168.1.1/32` on UDP 1514 (runs before Podman NAT; authoritative) |
| 2 | `PublishPort=192.168.1.70:1514:1514/udp` (LAN IP only, not `0.0.0.0`) |
| 3 | Dedicated `syslog.network` with `Internal=true` (no egress from the receiver) |
| 4 | File-based Promtail ingestion (read-only bind mount; no network coupling between receiver and monitoring) |

Rootless Podman's UDP NAT rewrites source IPs, so in-container source filters are not a trust boundary — firewalld is. Comment in `syslog-ng.conf` names this explicitly.

## Components

| File | Purpose |
|---|---|
| `quadlets/syslog.network` | Dedicated `Internal=true` network `10.89.7.0/24` |
| `quadlets/unifi-syslog.container` | linuxserver/syslog-ng, `PUID=0 PGID=0` for rootless-root ownership match with bind mount |
| `config/unifi-syslog/syslog-ng.conf` | UDP listener, parseable template: `ISODATE src=... host=... prog=... pid=... pri=... fac=... msg=...` |
| `quadlets/promtail.container` + `config/promtail/promtail-config.yml` | New `unifi-syslog` scrape job with `program`/`facility`/`priority` labels |
| `config/logrotate/unifi-syslog` | daily × 14, `copytruncate` (avoids cross-user podman signaling) |
| `config/grafana/provisioning/dashboards/json/unifi-syslog.json` | New dashboard |
| `docs/00-foundation/decisions/2026-04-22-ADR-027-*.md` | Forward-only NOCOW placement policy on `subvol8-db` |
| `docs/98-journals/2026-04-22-udm-pro-siem-syslog-pipeline.md` | Build retrospective + lessons learned |

## ADR boundary (ADR-025 vs ADR-027)

- **ADR-025** (deferred; earliest review 2026-06-18): whether to **migrate five existing DBs** in `subvol7-containers` onto `subvol8-db`. Unchanged.
- **ADR-027** (this PR; accepted): where **new** write-hot workloads land going forward. Greenfield placement has no migration risk, so it doesn't inherit ADR-025's measurement gate.

## Verification

- ✅ `promtail_read_lines_total{path=".*udm.log"}` advancing; `promtail_sent_entries_total` advancing without `promtail_dropped_entries_total` increments.
- ✅ Real UDM events in Loki via `{job="unifi-syslog"}` — observed `ubios-udapi-server` DHCP renewals on eth8 (WAN) and hostname `patriarkatet-udm`.
- ✅ `firewall-cmd --list-rich-rules` shows the `192.168.1.1/32` source rule persistent.
- ✅ `ss -ulnp` shows `192.168.1.70:1514` bound (not `0.0.0.0`).
- ✅ `podman network inspect systemd-syslog` shows `Internal: true`.
- ✅ `unifi-syslog.service` and `promtail.service` both `active` and healthy.
- ✅ Grafana dashboard JSON validates; provisioner re-scan tick logged without errors.

## Test plan

- [ ] Open Grafana → "UniFi UDM Pro SIEM" dashboard; confirm "Events Read (5m)" stat > 0.
- [ ] Explore `{job="unifi-syslog"}` in Grafana Explore (Loki datasource) over last 1h.
- [ ] Trigger logrotate dry-run after file growth: `sudo logrotate -d /etc/logrotate.d/unifi-syslog`.
- [ ] Watch for 24–48h; tune `syslog-ng.conf` filters based on observed event patterns (follow-up, not in this PR).
- [ ] Add Prometheus "no UDM events in 10 min" alert (follow-up, not in this PR).

## Related

- ADR-025 — `docs/00-foundation/decisions/2026-04-18-ADR-025-db-storage-migration-deferred.md` (unchanged)
- ADR-024 — dump-based backup (not invoked by this PR; relevant when DB tenants land)
- Journal — `docs/98-journals/2026-04-22-udm-pro-siem-syslog-pipeline.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)