### PR TITLE
feat(traefik): add sso-rate-limit middleware for authelia-portal (closes #145)

### DIFF
--- a/config/traefik/dynamic/middleware.yml
+++ b/config/traefik/dynamic/middleware.yml
@@ -123,6 +123,19 @@ http:
           ipStrategy:
             depth: 1
 
+    # Authelia portal — sized for parallel JS module loads at login.
+    # The shared rate-limit (100/min) was removed 2026-03-31 because it
+    # starved concurrent asset fetches and caused SSO blank pages.
+    # Burst covers the worst-case parallel module fetch on a cold load.
+    sso-rate-limit:
+      rateLimit:
+        average: 30
+        burst: 100
+        period: 1m
+        sourceCriterion:
+          ipStrategy:
+            depth: 1
+
     # ═══════════════════════════════════════════════════════════
     # AUTHENTICATION
     # ═══════════════════════════════════════════════════════════

--- a/config/traefik/dynamic/routers.yml
+++ b/config/traefik/dynamic/routers.yml
@@ -53,6 +53,7 @@ http:
         - websecure
       middlewares:
         - crowdsec-bouncer@file
+        - sso-rate-limit@file          # 30/min avg, burst 100 — sized for parallel module loads
         - hsts-only@file               # HSTS + strip server headers (Authelia sets own CSP)
       tls:
         certResolver: letsencrypt


### PR DESCRIPTION
## Summary
- Adds a dedicated `sso-rate-limit` middleware (avg=30, burst=100/min) for the `authelia-portal` router, restoring HTTP-layer brute-force protection that was removed on 2026-03-31 when the shared `rate-limit` starved parallel module loads
- Wires it into the `authelia-portal` middleware chain between `crowdsec-bouncer@file` and `hsts-only@file`

## Why this sizing
- `burst=100` covers the worst-case parallel JS module fetch on a cold SSO login (the exact failure mode that motivated removing the shared 100/min + burst=50 last time)
- `average=30/min` rate-limits sustained traffic — well above steady-state SSO usage but tight enough to throttle HTTP-layer brute-force on asset endpoints

## Verification (live, against running Traefik)
- 20 parallel requests to `sso.patriark.org` → all 200 (burst absorbs cold-load)
- 200 parallel requests → 100 × 200, 100 × 429 (rate-limit enforced after burst exhausted)
- SSO portal HEAD returns 200 OK, no Traefik errors in journal after dynamic config reload
- Pre-commit Traefik YAML validator passed

## Test plan
- [x] Validate YAML syntax (pre-commit hook)
- [x] Confirm parallel asset fetch within burst is not throttled
- [x] Confirm sustained brute-force triggers 429
- [x] Confirm SSO portal still serves 200 OK
- [ ] After merge: end-to-end SSO login via browser (YubiKey flow)

Closes #145.