### PR TITLE
fix: workaround ABS bug #4630 — extend access token to 24h

### DIFF
--- a/quadlets/audiobookshelf.container
+++ b/quadlets/audiobookshelf.container
@@ -28,6 +28,12 @@ Network=systemd-reverse_proxy:ip=10.89.2.74
 Environment=TZ=Europe/Oslo
 Environment=PORT=80
 
+# Auth token lifetimes — workaround for upstream bug #4630
+# Default 1h access token forces frequent refresh; rotation has no grace period,
+# so any lost refresh response (mobile network transition, app suspend) permanently
+# breaks the session. Longer access token = fewer refreshes = fewer broken sessions.
+Environment=ACCESS_TOKEN_EXPIRY=86400
+
 # Config & metadata (exclusive - NOCOW for SQLite)
 Volume=/mnt/btrfs-pool/subvol7-containers/audiobookshelf/config:/config:Z
 Volume=/mnt/btrfs-pool/subvol7-containers/audiobookshelf/metadata:/metadata:Z


### PR DESCRIPTION
## Summary

Set `ACCESS_TOKEN_EXPIRY=86400` on the audiobookshelf container to mitigate frequent Prologue iOS logouts (~once per day). This is a workaround for [advplyr/audiobookshelf#4630](https://github.com/advplyr/audiobookshelf/issues/4630), an open upstream bug.

## Root cause

`rotateTokensForSession` in `audiobookshelf/server/auth/TokenManager.js` overwrites the session row's `refreshToken` and persists it **before** the client confirms receipt of the new token, with no grace window or idempotency. If the rotation response is lost mid-flight — mobile network handoff, app suspend, dropped TCP — the client is stuck with a refresh token that no session row matches. On the next refresh attempt the server returns `Session not found for refresh token` and the app forces re-login.

## Forensics

Decoded the failed JWT's `iat` and compared to the session row's `updatedAt` across two failure events:

| Event | Failed JWT `iat` | Session `updatedAt` | Gap |
|---|---|---|---|
| Failure 1 | T₀ | T₀ + 92 min | ~92 min |
| Failure 2 | T₀ | T₀ + 70 min | ~70 min |

In both cases the server **did** rotate the session after the failing token was issued — proving the failure mode is a lost rotation response, not server-side session loss. The Firefox web client on the same server has been alive 60+ days with no failures (atomic `Set-Cookie` is immune).

Full forensics writeup ready to post to upstream issue at `docs/99-reports/abs-issue-4630-forensics.md` (gitignored, local only).

## Trade-off

- **Before:** access token expires every 1h → ~24 refresh attempts per day → ~24 chances to lose a rotation
- **After:** access token expires every 24h → ~1 refresh attempt per day → ~24× lower per-day failure probability
- **Cost:** stolen access token is valid for 24h instead of 1h. Acceptable: refresh-token lifetime is still 30 days, no other auth in front of audiobookshelf.

## Test plan

- [x] Container restarts cleanly with new env var
- [x] Startup log: `Access token expiry set from ENV variable to 86400 seconds`
- [x] HTTPS endpoint returns 200 through Traefik
- [ ] Observe Prologue iOS logout frequency over next 7 days
- [ ] Revert if upstream merges a proper fix (grace-window or idempotency-cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)