### PR TITLE
chore: bump Immich v2.6.3 → v2.7.5 (server + ML)

### DIFF
--- a/quadlets/immich-ml.container
+++ b/quadlets/immich-ml.container
@@ -4,7 +4,7 @@ After=network-online.target photos-network.service
 Wants=network-online.target photos-network.service
 
 [Container]
-Image=ghcr.io/immich-app/immich-machine-learning:v2.6.3
+Image=ghcr.io/immich-app/immich-machine-learning:v2.7.5
 ContainerName=immich-ml
 
 # Network (isolated - only on photos network)

--- a/quadlets/immich-server.container
+++ b/quadlets/immich-server.container
@@ -5,7 +5,7 @@ Wants=network-online.target photos-network.service
 Requires=postgresql-immich.service redis-immich.service
 
 [Container]
-Image=ghcr.io/immich-app/immich-server:v2.6.3
+Image=ghcr.io/immich-app/immich-server:v2.7.5
 ContainerName=immich-server
 
 # Run as non-root user (security: ADR-001 Rootless Containers)


### PR DESCRIPTION
## Summary

Routine upstream tracking. Per CLAUDE.md update strategy, Immich is intentionally pinned (tight ML/postgres coupling); server and ML must be bumped together to the same version.

- `immich-server:v2.6.3` → `v2.7.5`
- `immich-machine-learning:v2.6.3` → `v2.7.5`
- `postgresql-immich` and `redis-immich` untouched — no version coupling required for this bump

## Procedure (already executed on host)

1. `podman pull` both images first — image fetch is the most likely failure mode and runs against unchanged units
2. Edit both quadlet `Image=` lines on a feature branch
3. `systemctl --user daemon-reload && systemctl --user restart immich-server immich-ml`
4. Wait for `(healthy)` from both containers, verify migrations ran cleanly

## Verification

```
$ curl -sk https://photos.patriark.org/api/server/version
{"major":2,"minor":7,"patch":5}

$ podman exec immich-ml python3 -c "import urllib.request; print(urllib.request.urlopen('http://127.0.0.1:3003/ping').read())"
b'pong'

$ podman ps | grep immich
immich-ml      Up 5 minutes (healthy)
immich-server  Up 4 minutes (healthy)

$ podman inspect immich-server --format '{{.ImageName}}'
ghcr.io/immich-app/immich-server:v2.7.5

$ journalctl --user -u immich-server --since 8m | grep Migration
LOG [Microservices:DatabaseRepository] Running migrations
LOG [Microservices:DatabaseRepository] Migration "1774548649115-AddChecksumAlgorithm.ts" succeeded
LOG [Microservices:DatabaseRepository] Migration "1775165531374-AddPersonNameTrigramIndex" succeeded
LOG [Microservices:DatabaseRepository] Finished running migrations
LOG [Microservices:PluginService] Plugin immich-core is up to date (version 2.0.1). Skipping
```

Two schema migrations applied during the v2.6→v2.7 transition (checksum-algorithm column + person-name trigram index). Both succeeded; no rollback needed.

## Test plan
- [x] Both images pulled before any unit change (fail-early on registry issues)
- [x] Quadlets edited and `daemon-reload`'d
- [x] Both containers `(healthy)` post-restart
- [x] DB migrations ran clean (no manual intervention needed)
- [x] API serves `{"major":2,"minor":7,"patch":5}`
- [x] ML `/ping` reachable
- [ ] Soak: confirm a manual photo upload + thumbnail generation cycle still works end-to-end (UI test, not curl)
- [ ] Soak: confirm ML face/object recognition still classifies new uploads correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)