### PR TITLE
feat: surface Urd drift telemetry gauges in backup-health dashboard

### DIFF
--- a/config/grafana/provisioning/dashboards/json/backup-health.json
+++ b/config/grafana/provisioning/dashboards/json/backup-health.json
@@ -686,6 +686,190 @@
       ],
       "title": "Snapshot Count Trends Over Time",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Rolling time-windowed churn rate per subvolume, computed from wire_bytes of recent successful incremental sends. Useful for capacity planning and detecting sustained write-rate growth. Absent for cold-start subvolumes and for subvolumes whose latest in-window send was a full send (see neighboring panel). Added in Urd v0.16 (UPI 030).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "Bps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 32
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "backup_subvolume_churn_bytes_per_second",
+          "legendFormat": "{{subvolume}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Subvolume Churn Rate (rolling window)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Size of the most recent in-window full send per subvolume. Present only for subvolumes whose latest send was a full send (typically transient/storage-critical subvolumes that re-baseline). An empty panel is expected when all in-window sends are incremental. Use to baseline expected full-send sizes for capacity planning. Added in Urd v0.16 (UPI 030).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "lineWidth": 1,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 32
+      },
+      "id": 8,
+      "options": {
+        "barRadius": 0,
+        "barWidth": 0.97,
+        "fullHighlight": false,
+        "groupWidth": 0.7,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "orientation": "horizontal",
+        "showValue": "always",
+        "stacking": "none",
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        },
+        "xTickLabelRotation": 0,
+        "xTickLabelSpacing": 0
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "backup_subvolume_last_full_send_bytes",
+          "legendFormat": "{{subvolume}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Last Full Send Size (per subvolume)",
+      "type": "barchart"
     }
   ],
   "refresh": "30s",
@@ -706,6 +890,6 @@
   "timezone": "browser",
   "title": "Backup Health Dashboard",
   "uid": "backup-health",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }

--- a/docs/00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md
+++ b/docs/00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md
@@ -71,6 +71,26 @@ Key metrics consumed by homelab alerts (`config/prometheus/alerts/backup-alerts.
 | `backup_send_type` | gauge | `subvolume` | Grafana dashboard |
 | `backup_external_drive_mounted` | gauge | — | Grafana dashboard |
 | `backup_external_free_bytes` | gauge | — | Grafana dashboard |
+| `backup_subvolume_churn_bytes_per_second` | gauge | `subvolume` | `backup-health` Grafana dashboard (added Urd v0.16, [UPI 030](https://github.com/vonrobak/urd/pull/108)) |
+| `backup_subvolume_last_full_send_bytes` | gauge | `subvolume` | `backup-health` Grafana dashboard (added Urd v0.16, [UPI 030](https://github.com/vonrobak/urd/pull/108)) |
+
+**Drift telemetry (Urd v0.16+).** Urd computes a rolling time-windowed churn rate per
+subvolume from `wire_bytes` of recent successful sends, and emits two gauges:
+
+- `backup_subvolume_churn_bytes_per_second` — present for subvolumes whose latest
+  in-window send was incremental. Absent for cold-start subvolumes and for subvolumes
+  whose latest in-window send was a full send.
+- `backup_subvolume_last_full_send_bytes` — present for subvolumes whose latest
+  in-window send was a full send (e.g. transient or storage-critical subvolumes that
+  re-baseline). Absent otherwise.
+
+The two are mutually exclusive by design: a subvolume has either a churn rate (last
+send was incremental) or a last-full-send size (last send was a full send), never both.
+
+Two panels in the `backup-health` Grafana dashboard surface these gauges for capacity
+planning: a churn-rate timeseries (per-subvolume) and a last-full-send-size barchart.
+No alerts consume these yet — thresholds will be defined once enough data has
+accumulated to establish per-subvolume baselines (target: ~2–4 weeks post-deployment).
 
 ### File paths
 
@@ -78,9 +98,17 @@ Key metrics consumed by homelab alerts (`config/prometheus/alerts/backup-alerts.
 |------|---------|
 | `~/.config/urd/urd.toml` | Urd configuration |
 | `~/.local/share/urd/urd.db` | SQLite run history |
-| `~/.local/share/urd/heartbeat.json` | Health signal (Sentinel reads this) |
+| `~/.local/share/urd/heartbeat.json` | Health signal — read by Urd's own Sentinel daemon. **Not consumed by the homelab.** See note below. |
 | `~/containers/data/backup-metrics/backup.prom` | Prometheus metrics (shared with homelab) |
 | `~/containers/data/backup-logs/` | Log directory |
+
+**On `heartbeat.json`.** The heartbeat is an internal Urd contract between its nightly
+runner and the Sentinel daemon. The homelab consumes Urd state exclusively through the
+Prometheus textfile (`backup.prom`); there is no JSON parser on this side and none is
+planned. Urd versions the heartbeat schema (`schema_version`, currently `3` as of UPI
+030) for its own internal evolution. If a future homelab feature ever needs to read the
+heartbeat directly, add a new ADR entry covering the parser's schema tolerance — do not
+quietly take a dependency on the JSON shape.
 
 ### Notification path
 


### PR DESCRIPTION
## Summary

Consumes the two new Prometheus gauges added by Urd v0.16 ([UPI 030](https://github.com/vonrobak/urd/pull/108)):

- `backup_subvolume_churn_bytes_per_second` → **Subvolume Churn Rate** timeseries panel (per-subvolume, `Bps` unit, `lastNotNull/mean/max` legend calcs)
- `backup_subvolume_last_full_send_bytes` → **Last Full Send Size** horizontal barchart (per-subvolume, `bytes` unit)

Both panels added at the bottom of the `backup-health` dashboard (y=32, 12+12 split) following the existing row layout. Each carries a `description` (info-hover) explaining when the metric is absent — the two are mutually exclusive by design.

ADR-021 updated:
- Metrics table: `Used by` column changed from "Not yet consumed" → `backup-health` Grafana dashboard.
- Drift telemetry section: documents the panels and the deferred-alerts rationale (need ~2–4 weeks of baseline data before setting thresholds).

No alerts in this PR — thresholds are guesses without baseline data. Revisit once per-subvolume churn distributions are visible in Prometheus.

## Verification

- ✓ JSON validated (`python3 -c "json.load(...)"`), 8 panels total, no schema drift
- ✓ Gauges already flowing — `~/containers/data/backup-metrics/backup.prom` contains both metric families (Urd v0.16.2 installed)
- ✓ Grafana provisioning is `updateIntervalSeconds: 30 / allowUiUpdates: true` — auto-reload, no restart
- ✓ Pre-commit Traefik config check passed
- ✓ GPG-signed commit

## Test Plan

- [ ] Open Grafana `backup-health` dashboard within ~30s of merge
- [ ] Confirm "Subvolume Churn Rate (rolling window)" panel renders with per-subvolume lines
- [ ] Confirm "Last Full Send Size (per subvolume)" panel renders (may be empty — expected if no in-window full sends)
- [ ] Hover the panel info icons to verify descriptions render correctly
- [ ] After next nightly Urd run (04:00), confirm churn values update

## Related

- Urd PR: [vonrobak/urd#108 (UPI 030)](https://github.com/vonrobak/urd/pull/108)
- ADR-021: integration contract update
- Future work: define alert thresholds after ~2–4 weeks of baseline data

🤖 Generated with [Claude Code](https://claude.com/claude-code)