### PR TITLE
fix: stop leaking nextcloud-redis password via argv (#154)

### DIFF
--- a/quadlets/nextcloud-redis.container
+++ b/quadlets/nextcloud-redis.container
@@ -8,9 +8,11 @@ Wants=network-online.target
 Image=docker.io/library/redis:7-alpine
 ContainerName=nextcloud-redis
 
-# Redis password authentication (using podman secret)
-Secret=nextcloud_redis_password
-Exec=sh -c 'redis-server --requirepass "$(cat /run/secrets/nextcloud_redis_password)"'
+# Redis password authentication via REDISCLI_AUTH env (avoids password on argv).
+# redis-cli auto-reads REDISCLI_AUTH; redis-server gets it via shell expansion
+# and rewrites its own argv post-startup. See issue #154.
+Secret=nextcloud_redis_password,type=env,target=REDISCLI_AUTH
+Exec=sh -c 'exec redis-server --requirepass "$REDISCLI_AUTH"'
 
 # Storage
 Volume=/mnt/btrfs-pool/subvol7-containers/nextcloud-redis/data:/data:Z
@@ -19,7 +21,7 @@ Volume=/mnt/btrfs-pool/subvol7-containers/nextcloud-redis/data:/data:Z
 Network=systemd-nextcloud
 
 # Health check
-HealthCmd=sh -c 'redis-cli --no-auth-warning -a "$(cat /run/secrets/nextcloud_redis_password)" ping'
+HealthCmd=redis-cli ping
 HealthInterval=30s
 HealthTimeout=10s
 HealthRetries=5


### PR DESCRIPTION
## Summary
Closes #154. Switches `nextcloud-redis.container` to pass the redis password via the `REDISCLI_AUTH` environment variable instead of a file-mounted secret, eliminating the recurring argv exposure during healthchecks.

## What changed
- `Secret=` now uses `type=env,target=REDISCLI_AUTH` (no longer mounted at `/run/secrets/`)
- `Exec=sh -c 'exec redis-server --requirepass "$REDISCLI_AUTH"'` — shell `exec`'s into redis-server, which then sanitizes its own argv on startup
- `HealthCmd=redis-cli ping` — redis-cli auto-reads `REDISCLI_AUTH`, so the password never appears on argv

## Why a slightly different approach than the issue proposed
While investigating I confirmed that **redis-server already rewrites its own argv** at startup (the verification command in the issue actually shows a clean cmdline today). The real, recurring leak was the **HealthCmd** running every 30s as a fresh `sh -c 'redis-cli ... -a "<password>" ping'` process. So the fix targets that:

| Surface | Before | After |
|---|---|---|
| `redis-server` cmdline | Clean (Redis self-sanitizes) | Clean (same) |
| Healthcheck argv (every 30s) | **Password visible for tens of ms** | No password on argv |
| `/run/secrets/` file | Present, world-readable inside container | Removed |

## Verification
```
$ tr '\0' ' ' < /proc/$(podman inspect nextcloud-redis --format '{{.State.Pid}}')/cmdline
redis-server *:6379

$ podman healthcheck run nextcloud-redis
# (exit 0)

$ podman exec nextcloud php -r '$r=new Redis(); $r->connect("nextcloud-redis",6379); $r->auth(getenv("REDIS_HOST_PASSWORD")); echo $r->ping();'
+PONG
```

## Test plan
- [x] `systemctl --user daemon-reload && systemctl --user restart nextcloud-redis.service` — service starts cleanly
- [x] `/proc/<pid>/cmdline` of redis-server contains no password
- [x] `podman healthcheck run nextcloud-redis` exits 0
- [x] Nextcloud successfully authenticates and pings via `REDIS_HOST_PASSWORD` env
- [ ] Reviewer: confirm Nextcloud sessions remain valid (no forced logout) after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)