### PR TITLE
feat: deploy redis & postgres prometheus exporters (1/2 for #150)

### DIFF
--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -125,3 +125,28 @@ scrape_configs:
           service: 'home-assistant'
     metrics_path: '/api/prometheus'
     bearer_token_file: '/run/secrets/ha-prometheus-token'
+
+  # Redis exporter — redis-authelia (session cache + regulation counters)
+  # Scraped via monitoring network static IP (ADR-018)
+  - job_name: 'redis-authelia'
+    static_configs:
+      - targets: ['10.89.4.92:9121']
+        labels:
+          instance: 'fedora-htpc'
+          service: 'redis-authelia'
+
+  # Redis exporter — redis-immich (Valkey, Redis-protocol-compatible)
+  - job_name: 'redis-immich'
+    static_configs:
+      - targets: ['10.89.4.93:9121']
+        labels:
+          instance: 'fedora-htpc'
+          service: 'redis-immich'
+
+  # PostgreSQL exporter — postgresql-immich
+  - job_name: 'postgres-immich'
+    static_configs:
+      - targets: ['10.89.4.94:9187']
+        labels:
+          instance: 'fedora-htpc'
+          service: 'postgres-immich'

--- a/quadlets/postgres-exporter.container
+++ b/quadlets/postgres-exporter.container
@@ -1,0 +1,36 @@
+[Unit]
+Description=PostgreSQL Exporter for postgresql-immich (Prometheus)
+After=network-online.target photos-network.service monitoring-network.service postgresql-immich.service
+Wants=network-online.target photos-network.service monitoring-network.service
+Requires=postgresql-immich.service
+
+[Container]
+Image=quay.io/prometheuscommunity/postgres-exporter:latest
+ContainerName=postgres-exporter
+HostName=postgres-exporter
+
+# Reach postgresql-immich on photos; expose metrics on monitoring.
+Network=systemd-monitoring:ip=10.89.4.94
+Network=systemd-photos:ip=10.89.5.94
+
+# Credentials: dedicated prometheus_exporter role with pg_monitor (created out-of-band, not in quadlet).
+Secret=postgres-exporter-password,type=env,target=DATA_SOURCE_PASS
+Environment=DATA_SOURCE_URI=postgresql-immich:5432/immich?sslmode=disable
+Environment=DATA_SOURCE_USER=prometheus_exporter
+
+HealthCmd=wget --no-verbose --tries=1 -O /dev/null http://localhost:9187/metrics || exit 1
+HealthInterval=30s
+HealthTimeout=5s
+HealthRetries=3
+AutoUpdate=registry
+
+[Service]
+Slice=container.slice
+Restart=on-failure
+TimeoutStartSec=60
+
+MemoryMax=128M
+MemoryHigh=115M
+
+[Install]
+WantedBy=default.target

--- a/quadlets/redis-authelia-exporter.container
+++ b/quadlets/redis-authelia-exporter.container
@@ -1,0 +1,32 @@
+[Unit]
+Description=Redis Exporter for redis-authelia (Prometheus)
+After=network-online.target auth_services-network.service monitoring-network.service redis-authelia.service
+Wants=network-online.target auth_services-network.service monitoring-network.service
+Requires=redis-authelia.service
+
+[Container]
+Image=quay.io/oliver006/redis_exporter:latest
+ContainerName=redis-authelia-exporter
+HostName=redis-authelia-exporter
+
+# Reach redis-authelia on auth_services; expose metrics on monitoring (static IPs per ADR-018).
+Network=systemd-monitoring:ip=10.89.4.92
+Network=systemd-auth_services:ip=10.89.3.92
+
+Environment=REDIS_ADDR=redis://redis-authelia:6379
+
+# No HealthCmd: oliver006/redis_exporter is a scratch image (no shell/wget).
+# Process health is enforced by Restart=on-failure; scrape health is visible
+# via Prometheus `redis_up` metric for redis-authelia.
+AutoUpdate=registry
+
+[Service]
+Slice=container.slice
+Restart=on-failure
+TimeoutStartSec=60
+
+MemoryMax=64M
+MemoryHigh=58M
+
+[Install]
+WantedBy=default.target

--- a/quadlets/redis-immich-exporter.container
+++ b/quadlets/redis-immich-exporter.container
@@ -1,0 +1,32 @@
+[Unit]
+Description=Redis Exporter for redis-immich (Prometheus)
+After=network-online.target photos-network.service monitoring-network.service redis-immich.service
+Wants=network-online.target photos-network.service monitoring-network.service
+Requires=redis-immich.service
+
+[Container]
+Image=quay.io/oliver006/redis_exporter:latest
+ContainerName=redis-immich-exporter
+HostName=redis-immich-exporter
+
+# Reach redis-immich (Valkey, Redis-protocol-compatible) on photos; expose metrics on monitoring.
+Network=systemd-monitoring:ip=10.89.4.93
+Network=systemd-photos:ip=10.89.5.93
+
+Environment=REDIS_ADDR=redis://redis-immich:6379
+
+# No HealthCmd: oliver006/redis_exporter is a scratch image (no shell/wget).
+# Process health is enforced by Restart=on-failure; scrape health is visible
+# via Prometheus `redis_up` metric for redis-immich.
+AutoUpdate=registry
+
+[Service]
+Slice=container.slice
+Restart=on-failure
+TimeoutStartSec=60
+
+MemoryMax=64M
+MemoryHigh=58M
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

First of two PRs closing #150 (audit §4 MEDIUM-8). Adds the three exporter containers and Prometheus scrape configs; dashboards land in PR 2.

- `redis-authelia-exporter` — `quay.io/oliver006/redis_exporter`, talks to redis-authelia on `auth_services`, exposes metrics on `monitoring` (10.89.4.92:9121)
- `redis-immich-exporter` — same exporter image, talks to redis-immich (Valkey) on `photos`, exposes on `monitoring` (10.89.4.93:9121)
- `postgres-exporter` — `quay.io/prometheuscommunity/postgres-exporter`, talks to postgresql-immich on `photos`, exposes on `monitoring` (10.89.4.94:9187)

Each exporter is multi-network with static IPs per ADR-018. Prometheus scrapes by IP on the monitoring network — no DNS-resolution ambiguity.

## Out-of-repo state changes

Two changes that aren't in this diff but are required for the deployment to work. If reproducing on a fresh system, run these before `systemctl --user daemon-reload`:

```bash
# 1. Generate and store the postgres exporter password
openssl rand -base64 32 | tr -d '/+=' | head -c 40 | podman secret create postgres-exporter-password -

# 2. Create the read-only monitoring role in postgresql-immich
podman exec -i postgresql-immich psql -U immich -d immich <<SQL
CREATE ROLE prometheus_exporter LOGIN PASSWORD '<value-from-step-1>';
GRANT pg_monitor TO prometheus_exporter;
SQL
```

The role has `pg_monitor` only — least privilege, no DML, no schema access.

## Implementation notes

- Redis exporters have **no `HealthCmd`** because `oliver006/redis_exporter` is a scratch image (no `wget`/shell). Process health is `Restart=on-failure`; the real signal is the Prometheus `redis_up` metric.
- Memory caps: 64M for redis exporters, 128M for postgres exporter. Total monitoring overhead ~150M.
- `redis-immich` is Valkey, not Redis — but Valkey is wire-protocol-compatible and oliver006/redis_exporter works against it transparently (verified: 77 connected clients reported).

## Test plan

- [x] All three containers `Up` in `podman ps` (postgres-exporter healthy; redis exporters no healthcheck by design)
- [x] Metrics endpoints return expected series (`redis_up`, `pg_up`, etc.)
- [x] Prometheus targets show `health=up` for `redis-authelia`, `redis-immich`, `postgres-immich`
- [x] Prometheus query `redis_up or pg_up` returns 3 series, all = 1
- [ ] Reviewer sanity-check: no extra container restarts in `podman ps` after merge

## Verification output

```
$ podman exec prometheus wget -qO- 'http://localhost:9090/api/v1/query?query=redis_up+or+pg_up'
redis-immich    = 1
redis-authelia  = 1
postgres-immich = 1
```

## Follow-up (PR 2)

Provision Grafana dashboards via `config/grafana/provisioning/dashboards/`:
- Redis: community ID 763
- Postgres: community ID 9628

Refs #150

🤖 Generated with [Claude Code](https://claude.com/claude-code)