### PR TITLE
fix: close Tier 2 security punchlist (T2.1, T2.3, T2.2 Nextcloud)

### DIFF
--- a/config/traefik/dynamic/middleware.yml
+++ b/config/traefik/dynamic/middleware.yml
@@ -107,12 +107,14 @@ http:
             depth: 1
 
     # Nextcloud (per-IP post-ADR-022) — sized for one user's worst-case bulk op.
-    # Burst covers Music library tree walk (~2080 PROPFINDs, parallel ~4–8 conns).
-    # Average drops from NAT-era 600 to steady-state-realistic 300/min.
+    # Average steady-state browse rate; burst absorbs PROPFIND tree walks
+    # (Music library is ~2080 PROPFINDs, but client parallelism caps the
+    # 1-minute window at a few hundred). Tier 2 staged downsize 1500→800
+    # (2026-04-28); next step pending 7-day soak with zero 429s.
     rate-limit-nextcloud:
       rateLimit:
         average: 300
-        burst: 1500
+        burst: 800
         period: 1m
         sourceCriterion:
           ipStrategy:


### PR DESCRIPTION
## Summary

Closes Tier 2 of the [2026-04-23 security posture punchlist](docs/98-journals/2026-04-23-security-posture-punchlist-private.md). Follow-up to PR #176 (Tier 1).

- **T2.1** (per-IP rate-limit bucket verification): passive evidence — 18 distinct external client IPs in the Traefik access log over 12 days post-ADR-022, zero entries with the NAT signature `10.89.2.69`. ADR-022 architecture (systemd socket activation + `sourceCriterion.ipStrategy.depth: 1`) leaves no plausible failure mode given real IPs are observed; active two-IP `ab` test skipped.
- **T2.3** (CrowdSec drops against real IPs): `sum(increase(cs_lapi_decisions_ko_total[7d]))` = 86 bouncer drops in last 7 days against 6,519 active CAPI decisions. Threshold ("≥1 drop in 14 days") already met; 14-day wait skipped.
- **T2.2** Nextcloud burst 1500 → 800 (`config/traefik/dynamic/middleware.yml`). Staged downsize per punchlist; 7-day 429 watch begins today. Immich + qBt deferred until the soak clears.

## Verification

- ✓ Traefik file-provider auto-reload triggered (file mtime → inotify; no service restart)
- ✓ Pre-commit Traefik config validator passed (YAML syntax, no orphans)
- ✓ Smoke test: `curl https://nextcloud.patriark.org/status.php` → 200; 5 rapid follow-up GETs → 200 (no 429)
- ✓ ADR-022 invariant intact: live access log shows real client IPs in `ClientAddr`, no `10.89.2.69`

## Test Plan

- [ ] Daily Loki check during 7-day soak: `count_over_time({job="traefik-access", service="nextcloud-secure@file", status="429"}[1d])` should remain 0
- [ ] At day-7 (2026-05-05): if zero 429s → schedule Immich + qBt downsize session; if any 429s → roll back to 1500 (one-line revert) and investigate the responsible client
- [ ] Periodic spot-check of `tail /mnt/btrfs-pool/subvol7-containers/traefik-logs/access.log | jq '.ClientAddr'` to catch a regression of the NAT signature

## Notes

- **Pre-existing dead alert flagged for Tier 3:** `CrowdSecBanSpike` at `config/prometheus/alerts/security-alerts.yml:14-26` references `crowdsec_decisions_total`, which doesn't exist (the live metric prefix is `cs_*`, not `crowdsec_*`). Will rewrite as part of the Tier 3 hygiene batch.
- **Loki promtail strips `client_addr`** from indexed content (`config/promtail/promtail-config.yml:202-220`) — per-IP investigations need the host access log directly, not Loki. Worth documenting; not a defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)