### PR TITLE
fix: close Tier 3 security punchlist + ADR-027 chattr +C workaround

### DIFF
--- a/docs/00-foundation/decisions/2026-04-22-ADR-027-forward-nocow-workloads-subvol8-db.md
+++ b/docs/00-foundation/decisions/2026-04-22-ADR-027-forward-nocow-workloads-subvol8-db.md
@@ -55,7 +55,19 @@ ADR-025's acceptance criteria, migration procedure, and defensive tooling requir
     └── udm.log                        [syslog-ng output; rotated daily × 14 by logrotate]
 ```
 
-Compression on the subvolume root: `btrfs property set ... compression none`. NOCOW via `chattr +C` was attempted and returned EINVAL on kernel 6.19 for reasons not yet traced; for the `unifi-syslog` tenant this is accepted because (a) the subvolume is not snapshotted, so there's no COW-amplification fight to win, and (b) append-only log writes are not the fragmentation-sensitive pattern NOCOW is most valuable for. Future DB tenants (if ADR-025 accepts migration) will need the flag to work; that's on ADR-025 to resolve.
+Compression on the subvolume root: `btrfs property set ... compression none`. This sets the `m` (no-compress) inode flag on the subvol root, which **propagates to every directory created beneath it via inheritance**. The `m` flag and `+C` (NOCOW) are mutually exclusive at the inode level — `chattr +C` returns EINVAL on a directory that already has `m`.
+
+**Workaround (discovered 2026-04-28 during Loki tenant onboarding):** when adding a NOCOW-requiring tenant, drop the inherited `m` flag *first*, then set `+C`:
+
+```bash
+sudo mkdir -p /mnt/btrfs-pool/subvol8-db/<tenant>
+sudo chattr -m /mnt/btrfs-pool/subvol8-db/<tenant>   # remove inherited no-compress
+sudo chattr +C /mnt/btrfs-pool/subvol8-db/<tenant>   # then NOCOW
+lsattr -d /mnt/btrfs-pool/subvol8-db/<tenant>        # verify '+C' is set
+# rsync data into the (still-empty) dir; new files inherit +C from parent
+```
+
+`unifi-syslog` was deployed before this was traced; it remains without `+C`, which is acceptable because its workload (append-only UDP syslog) is not the fragmentation-sensitive pattern NOCOW is most valuable for. New tenants requiring NOCOW now have a working procedure.
 
 ## Integration requirements per new tenant
 
@@ -68,9 +80,10 @@ When adding a tenant to `subvol8-db`, the deploying change must:
 
 ## Tenants
 
-| Tenant | Added | Workload class | Backup |
-|---|---|---|---|
-| `unifi-syslog` | 2026-04-22 | Append-only UDP syslog receiver | None — forensic logs are replayable from UDM retention; 14-day logrotate locally |
+| Tenant | Added | Workload class | NOCOW (`+C`) | Backup |
+|---|---|---|---|---|
+| `unifi-syslog` | 2026-04-22 | Append-only UDP syslog receiver | No — accepted (append-only writes, not fragmentation-sensitive) | None — forensic logs are replayable from UDM retention; 14-day logrotate locally |
+| `loki` | 2026-04-28 | Log aggregator with compaction-rewrite I/O patterns | Yes — `+C` set after dropping inherited `m` flag (see workaround above) | None — Promtail re-ingests on restart; logs are not the source of truth, the originating systems are |
 
 This table is the living record. New tenants add a row; it does not require a new ADR unless the placement policy itself changes.
 

--- a/docs/98-journals/2026-04-28-db-migration-to-subvol8-strategy.md
+++ b/docs/98-journals/2026-04-28-db-migration-to-subvol8-strategy.md
@@ -1,0 +1,168 @@
+# Database Migration to subvol8-db — Long-Term Strategy
+
+**Date:** 2026-04-28
+**Status:** Planning. Captures intent, not yet a binding ADR.
+**Trigger:** During T3.2 (Loki → subvol8-db) we discovered that `chattr +C` on subvol8-db actually works once the inherited `m` (no-compress) flag is dropped first. ADR-027 had recorded "EINVAL on kernel 6.19, reasons not yet traced" and accepted the limitation; that limitation is now lifted. The path is open to migrate the homelab's existing databases off the snapshotted `subvol7-containers` and onto the dedicated, NOCOW-capable `subvol8-db` — which is what ADR-025 deferred to a 2026-06-18 measurement review.
+**Companion ADRs:** ADR-024 (dump-based backup), ADR-025 (deferred DB migration), ADR-027 (forward-only NOCOW placement on subvol8-db).
+
+---
+
+## Why this is worth doing carefully, not quickly
+
+These are the homelab's most important persistent stores. A botched migration loses real user data — Nextcloud files, Immich photos, password history, event invitations — that is not reconstructible from logs or replay. The reward (better fragmentation behavior + escape from snapshot extent-pinning) is real but bounded; the cost of a mistake is high and highly visible. There's no operational pressure forcing this — current databases work, just sub-optimally on COW + snapshots. So this is explicitly **a careful, measured, multi-month workstream**, not a sprint.
+
+Best practices that follow from this:
+- **One database at a time.** No batched migrations. Each gets its own PR, its own validation window, its own rollback decision.
+- **Dump-based migration where the engine supports it.** `mariadb-dump`, `pg_dump`, `mongodump` produce logically-consistent backups that can be restored to any version-compatible target. Filesystem-level `rsync` is a fallback only when (a) the engine has no dump format that captures all state, or (b) the data volume makes dump+restore wall-time prohibitive.
+- **Service stop is required.** Live `rsync` of an active DB is wrong; the WAL/transaction log moves while you copy. Best practice is a clean shutdown, dump or rsync, restore, start, validate.
+- **Old data path stays in place** for ≥7 days post-migration as a rollback artifact.
+- **Application-level smoke test** before declaring success. "DB starts" is necessary, not sufficient. Need to actually use the application end-to-end (upload a file to Nextcloud, view a photo in Immich, decrypt a password in Vaultwarden) before considering a migration complete.
+
+---
+
+## Inventory of candidates
+
+After today's Loki migration, the following candidates remain on `subvol7-containers`. The "NOCOW today" column reflects whether the existing directory has `+C` set (per `lsattr -d`) — a "No" means COW writes have been happening since the directory was first created, and the database is paying full fragmentation cost on the existing path.
+
+| Service | Engine | Current path on subvol7 | NOCOW today | Snapshotted | User-data sensitivity | Migration approach |
+|---|---|---|---|---|---|---|
+| `prometheus` | TSDB | `subvol7-containers/prometheus` | **Yes** (`+C`) | Yes | Low — TSDB rebuilds from scrape; 30-day retention is recovery-cheap | rsync (engine-level dump not standard) |
+| `gathio-db` | MongoDB | `subvol7-containers/gathio-db` | **Yes** (`+C`) | Yes | Medium — event invitations & RSVPs, no replay source | `mongodump` + restore |
+| `nextcloud-db` | MariaDB 11 | `subvol7-containers/nextcloud-db/data` | **No** | Yes | High — file metadata, share links, user accounts | `mariadb-dump` + restore |
+| `nextcloud-redis` | Redis 7 | `subvol7-containers/nextcloud-redis/data` | n/a (cache, RDB whole-file rewrite) | Yes | Low — session cache, regenerable | **Stays** on subvol7 per ADR-027 ("whole-file rewrites" exclusion) |
+| `immich-postgres` | Postgres 16 + vectorchord | `subvol7-containers/immich/postgres` | **Yes** (`+C`) | Yes | High — photo metadata, ML embeddings, ~10K assets | `pg_dump` + restore (vectorchord version-pinned per ADR-015) |
+| `immich-redis` | Redis | (verify) | n/a | Yes | Low | **Stays** on subvol7 |
+| `home-assistant` | SQLite | `subvol7-containers/home-assistant/home-assistant_v2.db` | (verify) | Yes | Medium — automation history, sensor data | Stop, file-copy, start (SQLite is small-file) |
+| `authelia-redis` | Redis | (verify) | n/a | Yes | Low — session cache | **Stays** on subvol7 |
+
+**Loki** (already on subvol8-db post-2026-04-28): not listed above. Already migrated.
+
+**Discovered defects worth flagging:**
+- `nextcloud-db` directory has **no `+C` flag** despite being a MariaDB instance with InnoDB random-write patterns. The CLAUDE.md gotcha "Loki/PostgreSQL/Prometheus need `chattr +C` before first use" was not enforced for MariaDB at first deploy. Cannot retrofit with `chattr +C` on a populated directory (no-op on existing extents). The migration to subvol8-db is the natural fix — restore lands in a fresh dir that inherits `+C`.
+
+---
+
+## Migration order (risk-graduated)
+
+The first migration is the riskiest because it's the first time we're exercising the full procedure on a real DB. Pick the lowest-stakes service to learn on:
+
+### Phase 1 — Pilot: `prometheus`
+
+**Why first:** TSDB data is reconstructible from active scrapes. If the migration corrupts data, we lose at most 30 days of historical metrics — recoverable, non-personal, no user-visible regression. Also: rsync rather than dump-based, which exercises the simpler half of the procedure first.
+
+**Procedure:**
+1. Stop `prometheus.service` cleanly (sends SIGTERM; Prometheus flushes head block to disk on shutdown).
+2. Create `/mnt/btrfs-pool/subvol8-db/prometheus`, drop `m`, set `+C`, verify with `lsattr -d`.
+3. `rsync -aAXH --info=progress2` from old to new.
+4. Update `quadlets/prometheus.container` `Volume=` line.
+5. `daemon-reload`, start, verify scrape resumes (check `up` metric for self-scrape).
+6. Application smoke test: a Grafana dashboard panel renders correctly with data spanning the migration window.
+7. Old path stays in place for ≥7 days. New path's first daily compaction (after ~2h) writes new files into the `+C` directory — verify via `lsattr` on a chunk file.
+
+**Acceptance:** zero data gap visible in any retention-window dashboard, zero scrape errors, fragmentation visibly lower on next `filefrag` check (forward-looking; baseline today is unmeasured but should be measured pre-migration).
+
+### Phase 2 — `gathio-db` (MongoDB)
+
+**Why second:** dump-based engine with stable backup format, but a relatively simple schema and small data volume. Validates the dump-restore half of the procedure on something low-stakes.
+
+**Procedure:**
+1. `podman exec gathio-mongo mongodump --out /tmp/dump` (with auth flags from secret).
+2. Stop `gathio-mongo.service`.
+3. Create new path on subvol8-db, set `+C`, update quadlet `Volume=`.
+4. Start, then `mongorestore` the dump.
+5. Application smoke test: view event list at `gathio.patriark.org`, RSVP a test event end-to-end.
+
+**Acceptance:** all pre-existing events visible with attendees intact, RSVP flow works, no auth errors.
+
+### Phase 3 — `home-assistant` (SQLite)
+
+**Why third:** simple single-file DB; gives us a reference for how SQLite behaves on subvol8-db before we attempt the larger relational engines.
+
+**Procedure:** stop HA, copy the .db file, update quadlet `Volume=` (only the data subdir), start. Validate via Lovelace dashboard rendering recent sensor history.
+
+### Phase 4 — `nextcloud-db` (MariaDB)
+
+**Why fourth:** the highest-value migration in personal terms (file metadata, share links, user accounts), and the one with no current `+C`. This is also where `mariadb-dump` workflow gets a real test.
+
+**Procedure:**
+1. Pre-flight: trigger a Nextcloud OCC `db:add-missing-indices` and `db:convert-filecache-bigint` to ensure schema is healthy.
+2. Stop `nextcloud.service` first (clients see read-only mode briefly), then `nextcloud-db.service`.
+3. From a temporary mariadb container with the same image version, mount old data path read-only, dump to file: `mariadb-dump --all-databases --single-transaction --routines --triggers > nextcloud-full.sql`. (Single-transaction guarantees consistency on InnoDB; routines/triggers cover stored procedures Nextcloud may install.)
+4. Create fresh `/mnt/btrfs-pool/subvol8-db/nextcloud-db/data`, set `+C`, set ownership to MariaDB's container UID.
+5. Update quadlet `Volume=`, start `nextcloud-db.service`. Wait for `mysqld` to initialize empty data dir.
+6. Restore: `mariadb < nextcloud-full.sql`.
+7. Start `nextcloud.service`, wait for healthcheck (`needsDbUpgrade:false`).
+8. Application smoke test:
+   - Login as admin via web UI
+   - Browse to a known directory and verify file listing matches pre-migration
+   - Open a calendar event (CalDAV)
+   - Trigger a desktop client sync and verify zero-conflict completion
+9. Run `occ files:scan --all` to verify file index integrity against actual files on disk.
+
+**Acceptance:** all pre-existing files accessible to all users, share links resolve, calendar/contacts intact, mobile clients sync without re-prompting credentials.
+
+**Rollback discipline:** if any acceptance criterion fails, the rollback path is straightforward — the old `subvol7-containers/nextcloud-db/data` is untouched; flip the quadlet `Volume=` line back, restart. The dump file is the artifact you fall back FROM if the new path is corrupt; the old data dir is what you fall back TO if the dump-restore was flawed.
+
+### Phase 5 — `immich-postgres`
+
+**Why last:** highest complexity. vectorchord extension is version-pinned per ADR-015, ML embeddings are large, photo metadata is irreplaceable in the sense that re-derivation from raw files would lose user actions (album organization, tags, favorites).
+
+**Procedure:** broadly mirrors phase 4 with `pg_dump --format=custom` instead of `mariadb-dump`. Critical version match: postgres-vectorchord image at the exact pinned tag (no upgrade jumps during migration). Validate vectorchord index integrity post-restore by triggering a smart-search query.
+
+**Pre-condition:** phase 4 must be fully clean (≥14 days post-migration with no rollback) before starting phase 5. We're not running two high-stakes migrations simultaneously.
+
+---
+
+## What stays on subvol7 deliberately
+
+Per ADR-027's exclusion criteria:
+
+- Redis instances (whole-file RDB snapshots, not random-write patterns)
+- Container config directories (snapshot-based rollback genuinely valuable)
+- Caches and ephemeral state
+
+These are correct on subvol7-containers and should not be migrated.
+
+---
+
+## Per-migration checklist (template)
+
+For each phase, the executing PR/journal must answer:
+
+- [ ] Pre-migration data size measured (`du -sh`)
+- [ ] Pre-migration fragmentation measured (`filefrag` on a representative file) — gives us a quantitative before/after
+- [ ] Service successfully stopped and verified inactive (no zombie process)
+- [ ] New path created with `chattr -m && chattr +C`, verified by `lsattr -d`
+- [ ] Dump or rsync completed with byte/row count verification
+- [ ] Fresh start succeeds, healthcheck passes
+- [ ] Application-level smoke test executed and documented
+- [ ] Old path retained for ≥7 days as rollback artifact
+- [ ] `lsattr` on a newly-written file confirms `+C` inherited
+- [ ] Post-migration fragmentation measured (compare to baseline)
+- [ ] Tenant table in ADR-027 updated with new row
+
+The post-migration `filefrag` measurement is the empirical signal that the whole exercise was worth doing. If extents are still fragmenting on subvol8-db (somehow), we've learned something important; if they hold flat, ADR-025's hypothesis is validated.
+
+---
+
+## Calendar and gating
+
+- **2026-05-28 (~1 month)**: phase 1 (`prometheus`) candidate window. Earliest. Only after the Nextcloud burst-rate-limit soak (T2.2) finishes cleanly on 2026-05-05 and a few weeks of stable operation are observed.
+- **+30 days per phase**: phase N+1 may start 30 days after phase N succeeds without rollback. This is a soft gate — adjust based on real observations.
+- **2026-06-18 ADR-025 review**: this strategy supersedes ADR-025's "wait until 2026-06-18 to decide" framing with a "we have a plan, executing it" framing. ADR-025 should be updated (or marked superseded) on or before that date to reflect the new posture.
+
+There is no deadline. If a phase reveals a structural problem (e.g., fragmentation doesn't actually improve on subvol8-db), the strategy halts and we re-evaluate before continuing.
+
+---
+
+## What this document is not
+
+- Not a binding ADR. It's a planning record. Each phase will produce its own PR, its own journal, and either succeed or get rolled back. ADR-025 owns the architectural decision; this owns the execution plan.
+- Not a guarantee that all five phases will happen. If midway through we conclude the cost-benefit doesn't justify continuing (e.g., subvol8-db's NOCOW behavior turns out to be marginally better only), we stop and document why.
+- Not exhaustive. CrowdSec's local DB, Authelia's session store, and other minor stateful surfaces are not enumerated above; they are evaluated against ADR-027's criteria when their migration becomes interesting (or not).
+
+## What's open for the next session
+
+- Decide whether this should become a new ADR (e.g. ADR-029) or remain a planning journal that updates ADR-025 in-place. Recommendation: leave as planning journal until phase 1 is complete; convert to ADR-029 after the first migration validates the procedure.
+- Run baseline fragmentation measurement on all candidate services so phase 1 has something to compare against. ~10 min: `for d in prometheus nextcloud-db immich/postgres ...; do sudo filefrag -v /path/to/largest-file | tail -1; done`.
+- Confirm `+C` status on the directories listed as "(verify)" above.

--- a/docs/98-journals/2026-04-28-traefik-access-empty-query-investigation.md
+++ b/docs/98-journals/2026-04-28-traefik-access-empty-query-investigation.md
@@ -1,0 +1,102 @@
+# Traefik Access-Log Empty Query — Investigation & Reading Guide
+
+**Date:** 2026-04-28
+**Status:** No action needed. Empty query result was correct; documenting so a fresh session doesn't repeat the chase.
+**Trigger:** During T3.2 (Loki move to subvol8-db) post-deployment validation, `count_over_time({job="traefik-access"}[5m])` returned an empty vector. First reading was "Promtail isn't pushing traefik logs" — second reading and investigation showed it's a quiet stack returning the truth.
+
+---
+
+## What was checked
+
+### 1. Promtail → Loki pipeline
+
+- `promtail` container `Up X minutes (healthy)`, no errors after Loki cut over to new path.
+- Loki ingest receiving `systemd-journal` entries at ~1322/30s (verified via `count_over_time({job="systemd-journal"}[30s])`). So the pipeline itself is alive.
+- `unifi-syslog` and `traefik-access` both appear in `loki/api/v1/label/job/values` → Promtail HAS pushed traefik-access entries historically; the label is registered.
+
+### 2. Promtail config
+
+`config/promtail/promtail-config.yml` defines a `traefik-access` job that tails `/var/log/traefik/access.log` (mounted from `/mnt/btrfs-pool/subvol7-containers/traefik-logs`). JSON pipeline extracts method/status/service into Loki labels and replaces the line body with the request path. Mount path verified via `podman inspect promtail`.
+
+### 3. Traefik access log itself
+
+- File present: `/mnt/btrfs-pool/subvol7-containers/traefik-logs/access.log`, 50MB
+- Last write timestamp: 2026-04-28 20:53 local (22 minutes before the empty-query observation)
+- Last 5 entries inspected (via `podman exec promtail tail -5`): all 4xx/5xx responses (503/401/401/401/404), spread across nextcloud-secure and audiobookshelf-secure routers. Latest at 18:53:39 UTC.
+
+### 4. The smoking gun: filter config
+
+`config/traefik/traefik.yml`:
+
+```yaml
+accessLog:
+  filters:
+    statusCodes:
+      - "400-599"  # Only log errors (reduce volume)
+```
+
+**Successful (2xx/3xx) responses are not written to access.log at all.** Promtail therefore has nothing to ingest unless an actual error occurs. In a quiet stack, gaps of 20+ minutes between log entries are normal.
+
+### 5. Cross-check: is Traefik actually receiving traffic?
+
+`traefik_service_requests_total[5m]`: 170 requests in 5 min, **all attributed to the `traefik` service** — i.e. Prometheus scraping `/metrics`, Promtail querying internal endpoints, and the user's own dashboard polling. No external-user traffic to `nextcloud-secure@file` / `immich-secure@file` / etc. during the observation window.
+
+Conclusion: stack is genuinely idle. Empty Loki query is the correct answer.
+
+---
+
+## What to look for at the Traefik dashboard
+
+The dashboard is at `https://traefik.patriark.org` (Authelia-protected). Useful panels for "is the stack actually working":
+
+- **HTTP → Routers** — should list ~18 routers. Click into any to inspect its middleware chain. Every internet-facing route should start with `crowdsec-bouncer@file`. If a router shows up but has no middlewares, that's a misconfig (and would also fail security audit `SA-TRF-04`).
+- **HTTP → Services** — green dot = backend container is reachable. Red = look at `journalctl --user -u <svc>.service`.
+- **HTTP → Entrypoints → websecure (port 443)** — request rate timeseries. Flatline during idle hours is normal; flatline during your active use of `nextcloud.patriark.org` would be pathological.
+- **`traefik@internal` router** — usually the busiest in any 5-min window during quiet times, because Prometheus scrapes `/metrics` on it every scrape interval. Don't mistake this for user traffic.
+
+For "did real users hit anything in the last hour", a better source than the dashboard is Prometheus:
+
+```
+# Per-service request rate (last 1h average), excluding internal scrape noise
+sum by (service) (rate(traefik_service_requests_total{service!~"traefik|prometheus.*"}[1h]))
+```
+
+Anything > 0 there means at least one external request reached that backend.
+
+---
+
+## Why the empty query was misleading at first
+
+The query `count_over_time({job="traefik-access"}[5m])` returns "no entries in this 5-minute window for this job." That sounds like "Loki has no data for that label," but it's actually "the access log file has not had a write in 5 minutes that Promtail could ingest." Two distinct failure modes share an identical empty-result surface:
+
+1. **Pipeline broken** (Promtail not pushing, Loki not ingesting, label dropped) — would be persistent and reproducible across all jobs.
+2. **No data to ingest** (Traefik filter excludes 2xx/3xx, no errors in window) — affects this one job only, depends on activity.
+
+The discriminator is: query the same window with a different active job (here `systemd-journal`, which writes constantly). Non-zero result there proves the pipeline works; the empty `traefik-access` is just absence-of-errors.
+
+---
+
+## What this means for future debugging
+
+If the question is "is `traefik-access` ingest broken?", the right test is:
+
+```bash
+# Generate a deliberate 4xx and check it lands in Loki within ~30s
+curl -s -o /dev/null -w "%{http_code}\n" https://traefik.patriark.org/this-path-does-not-exist
+sleep 30
+podman exec grafana wget -qO- 'http://loki:3100/loki/api/v1/query?query=sum(count_over_time({job="traefik-access"}[1m]))'
+```
+
+If the second command returns > 0, the pipeline is healthy. If it stays at 0 after a guaranteed-error request, then there's a real problem to investigate.
+
+---
+
+## What's invariant after this
+
+- **Empty `traefik-access` query during quiet hours is benign** — the access log filter is intentionally errors-only.
+- **Promtail's pipeline strips `client_addr` from indexed content** (see 2026-04-28 T3.2 journal) — for per-IP forensics, query the raw access log, not Loki.
+- **The 170 req/5min on `service=traefik` is dashboard + scrape noise**, not user traffic. Real user traffic appears under `nextcloud-secure@file`, `immich-secure@file`, `vaultwarden-secure@file`, etc.
+
+## What's open
+
+Nothing. This investigation is closed. Recorded as a handoff so a fresh session doesn't burn cycles re-deriving the answer when someone next sees an empty query result.

