### PR TITLE
feat: security posture intel scripts (local + remote)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,12 @@ docs/90-archive/
 # to keep it local (not version-controlled)
 docs/98-journals/*-private.md
 
+# Active-probe posture script — tuned attack tool for this specific perimeter
+# (curated attack paths, CrowdSec burst logic, Region Block negative test).
+# Low reconstruction cost but publishing it hands adversaries a pre-built
+# kit. Distributed to owner's MacBook via scp out-of-band, not via git.
+scripts/security/posture-remote.py
+
 # (Entire .claude/ directory is ignored above)
 
 # Container Runtime

--- a/docs/98-journals/2026-04-22-posture-intel-scripts-handoff.md
+++ b/docs/98-journals/2026-04-22-posture-intel-scripts-handoff.md
@@ -1,0 +1,232 @@
+# Posture Intel Scripts — Handoff for Fresh Sessions
+
+**Date:** 2026-04-22
+**PR:** _pending_
+**Context:** Built two Python scripts (`scripts/security/posture-local.py`, `scripts/security/posture-remote.py`) that actively gather forensic security intel from two disjoint vantages and emit a shared JSON schema. They are purpose-built to be *consumed by a fresh Claude Code session* that doesn't have today's context. This entry is the handoff — what shipped, what the expected false-positives look like, and the two prompts that orient a new session efficiently.
+
+---
+
+## What shipped
+
+| File | Purpose |
+|---|---|
+| `scripts/security/posture-local.py` | 11-category internal-plane gap finder run on fedora-htpc. No sudo. **Committed.** |
+| `scripts/security/posture-remote.py` | External-plane perimeter probe with active attacks against our own edge. **Gitignored** — distributed to the MacBook via scp, not via `git clone`. Publishing a perimeter-tuned attack kit on a public repo hands adversaries recon-time. |
+| `scripts/security/README.md` | Ingestion contract, severity scale, active-probe footprint, cadence table. |
+| `scripts/security/README-ssh-sync.md` | Old README (YubiKey SSH sync), renamed to free the canonical path. |
+
+Output lands at `data/security-posture/{local,remote}/<UTC>.json` (gitignored via `data/*`). Shared schema: `meta`, `summary`, `findings[]`, `raw{}`. Finding IDs are stable per category (`LBIND-0001`, `RAUTH-0001`) so reports diff cleanly across runs.
+
+Severity is a heuristic. The scripts do not interpret — they gather. All triage belongs to the consuming session.
+
+---
+
+## Handoff prompt A — local session (on fedora-htpc)
+
+Paste into a fresh Claude Code session invoked inside `~/containers`:
+
+```
+You are triaging a security-posture report produced by
+scripts/security/posture-local.py. Read the most recent JSON under
+data/security-posture/local/ (ls -t | head -1). If none exists, run the
+script first: `python3 scripts/security/posture-local.py`.
+
+Your job is to turn the JSON into a prioritised hardening plan for this
+homelab.
+
+Process:
+1. Skim meta.summary. Spend 0 time on findings with severity=info until
+   after critical/high/medium are cleared.
+2. For EACH finding with severity >= medium, classify it as one of:
+     (a) real gap — propose a concrete file edit or config change
+     (b) known-accepted — cite the ADR, journal, or repo state that accepts
+         it (e.g., cadvisor privileged is intentional for metric collection)
+     (c) collector false-positive — explain which assumption is wrong and
+         propose a patch to the script
+3. Group remediations by effort: ≤15 min, ≤1 hour, ≤half-day, requires ADR.
+4. Cross-check against the latest remote report under
+   data/security-posture/remote/ if one exists. Pay special attention to
+   findings that contradict each other — e.g., local says rate-limit is
+   300rpm, remote observed first 429 at request N; is N consistent?
+5. Do NOT re-run the script to collect new data in this first pass unless
+   a finding is ambiguous and a fresh datapoint would resolve it. In that
+   case, use `--category <name>` to keep the run narrow.
+
+Context you MUST read before starting (load these files):
+- CLAUDE.md (architecture principles and ADR-016/018 constraints)
+- docs/98-journals/2026-04-22-posture-intel-scripts-handoff.md (this file —
+  contains known false-positives you should not re-derive)
+- docs/98-journals/2026-04-22-ingress-forensics-udm-blindspot-private.md
+  (UDM Region Block is syslog-invisible — shapes what "quiet logs" means)
+- docs/98-journals/2026-04-21-crowdsec-acquisition-and-rate-limit-retune.md
+  (post-ADR-022 rate-limit values and CrowdSec acquisition state)
+
+Output format: a markdown triage document written to docs/99-reports/
+with filename posture-triage-local-<YYYY-MM-DD>.md. Sections:
+  ## Summary (counts + headline risks)
+  ## Real gaps (numbered, with proposed edits)
+  ## Known-accepted (one line each, with citation)
+  ## Collector false-positives (if any, with proposed script patches)
+  ## Recommended next actions (≤5 items, concrete)
+
+Do not edit code in this pass. The deliverable is the triage document.
+```
+
+---
+
+## Handoff prompt B — remote session (on MacBook Air)
+
+Paste into a Claude Code session on the MacBook. The remote script is NOT in the homelab repo (gitignored — it's a tuned attack kit against our own perimeter and the repo is public). It lives at `~/posture/posture-remote.py` on the Mac, transferred out-of-band via:
+
+```bash
+scp fedora-htpc.lokal:~/containers/scripts/security/posture-remote.py ~/posture/
+```
+
+Reports land at `~/posture/data/security-posture/remote/<UTC>.json` (script auto-detects it's outside the repo and falls back to its own directory). When the user returns home, those JSONs can be scp'd back into `~/containers/data/security-posture/remote/` on fedora-htpc so the local session can cross-reference.
+
+```
+You are triaging external-plane security-posture reports produced by
+~/posture/posture-remote.py from foreign networks. The script is NOT in
+the homelab repo — it is gitignored because the repo is public and
+publishing an active attack kit against our own edge is an own-goal.
+Read the most recent JSON under ~/posture/data/security-posture/remote/
+(or the --out path the user provides). If no report exists yet and the
+user is still on a foreign network, run the script first:
+
+    pip3 install requests   # one-time
+    python3 ~/posture/posture-remote.py --tag <vantage-label>
+
+--tag should describe the physical vantage (e.g., mbp-oslo-cafe-hotspot,
+mbp-airport-osl-ter3, mbp-hotel-berlin-wifi). It lands in X-Probe-Tag
+headers on every active probe so the homelab's Loki can correlate.
+
+Your job is to decide: is the perimeter safe? Specifically, what did the
+internet actually see that the internal plane cannot?
+
+Process:
+1. Read meta first. wan_ip, wan_country, and active_probes matter:
+   - If wan_country starts with "Nor", the Region Block negative test is
+     uninformative — user is already inside the allowed country.
+   - If a corporate/ISP VPN exits in Norway, same problem. Flag this
+     ambiguity rather than trusting the finding's severity.
+2. Walk findings by category in this order: regionblock, auth,
+   crowdsec, ratelimit, scan, tls, http, dns, ct. That ordering mirrors
+   the fail-fast chain, so a gap near the top invalidates lower findings
+   (e.g., if Region Block leaks, expect other findings to multiply next
+   time an abuser shows up).
+3. For findings in categories `crowdsec` and `ratelimit`, the raw block
+   contains timestamps (ts_ns) for every probe request. Include those
+   timestamps in the triage doc so the homelab session can run Loki
+   queries:
+     {job="traefik-access"} |= "<X-Probe-Tag value>"
+4. For `regionblock`, the raw block contains both current_vantage and
+   external_probe results. If they disagree (one can reach, the other
+   cannot), explain the asymmetry. The UDM Pro's Region Blocking is a
+   CyberSecure-internal plane (see journal 2026-04-22-ingress-forensics);
+   it cannot be verified from logs, only from probes like this one.
+5. Cross-reference the most recent local report under
+   data/security-posture/local/ if the repo is available. Divergences are
+   the most useful signal — a local "rate-limit middleware present" vs
+   remote "no 429 ever" says the limit is not firing.
+
+Context you MUST read before starting:
+- scripts/security/README.md (finding severity scale, active-probe
+  footprint, unban command if your vantage got banned)
+- docs/98-journals/2026-04-22-ingress-forensics-udm-blindspot-private.md
+  (F3 follow-up is exactly what this script implements)
+- docs/98-journals/2026-04-22-posture-intel-scripts-handoff.md (this file)
+
+Output: a markdown triage at docs/99-reports/posture-triage-remote-<vantage>-
+<YYYY-MM-DD>.md. Sections:
+  ## Meta (vantage details + caveats about country attribution)
+  ## Perimeter verdict (one-paragraph: is the edge holding?)
+  ## Active-probe observations (what the attack tests produced)
+  ## Passive findings by category
+  ## Correlation queries (LogQL snippets the homelab session can run)
+  ## Recommended hardening actions
+
+If the user wants to verify active-probe traces actually landed in Loki,
+hand them the exact LogQL snippet — do not run it yourself from the Mac.
+```
+
+---
+
+## Expected false-positives (already observed on 2026-04-22)
+
+These showed up in the first smoke run and the interpreting session should recognise them without re-deriving:
+
+**Local:**
+- `LBIND-000[1-5]` wildcard UDP binds (27500, 5353, 47819/55099) — mDNS and ephemeral SSDP/UPnP. LAN multicast, not a WAN exposure. Firewall blocks them at the edge. Not a gap.
+- `LCHAIN-0003` `authelia-portal missing rate-limit` — intentional. Authelia's portal applies its own rate-limit in-app; the Traefik chain uses `hsts-only` on purpose.
+- `LCHAIN-0008..0019` 12 dead middlewares — real (issue #156), but cleanup not a security risk.
+- `LCONTA-0001` traefik mounts `podman.sock` — intentional (Docker provider). Documented in ADR-016. Keep as explicit data point, not a gap.
+- `LCONTA-0002/0003` cadvisor privileged + podman.sock — required for container metrics. Intentional. Document, don't remove.
+- `LAUTH-0002` `sshd passwordauthentication=yes` — parser did NOT expand `Match` blocks and did NOT read `sshd_config.d/*.conf` drop-ins that flip it. Verify actual effective state with `sudo sshd -T | grep -i passwordauth` before acting.
+- `LJOURN-0002` 16 failed user units — triage individually; most are one-shot services that ran to completion with non-zero rc, not live failures.
+
+**Real** (from the same run, worth keeping on the radar):
+- `LCHAIN-0020` router references undefined middleware `nextcloud-caldav` — genuine orphan, route silently broken for that path.
+- `LJOURN-0001` SELinux denials in last 24h — worth investigating.
+
+**Remote:**
+- `RDNS-0001` split-horizon DNS — only appears when the remote script runs from inside the LAN. On the MacBook's foreign ISP this will not fire.
+- `RAUTH-0001` `events.patriark.org returns 200` despite Authelia middleware — known per journal 2026-03-31-authelia-sso-gathio-debugging. Gathio serves public event pages at `/`; Authelia gates creation/admin paths only. The interpreting session should reconcile this against the router config, not treat it as critical.
+- `RHTTP-000N` HSTS missing — often because the measured response is a 302 to Authelia and the redirect response doesn't carry HSTS. Reconcile against the *destination* response where possible.
+
+Document these in the triage; don't pretend they're new.
+
+---
+
+## Cadence
+
+| Occasion | Local | Remote |
+|---|:---:|:---:|
+| Weekly baseline | yes | passive only (if travelling) |
+| After `routers.yml` / `middleware.yml` edit | yes | passive next time away |
+| After `.network` quadlet change (Internal=true, etc.) | yes | passive |
+| After new container deployed | yes | full active next trip |
+| After UDM firmware / Region Block config change | yes | full active |
+| Post-incident | yes | full active |
+
+Not a daily job. Full active probing burns 60 HTTP requests at the Nextcloud endpoint + a scan of 40 ports — mild, but not something that should run on a cron. Local is cheaper (~45s, no external traffic) and can be cron'd if desired.
+
+---
+
+## Design notes worth writing down
+
+### Severity is intentionally permissive
+
+The scripts err on flagging over silence. A `high` on the local report does not mean "immediately act" — it means "explicitly decide." Known-accepted findings (cadvisor privileged, traefik's podman.sock) are still emitted so they show up as considered data points rather than invisible omissions. Making the interpreting session justify them each run is the point.
+
+This is a deliberate inversion of the `security-audit.sh` philosophy, which uses explicit pass/warn/fail logic tuned to skip known-accepted cases. Both tools coexist because they serve different purposes: `security-audit.sh` is a fast traffic-light check; the posture scripts are forensic gathering for LLM synthesis. If the interpreting session wants the traffic light, it can call `security-audit.sh`.
+
+### The remote script's `--tag` is load-bearing
+
+Every active probe writes `X-Probe-Tag: <tag>` as a request header. Traefik's access log captures it. Without that tag, correlating "did this probe land in Loki" requires matching on fragile substrings (user-agent, timestamp windows). With the tag, it's one LogQL line:
+
+```logql
+{job="traefik-access"} |= "<tag>"
+```
+
+Teach the interpreting session to ask for tags that describe vantage, not time — `mbp-oslo-cafe-hotspot` is better than `mbp-2026-04-22`.
+
+### Why Prometheus is the Loki probe container
+
+Promtail is distroless — no shell, no wget. Loki itself is distroless. CrowdSec has wget but is on reverse_proxy only. Prometheus has wget and sits on both reverse_proxy and monitoring networks, so it can reach Loki at `http://loki:3100/*` via Podman's aardvark-dns. The `collect_loki_liveness` collector execs through Prometheus for this reason. If Prometheus ever moves image or becomes distroless, swap to the `crowdsec` container (also has wget on reverse_proxy).
+
+---
+
+## Follow-ups
+
+- **Weekly passive-only cron for remote.** When the user is at home, a `--passive` remote run from an external VPS (or a scheduled GitHub Action) would catch regressions in CT logs and external TLS/header state without generating probe traffic. Defer until a foreign-vantage runner is decided.
+- **Local script could emit a `history.json`** linking successive runs for trend charts. Not urgent — the JSON files diff cleanly as-is.
+- **Third script for post-incident forensics** — a deeper dive that ingests a specific time window and pulls every matching Loki/UDM/CrowdSec record. Out of scope for this work; document the gap.
+- **Signed probe bundle.** Currently any client that knows `X-Probe-Tag` could spoof it in Loki. For higher-trust correlation, sign the tag with an HMAC and verify at query time. Probably overkill for single-user homelab.
+
+---
+
+## Scope note
+
+Built in one session, fully tested locally (bind, chain, egress, crowdsec, loki, cert, container, auth, drift, journal, adr) and partially tested remotely (passive only, from inside LAN — DNS split-horizon flagged as expected). Active probes against own perimeter not yet run from a true external vantage; that is the first real deliverable when the user next travels with the MacBook.
+
+The handoff prompts above are the single most important artefact. If they work, a future Claude session can start cold, read a JSON, and produce an actionable hardening plan without this author present.

--- a/scripts/security/README-ssh-sync.md
+++ b/scripts/security/README-ssh-sync.md
@@ -1,0 +1,69 @@
+# YubiKey SSH Key Sync — Quick Start
+
+This mini-toolkit distributes a **canonical** `authorized_keys` file (YubiKey-only)
+to multiple hosts (e.g., `fedora-htpc.lokal`, `raspberrypi.lokal`) with backups,
+correct permissions, and optional verification.
+
+## Files
+
+- `ssh-hosts.env` — configure target hosts, remote user, and path to canonical keys
+- `authorized_keys.lan` — example canonical key file (replace with your real keys)
+- `sync-ssh-keys.sh` — the sync tool
+
+## Recommended Canonical File
+
+Store your **source of truth** in your repo, e.g.:
+`~/containers/docs/30-security/authorized_keys.lan`
+
+Populate it from your verified YubiKey public keys (MacBook source of truth):
+```bash
+ssh-add -L | grep "sk-" > ~/containers/docs/30-security/authorized_keys.lan
+# (Optional) add LAN restriction if not present
+sed -i 's/^/from="192.168.1.0\/24" /' ~/containers/docs/30-security/authorized_keys.lan
+```
+
+## Configure
+
+Edit `ssh-hosts.env`:
+```bash
+HOSTS="fedora-htpc.lokal 192.168.1.70 raspberrypi.lokal 192.168.1.69"
+REMOTE_USER="patriark"
+AUTHORIZED_KEYS_PATH="${HOME}/containers/docs/30-security/authorized_keys.lan"
+SSH_PORT="22"
+```
+
+## Run
+
+```bash
+chmod +x sync-ssh-keys.sh
+# Preview
+./sync-ssh-keys.sh --dry-run
+# Execute and verify
+./sync-ssh-keys.sh --verify
+# Limit to a subset
+./sync-ssh-keys.sh --verify --limit "raspberrypi.lokal"
+```
+
+**What it does**
+1. Creates `~/.ssh` on remote if missing (700).
+2. Backs up existing `authorized_keys` with a timestamp.
+3. Uploads your canonical file, sets `600`, moves into place.
+4. Optional `--verify`: checks non-interactive key auth.
+
+> Policy tip: keep `from="192.168.1.0/24"` on each key line to enforce LAN-only auth.
+
+## Rollback
+
+Each run creates a backup like:
+`~/.ssh/authorized_keys.backup-YYYYmmddHHMMSS` on the remote.
+To restore:
+```bash
+ssh patriark@host "cp ~/.ssh/authorized_keys.backup-<stamp> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
+```
+
+## Troubleshooting
+
+- If `--verify` fails, check on the remote:
+  - `/etc/ssh/sshd_config` or `sshd_config.d/*.conf` (PubkeyAuthentication yes, PasswordAuthentication no, etc.).
+  - Permissions: `~/.ssh (700)`, `authorized_keys (600)`.
+  - Key order on the client (`~/.ssh/config`) so the correct YubiKey is attempted first.

--- a/scripts/security/README.md
+++ b/scripts/security/README.md
@@ -1,69 +1,243 @@
-# YubiKey SSH Key Sync — Quick Start
+# Security Intel — Posture Scripts
 
-This mini-toolkit distributes a **canonical** `authorized_keys` file (YubiKey-only)
-to multiple hosts (e.g., `fedora-htpc.lokal`, `raspberrypi.lokal`) with backups,
-correct permissions, and optional verification.
+Two scripts that actively probe the homelab's security posture and emit
+structured JSON. Designed to be consumed by a fresh Claude Code session that
+synthesises a hardening plan from one or more runs.
 
-## Files
+| Script | Vantage | What it sees | Distribution |
+|--------|---------|-------------|------------|
+| `posture-local.py`  | inside LAN, on fedora-htpc      | internal plane: bind surface, container egress, Traefik chain, CrowdSec/Loki pipeline liveness, certs, container hardening, SSH config, config drift, journal anomalies, ADR compliance | committed (defensive-only) |
+| `posture-remote.py` | outside LAN, from foreign ISP    | external plane: WAN port scan, CT-log enumeration, TLS/headers/auth matrix, DNS audit, live attack probes (CrowdSec bouncer, rate-limit, Region Block negative test) | **gitignored** — scp to MacBook out-of-band |
 
-- `ssh-hosts.env` — configure target hosts, remote user, and path to canonical keys
-- `authorized_keys.lan` — example canonical key file (replace with your real keys)
-- `sync-ssh-keys.sh` — the sync tool
+The two scripts deliberately do not overlap. Local sees what external probes
+cannot (container configs, CrowdSec acquisition, journal, SELinux); remote
+sees what the LAN cannot (Region Block enforcement, real CrowdSec behaviour
+against foreign IPs, what the internet actually negotiates).
 
-## Recommended Canonical File
+## Quickstart
 
-Store your **source of truth** in your repo, e.g.:
-`~/containers/docs/30-security/authorized_keys.lan`
-
-Populate it from your verified YubiKey public keys (MacBook source of truth):
-```bash
-ssh-add -L | grep "sk-" > ~/containers/docs/30-security/authorized_keys.lan
-# (Optional) add LAN restriction if not present
-sed -i 's/^/from="192.168.1.0\/24" /' ~/containers/docs/30-security/authorized_keys.lan
-```
-
-## Configure
-
-Edit `ssh-hosts.env`:
-```bash
-HOSTS="fedora-htpc.lokal 192.168.1.70 raspberrypi.lokal 192.168.1.69"
-REMOTE_USER="patriark"
-AUTHORIZED_KEYS_PATH="${HOME}/containers/docs/30-security/authorized_keys.lan"
-SSH_PORT="22"
-```
-
-## Run
+### Local (fedora-htpc)
 
 ```bash
-chmod +x sync-ssh-keys.sh
-# Preview
-./sync-ssh-keys.sh --dry-run
-# Execute and verify
-./sync-ssh-keys.sh --verify
-# Limit to a subset
-./sync-ssh-keys.sh --verify --limit "raspberrypi.lokal"
+python3 scripts/security/posture-local.py                  # full run, writes JSON
+python3 scripts/security/posture-local.py --category chain # single category
+python3 scripts/security/posture-local.py --pretty         # also dump to stdout
 ```
 
-**What it does**
-1. Creates `~/.ssh` on remote if missing (700).
-2. Backs up existing `authorized_keys` with a timestamp.
-3. Uploads your canonical file, sets `600`, moves into place.
-4. Optional `--verify`: checks non-interactive key auth.
+Writes: `data/security-posture/local/<UTC>.json` (gitignored).
 
-> Policy tip: keep `from="192.168.1.0/24"` on each key line to enforce LAN-only auth.
+Dependencies: `python3-pyyaml` (already on Fedora Workstation). No sudo
+required — SSH config is parsed from world-readable files, and every other
+check uses rootless `podman`.
 
-## Rollback
+### Remote (MacBook Air)
 
-Each run creates a backup like:
-`~/.ssh/authorized_keys.backup-YYYYmmddHHMMSS` on the remote.
-To restore:
+**`posture-remote.py` is deliberately NOT committed to this public repo**
+(see `.gitignore`). It is a tuned attack tool for this perimeter specifically
+and publishing it would hand adversaries a pre-built kit. Distribute it to the
+MacBook out-of-band and keep it there.
+
+1. Copy the script to the Mac via scp (run this from the Mac):
+
+   ```bash
+   scp fedora-htpc.lokal:~/containers/scripts/security/posture-remote.py \
+       ~/posture/posture-remote.py
+   ```
+
+   Suggested destination on the Mac: `~/posture/` (outside any cloned repo, so
+   a stale sync can't overwrite or publish it). The script auto-detects
+   whether it's inside the homelab repo and adapts output path accordingly.
+
+2. `pip3 install requests`
+3. Run:
+
+   ```bash
+   # Full run including active attack probes (default per user request)
+   python3 scripts/security/posture-remote.py --tag mbp-oslo-cafe
+
+   # Passive only (TLS/headers/DNS/CT, no attacks)
+   python3 scripts/security/posture-remote.py --passive --tag mbp-airport
+
+   # Write to explicit location (if repo not synced)
+   python3 scripts/security/posture-remote.py --out ~/posture-$(date +%s).json
+   ```
+
+   Writes: `data/security-posture/remote/<UTC>.json` when in repo, else the
+   script directory.
+
+**The `--tag` string is inserted into `X-Probe-Tag` headers on every active
+probe.** It shows up in Traefik access logs and lets the interpreting Claude
+session correlate probe timestamps back to Loki without guessing. Pick a tag
+per vantage (`mbp-oslo-cafe`, `mbp-airport-ter3`, etc.).
+
+### Running remote from inside the LAN
+
+You can, and the TLS/headers/DNS data still lands — but three gotchas:
+
+- **DNS is split-horizon.** `patriark.org` resolves to `192.168.1.70` from
+  the LAN; from the internet it's the public WAN IP. The script flags this
+  mismatch as `medium` when run from LAN, which is noise in that case.
+- **Region Block can't be tested.** You're already inside the allowed country.
+- **CrowdSec whitelist absorbs your probes.** `192.168.1.0/24` is
+  whitelisted (per `acquis.yaml` header). Attack probes will not trigger
+  bouncer responses. That by itself is a useful negative-verification of
+  the whitelist — but it means "no bouncer engagement" is expected.
+
+## Output schema
+
+Both scripts write the same JSON shape:
+
+```json
+{
+  "meta": {
+    "schema_version": 1,
+    "vantage": "local|remote",
+    "host": "fedora-htpc",
+    "generated_at": "2026-04-22T22:42:02+00:00",
+    "git_head": "...",
+    "git_dirty": false,
+    "wan_ip": null,              // remote only
+    "wan_country": null,         // remote only
+    "active_probes": true,       // remote only
+    "tag": "mbp-oslo-cafe",      // remote only
+    "run_id": "uuid"             // remote only
+  },
+  "summary": { "critical": 0, "high": 12, "medium": 5, "low": 16, "info": 2 },
+  "findings": [
+    {
+      "id": "LBIND-0001",
+      "category": "bind",
+      "severity": "high",
+      "title": "Listener on wildcard 0.0.0.0:27500/tcp beyond expected WAN ports",
+      "evidence": ["{\"proto\": \"tcp\", \"host\": \"0.0.0.0\", \"port\": 27500, \"process\": \"\"}"],
+      "adr_refs": ["#141", "#142"],
+      "hint": "Rebind to 192.168.1.70:PORT (LAN) or 127.0.0.1 (host-only). Pattern: ADR-free follow-on to PR #170."
+    }
+  ],
+  "raw": { "bind": {...}, "egress": {...}, ... }
+}
+```
+
+Finding IDs are `<vantage-prefix><category-prefix>-<counter>`:
+- `L*` = local, `R*` = remote
+- First five letters of the category, uppercased
+- Zero-padded 4-digit counter per category
+
+### Severity scale
+
+| Level | Meaning |
+|-------|---------|
+| `critical` | Probable active security gap. Treat as incident. |
+| `high` | Likely gap or clear hardening opportunity. Action within 7d. |
+| `medium` | Hardening recommendation; may be known-accepted. |
+| `low` | Cleanup / audit-surface reduction. |
+| `info` | Signal-only; often documents that something works as designed. |
+
+**The scripts do not interpret — they gather.** Severity is a heuristic. The
+consuming Claude session decides what action follows. Known-accepted findings
+(e.g., cadvisor's privileged flag, traefik's podman.sock mount for the Docker
+provider) will still be flagged — the intent is to make them explicit data
+points, not silent omissions.
+
+## How a fresh Claude Code session should consume these reports
+
+Prompt template (paste into a new Claude Code session on the homelab repo):
+
+```
+Read the most recent posture reports under data/security-posture/local/ and
+data/security-posture/remote/. Correlate findings across both vantages; give
+me a prioritised hardening plan. Specifically:
+
+1. For each finding with severity >= medium, decide: real gap, known-accepted,
+   or collector false-positive. Cite ADRs, journals, or repo state to justify.
+2. Identify findings that appear in one vantage but not the other — those are
+   the most forensically valuable because they describe a capability only
+   visible from one side.
+3. Group remediations by effort (≤15 min, ≤1 hour, requires ADR/approach
+   shift). Propose concrete file changes where effort is low.
+4. Flag any discrepancy between what the local report claims and what the
+   remote report measured. E.g., local says rate-limit is 300rpm; remote
+   observed first 429 at request N — is N consistent with 300?
+5. Do NOT run commands to collect new data in this first pass. Work from
+   what the JSON already contains. After you've triaged, you may ask to re-run
+   with a specific --category if you need a fresh datapoint.
+```
+
+Tight prompt that binds the session to the data without letting it
+re-collect everything from scratch.
+
+## Active probe footprint (remote, by default)
+
+When `--passive` is not set, the remote script sends these requests:
+
+| Probe | Target | Volume | Effect |
+|-------|--------|--------|--------|
+| TCP port scan | WAN IP | ~40 SYNs | Likely not flagged (no payload) |
+| CrowdSec web-shell burst | `nextcloud.patriark.org` | 6 paths over ~3s | Logged as Traefik 40x errors; may trigger CrowdSec scenarios |
+| Rate-limit burst | `nextcloud.patriark.org/status.php` | 60 rapid HEADs | Will appear in access.log; may or may not hit 429 |
+| Region Block TCP | WAN IP:443 | 1 connect | Logged as drop at UDM (if outside NO) |
+| External reflector | `api.hackertarget.com` | 1 call out | Third-party probe; not our infra |
+
+All active probes carry `User-Agent: posture-remote/1.0 (authorized-probe)`
+and an `X-Probe-Tag: <tag>` header so correlation in Loki is trivial:
+
+```logql
+{job="traefik-access"} |= `posture-remote/1.0`
+{job="traefik-access"} |= `X-Probe-Tag`
+```
+
+**Plan for getting banned by your own bouncer.** If the burst crosses a
+CrowdSec scenario threshold, your vantage IP becomes a decision. Expected
+outcomes:
+
+- Passes: burst absorbed by rate-limiter (429s), no CrowdSec decision → normal.
+- Fail-open: burst treated as legitimate (all 200/40x, no throttle) → gap.
+- Fail-closed: bouncer engages mid-burst (403s) → desired behaviour.
+
+To unban your own vantage IP after a test (only needed if a decision persists):
+
 ```bash
-ssh patriark@host "cp ~/.ssh/authorized_keys.backup-<stamp> ~/.ssh/authorized_keys && chmod 600 ~/.ssh/authorized_keys"
+# on fedora-htpc
+podman exec crowdsec cscli decisions delete --ip <your-wan-ip>
 ```
 
-## Troubleshooting
+## When to run
 
-- If `--verify` fails, check on the remote:
-  - `/etc/ssh/sshd_config` or `sshd_config.d/*.conf` (PubkeyAuthentication yes, PasswordAuthentication no, etc.).
-  - Permissions: `~/.ssh (700)`, `authorized_keys (600)`.
-  - Key order on the client (`~/.ssh/config`) so the correct YubiKey is attempted first.
+| Occasion | Local | Remote |
+|----------|:-----:|:------:|
+| Weekly cron (quiet baseline) | yes | passive only |
+| After any `routers.yml` / `middleware.yml` edit | yes | passive |
+| After network topology change | yes | yes (when next travelling) |
+| When a journal entry proposes a hardening | yes | passive — use as baseline |
+| After shipping a security ADR | yes | full active |
+| Before and after a UDM firmware update | yes | yes |
+
+## Known limitations (document, don't paper over)
+
+- **Local SSH audit does not expand `Match` blocks.** `sshd -T` would, but
+  requires root. The parser is correct for the common case.
+- **Container egress probe uses example.com + 1.1.1.1:443.** Inherits the
+  assumption those remain reachable. Swap to a self-hosted canary if that
+  becomes a constraint.
+- **Remote CT enumeration depends on crt.sh uptime.** Failures degrade to a
+  `low` finding, not a hard error.
+- **Remote region-block interpretation requires trusting ipapi.co's country
+  attribution.** Corporate VPNs that exit from Norway make the test always
+  return "allowed" regardless of user's physical location. The `wan_country`
+  field in meta captures this — the interpreting session should read it.
+- **Rate-limit empirical probe is 60 requests.** Below burst thresholds by
+  design (post-ADR-022: 1500 burst). A true saturation test would require
+  distributed probes; not in scope.
+
+## See also
+
+- `security-audit.sh` — rules-based bash audit (53 checks, same repo). This
+  new tool is complementary, not a replacement: it is forensic (gathers more
+  context per finding) and structured for LLM consumption, whereas
+  `security-audit.sh` is optimised for fast pass/warn/fail reporting.
+- `scripts/security/README-ssh-sync.md` — YubiKey SSH key sync toolkit (was
+  the old README at this path).
+- `docs/98-journals/2026-04-21-crowdsec-acquisition-and-rate-limit-retune.md`
+  — why CrowdSec probes are worth doing.
+- `docs/98-journals/2026-04-22-ingress-forensics-udm-blindspot-private.md`
+  — F3 follow-up; this script is the negative-test the journal calls for.

--- a/scripts/security/posture-local.py
+++ b/scripts/security/posture-local.py
@@ -1,0 +1,1261 @@
+#!/usr/bin/env python3
+"""
+posture-local.py — Internal-plane security posture intel for fedora-htpc.
+
+Active gap-finder run from inside the LAN. Looks at the things external probes
+cannot see: bind surfaces, container egress reality, Traefik middleware chain
+completeness, CrowdSec/Loki pipeline liveness, cert/ACL/SELinux hygiene,
+config drift, and journal anomalies.
+
+Output: one JSON file per run at
+    data/security-posture/local/<UTC timestamp>.json
+
+The output is designed to be ingested by a fresh Claude Code session that
+synthesises a hardening plan from one or more runs. Fields:
+    meta       — vantage, timestamp, host, git HEAD, tool versions
+    findings   — one entry per observation, with severity and evidence
+    raw        — structured dumps (listeners, middleware graph, etc.)
+
+Findings schema (per entry):
+    id            — stable short ID, e.g., LBIND-0001
+    category      — bind | egress | chain | crowdsec | loki | cert | auth |
+                    container | firewall | drift | journal | adr
+    severity      — info | low | medium | high | critical
+    title         — one-line human summary
+    evidence      — list of raw strings (command output fragments)
+    adr_refs      — list of ADR IDs this finding bears on
+    hint          — short remediation pointer (no auto-fix)
+
+Philosophy: gather, do not interpret. Severity is heuristic; the
+interpretation is done by the consuming Claude session.
+
+Usage:
+    ./scripts/security/posture-local.py                  # full run
+    ./scripts/security/posture-local.py --pretty         # also print to stdout
+    ./scripts/security/posture-local.py --category chain # single category
+
+Exit codes:
+    0  run completed (findings may exist)
+    2  run aborted due to environment (not in repo, podman unavailable, ...)
+    3  script-internal error
+
+Status: ACTIVE
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import shlex
+import socket
+import ssl
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Iterable
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPT_DIR.parent.parent
+REPORT_DIR = REPO_ROOT / "data" / "security-posture" / "local"
+QUADLETS = REPO_ROOT / "quadlets"
+DYNAMIC = REPO_ROOT / "config" / "traefik" / "dynamic"
+
+EXPECTED_WAN_PORTS = {80, 443, 8096, 7359}
+EXPECTED_LAN_LISTEN_IPS = {"192.168.1.70", "127.0.0.1", "::1", "0.0.0.0"}
+EXPECTED_INTERNAL_NETWORKS = {
+    "auth_services",
+    "gathio",
+    "home_automation",
+    "mail",
+    "media_services",
+    "monitoring",
+    "nextcloud",
+    "photos",
+    "syslog",
+}
+# CrowdSec's local whitelist absorbs these; documented in acquis notes
+LAN_CIDRS = ("192.168.1.", "192.168.100.", "10.89.")
+
+
+# ---------------------------------------------------------------------------
+# Utility layer
+# ---------------------------------------------------------------------------
+
+
+class FindingStore:
+    def __init__(self) -> None:
+        self._items: list[dict[str, Any]] = []
+        self._counters: dict[str, int] = {}
+
+    def add(
+        self,
+        category: str,
+        severity: str,
+        title: str,
+        evidence: Iterable[str] | str = (),
+        adr_refs: Iterable[str] = (),
+        hint: str = "",
+        prefix: str | None = None,
+    ) -> None:
+        prefix = prefix or category[:5].upper()
+        self._counters[prefix] = self._counters.get(prefix, 0) + 1
+        fid = f"L{prefix}-{self._counters[prefix]:04d}"
+        if isinstance(evidence, str):
+            evidence = [evidence]
+        self._items.append(
+            {
+                "id": fid,
+                "category": category,
+                "severity": severity,
+                "title": title,
+                "evidence": [e for e in evidence if e],
+                "adr_refs": list(adr_refs),
+                "hint": hint,
+            }
+        )
+
+    def all(self) -> list[dict[str, Any]]:
+        return list(self._items)
+
+
+def run(cmd: list[str] | str, timeout: int = 15) -> tuple[int, str, str]:
+    """Run a command, return (rc, stdout, stderr). Never raises."""
+    if isinstance(cmd, str):
+        cmd_list = shlex.split(cmd)
+    else:
+        cmd_list = cmd
+    try:
+        p = subprocess.run(
+            cmd_list,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            check=False,
+        )
+        return p.returncode, p.stdout, p.stderr
+    except FileNotFoundError:
+        return 127, "", f"{cmd_list[0]}: not found"
+    except subprocess.TimeoutExpired:
+        return 124, "", f"timeout after {timeout}s"
+    except Exception as e:
+        return 1, "", f"{type(e).__name__}: {e}"
+
+
+def read_text(path: Path) -> str:
+    try:
+        return path.read_text(errors="replace")
+    except OSError:
+        return ""
+
+
+def podman(*args: str, timeout: int = 15) -> tuple[int, str, str]:
+    return run(["podman", *args], timeout=timeout)
+
+
+def have(bin_name: str) -> bool:
+    rc, _, _ = run(["which", bin_name], timeout=3)
+    return rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Meta
+# ---------------------------------------------------------------------------
+
+
+def collect_meta() -> dict[str, Any]:
+    rc, head, _ = run(["git", "-C", str(REPO_ROOT), "rev-parse", "HEAD"])
+    rc2, dirty, _ = run(
+        ["git", "-C", str(REPO_ROOT), "status", "--porcelain", "--untracked-files=no"]
+    )
+    rc3, podver, _ = run(["podman", "--version"])
+    rc4, krn, _ = run(["uname", "-r"])
+    return {
+        "schema_version": 1,
+        "vantage": "local",
+        "host": socket.gethostname(),
+        "generated_at": dt.datetime.now(dt.timezone.utc).isoformat(timespec="seconds"),
+        "git_head": head.strip() if rc == 0 else None,
+        "git_dirty": bool(dirty.strip()) if rc2 == 0 else None,
+        "podman_version": podver.strip() if rc3 == 0 else None,
+        "kernel": krn.strip() if rc4 == 0 else None,
+        "repo_root": str(REPO_ROOT),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Category: bind surface (ss + firewalld)
+# ---------------------------------------------------------------------------
+
+
+def collect_bind_surface(f: FindingStore) -> dict[str, Any]:
+    """Every TCP/UDP listener, cross-checked against firewalld open ports."""
+    raw: dict[str, Any] = {}
+
+    # Listeners
+    _, tcp, _ = run(["ss", "-tlnpH"])
+    _, udp, _ = run(["ss", "-ulnpH"])
+    raw["ss_tcp"] = tcp.strip().splitlines()
+    raw["ss_udp"] = udp.strip().splitlines()
+
+    listeners: list[dict[str, Any]] = []
+    for proto, block in (("tcp", tcp), ("udp", udp)):
+        for line in block.splitlines():
+            parts = line.split()
+            if len(parts) < 5:
+                continue
+            local = parts[3]
+            proc = " ".join(parts[5:]) if len(parts) > 5 else ""
+            host, _, port = local.rpartition(":")
+            host = host.strip("[]")
+            try:
+                port_i = int(port)
+            except ValueError:
+                continue
+            listeners.append(
+                {"proto": proto, "host": host, "port": port_i, "process": proc}
+            )
+    raw["listeners"] = listeners
+
+    # Firewalld
+    _, fw, _ = run(["firewall-cmd", "--list-all"])
+    raw["firewalld"] = fw.strip().splitlines()
+
+    fw_ports: set[tuple[int, str]] = set()
+    for line in fw.splitlines():
+        line = line.strip()
+        if line.startswith("ports:"):
+            for tok in line.replace("ports:", "").strip().split():
+                if "/" in tok:
+                    p, proto = tok.split("/", 1)
+                    try:
+                        fw_ports.add((int(p), proto))
+                    except ValueError:
+                        pass
+    raw["firewall_open_ports"] = sorted(fw_ports)
+
+    # Gap check 1: any 0.0.0.0 bind that isn't 80/443 (those are Traefik's edge).
+    for lst in listeners:
+        if lst["host"] in ("0.0.0.0", "::") and lst["port"] not in EXPECTED_WAN_PORTS:
+            # Allow ssh on 22 (LAN-restricted at firewall)
+            if lst["port"] == 22:
+                continue
+            # Loopback-bound listeners show up as 127.0.0.1/::1 — not here
+            f.add(
+                "bind",
+                "high",
+                f"Listener on wildcard {lst['host']}:{lst['port']}/{lst['proto']} beyond expected WAN ports",
+                evidence=[json.dumps(lst)],
+                adr_refs=["#141", "#142"],
+                hint="Rebind to 192.168.1.70:PORT (LAN) or 127.0.0.1 (host-only). Pattern: ADR-free follow-on to PR #170.",
+            )
+
+    # Gap check 2: firewall open ports with no matching listener = dead rule.
+    listen_tcp_ports = {
+        l["port"] for l in listeners if l["proto"] == "tcp" and l["host"] != "127.0.0.1"
+    }
+    listen_udp_ports = {
+        l["port"] for l in listeners if l["proto"] == "udp" and l["host"] != "127.0.0.1"
+    }
+    for port, proto in fw_ports:
+        listen_set = listen_tcp_ports if proto == "tcp" else listen_udp_ports
+        if port not in listen_set:
+            f.add(
+                "firewall",
+                "low",
+                f"Firewalld allows {port}/{proto} but nothing is listening on it",
+                evidence=[f"fw open={port}/{proto}", f"listeners={sorted(listen_set)}"],
+                hint="Dead firewall rule — remove if service decommissioned (firewall-cmd --remove-port).",
+            )
+
+    # Gap check 3: listener on LAN IP with port not in firewalld = inconsistent
+    for lst in listeners:
+        if lst["host"] == "192.168.1.70":
+            if (lst["port"], lst["proto"]) not in fw_ports:
+                f.add(
+                    "firewall",
+                    "low",
+                    f"LAN-bound listener {lst['port']}/{lst['proto']} has no explicit firewall rule",
+                    evidence=[json.dumps(lst)],
+                    hint="LAN-bound means LAN clients reach it by default. Either add explicit rule for intent, or unbind.",
+                )
+
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Category: container egress reality (Internal=true enforcement)
+# ---------------------------------------------------------------------------
+
+
+def collect_container_egress(f: FindingStore) -> dict[str, Any]:
+    raw: dict[str, Any] = {"networks": {}, "probes": []}
+
+    rc, nets_json, _ = podman("network", "ls", "--format", "json")
+    if rc != 0:
+        f.add(
+            "egress",
+            "medium",
+            "podman network ls failed",
+            evidence=[nets_json],
+            hint="Investigate podman state before trusting egress posture.",
+        )
+        return raw
+
+    try:
+        nets = json.loads(nets_json)
+    except json.JSONDecodeError:
+        return raw
+
+    for net in nets:
+        name = net.get("name", "")
+        internal_flag = net.get("internal", False)
+        short = name.replace("systemd-", "")
+        raw["networks"][name] = {
+            "internal": internal_flag,
+            "subnets": [s.get("subnet") for s in net.get("subnets", [])],
+        }
+        if short in EXPECTED_INTERNAL_NETWORKS and not internal_flag:
+            f.add(
+                "egress",
+                "high",
+                f"Network {name} expected Internal=true but podman reports false",
+                evidence=[json.dumps(net)[:400]],
+                adr_refs=["#141"],
+                hint=(
+                    "Known gotcha (journal 2026-04-21): edits to .network files don't re-apply via "
+                    "systemctl restart because `podman network create --ignore` short-circuits. "
+                    "Fix: podman network rm then restart *-network.service."
+                ),
+            )
+
+    # Active probe: pick one container per internal network and attempt DNS + HTTPS out.
+    _, ps_json, _ = podman("ps", "--format", "json")
+    try:
+        containers = json.loads(ps_json)
+    except json.JSONDecodeError:
+        containers = []
+
+    tested_nets: set[str] = set()
+    for c in containers:
+        c_name = c.get("Names", [""])[0] if c.get("Names") else c.get("Name", "")
+        c_nets = c.get("Networks") or []
+        for net_name in c_nets:
+            short = net_name.replace("systemd-", "")
+            if short not in EXPECTED_INTERNAL_NETWORKS or net_name in tested_nets:
+                continue
+            # Only test if this container is NOT also on reverse_proxy (which is the escape hatch).
+            if any(n.replace("systemd-", "") == "reverse_proxy" for n in c_nets):
+                continue
+            tested_nets.add(net_name)
+            probe = {"container": c_name, "network": net_name, "checks": {}}
+            # DNS probe — expect failure on Internal=true
+            rc_d, out_d, err_d = podman(
+                "exec",
+                c_name,
+                "sh",
+                "-c",
+                "getent hosts example.com || nslookup example.com 2>&1 | head -5",
+                timeout=10,
+            )
+            probe["checks"]["dns"] = {
+                "rc": rc_d,
+                "out": (out_d + err_d).strip()[:400],
+            }
+            # Connect probe (port 443 to a public host by IP to bypass DNS)
+            rc_c, out_c, err_c = podman(
+                "exec",
+                c_name,
+                "sh",
+                "-c",
+                # 1.1.1.1 is stable; timeout quickly
+                "timeout 3 sh -c '(echo > /dev/tcp/1.1.1.1/443) 2>&1' || echo BLOCKED",
+                timeout=10,
+            )
+            probe["checks"]["tcp_out"] = {
+                "rc": rc_c,
+                "out": (out_c + err_c).strip()[:400],
+            }
+            raw["probes"].append(probe)
+
+            # Analyse
+            dns_reached = (
+                rc_d == 0 and "example.com" in out_d and "can't" not in (out_d + err_d)
+            )
+            tcp_reached = "BLOCKED" not in (out_c + err_c) and rc_c == 0
+            short = net_name.replace("systemd-", "")
+            expected_isolated = short in EXPECTED_INTERNAL_NETWORKS
+            if expected_isolated and (dns_reached or tcp_reached):
+                f.add(
+                    "egress",
+                    "critical",
+                    f"{c_name} on {net_name} reached the internet — egress isolation broken",
+                    evidence=[
+                        f"dns_rc={rc_d} dns_out={out_d.strip()[:200]}",
+                        f"tcp_rc={rc_c} tcp_out={out_c.strip()[:200]}",
+                    ],
+                    adr_refs=["#141"],
+                    hint="Expected Internal=true. Investigate podman network flags and container multi-network membership.",
+                )
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Category: Traefik routing chain (middleware completeness)
+# ---------------------------------------------------------------------------
+
+MIDDLEWARE_MIN_CHAIN = {
+    "crowdsec": "crowdsec-bouncer",
+    "rate_limit_prefix": "rate-limit",
+    "headers": "security-headers",
+}
+
+
+def collect_traefik_chain(f: FindingStore) -> dict[str, Any]:
+    raw: dict[str, Any] = {}
+    routers_yml = read_text(DYNAMIC / "routers.yml")
+    middleware_yml = read_text(DYNAMIC / "middleware.yml")
+    raw["routers_yml_path"] = str(DYNAMIC / "routers.yml")
+    raw["routers_yml_size"] = len(routers_yml)
+    if not routers_yml:
+        f.add(
+            "chain",
+            "critical",
+            "routers.yml missing or empty — Traefik has no dynamic config",
+            hint="Verify config/traefik/dynamic/routers.yml exists.",
+        )
+        return raw
+
+    # Parse router blocks by naive regex (avoid PyYAML dep). Each router starts
+    # at `<name>:` under `routers:` and ends before the next router or service.
+    try:
+        import yaml  # type: ignore
+    except ImportError:
+        yaml = None
+    if not yaml:
+        f.add(
+            "chain",
+            "low",
+            "PyYAML not installed — skipping deep chain audit",
+            hint="dnf install python3-pyyaml for full chain introspection.",
+        )
+        return raw
+
+    # Strip Go-template expressions (e.g., `"{{ env "X" }}"`) so PyYAML doesn't
+    # choke on nested quotes. They only appear in values we don't audit here.
+    def _strip_templates(src: str) -> str:
+        return re.sub(r'"?\{\{[^}]*\}\}"?', '"__tmpl__"', src)
+
+    try:
+        doc = yaml.safe_load(_strip_templates(routers_yml)) or {}
+    except Exception as e:
+        f.add("chain", "high", f"routers.yml parse failure: {e}")
+        return raw
+    try:
+        mid_doc = yaml.safe_load(_strip_templates(middleware_yml)) or {}
+    except Exception as e:
+        f.add("chain", "medium", f"middleware.yml parse failure: {e}")
+        mid_doc = {}
+
+    routers = (doc.get("http", {}) or {}).get("routers", {}) or {}
+    defined_mw = set((mid_doc.get("http", {}) or {}).get("middlewares", {}).keys())
+    referenced_mw: set[str] = set()
+
+    router_audit: list[dict[str, Any]] = []
+    for rname, rconf in routers.items():
+        entrypoints = rconf.get("entryPoints") or []
+        if "websecure" not in entrypoints:
+            continue
+        host_rule = rconf.get("rule", "")
+        mws = [m.rsplit("@", 1)[0] for m in (rconf.get("middlewares") or [])]
+        for m in mws:
+            referenced_mw.add(m)
+        has_crowdsec = any(m.startswith("crowdsec-bouncer") for m in mws)
+        has_rate = any(m.startswith("rate-limit") for m in mws)
+        has_headers = any(m.startswith("security-headers") or m == "hsts-only" for m in mws)
+        has_auth = any(m in ("authelia",) for m in mws)
+        router_audit.append(
+            {
+                "name": rname,
+                "rule": host_rule,
+                "middlewares": mws,
+                "has_crowdsec": has_crowdsec,
+                "has_rate_limit": has_rate,
+                "has_headers": has_headers,
+                "has_authelia": has_auth,
+            }
+        )
+
+        if not has_crowdsec:
+            f.add(
+                "chain",
+                "high",
+                f"Router {rname} missing CrowdSec bouncer",
+                evidence=[f"rule={host_rule}", f"mws={mws}"],
+                adr_refs=["ADR-008", "ADR-016"],
+                hint="Every websecure router must start with crowdsec-bouncer@file (fail-fast).",
+            )
+        if not has_rate:
+            f.add(
+                "chain",
+                "high",
+                f"Router {rname} missing rate-limit middleware",
+                evidence=[f"rule={host_rule}", f"mws={mws}"],
+                adr_refs=["ADR-008"],
+                hint="Add rate-limit@file or a service-specific variant.",
+            )
+        if not has_headers:
+            f.add(
+                "chain",
+                "medium",
+                f"Router {rname} missing security-headers middleware",
+                evidence=[f"rule={host_rule}", f"mws={mws}"],
+                adr_refs=["ADR-016"],
+                hint="Add security-headers@file (or -public/-strict) to emit HSTS/CSP.",
+            )
+
+    # Middleware drift
+    dead = defined_mw - referenced_mw
+    orphan = referenced_mw - defined_mw
+    for m in sorted(dead):
+        f.add(
+            "chain",
+            "low",
+            f"Middleware '{m}' defined but never referenced",
+            adr_refs=["#156"],
+            hint="Candidate for deletion — reduces audit surface.",
+        )
+    for m in sorted(orphan):
+        # Exclude inline Traefik defaults (e.g., @internal)
+        if m in {"chain", "plugin"}:
+            continue
+        f.add(
+            "chain",
+            "high",
+            f"Router references undefined middleware '{m}'",
+            hint="Traefik will log an error and the chain won't apply. Define it or remove the reference.",
+        )
+
+    raw["routers"] = router_audit
+    raw["middlewares_defined"] = sorted(defined_mw)
+    raw["middlewares_referenced"] = sorted(referenced_mw)
+    raw["middlewares_dead"] = sorted(dead)
+    raw["middlewares_orphan"] = sorted(orphan)
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Category: CrowdSec posture
+# ---------------------------------------------------------------------------
+
+
+def collect_crowdsec(f: FindingStore) -> dict[str, Any]:
+    raw: dict[str, Any] = {}
+    rc_ps, _, _ = podman("exec", "crowdsec", "true", timeout=5)
+    if rc_ps != 0:
+        f.add(
+            "crowdsec",
+            "critical",
+            "CrowdSec container not reachable",
+            hint="Check systemctl --user status crowdsec.service.",
+        )
+        return raw
+
+    for sub, label in [
+        (["bouncers", "list", "-o", "json"], "bouncers"),
+        (["decisions", "list", "-o", "json"], "decisions"),
+        (["alerts", "list", "--since", "24h", "-o", "json"], "alerts_24h"),
+        (["scenarios", "list", "-o", "json"], "scenarios"),
+        (["metrics", "show", "acquisition", "-o", "json"], "acquisition"),
+    ]:
+        rc, out, err = podman("exec", "crowdsec", "cscli", *sub, timeout=15)
+        if rc != 0:
+            raw[label] = {"error": err[:200]}
+            continue
+        try:
+            raw[label] = json.loads(out)
+        except json.JSONDecodeError:
+            raw[label] = {"raw": out[:1200]}
+
+    # Bouncer presence
+    if not raw.get("bouncers"):
+        f.add(
+            "crowdsec",
+            "high",
+            "CrowdSec has no registered bouncers",
+            hint="Traefik's crowdsec-bouncer plugin must be enrolled. Without a bouncer, decisions do not reach traffic.",
+        )
+
+    # Acquisition sources
+    acq = raw.get("acquisition") or {}
+    if isinstance(acq, dict):
+        sources = list(acq.keys()) if acq else []
+        raw["acquisition_sources"] = sources
+        if not sources:
+            f.add(
+                "crowdsec",
+                "high",
+                "CrowdSec acquisition is empty — no log sources tailed",
+                adr_refs=["#137"],
+                hint="Configure data/crowdsec/config/acquis.d/*.yaml. See journal 2026-04-21.",
+            )
+        else:
+            # Sanity: Traefik acquisition should be reading > 0 lines since uptime.
+            for src, stats in acq.items():
+                if not isinstance(stats, dict):
+                    continue
+                read = stats.get("reads") or stats.get("lines_read")
+                if read == 0:
+                    f.add(
+                        "crowdsec",
+                        "medium",
+                        f"Acquisition source {src} has read 0 lines",
+                        evidence=[json.dumps(stats)[:300]],
+                        hint="Container restarted recently, or the log path is wrong.",
+                    )
+
+    # Decision count
+    decs = raw.get("decisions") or []
+    raw["decision_count"] = len(decs) if isinstance(decs, list) else 0
+    # 0 decisions is normal for a quiet week (see journal 2026-04-22) — info only.
+    if raw["decision_count"] == 0:
+        f.add(
+            "crowdsec",
+            "info",
+            "CrowdSec has zero active decisions",
+            hint=(
+                "Not necessarily bad — layered defense upstream (UDM Region Block) "
+                "may be absorbing most traffic. See journal 2026-04-22-ingress-forensics. "
+                "Cross-check with remote-vantage probes."
+            ),
+        )
+
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Category: Loki/Promtail pipeline liveness
+# ---------------------------------------------------------------------------
+
+
+def collect_loki_liveness(f: FindingStore) -> dict[str, Any]:
+    raw: dict[str, Any] = {}
+    # Loki is on reverse_proxy + monitoring networks, bound to 3100 internally.
+    # Use Traefik's /etc/hosts shim: resolve via container exec.
+    # Probe via prometheus container (has wget; shares reverse_proxy network with loki).
+    # promtail is distroless — no shell/wget available.
+    rc, labels, err = podman(
+        "exec", "prometheus", "wget", "-qO-",
+        "http://loki:3100/loki/api/v1/labels", timeout=10,
+    )
+    if rc != 0:
+        f.add(
+            "loki",
+            "high",
+            "Loki /loki/api/v1/labels unreachable from prometheus probe",
+            evidence=[err[:200]],
+            hint="Pipeline break — without Loki, security events don't index.",
+        )
+        return raw
+    try:
+        raw["labels"] = json.loads(labels).get("data", [])
+    except json.JSONDecodeError:
+        raw["labels"] = []
+
+    # Per-job last-ingest probe
+    _, jobs_out, _ = podman(
+        "exec", "prometheus", "wget", "-qO-",
+        "http://loki:3100/loki/api/v1/label/job/values", timeout=10,
+    )
+    try:
+        jobs = json.loads(jobs_out).get("data", [])
+    except json.JSONDecodeError:
+        jobs = []
+    raw["jobs"] = jobs
+
+    now = int(dt.datetime.now(dt.timezone.utc).timestamp() * 1_000_000_000)
+    window = 30 * 60 * 1_000_000_000  # 30 minutes
+    per_job_last: dict[str, int | None] = {}
+    for job in jobs:
+        # Query last entry timestamp
+        q = f'{{job="{job}"}}'
+        url = (
+            f"http://loki:3100/loki/api/v1/query_range?"
+            f"query={q}&limit=1&start={now - window}&end={now}&direction=backward"
+        )
+        rc_q, out_q, _ = podman("exec", "prometheus", "wget", "-qO-", url, timeout=10)
+        if rc_q != 0:
+            per_job_last[job] = None
+            continue
+        try:
+            data = json.loads(out_q)
+            results = data.get("data", {}).get("result", [])
+            last_ts = None
+            for stream in results:
+                values = stream.get("values", [])
+                if values:
+                    last_ts = int(values[0][0])
+                    break
+            per_job_last[job] = last_ts
+        except json.JSONDecodeError:
+            per_job_last[job] = None
+
+    raw["per_job_last_ingest_ns"] = per_job_last
+    raw["now_ns"] = now
+
+    for job, last in per_job_last.items():
+        if last is None:
+            f.add(
+                "loki",
+                "medium",
+                f"Loki job '{job}' has no entries in last 30 min",
+                adr_refs=[],
+                hint=(
+                    "Silent pipeline failure is worse than a broken one — verify promtail "
+                    "target. See journal 2026-04-22-udm-pro-siem-syslog-pipeline lesson on "
+                    "healthy-queue-with-wrong-data."
+                ),
+            )
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Category: Cert expiry
+# ---------------------------------------------------------------------------
+
+
+def collect_certs(f: FindingStore) -> dict[str, Any]:
+    raw: dict[str, Any] = {}
+    rc, acme, _ = podman("exec", "traefik", "cat", "/letsencrypt/acme.json", timeout=10)
+    if rc != 0 or not acme.strip():
+        f.add(
+            "cert",
+            "medium",
+            "Cannot read Traefik acme.json",
+            hint="Verify /letsencrypt/acme.json exists with 600 perms.",
+        )
+        return raw
+    try:
+        data = json.loads(acme)
+    except json.JSONDecodeError:
+        return raw
+
+    certs = []
+    for resolver, v in data.items():
+        for cert in v.get("Certificates") or []:
+            main = cert.get("domain", {}).get("main", "?")
+            sans = cert.get("domain", {}).get("sans", []) or []
+            pem_b64 = cert.get("certificate", "")
+            not_after = None
+            try:
+                import base64
+
+                pem = base64.b64decode(pem_b64).decode(errors="replace")
+                # Parse notAfter via openssl
+                rc_o, out_o, _ = run(
+                    ["openssl", "x509", "-noout", "-enddate"],
+                    timeout=5,
+                )
+                # Re-run with input piped
+                p = subprocess.run(
+                    ["openssl", "x509", "-noout", "-enddate"],
+                    input=pem,
+                    text=True,
+                    capture_output=True,
+                    timeout=5,
+                )
+                if p.returncode == 0:
+                    m = re.search(r"notAfter=(.+)", p.stdout)
+                    if m:
+                        not_after = m.group(1).strip()
+            except Exception:
+                pass
+            days_left = None
+            if not_after:
+                try:
+                    end = dt.datetime.strptime(
+                        not_after, "%b %d %H:%M:%S %Y %Z"
+                    ).replace(tzinfo=dt.timezone.utc)
+                    days_left = (end - dt.datetime.now(dt.timezone.utc)).days
+                except ValueError:
+                    pass
+            entry = {
+                "main": main,
+                "sans": sans,
+                "not_after": not_after,
+                "days_left": days_left,
+                "resolver": resolver,
+            }
+            certs.append(entry)
+            if days_left is not None and days_left < 21:
+                sev = "critical" if days_left < 7 else "high"
+                f.add(
+                    "cert",
+                    sev,
+                    f"Certificate for {main} expires in {days_left} days",
+                    evidence=[json.dumps(entry)],
+                    hint="Traefik should auto-renew. If not, check ACME DNS-01 challenge state.",
+                )
+    raw["certificates"] = certs
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Category: Container hardening (privileges, caps, mounts)
+# ---------------------------------------------------------------------------
+
+SENSITIVE_MOUNT_PATTERNS = [
+    "/run/user/1000/podman/podman.sock",
+    "/var/run/docker.sock",
+    "/etc/shadow",
+    "/root/",
+]
+
+
+def collect_container_hardening(f: FindingStore) -> dict[str, Any]:
+    raw: dict[str, Any] = {"containers": []}
+    rc, ps_json, _ = podman("ps", "--format", "json")
+    if rc != 0:
+        return raw
+    try:
+        containers = json.loads(ps_json)
+    except json.JSONDecodeError:
+        return raw
+
+    for c in containers:
+        names = c.get("Names") or [c.get("Name", "")]
+        name = names[0] if names else ""
+        rc_i, insp, _ = podman("inspect", name, timeout=15)
+        if rc_i != 0:
+            continue
+        try:
+            data = json.loads(insp)[0]
+        except (json.JSONDecodeError, IndexError):
+            continue
+        hc = data.get("HostConfig", {}) or {}
+        cfg = data.get("Config", {}) or {}
+        privileged = hc.get("Privileged", False)
+        cap_add = hc.get("CapAdd") or []
+        cap_drop = hc.get("CapDrop") or []
+        ipc = hc.get("IpcMode", "")
+        pid_mode = hc.get("PidMode", "")
+        readonly = hc.get("ReadonlyRootfs", False)
+        userns = hc.get("UsernsMode", "")
+        security_opt = hc.get("SecurityOpt") or []
+
+        mounts = data.get("Mounts") or []
+        mount_paths = [m.get("Source", "") for m in mounts]
+
+        entry = {
+            "name": name,
+            "privileged": privileged,
+            "cap_add": cap_add,
+            "cap_drop": cap_drop,
+            "ipc_mode": ipc,
+            "pid_mode": pid_mode,
+            "readonly_rootfs": readonly,
+            "userns_mode": userns,
+            "security_opt": security_opt,
+            "mounts": [
+                {
+                    "src": m.get("Source"),
+                    "dst": m.get("Destination"),
+                    "mode": m.get("Mode"),
+                    "rw": m.get("RW"),
+                }
+                for m in mounts
+            ],
+        }
+        raw["containers"].append(entry)
+
+        if privileged:
+            f.add(
+                "container",
+                "critical",
+                f"{name} runs privileged",
+                evidence=[json.dumps({"privileged": True})],
+                adr_refs=["ADR-001"],
+                hint="Violates rootless-containers principle. Pin down which cap is actually needed and grant selectively.",
+            )
+        for cap in cap_add:
+            f.add(
+                "container",
+                "medium",
+                f"{name} adds capability {cap}",
+                adr_refs=["ADR-001"],
+                hint=f"Justify CAP_{cap}; remove if unused.",
+            )
+        if pid_mode == "host":
+            f.add(
+                "container",
+                "high",
+                f"{name} shares host PID namespace",
+                hint="host PID namespace defeats process isolation.",
+            )
+        if ipc == "host":
+            f.add(
+                "container",
+                "medium",
+                f"{name} shares host IPC namespace",
+                hint="Rare legitimate need. Verify.",
+            )
+        for mp in mount_paths:
+            for pattern in SENSITIVE_MOUNT_PATTERNS:
+                if pattern in mp:
+                    f.add(
+                        "container",
+                        "high",
+                        f"{name} mounts sensitive host path {mp}",
+                        hint="Container escape risk. Especially podman.sock = full rootless control.",
+                    )
+
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Category: SSH + auth surface
+# ---------------------------------------------------------------------------
+
+
+def _parse_sshd_config() -> dict[str, str]:
+    """Read /etc/ssh/sshd_config + drop-ins without sudo. Last value wins (matches sshd -T semantics closely enough for audit purposes; does not honor Match blocks)."""
+    effective: dict[str, str] = {}
+    paths: list[Path] = []
+    main = Path("/etc/ssh/sshd_config")
+    if main.exists():
+        paths.append(main)
+    dropin = Path("/etc/ssh/sshd_config.d")
+    if dropin.is_dir():
+        # Include order matters; sshd reads *.conf lexically
+        paths.extend(sorted(dropin.glob("*.conf")))
+    for p in paths:
+        try:
+            for line in p.read_text(errors="replace").splitlines():
+                s = line.strip()
+                if not s or s.startswith("#") or s.lower().startswith("match "):
+                    continue
+                parts = s.split(None, 1)
+                if len(parts) == 2:
+                    effective[parts[0].lower()] = parts[1].strip()
+        except OSError:
+            continue
+    return effective
+
+
+def collect_ssh_surface(f: FindingStore) -> dict[str, Any]:
+    raw: dict[str, Any] = {}
+    effective = _parse_sshd_config()
+    raw["sshd_effective"] = effective
+    raw["sshd_note"] = "Parsed from sshd_config + sshd_config.d/*.conf (no sudo). Match blocks not expanded."
+
+    defaults_if_missing = {
+        "permitrootlogin": "prohibit-password",
+        "passwordauthentication": "yes",
+        "permitemptypasswords": "no",
+        "x11forwarding": "no",
+    }
+    for k, bad_values in [
+        ("permitrootlogin", ("yes", "without-password", "prohibit-password")),
+        ("passwordauthentication", ("yes",)),
+        ("permitemptypasswords", ("yes",)),
+        ("x11forwarding", ("yes",)),
+    ]:
+        val = effective.get(k, defaults_if_missing[k]).lower()
+        if val in bad_values:
+            sev = "high" if k in ("passwordauthentication", "permitemptypasswords") else "medium"
+            f.add(
+                "auth",
+                sev,
+                f"sshd_config {k} = {val}",
+                evidence=[f"source={'config' if k in effective else 'default'}"],
+                hint="Harden sshd per CIS baseline; prefer PubkeyAuthentication only.",
+            )
+
+    # authorized_keys
+    ak = Path.home() / ".ssh" / "authorized_keys"
+    if ak.exists():
+        content = read_text(ak)
+        lines = [
+            l for l in content.splitlines() if l.strip() and not l.startswith("#")
+        ]
+        raw["authorized_keys_count"] = len(lines)
+        raw["authorized_keys_types"] = [
+            l.split()[0] for l in lines if l.split()
+        ]
+        for l in lines:
+            if l.startswith("ssh-rsa ") and "from=" not in l:
+                f.add(
+                    "auth",
+                    "medium",
+                    "authorized_keys: RSA key with no from= restriction",
+                    evidence=[l[:80]],
+                    hint="Prefer FIDO2 sk-* keys (ADR-006). Old RSA keys should carry from=\"192.168.1.0/24\".",
+                )
+            if not l.startswith("sk-") and "from=" not in l:
+                f.add(
+                    "auth",
+                    "low",
+                    "authorized_keys: non-FIDO key without LAN restriction",
+                    evidence=[l[:80]],
+                    adr_refs=["ADR-006"],
+                    hint='Add from="192.168.1.0/24" or migrate to YubiKey sk-*.',
+                )
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Category: Config drift
+# ---------------------------------------------------------------------------
+
+
+def collect_drift(f: FindingStore) -> dict[str, Any]:
+    raw: dict[str, Any] = {}
+    # Working tree
+    rc, wt, _ = run(
+        ["git", "-C", str(REPO_ROOT), "status", "--porcelain"], timeout=10
+    )
+    raw["working_tree"] = wt.splitlines()
+    if wt.strip():
+        f.add(
+            "drift",
+            "low",
+            f"Git working tree has {len(wt.splitlines())} uncommitted entries",
+            evidence=wt.splitlines()[:20],
+            hint="Not a security issue per se, but untracked configs are un-audited configs.",
+        )
+
+    # Unpushed commits
+    rc, ahead, _ = run(
+        ["git", "-C", str(REPO_ROOT), "log", "--oneline", "@{u}..HEAD"], timeout=10
+    )
+    if rc == 0 and ahead.strip():
+        raw["unpushed"] = ahead.splitlines()
+        f.add(
+            "drift",
+            "info",
+            f"{len(ahead.splitlines())} unpushed commits",
+            evidence=ahead.splitlines()[:5],
+        )
+
+    # check-drift.sh if present
+    drift_script = REPO_ROOT / "scripts" / "check-drift.sh"
+    if drift_script.exists():
+        rc, out, err = run(["bash", str(drift_script)], timeout=60)
+        raw["check_drift_rc"] = rc
+        raw["check_drift_out"] = (out + err).splitlines()[:60]
+        if rc not in (0, 1):
+            f.add(
+                "drift",
+                "medium",
+                f"check-drift.sh returned non-standard rc={rc}",
+                evidence=raw["check_drift_out"][:15],
+            )
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Category: Journal anomalies
+# ---------------------------------------------------------------------------
+
+
+def collect_journal(f: FindingStore) -> dict[str, Any]:
+    raw: dict[str, Any] = {}
+    # SELinux denials in last 24h
+    rc, denials, _ = run(
+        [
+            "journalctl",
+            "--since",
+            "24 hours ago",
+            "-g",
+            "SELinux.*denied|avc:.*denied",
+            "-o",
+            "short",
+            "--no-pager",
+        ],
+        timeout=15,
+    )
+    lines = [l for l in denials.splitlines() if "denied" in l.lower()]
+    raw["selinux_denials_24h"] = lines[-50:]
+    if lines:
+        f.add(
+            "journal",
+            "medium",
+            f"{len(lines)} SELinux denials in last 24h",
+            evidence=lines[-5:],
+            hint="Check for mislabeled bind mounts. Pattern: ausearch -m avc -ts recent.",
+        )
+
+    # OOM kills
+    rc, oom, _ = run(
+        [
+            "journalctl",
+            "--since",
+            "24 hours ago",
+            "-g",
+            "Out of memory|oom-killer|OOM",
+            "--no-pager",
+        ],
+        timeout=10,
+    )
+    oom_lines = [l for l in oom.splitlines() if "oom" in l.lower() or "Out of memory" in l]
+    raw["oom_24h"] = oom_lines[-20:]
+    if oom_lines:
+        f.add(
+            "journal",
+            "high",
+            f"{len(oom_lines)} OOM events in last 24h",
+            evidence=oom_lines[-5:],
+            hint="Memory pressure — could be a leak, could be an attack. Correlate with container stats.",
+        )
+
+    # Failed systemd units (user + system)
+    for scope in ([], ["--user"]):
+        rc, failed, _ = run(
+            ["systemctl", *scope, "--failed", "--no-legend", "--plain"], timeout=10
+        )
+        key = "system_failed" if not scope else "user_failed"
+        raw[key] = [l for l in failed.splitlines() if l.strip()]
+        if raw[key]:
+            f.add(
+                "journal",
+                "high",
+                f"Failed systemd units ({'user' if scope else 'system'}): {len(raw[key])}",
+                evidence=raw[key][:10],
+                hint="Run systemctl status <unit> -n 50 on each.",
+            )
+
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Category: ADR compliance cross-checks
+# ---------------------------------------------------------------------------
+
+
+def collect_adr_compliance(f: FindingStore) -> dict[str, Any]:
+    raw: dict[str, Any] = {}
+    # ADR-018: multi-network containers get static IPs + /etc/hosts shim
+    rc, ps_json, _ = podman("ps", "--format", "json")
+    try:
+        containers = json.loads(ps_json)
+    except (json.JSONDecodeError, TypeError):
+        containers = []
+
+    multi_net = []
+    for c in containers:
+        nets = c.get("Networks") or []
+        name = (c.get("Names") or [c.get("Name", "")])[0]
+        if len(nets) > 1:
+            multi_net.append({"name": name, "networks": nets})
+    raw["multi_network_containers"] = multi_net
+
+    # Check for /etc/hosts overrides in traefik container (where the shim lives)
+    rc, hosts, _ = podman("exec", "traefik", "cat", "/etc/hosts", timeout=5)
+    raw["traefik_etc_hosts"] = hosts.splitlines() if rc == 0 else []
+    static_ip_entries = [
+        l for l in raw["traefik_etc_hosts"] if "10.89." in l and not l.startswith("#")
+    ]
+    raw["static_ip_entries"] = static_ip_entries
+
+    # ADR-016: labels=false for Traefik provider (no routing in container labels)
+    rc, trfk_yml, _ = podman("exec", "traefik", "cat", "/etc/traefik/traefik.yml", timeout=5)
+    if rc == 0 and "exposedByDefault: false" not in trfk_yml:
+        f.add(
+            "adr",
+            "high",
+            "Traefik provider.docker.exposedByDefault != false",
+            adr_refs=["ADR-016"],
+            hint="Enforces 'no routing in labels' rule. See ADR-016.",
+        )
+    raw["traefik_static_config_snippet"] = trfk_yml[:2000]
+
+    return raw
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+COLLECTORS: dict[str, Any] = {
+    "bind": collect_bind_surface,
+    "egress": collect_container_egress,
+    "chain": collect_traefik_chain,
+    "crowdsec": collect_crowdsec,
+    "loki": collect_loki_liveness,
+    "cert": collect_certs,
+    "container": collect_container_hardening,
+    "auth": collect_ssh_surface,
+    "drift": collect_drift,
+    "journal": collect_journal,
+    "adr": collect_adr_compliance,
+}
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("--category", choices=sorted(COLLECTORS.keys()), help="run one only")
+    ap.add_argument("--pretty", action="store_true", help="also print JSON to stdout")
+    ap.add_argument("--stdout-only", action="store_true", help="don't write report file")
+    args = ap.parse_args(argv)
+
+    if not (REPO_ROOT / "CLAUDE.md").exists():
+        print(f"ERROR: not in repo root ({REPO_ROOT})", file=sys.stderr)
+        return 2
+    if not have("podman"):
+        print("ERROR: podman not found", file=sys.stderr)
+        return 2
+
+    findings = FindingStore()
+    raw: dict[str, Any] = {}
+
+    cats = [args.category] if args.category else list(COLLECTORS.keys())
+    for cat in cats:
+        try:
+            raw[cat] = COLLECTORS[cat](findings) or {}
+        except Exception as e:
+            findings.add(
+                cat,
+                "medium",
+                f"collector '{cat}' crashed: {type(e).__name__}",
+                evidence=[str(e)[:400]],
+                hint="Collector bug — does not invalidate other categories.",
+            )
+
+    meta = collect_meta()
+    items = findings.all()
+    summary: dict[str, int] = {}
+    for it in items:
+        summary[it["severity"]] = summary.get(it["severity"], 0) + 1
+    report = {
+        "meta": meta,
+        "summary": summary,
+        "findings": items,
+        "raw": raw,
+    }
+
+    if not args.stdout_only:
+        REPORT_DIR.mkdir(parents=True, exist_ok=True)
+        ts = meta["generated_at"].replace(":", "-")
+        out_path = REPORT_DIR / f"{ts}.json"
+        out_path.write_text(json.dumps(report, indent=2, default=str))
+        print(f"wrote {out_path}", file=sys.stderr)
+
+    if args.pretty or args.stdout_only:
+        json.dump(report, sys.stdout, indent=2, default=str)
+        sys.stdout.write("\n")
+    else:
+        # short human summary
+        print(
+            f"local posture: {sum(summary.values())} findings "
+            f"(crit={summary.get('critical',0)} high={summary.get('high',0)} "
+            f"med={summary.get('medium',0)} low={summary.get('low',0)} info={summary.get('info',0)})",
+            file=sys.stderr,
+        )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- **New tooling:** two active gap-finders that emit a shared JSON schema, designed for ingestion by fresh Claude Code sessions that synthesise hardening plans from the output.
- **Local script** (committed): 11-category internal-plane audit on fedora-htpc, no sudo.
- **Remote script** (**gitignored**): external-plane perimeter probe with active attacks against our own edge, distributed to the MacBook out-of-band via scp. Publishing a perimeter-tuned attack kit on a public repo hands adversaries recon-time.
- **Handoff journal** with two self-contained prompts (one per vantage) so future sessions can start cold with the expected false-positives already documented.

## Why

Closes F3 from [`2026-04-22-ingress-forensics-udm-blindspot-private.md`](docs/98-journals/2026-04-22-ingress-forensics-udm-blindspot-private.md) (a journal kept local — discusses the UDM CyberSecure Region Blocking plane's syslog invisibility). That journal's conclusion: the single highest-leverage hardening action is a **negative test that probes the WAN IP from a foreign source** and verifies drop behaviour end-to-end.

Secondary drivers:
- Post-ADR-022 rate-limit retune was never empirically verified — all 429 probes from inside LAN hit TCP shedding before rate-limit fires. Only external traffic can measure real thresholds.
- CrowdSec acquisition was wired to Traefik logs on 2026-04-21 but the bouncer-engagement pipeline cannot be verified from LAN (whitelist absorbs probes). External probing is the only acceptance test.
- Structured posture data with stable finding IDs makes trend analysis across runs tractable, which bash-based audits cannot do cheaply.

## What shipped

| File | Role |
|---|---|
| `scripts/security/posture-local.py` | Internal-plane audit: bind surface, container egress reality, Traefik middleware chain, CrowdSec posture, Loki per-job liveness, cert expiry, container hardening, SSH config (no sudo), config drift, journal anomalies, ADR compliance cross-checks |
| `scripts/security/posture-remote.py` (gitignored) | External perimeter probe with active attacks: WAN port scan, CT-log subdomain discovery, TLS/headers/auth matrix, DNS audit, CrowdSec bouncer burst, rate-limit empirical, Region Block negative test |
| `scripts/security/README.md` | Ingestion contract, severity scale, active-probe footprint, out-of-band distribution, consumption prompt for fresh Claude sessions |
| `scripts/security/README-ssh-sync.md` | Prior YubiKey SSH sync README renamed to free the canonical path |
| `docs/98-journals/2026-04-22-posture-intel-scripts-handoff.md` | Handoff journal: two self-contained prompts (local + remote) + expected false-positives already observed on 2026-04-22 smoke run |
| `.gitignore` | Excludes `scripts/security/posture-remote.py` with rationale comment |

## Output schema (shared)

```json
{
  "meta":     { "schema_version": 1, "vantage": "local|remote", "git_head": "...", "wan_ip": "...", "tag": "...", "active_probes": true },
  "summary":  { "critical": 0, "high": 12, "medium": 5, "low": 16, "info": 2 },
  "findings": [ { "id": "LBIND-0001", "category": "bind", "severity": "high", "title": "...", "evidence": [...], "adr_refs": [...], "hint": "..." } ],
  "raw":      { "bind": {...}, "egress": {...}, ... }
}
```

Finding IDs are stable (`LBIND-0001`, `RAUTH-0003`, etc.) so reports diff cleanly across runs. **Scripts gather, do not interpret** — severity is a heuristic; the consuming Claude session decides what action follows.

## Security consideration — why the remote script is gitignored

The remote script knows every hostname, runs a curated web-shell fingerprint list, encodes CrowdSec burst logic tuned to our thresholds, and includes the Region Block negative-test procedure. Each piece is reconstructable from public information, but the **curation** is what saves adversaries reconnaissance time. On a public repo this is an own-goal.

Distribution: `scp fedora-htpc.lokal:~/containers/scripts/security/posture-remote.py ~/posture/` from the MacBook. The script auto-detects whether it's inside a homelab repo checkout and adapts its output path accordingly.

The local script stays committed — it only inspects state of systems the runner already owns, has no offensive capability when redirected elsewhere, and is useful reference material for other homelab operators.

## Verification

### Local script — full run on fedora-htpc (~47s)

```
local posture: 39 findings (crit=1 high=12 med=9 low=16 info=1)
```

Real signal found (not false positives):
- `LCHAIN-0020` — router references undefined middleware `nextcloud-caldav` (orphan, silently broken)
- `LCHAIN-0008..0019` — 12 dead middlewares in `middleware.yml` (confirms issue #156)
- `LJOURN-0001` — SELinux denials worth investigating
- Loki liveness check confirmed all three jobs (`systemd-journal`, `traefik-access`, `unifi-syslog`) ingesting within last 30 min

Known-accepted findings (documented in handoff journal so future sessions don't re-derive):
- cadvisor privileged + traefik podman.sock — intentional per ADR-001/ADR-016
- `authelia-portal` missing rate-limit middleware — intentional (Authelia's own in-app limit + `hsts-only`)
- `passwordauthentication=yes` — parser doesn't expand `Match` blocks; verify with `sudo sshd -T` before acting
- Wildcard UDP binds on mDNS / ephemeral SSDP — LAN multicast, not WAN exposure

### Remote script — passive smoke test from inside LAN

```
remote posture (remote-fedora-htpc-...): 9 findings (crit=1 high=7 med=1)
```

All findings triage cleanly against expected behaviour:
- Split-horizon DNS flagged (expected from LAN; won't fire from MacBook's foreign ISP)
- HSTS-missing on redirect responses (the chain redirects unauth traffic to sso; follow-up to check destination headers)
- `events.patriark.org` returns 200 despite Authelia middleware — known per `2026-03-31-authelia-sso-gathio-debugging.md` (gathio public event pages at `/`; Authelia gates creation paths)

### Active probes

Not exercised yet — first real test is from the MacBook on a foreign ISP. Handoff journal prompt B walks through correlation via `X-Probe-Tag` headers (one-line LogQL query: `{job="traefik-access"} |= "<tag>"`).

## Test plan

- [ ] First trip with MacBook: run `python3 ~/posture/posture-remote.py --tag <vantage>` on foreign network; capture output
- [ ] Back at home: scp the remote JSON into `data/security-posture/remote/` on fedora-htpc
- [ ] Open fresh Claude Code session, paste handoff prompt A, verify it produces a triage document at `docs/99-reports/posture-triage-local-<date>.md`
- [ ] Confirm `X-Probe-Tag` header lands in Loki for each active probe
- [ ] Verify Region Block negative test: external vantage in non-NO → port 443 should time out (Region Block silently drops); external probe reflector should confirm
- [ ] Verify CrowdSec bouncer engagement: attack burst followed by control request should show 403 post-engagement (or clear fail-open evidence if it doesn't)
- [ ] Validate no false negatives from `--passive` mode by comparing active and passive reports from same vantage

## Known limitations (documented, not hidden)

- Local SSH audit does not expand `Match` blocks (would need root).
- Remote CT enumeration depends on crt.sh uptime — failure degrades to a `low` finding.
- Remote region-block interpretation trusts ipapi.co's country attribution — corporate VPNs exiting in Norway mask the result. `wan_country` in meta makes this explicit.
- Rate-limit empirical probe is 60 requests (below burst threshold by design; true saturation would need distributed probes).

## Related

- Journal (private): `docs/98-journals/2026-04-22-ingress-forensics-udm-blindspot-private.md` (F3 is this work)
- Journal: `docs/98-journals/2026-04-21-crowdsec-acquisition-and-rate-limit-retune.md`
- Journal: `docs/98-journals/2026-04-22-udm-pro-siem-syslog-pipeline.md` (`unifi-syslog` is the correlation sink)
- Complement: `scripts/security-audit.sh` (rules-based traffic-light audit; this work is forensic-LLM-oriented, not a replacement)

🤖 Generated with [Claude Code](https://claude.com/claude-code)