### PR TITLE
chore: gitignore pattern for private journal entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,10 @@ docs/99-reports/
 # but not version-controlled. See docs/CONTRIBUTING.md for archive conventions.
 docs/90-archive/
 
+# Private journal entries — suffix any journal filename with `-private.md`
+# to keep it local (not version-controlled)
+docs/98-journals/*-private.md
+
 # (Entire .claude/ directory is ignored above)
 
 # Container Runtime


### PR DESCRIPTION
## Summary

Adds `docs/98-journals/*-private.md` to `.gitignore`. Any journal entry saved with a `-private.md` suffix stays local and isn't version-controlled.

## Why

Some journal entries are exploratory or contain raw forensic data intended for personal consumption rather than repo history. A suffix-based convention is lighter than editing `.gitignore` per entry, and explicit at write-time (you know from the filename whether a journal is public or private).

## Test Plan

- [x] `git check-ignore -v docs/98-journals/<name>-private.md` returns the ignore rule
- [x] `git status` does not show a `-private.md` file as untracked
- [ ] Existing public journals (no `-private` suffix) remain tracked normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)