--- a/docs/AUTO-DEPENDENCY-GRAPH.md
+++ b/docs/AUTO-DEPENDENCY-GRAPH.md
@@ -1,6 +1,6 @@
 # Service Dependency Graph (Auto-Generated)
 
-**Generated:** 2026-04-22 05:02:53 UTC
+**Generated:** 2026-04-28 19:15:37 UTC
 **System:** fedora-htpc
 
 ---
@@ -54,6 +54,7 @@ graph TB
         promtail[promtail]
         proton_bridge[proton-bridge]
         qbittorrent[qbittorrent]
+        unifi_syslog[unifi-syslog]
         unpoller[unpoller]
     end
 
@@ -150,6 +151,7 @@ graph TB
 | **promtail** | — | 🟢 Service-specific impact |
 | **proton-bridge** | — | 🟢 Service-specific impact |
 | **qbittorrent** | — | 🟢 Service-specific impact |
+| **unifi-syslog** | — | 🟢 Service-specific impact |
 | **unpoller** | — | 🟢 Service-specific impact |
 
 ---
@@ -189,6 +191,7 @@ Derived from `After=` directives in quadlet files. systemd handles this automati
 | redis-authelia | (no ordering constraints) |
 | redis-immich | (no ordering constraints) |
 | traefik | http.socket,https.socket |
