### PR TITLE
fix: remove unreachable HA rule from Authelia access_control (#148)

### DIFF
--- a/config/authelia/configuration.yml
+++ b/config/authelia/configuration.yml
@@ -78,11 +78,13 @@ access_control:
         - 'loki.patriark.org'
         - 'home.patriark.org'
         - 'patriark.org'
-        - 'ha.patriark.org'
         - 'torrent.patriark.org'
       policy: two_factor
       subject:
         - 'group:admins'
+
+    # Home Assistant (ha.patriark.org) - Not protected by Authelia (uses native auth)
+    # See config/traefik/dynamic/routers.yml: home-assistant-secure router has no authelia@file
 
     # Tier 2: Application-Specific Access Control
     # (Jellyfin rules removed - router uses native auth, not Authelia middleware)


### PR DESCRIPTION
## Summary

- Removed `ha.patriark.org` from Authelia's Tier 1 admin `access_control` rule. The `home-assistant-secure` router in `config/traefik/dynamic/routers.yml` has no `authelia@file` middleware (HA uses its built-in auth), so the entry was dead config — never evaluated, but misleading for future audit review.
- Added a short pointer comment matching the existing Jellyfin/Immich removal markers in the same file.

## Verification

```
$ grep -n 'ha.patriark.org' config/authelia/configuration.yml
86:    # Home Assistant (ha.patriark.org) - Not protected by Authelia (uses native auth)
```
Only match is the explanatory comment, as the issue's verification step anticipated.

```
$ systemctl --user restart authelia.service
$ systemctl --user is-active authelia.service
active
```
Authelia journalctl shows clean startup, no config errors.

```
$ curl -s -D - https://ha.patriark.org/ -o /dev/null | head -1
HTTP/2 200
```
HA still serves directly through Traefik (HA's own headers in the response — CSP `frame-ancestors 'self'`, HA-specific `connect-src ws: wss:`). No redirect to `sso.patriark.org`, confirming Authelia is not in the path.

## Test plan

- [x] Confirm only the explanatory comment remains for `ha.patriark.org` in Authelia config
- [x] Authelia restarts cleanly with no config errors
- [x] HA endpoint reachable end-to-end without Authelia interception
- [ ] Reviewer sanity-check: no other config still references `ha.patriark.org` or `home-assistant` in `config/authelia/` (verified locally — only the new comment)

Closes #148

🤖 Generated with [Claude Code](https://claude.com/claude-code)