### PR TITLE
fix: silence alert noise from no-change backups and slow-moving disk fill

### DIFF
--- a/config/alertmanager/alertmanager.yml
+++ b/config/alertmanager/alertmanager.yml
@@ -73,6 +73,14 @@ route:
 
     # Discord notification routes (standard behavior, unchanged)
 
+    # Slow-moving capacity alert: daily reminder, not hourly noise.
+    # Disk fill is real but not a 1h emergency — must precede the generic
+    # severity=critical route since first-match wins (continue defaults to false).
+    - matchers:
+        - alertname = "SystemDiskSpaceCritical"
+      receiver: 'discord-critical'
+      repeat_interval: 24h
+
     # Critical alerts: Discord for instant notifications
     - matchers:
         - severity = "critical"

--- a/config/prometheus/alerts/backup-alerts.yml
+++ b/config/prometheus/alerts/backup-alerts.yml
@@ -15,8 +15,14 @@ groups:
           description: "Last backup attempt for {{ $labels.subvolume }} failed. Check backup logs immediately."
 
       # Critical: Backup hasn't run in 2+ days (for daily backups)
+      # Excludes subvolumes whose latest urd run was a no-send (send_type=2):
+      # urd correctly skips remote send when nothing changed, which would
+      # otherwise look stale forever for cold subvolumes (e.g. subvol2-pics).
+      # BackupScriptNotRunning catches the case where urd itself stops running.
       - alert: BackupStale
-        expr: (time() - backup_last_success_timestamp) > (86400 * 2)
+        expr: |
+          (time() - backup_last_success_timestamp) > (86400 * 2)
+          unless on(subvolume) backup_send_type == 2
         for: 1h
         labels:
           severity: critical


### PR DESCRIPTION
## Summary

Two distinct alert-noise sources were hitting Discord constantly. Both have clean structural fixes — neither suppresses real signal.

### `BackupStale` — false positive on cold subvolumes
Urd correctly skips remote send when a subvolume has no changes (emits `backup_send_type=2`), but `backup_last_success_timestamp` doesn't advance, so the alert fires forever for cold data (subvol2-pics, subvol1-docs, subvol3-opptak, subvol4-multimedia, subvol5-music, subvol6-tmp).

**Fix:** add `unless on(subvolume) backup_send_type == 2` to the alert expression in `config/prometheus/alerts/backup-alerts.yml`. Treats "urd verified there's nothing to send" as a successful outcome. `BackupScriptNotRunning` still catches the case where urd itself stops running.

### `SystemDiskSpaceCritical` — real signal, wrong cadence
Disk is genuinely at 88% (system SSD). Real issue, but a 1h Discord repeat is wrong for a slow-moving capacity problem.

**Fix:** dedicated Alertmanager route for this alertname with `repeat_interval: 24h`, placed before the generic `severity=critical` route so first-match wins. The remediation webhook still fires hourly (action cadence is correct); only the Discord ping cadence drops to once a day.

## Verification

- `promtool check rules` and `amtool check-config` both passed.
- Hot-reloaded both services via `/-/reload` (had to use `podman exec` — port 9090 isn't published on the host).
- Confirmed Prometheus loaded the new expression: `(time() - backup_last_success_timestamp) > (86400 * 2) unless on (subvolume) backup_send_type == 2`.
- Post-reload alert count: `BackupStale firing: 0` (was 1: subvol2-pics).
- Direct expression eval: 0 series across all subvolumes.

## Test plan

- [ ] Observe Discord channel over next 24h — no `BackupStale` for subvol2-pics.
- [ ] Confirm `SystemDiskSpaceCritical` reminder arrives once (not 24×) over next day.
- [ ] When a real new file lands in subvol2-pics and urd next runs as `send_type=1`, alert should still be capable of firing if backup later breaks.
- [ ] Tackle the underlying disk fill (separate work) to clear `SystemDiskSpaceCritical` for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)