+| unifi-syslog | (no ordering constraints) |
 | unpoller | prometheus |
 | vaultwarden | traefik |
 
@@ -215,6 +218,8 @@ Services on the same network can communicate:
 **photos:** immich-ml,immich-server,postgresql-immich,redis-immich
 
 **reverse_proxy:** alert-discord-relay,alertmanager,audiobookshelf,authelia,crowdsec,gathio,grafana,home-assistant,homepage,immich-server,jellyfin,loki,navidrome,nextcloud,prometheus,proton-bridge,qbittorrent,traefik,unpoller,vaultwarden
+
+**syslog:** unifi-syslog
 
 ---
 

--- a/docs/AUTO-DOCUMENTATION-INDEX.md
+++ b/docs/AUTO-DOCUMENTATION-INDEX.md
@@ -1,7 +1,7 @@
 # Documentation Index (Auto-Generated)
 
-**Generated:** 2026-04-22 05:02:54 UTC
-**Total Documents:** 390
+**Generated:** 2026-04-28 19:15:38 UTC
+**Total Documents:** 400
 
 ---
 
@@ -22,7 +22,7 @@
 
 ## Documentation by Category
 
-### 00-foundation/ (21 documents)
+### 00-foundation/ (23 documents)
 
 **Fundamentals and core concepts**
 
