### PR TITLE
fix(nextcloud): use shared SELinux label for /external/downloads

### DIFF
--- a/quadlets/nextcloud.container
+++ b/quadlets/nextcloud.container
@@ -44,7 +44,7 @@ Volume=/mnt/btrfs-pool/subvol5-music:/external/music:ro,z
 # Immich has exclusive :Z access to this subdirectory
 
 # External storage - read-write
-Volume=/mnt/btrfs-pool/subvol6-tmp/Downloads:/external/downloads:Z
+Volume=/mnt/btrfs-pool/subvol6-tmp/Downloads:/external/downloads:z
 Volume=/mnt/btrfs-pool/subvol1-docs:/external/user-documents:Z
 Volume=/mnt/btrfs-pool/subvol2-pics:/external/user-photos:Z
 


### PR DESCRIPTION
## Summary

- Change `/external/downloads` volume mount from `:Z` (private) to `:z` (shared) in `quadlets/nextcloud.container`.
- Ends 5 days of repo/runtime drift: the running Nextcloud container has been on `:z` since 2026-05-13, but `main` still showed `:Z`.
- Surfaced by today's security audit (SA-CMP-01 — uncommitted changes).

## Why shared (`:z`)

`/mnt/btrfs-pool/subvol6-tmp/Downloads` is written by qBittorrent (UID 100999) and read/written by Nextcloud (UID 100032). A private `:Z` label would relabel the directory for exclusive use by whichever container mounted it last, breaking the other on its next start. Shared `:z` is the correct label for this access pattern.

## Verification

- Running container already uses `:z` — confirmed in generated unit:
  ```
  /run/user/1000/systemd/generator/nextcloud.service
  Volume=/mnt/btrfs-pool/subvol6-tmp/Downloads:/external/downloads:z
  ```
- `verify-permissions.sh` reports both Nextcloud and qBittorrent can write Downloads (`[7] qBittorrent abc can write to Downloads` + `[6] Nextcloud www-data can write to Downloads`).
- No service restart required — repo is catching up to runtime.

## Test Plan

- [ ] CI / pre-commit hooks pass (Traefik + secret scan)
- [ ] `git diff main..HEAD -- quadlets/nextcloud.container` shows only the `:Z` → `:z` change
- [ ] After merge, re-run `./scripts/security-audit.sh --category compliance` and confirm SA-CMP-01 drops the quadlet from its uncommitted list

🤖 Generated with [Claude Code](https://claude.com/claude-code)