### PR TITLE
fix: reconcile Nextcloud middleware with Immich stress-test findings (closes #146)

### DIFF
--- a/config/traefik/dynamic/middleware.yml
+++ b/config/traefik/dynamic/middleware.yml
@@ -274,23 +274,9 @@ http:
           - text/event-stream  # Don't compress SSE
         minResponseBodyBytes: 1024  # Only compress responses > 1KB
 
-    # ═══════════════════════════════════════════════════════════
-    # RELIABILITY PATTERNS
-    # ═══════════════════════════════════════════════════════════
-
-    # Circuit breaker (prevents cascade failures)
-    # Tuned for low-traffic services: higher network error threshold (50%)
-    # to prevent false positives from single failures, while still protecting
-    # against server errors (30% threshold for 5xx responses)
-    circuit-breaker:
-      circuitBreaker:
-        expression: "NetworkErrorRatio() > 0.50 || ResponseCodeRatio(500, 600, 0, 600) > 0.30"
-        checkPeriod: 10s
-        fallbackDuration: 30s
-        recoveryDuration: 10s
-
-    # Retry logic for transient failures
-    retry:
-      retry:
-        attempts: 3
-        initialInterval: 100ms
+    # Circuit-breaker and retry middlewares were removed 2026-05-15 (issue #146).
+    # The homelab converged on no-circuit-breaker / no-retry across all routers
+    # after the 2026-02-08 Immich stress test: client ECONNRESET from sync clients
+    # inflates NetworkErrorRatio (false trips), and retry cannot replay streamed
+    # request bodies. Reintroduce only with a router-specific definition and
+    # documented justification.

--- a/config/traefik/dynamic/routers.yml
+++ b/config/traefik/dynamic/routers.yml
@@ -152,6 +152,14 @@ http:
     # CalDAV/CardDAV clients and web UI use Nextcloud's built-in auth
     # NO security-headers middleware (Nextcloud sets own CSP)
     # HSTS-only middleware (Nextcloud sets CSP, we add HSTS)
+    # NOTE: No circuit-breaker or retry middleware. Same rationale as Immich
+    # (2026-02-08 stress test). For upload-heavy services with mobile/desktop
+    # sync clients:
+    #   - Circuit breaker trips on client ECONNRESET (sync clients disconnect
+    #     constantly: sleep, network changes, app backgrounding ≠ backend failure)
+    #   - Retry can't replay streamed request bodies; WebDAV chunk PUT bodies
+    #     are consumed once forwarded. Nextcloud sync clients have their own
+    #     retry logic at the WebDAV layer.
     nextcloud-secure:
       rule: "Host(`nextcloud.patriark.org`)"
       service: "nextcloud"
@@ -160,8 +168,6 @@ http:
       middlewares:
         - crowdsec-bouncer@file
         - rate-limit-nextcloud@file     # High capacity for WebDAV sync (600/min, 3000 burst for PROPFIND tree walks)
-        - circuit-breaker@file          # Prevent cascade failures
-        - retry@file                    # Retry transient errors
         - nextcloud-caldav              # CalDAV/.well-known redirects
         - hsts-only@file                # Add HSTS without conflicting with Nextcloud's CSP
       tls:


### PR DESCRIPTION
## Summary
- Removes `circuit-breaker@file` and `retry@file` from the Nextcloud router. Nextcloud was the last router still using them — every other service has already converged on removing them after the 2026-02-08 Immich stress test.
- Deletes the now-unreferenced `circuit-breaker` and `retry` middleware definitions from `middleware.yml`, leaving a comment with the rationale.
- Updates the inline comment on `nextcloud-secure` to document why, mirroring Immich's comment block.

## Why
Same failure modes the Immich stress test (2026-02-08) and Authelia SSO debugging (2026-03-31) identified apply to Nextcloud:
- **Circuit breaker:** Sync clients (iOS/Android/desktop) drop connections constantly — sleep, network changes, app backgrounding. These ECONNRESETs inflate `NetworkErrorRatio()` and false-trip the breaker. Nextcloud is single-backend localhost; no cascade to prevent.
- **Retry:** WebDAV chunk PUT bodies are streamed and consumed when forwarded. Traefik retry can't replay them. Nextcloud sync clients already retry at the WebDAV protocol layer.

ADR-013 (2025-12-20) prescribed these middlewares but predates the stress test that invalidated the pattern. No one circled back to apply the lesson to Nextcloud until now.

## Test plan
- [x] `traefik-config-validator` pre-commit hook passes
- [x] Traefik file watcher reload — no missing-middleware warnings in `podman logs traefik`
- [x] `curl -I https://nextcloud.patriark.org` → HTTP 302 → `/login` (Nextcloud's native auth landing)
- [ ] Large-file desktop sync test (e.g. several-GB file) completes without errors
- [ ] CalDAV/CardDAV sync still works (the `nextcloud-caldav` middleware is unchanged)
- [ ] Watch `journalctl --user -u nextcloud.service` for 24h post-merge — no regression

Closes #146.

🤖 Generated with [Claude Code](https://claude.com/claude-code)