@@ -49,6 +49,8 @@
 - ADR-025: [2026-04-18-ADR-025-db-storage-migration-deferred](00-foundation/decisions/2026-04-18-ADR-025-db-storage-migration-deferred.md)
 - ADR-023: [2026-04-21-ADR-023-monitoring-bind-propagation](00-foundation/decisions/2026-04-21-ADR-023-monitoring-bind-propagation.md)
 - ADR-026: [2026-04-21-ADR-026-nextcloud-pinned-major-version](00-foundation/decisions/2026-04-21-ADR-026-nextcloud-pinned-major-version.md)
+- ADR-027: [2026-04-22-ADR-027-forward-nocow-workloads-subvol8-db](00-foundation/decisions/2026-04-22-ADR-027-forward-nocow-workloads-subvol8-db.md)
+- ADR-028: [2026-04-27-ADR-028-podman-secret-store-path-split](00-foundation/decisions/2026-04-27-ADR-028-podman-secret-store-path-split.md)
 - ADR-023: [2026-04-18-ADR-023-btrfs-storage-architecture-databases](00-foundation/decisions/withdrawn/2026-04-18-ADR-023-btrfs-storage-architecture-databases.md)
 
 ---
@@ -210,7 +212,7 @@
 
 ---
 
-### 98-journals/ (200 documents)
+### 98-journals/ (208 documents)
 
 **Chronological project history (append-only log)**
 
