### PR TITLE
fix(scripts): daily-drift-check.sh arithmetic error + close #203 not-reproducible

### DIFF
--- a/scripts/daily-drift-check.sh
+++ b/scripts/daily-drift-check.sh
@@ -33,8 +33,13 @@ if ! "$DRIFT_SCRIPT" > "$DRIFT_OUTPUT" 2>&1; then
 fi
 
 # Parse results
-DRIFT_COUNT=$(grep -c "✗ DRIFT" "$DRIFT_OUTPUT" 2>/dev/null || echo "0")
-WARNING_COUNT=$(grep -c "⚠ WARNING" "$DRIFT_OUTPUT" 2>/dev/null || echo "0")
+# grep -c exits 1 on no-match while still printing "0"; the trailing `|| echo "0"`
+# would then concatenate to "0\n0" and break the arithmetic test below. Suppress
+# the non-zero exit and default to 0 instead.
+DRIFT_COUNT=$(grep -c "✗ DRIFT" "$DRIFT_OUTPUT" 2>/dev/null; true)
+DRIFT_COUNT=${DRIFT_COUNT:-0}
+WARNING_COUNT=$(grep -c "⚠ WARNING" "$DRIFT_OUTPUT" 2>/dev/null; true)
+WARNING_COUNT=${WARNING_COUNT:-0}
 
 # Write status to daily digest directory (consolidated Discord notification)
 DIGEST_DIR="/tmp/daily-digest"


### PR DESCRIPTION
## Summary

PR-1 of the audit-subsystem hardening initiative (see plan @ `/home/patriark/.claude/plans/tingly-noodling-lighthouse.md`). Fixes the daily drift notification breakage from #202; documents #203 as not-reproducible against current `main`.

## Changes

### #202 — `daily-drift-check.sh` arithmetic error (fixed)

Root cause: `grep -c "✗ DRIFT" file` exits 1 on no-match while still printing `0`. The trailing `|| echo "0"` then fires and appends a second `0`, producing `"0\n0"`. The subsequent `[[ "$DRIFT_COUNT" -gt 0 ]]` test fails:

```
./scripts/daily-drift-check.sh: line 43: [[: 0
0: arithmetic syntax error in expression (error token is "0")
```

This silently broke daily Discord drift notifications.

Fix: replace `|| echo "0"` with `; true` + `${VAR:-0}` — suppresses grep's non-zero exit and defaults to `0` cleanly, independent of input or grep version.

### #203 — `verify-permissions.sh` qBittorrent detection (not reproducible)

The current line 263 already uses `grep -q '^qbittorrent$'` — the exact-match pattern the issue proposes. Live reproduction on current `main`:

```
$ ./scripts/verify-permissions.sh 2>&1 | grep -A2 "Check 7\|\[7\]"
[7] Checking qBittorrent write access...
✅ PASS: qBittorrent abc can write to Multimedia (/mnt/btrfs-pool/subvol4-multimedia)
✅ PASS: qBittorrent abc can write to Downloads (/mnt/btrfs-pool/subvol6-tmp/Downloads)
```

The script is also gitignored as host-specific since `ae37201`, so any fix would be local-only. Closing #203 as not-reproducible against current state.

## Test plan

- [x] Reproduced the `[[: 0\n0: arithmetic syntax error` from #202 in a minimal shell.
- [x] After fix: `./scripts/daily-drift-check.sh` exits 0, `/tmp/daily-digest/drift-check.json` is valid JSON populated with `status`, `drift_count`, `warning_count`.
- [x] Verified #203 detection passes on the current host (qBittorrent up 4d, both mount checks PASS).

## Issue references

- Closes #202
- Closes #203 (not reproducible — see above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)