@@ -229,25 +231,22 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 ## Recently Updated (Last 7 Days)
 
 - 2026-04-22: [2026-03-28-ADR-021-urd-backup-tool.md](00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md)
-- 2026-04-16: [2026-04-16-ADR-022-traefik-socket-activation.md](00-foundation/decisions/2026-04-16-ADR-022-traefik-socket-activation.md)
-- 2026-04-21: [2026-04-18-ADR-024-database-dump-backup.md](00-foundation/decisions/2026-04-18-ADR-024-database-dump-backup.md)
-- 2026-04-21: [2026-04-18-ADR-025-db-storage-migration-deferred.md](00-foundation/decisions/2026-04-18-ADR-025-db-storage-migration-deferred.md)
 - 2026-04-22: [2026-04-21-ADR-023-monitoring-bind-propagation.md](00-foundation/decisions/2026-04-21-ADR-023-monitoring-bind-propagation.md)
-- 2026-04-21: [2026-04-21-ADR-026-nextcloud-pinned-major-version.md](00-foundation/decisions/2026-04-21-ADR-026-nextcloud-pinned-major-version.md)
-- 2026-04-21: [2026-04-18-ADR-023-btrfs-storage-architecture-databases.md](00-foundation/decisions/withdrawn/2026-04-18-ADR-023-btrfs-storage-architecture-databases.md)
-- 2026-04-21: [2026-04-21-nextcloud-slo-collapse-postmortem.md](90-archive/2026-04-21-nextcloud-slo-collapse-postmortem.md)
-- 2026-04-21: [2026-03-17-pasta-source-nat-investigation.md](98-journals/2026-03-17-pasta-source-nat-investigation.md)
-- 2026-04-21: [2026-03-26-promtail-journal-export-outage.md](98-journals/2026-03-26-promtail-journal-export-outage.md)
-- 2026-04-21: [2026-03-28-podman-storage-migration.md](98-journals/2026-03-28-podman-storage-migration.md)
-- 2026-04-21: [2026-03-31-authelia-sso-gathio-debugging.md](98-journals/2026-03-31-authelia-sso-gathio-debugging.md)
-- 2026-04-21: [2026-03-31-proton-bridge-smtp-integration-attempt.md](98-journals/2026-03-31-proton-bridge-smtp-integration-attempt.md)
-- 2026-04-16: [2026-04-16-adr-022-socket-activation-prototype.md](98-journals/2026-04-16-adr-022-socket-activation-prototype.md)
-- 2026-04-21: [2026-04-18-podman-storage-migration-execution.md](98-journals/2026-04-18-podman-storage-migration-execution.md)
-- 2026-04-21: [2026-04-21-crowdsec-acquisition-and-rate-limit-retune.md](98-journals/2026-04-21-crowdsec-acquisition-and-rate-limit-retune.md)
-- 2026-04-21: [2026-04-21-ha-rate-limit-rollback-post-adr022.md](98-journals/2026-04-21-ha-rate-limit-rollback-post-adr022.md)
+- 2026-04-28: [2026-04-22-ADR-027-forward-nocow-workloads-subvol8-db.md](00-foundation/decisions/2026-04-22-ADR-027-forward-nocow-workloads-subvol8-db.md)
+- 2026-04-28: [2026-04-27-ADR-028-podman-secret-store-path-split.md](00-foundation/decisions/2026-04-27-ADR-028-podman-secret-store-path-split.md)
 - 2026-04-22: [2026-04-21-monitoring-bind-propagation.md](98-journals/2026-04-21-monitoring-bind-propagation.md)
-- 2026-04-21: [2026-04-21-network-ingress-egress-hardening.md](98-journals/2026-04-21-network-ingress-egress-hardening.md)
-- 2026-04-21: [2026-04-21-nextcloud-postmortem-followups.md](98-journals/2026-04-21-nextcloud-postmortem-followups.md)
+- 2026-04-23: [2026-04-22-ingress-forensics-udm-blindspot-private.md](98-journals/2026-04-22-ingress-forensics-udm-blindspot-private.md)
+- 2026-04-23: [2026-04-22-posture-intel-scripts-handoff.md](98-journals/2026-04-22-posture-intel-scripts-handoff.md)
+- 2026-04-22: [2026-04-22-udm-pro-siem-syslog-pipeline.md](98-journals/2026-04-22-udm-pro-siem-syslog-pipeline.md)
+- 2026-04-23: [2026-04-23-security-posture-punchlist-private.md](98-journals/2026-04-23-security-posture-punchlist-private.md)
+- 2026-04-23: [2026-04-23-udm-siem-qbittorrent-attribution-private.md](98-journals/2026-04-23-udm-siem-qbittorrent-attribution-private.md)
+- 2026-04-27: [2026-04-27-sso-recovery-and-secret-store-bomb-private.md](98-journals/2026-04-27-sso-recovery-and-secret-store-bomb-private.md)
+- 2026-04-27: [2026-04-27-tier1-punchlist-closeout-private.md](98-journals/2026-04-27-tier1-punchlist-closeout-private.md)
+- 2026-04-28: [2026-04-28-tier2-perip-verification-and-nextcloud-burst-downsize-private.md](98-journals/2026-04-28-tier2-perip-verification-and-nextcloud-burst-downsize-private.md)
+- 2026-04-28: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
+- 2026-04-28: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
+- 2026-04-28: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
+- 2026-04-28: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
 
 ---
 

--- a/docs/AUTO-NETWORK-TOPOLOGY.md
+++ b/docs/AUTO-NETWORK-TOPOLOGY.md
@@ -1,7 +1,7 @@
 # Network Topology (Auto-Generated)
 
-**Generated:** 2026-04-22 05:02:50 UTC
-**System:** fedora-htpc | **Networks:** 9 | **Containers:** 31
+**Generated:** 2026-04-28 19:15:30 UTC
+**System:** fedora-htpc | **Networks:** 10 | **Containers:** 32
 
 ---
 
@@ -140,6 +140,11 @@ graph TB
         reverse_proxy_vaultwarden[vaultwarden]
     end
 
+    subgraph syslog["syslog<br/>10.89.7.0/24"]
+        direction LR
+        syslog_unifi_syslog[unifi-syslog]
+    end
+
     %% Network styling
     classDef gatewayNet fill:#e6f3ff,stroke:#1a5490,stroke-width:3px
     classDef observeNet fill:#fff9e6,stroke:#d68910,stroke-width:3px
@@ -156,43 +161,44 @@ graph TB
 
 Shows which services belong to which networks. Dynamically generated from running container state.
 
-| Service | auth_services | gathio | home_automation | mail | media_services | monitoring | nextcloud | photos | reverse_proxy |
-|---------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Service | auth_services | gathio | home_automation | mail | media_services | monitoring | nextcloud | photos | reverse_proxy | syslog |
+|---------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **Gateway & Security** |
-| authelia | ✅ | - | - | ✅ | - | - | - | - | ✅ |
-| crowdsec | - | - | - | - | - | - | - | - | ✅ |
-| redis-authelia | ✅ | - | - | - | - | - | - | - | - |
-| traefik | - | - | - | - | - | - | - | - | ✅ |
+| authelia | ✅ | - | - | ✅ | - | - | - | - | ✅ | - |
+| crowdsec | - | - | - | - | - | - | - | - | ✅ | - |
+| redis-authelia | ✅ | - | - | - | - | - | - | - | - | - |
+| traefik | - | - | - | - | - | - | - | - | ✅ | - |
 | **Public Services** |
-| alert-discord-relay | - | - | - | - | - | ✅ | - | - | ✅ |
-| audiobookshelf | - | - | - | - | - | - | - | - | ✅ |
-| gathio | - | ✅ | - | - | - | - | - | - | ✅ |
-| home-assistant | - | - | ✅ | - | - | - | - | - | ✅ |
-| homepage | - | - | - | - | - | - | - | - | ✅ |
-| immich-server | - | - | - | - | - | - | - | ✅ | ✅ |
-| jellyfin | - | - | - | - | ✅ | - | - | - | ✅ |
-| navidrome | - | - | - | - | - | - | - | - | ✅ |
-| nextcloud | - | - | - | - | - | - | ✅ | - | ✅ |
-| proton-bridge | - | - | - | ✅ | - | - | - | - | ✅ |
-| qbittorrent | - | - | - | - | - | - | - | - | ✅ |
-| unpoller | - | - | - | - | - | ✅ | - | - | ✅ |
-| vaultwarden | - | - | - | - | - | - | - | - | ✅ |
+| alert-discord-relay | - | - | - | - | - | ✅ | - | - | ✅ | - |
+| audiobookshelf | - | - | - | - | - | - | - | - | ✅ | - |
+| gathio | - | ✅ | - | - | - | - | - | - | ✅ | - |
+| home-assistant | - | - | ✅ | - | - | - | - | - | ✅ | - |
+| homepage | - | - | - | - | - | - | - | - | ✅ | - |
+| immich-server | - | - | - | - | - | - | - | ✅ | ✅ | - |
+| jellyfin | - | - | - | - | ✅ | - | - | - | ✅ | - |
+| navidrome | - | - | - | - | - | - | - | - | ✅ | - |
+| nextcloud | - | - | - | - | - | - | ✅ | - | ✅ | - |
+| proton-bridge | - | - | - | ✅ | - | - | - | - | ✅ | - |
+| qbittorrent | - | - | - | - | - | - | - | - | ✅ | - |
+| unpoller | - | - | - | - | - | ✅ | - | - | ✅ | - |
+| vaultwarden | - | - | - | - | - | - | - | - | ✅ | - |
 | **Monitoring** |
-| alertmanager | - | - | - | - | - | ✅ | - | - | ✅ |
-| cadvisor | - | - | - | - | - | ✅ | - | - | - |
-| grafana | - | - | - | - | - | ✅ | - | - | ✅ |
-| loki | - | - | - | - | - | ✅ | - | - | ✅ |
-| node_exporter | - | - | - | - | - | ✅ | - | - | - |
-| prometheus | - | - | - | - | - | ✅ | - | - | ✅ |
-| promtail | - | - | - | - | - | ✅ | - | - | - |
+| alertmanager | - | - | - | - | - | ✅ | - | - | ✅ | - |
+| cadvisor | - | - | - | - | - | ✅ | - | - | - | - |
+| grafana | - | - | - | - | - | ✅ | - | - | ✅ | - |
+| loki | - | - | - | - | - | ✅ | - | - | ✅ | - |
+| node_exporter | - | - | - | - | - | ✅ | - | - | - | - |
+| prometheus | - | - | - | - | - | ✅ | - | - | ✅ | - |
+| promtail | - | - | - | - | - | ✅ | - | - | - | - |
 | **Backend Services** |
-| gathio-db | - | ✅ | - | - | - | - | - | - | - |
-| immich-ml | - | - | - | - | - | - | - | ✅ | - |
-| matter-server | - | - | ✅ | - | - | - | - | - | - |
-| nextcloud-db | - | - | - | - | - | - | ✅ | - | - |
-| nextcloud-redis | - | - | - | - | - | - | ✅ | - | - |
-| postgresql-immich | - | - | - | - | - | - | - | ✅ | - |
-| redis-immich | - | - | - | - | - | - | - | ✅ | - |
+| gathio-db | - | ✅ | - | - | - | - | - | - | - | - |
+| immich-ml | - | - | - | - | - | - | - | ✅ | - | - |
+| matter-server | - | - | ✅ | - | - | - | - | - | - | - |
+| nextcloud-db | - | - | - | - | - | - | ✅ | - | - | - |
+| nextcloud-redis | - | - | - | - | - | - | ✅ | - | - | - |
+| postgresql-immich | - | - | - | - | - | - | - | ✅ | - | - |
+| redis-immich | - | - | - | - | - | - | - | ✅ | - | - |
+| unifi-syslog | - | - | - | - | - | - | - | - | - | ✅ |
 
 ---
 
@@ -369,6 +375,16 @@ sequenceDiagram
 - traefik
 - unpoller
 - vaultwarden
+
+
+### syslog
+
+- **Full Name:** `systemd-syslog`
+- **Subnet:** 10.89.7.0/24
+- **Services:** 1
+
+**Members:**
+- unifi-syslog
 
 
 ---

--- a/docs/AUTO-SERVICE-CATALOG.md
+++ b/docs/AUTO-SERVICE-CATALOG.md
@@ -1,98 +1,99 @@
 # Service Catalog (Auto-Generated)
 
-**Generated:** 2026-04-22 05:02:49 UTC
-**System:** fedora-htpc | **Services:** 31/31 running | **Health:** 19/30 healthy (1 without healthcheck)
+**Generated:** 2026-04-28 19:15:29 UTC
+**System:** fedora-htpc | **Services:** 32/32 running | **Health:** 31/31 healthy (1 without healthcheck)
 
 ---
 
-## Other (4)
+## Other (5)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| audiobookshelf | advplyr/audiobookshelf:latest | ✅ healthy | 3d | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
-| navidrome | deluan/navidrome:latest | ⚠️ unhealthy | 3d | [musikk.patriark.org](https://musikk.patriark.org) | — |
-| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | 3d | — | — |
-| qbittorrent | linuxserver/qbittorrent:latest | ✅ healthy | 3d | [torrent.patriark.org](https://torrent.patriark.org) | — |
+| audiobookshelf | advplyr/audiobookshelf:latest | ✅ healthy | 10d | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
+| navidrome | deluan/navidrome:latest | ✅ healthy | 10d | [musikk.patriark.org](https://musikk.patriark.org) | — |
+| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | 10d | — | — |
+| qbittorrent | linuxserver/qbittorrent:latest | ✅ healthy | 24h | [torrent.patriark.org](https://torrent.patriark.org) | — |
+| unifi-syslog | linuxserver/syslog-ng:latest | ✅ healthy | 45m | — | — |
 
 ## Core Infrastructure (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| authelia | authelia/authelia:latest | ✅ healthy | 3d | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
-| crowdsec | crowdsecurity/crowdsec:latest | ✅ healthy | 22h | — | [guide](10-services/guides/crowdsec.md) |
-| redis-authelia | redis:7-alpine | ✅ healthy | 3d | — | — |
-| traefik | traefik:latest | ⚠️ unhealthy | 3d | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
+| authelia | authelia/authelia:latest | ✅ healthy | 6h | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
+| crowdsec | crowdsecurity/crowdsec:latest | ✅ healthy | 7d | — | [guide](10-services/guides/crowdsec.md) |
+| redis-authelia | redis:7-alpine | ✅ healthy | 10d | — | — |
+| traefik | traefik:latest | ✅ healthy | 24h | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
 
 ## Nextcloud (3)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| nextcloud-db | mariadb:11 | ⚠️ unhealthy | 3d | — | [guide](10-services/guides/nextcloud.md) |
-| nextcloud | nextcloud:latest | ⚠️ unhealthy | 3d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
-| nextcloud-redis | redis:7-alpine | ✅ healthy | 3d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-db | mariadb:11 | ✅ healthy | 25m | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud | nextcloud:33 | ✅ healthy | 22m | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-redis | redis:7-alpine | ✅ healthy | 25m | — | [guide](10-services/guides/nextcloud.md) |
 
 ## Immich (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| immich-ml | immich-app/immich-machine-learning:v2.6.3 | ✅ healthy | 3d | — | [guide](10-services/guides/immich.md) |
-| immich-server | immich-app/immich-server:v2.6.3 | ⚠️ unhealthy | 3d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
-| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3-pgvec | ⚠️ unhealthy | 3d | — | — |
-| redis-immich | valkey/valkey:latest | ✅ healthy | 3d | — | — |
+| immich-ml | immich-app/immich-machine-learning:v2.6.3 | ✅ healthy | 10d | — | [guide](10-services/guides/immich.md) |
+| immich-server | immich-app/immich-server:v2.6.3 | ✅ healthy | 10d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
+| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3-pgvec | ✅ healthy | 10d | — | — |
+| redis-immich | valkey/valkey:latest | ✅ healthy | 10d | — | — |
 
 ## Jellyfin (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| jellyfin | jellyfin/jellyfin:latest | ✅ healthy | 11h | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
+| jellyfin | jellyfin/jellyfin:latest | ✅ healthy | 7d | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
 
 ## Vaultwarden (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| vaultwarden | vaultwarden/server:latest | ✅ healthy | 3d | [vault.patriark.org](https://vault.patriark.org) | — |
+| vaultwarden | vaultwarden/server:latest | ✅ healthy | 24h | [vault.patriark.org](https://vault.patriark.org) | — |
 
 ## Home Automation (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 11h | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
-| matter-server | home-assistant-libs/python-matter-server:stab | ✅ healthy | 11h | — | [guide](10-services/guides/matter-server.md) |
+| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 7d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
+| matter-server | home-assistant-libs/python-matter-server:stab | ✅ healthy | 7d | — | [guide](10-services/guides/matter-server.md) |
 
 ## Gathio (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| gathio-db | mongo:7 | ⚠️ unhealthy | 3d | — | — |
-| gathio | lowercasename/gathio:latest | ✅ healthy | 3d | [events.patriark.org](https://events.patriark.org) | — |
+| gathio-db | mongo:7 | ✅ healthy | 10d | — | — |
+| gathio | lowercasename/gathio:latest | ✅ healthy | 10d | [events.patriark.org](https://events.patriark.org) | — |
 
 ## Homepage (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| homepage | gethomepage/homepage:latest | ⚠️ unhealthy | 3d | [patriark.org](https://patriark.org) | — |
+| homepage | gethomepage/homepage:latest | ✅ healthy | 10d | [patriark.org](https://patriark.org) | — |
 
 ## Monitoring (9)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| alert-discord-relay | localhost/alert-discord-relay:latest | ⚠️ unhealthy | 3d | — | [guide](10-services/guides/alert-discord-relay.md) |
-| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ healthy | 3d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ healthy | 7h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| grafana | grafana/grafana:latest | ⚠️ unhealthy | 3d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| loki | grafana/loki:latest | — no check | 3d | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| node_exporter | quay.io/prometheus/node-exporter:latest | ✅ healthy | 7h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 3d | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| promtail | grafana/promtail:latest | ✅ healthy | 3d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| unpoller | unpoller/unpoller:latest | ⚠️ unhealthy | 3d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| alert-discord-relay | localhost/alert-discord-relay:latest | ✅ healthy | 10d | — | [guide](10-services/guides/alert-discord-relay.md) |
+| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ healthy | ~anh | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ healthy | 6d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| grafana | grafana/grafana:latest | ✅ healthy | 10d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| loki | grafana/loki:latest | — no check | 4m | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| node_exporter | quay.io/prometheus/node-exporter:latest | ✅ healthy | 6d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 10d | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| promtail | grafana/promtail:latest | ✅ healthy | 3m | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| unpoller | unpoller/unpoller:latest | ✅ healthy | 25m | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
 
 ---
 
 ## Statistics
 
-- **Total Running:** 31
-- **Total Defined:** 31
-- **System Load:** 0,40, 0,49, 0,43
+- **Total Running:** 32
+- **Total Defined:** 32
+- **System Load:** 1,85, 2,39, 2,07
 
 ---
 

--- a/quadlets/loki.container
+++ b/quadlets/loki.container
@@ -13,7 +13,7 @@ Network=systemd-monitoring:ip=10.89.4.83
 
 # Loki configuration and data
 Volume=%h/containers/config/loki/loki-config.yml:/etc/loki/local-config.yaml:ro,Z
-Volume=/mnt/btrfs-pool/subvol7-containers/loki:/loki:Z
+Volume=/mnt/btrfs-pool/subvol8-db/loki:/loki:Z
 
 # Loki command line arguments
 Exec=-config.file=/etc/loki/local-config.yaml

--- a/quadlets/nextcloud-db.container
+++ b/quadlets/nextcloud-db.container
@@ -33,6 +33,7 @@ Label=prometheus.scrape=true
 Label=prometheus.port=3306
 
 [Service]
+Slice=container.slice
 Restart=on-failure
 TimeoutStartSec=300
 

--- a/quadlets/nextcloud-redis.container
+++ b/quadlets/nextcloud-redis.container
@@ -29,6 +29,7 @@ Label=prometheus.scrape=true
 Label=prometheus.port=6379
 
 [Service]
+Slice=container.slice
 Restart=on-failure
 TimeoutStartSec=120
 

--- a/quadlets/nextcloud.container
+++ b/quadlets/nextcloud.container
@@ -70,6 +70,7 @@ Label=prometheus.port=80
 Label=prometheus.path=/ocs/v2.php/apps/serverinfo/api/v1/info
 
 [Service]
+Slice=container.slice
 Restart=on-failure
 TimeoutStartSec=300
 

--- a/quadlets/qbittorrent.container
+++ b/quadlets/qbittorrent.container
@@ -9,8 +9,12 @@ ContainerName=qbittorrent
 HostName=qbittorrent
 AutoUpdate=registry
 Network=systemd-reverse_proxy:ip=10.89.2.85
-# No PublishPort - WebUI accessible only via Traefik reverse proxy
-# No BT port published - operates in passive/NAT mode (outbound connections only)
+# No PublishPort - WebUI (port 8085, set via WEBUI_PORT below) accessible only
+# via Traefik reverse proxy. No BT port published - Session\Port=30069 is set
+# in config/qbittorrent/qBittorrent/qBittorrent.conf but qBt operates in
+# passive/NAT mode (outbound connections only), so no UDM forward is required.
+# NOTE: `podman port qbittorrent` reports 6881/tcp, 6881/udp, 8080/tcp from the
+# upstream image's EXPOSE directives - those are NOT the actual ports in use.
 
 # linuxserver.io PUID/PGID
 Environment=PUID=1000

--- a/quadlets/unpoller.container
+++ b/quadlets/unpoller.container
@@ -44,6 +44,8 @@ NoNewPrivileges=true
 SecurityLabelDisable=false
 
 [Service]
+Slice=container.slice
+
 # Resource limits
 MemoryMax=256M
 MemoryHigh=230M


### PR DESCRIPTION
## Summary

Closes Tier 3 of the [2026-04-23 security posture punchlist](docs/98-journals/2026-04-23-security-posture-punchlist-private.md). Three hygiene items shipped together. The Loki migration also unblocks ADR-025's deferred DB migration by tracing and resolving the `chattr +C` EINVAL that ADR-027 had recorded as unsolved on kernel 6.19.

- **T3.1 Slice= cgroup placement** — added `Slice=container.slice` to nextcloud, nextcloud-db, nextcloud-redis, unpoller. Closes audit finding SA-CTR-11.
- **T3.2 Loki on subvol8-db with NOCOW** — 1.1G of Loki data moved off snapshotted `subvol7-containers` onto the dedicated NOCOW-capable subvolume. New writes inherit `+C`. Active ingest verified.
- **T3.3 qBittorrent port-declaration audit** — comments updated to clarify the `podman port` mismatch is image-level metadata (EXPOSE), not a quadlet drift.

## ADR-027 update — EINVAL solved

ADR-027 had accepted `chattr +C` returning EINVAL as unsolved (\"reasons not yet traced\"). Root cause turned out to be the inherited `m` (no-compress) flag from `btrfs property set compression none` on the subvol root. The `m` and `+C` flags are mutually exclusive at the inode level. Workaround: drop `m` first, then set `+C`.

```bash
sudo mkdir -p /mnt/btrfs-pool/subvol8-db/<tenant>
sudo chattr -m /mnt/btrfs-pool/subvol8-db/<tenant>
sudo chattr +C /mnt/btrfs-pool/subvol8-db/<tenant>
```

ADR-027 now documents this workaround. This unblocks ADR-025's deferred DB migration plan.

## Side-findings

- `nextcloud-db` on subvol7-containers has **no `+C` flag** despite being a MariaDB instance with InnoDB random-write patterns. Cannot retrofit on populated dir. Flagged for phase 4 of the long-term DB migration strategy.
- `traefik-access` Loki queries returning empty during quiet hours is **correct behavior** (Traefik filter is `statusCodes: [\"400-599\"]`). Documented in handoff journal so a fresh session doesn't chase a non-bug.

## Companion docs

- [`docs/98-journals/2026-04-28-db-migration-to-subvol8-strategy.md`](docs/98-journals/2026-04-28-db-migration-to-subvol8-strategy.md) — long-term, risk-graduated 5-phase plan: prometheus → gathio-db → home-assistant → nextcloud-db → immich-postgres. ≥30-day soak between phases, halt-and-re-evaluate gates, no deadline. Supersedes ADR-025's \"deferred until 2026-06-18\" framing.
- [`docs/98-journals/2026-04-28-traefik-access-empty-query-investigation.md`](docs/98-journals/2026-04-28-traefik-access-empty-query-investigation.md) — investigation handoff with deliberate-4xx test recipe.

## Verification

- ✓ `systemctl --user is-active nextcloud nextcloud-db nextcloud-redis unpoller loki promtail` → all active
- ✓ `systemd-cgls --user-unit nextcloud.service` → confirms `container.slice` cgroup placement
- ✓ `lsattr /mnt/btrfs-pool/subvol8-db/loki/*` → `+C` set on chunks/, compactor/, rules/, tsdb-cache/, tsdb-index/, wal/
- ✓ Promtail post-restart: zero errors
- ✓ Loki ingest: 1322 `systemd-journal` entries / 30s window (proves new path is healthy)
- ✓ `du -sh` on old vs new path: 1.1G == 1.1G, byte-perfect rsync
- ✓ Old `subvol7-containers/loki` path retained as rollback artifact (tracked in #181)

## Test plan

- [ ] Confirm Grafana dashboards still render Loki panels (Logs Browser, traefik-access)
- [ ] Confirm Nextcloud login + file listing works (Slice= restart-induced regression check)
- [ ] Confirm UnPoller scrape continues to feed UniFi panels in Grafana
- [ ] Monitor Loki for 24h: zero `level=error` lines in `journalctl --user -u loki.service`
- [ ] Verify daily BTRFS snapshot of subvol7-containers no longer pins Loki extents (check on next snapshot run)

## Related

- #181 — Old Loki path cleanup (≥7-day soak required)
- ADR-025 (deferred DB migration) — strategy supersedes its deferral framing
- ADR-027 (forward-only NOCOW placement) — tenant table updated, workaround documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)