### PR TITLE
fix(security-audit): JSON hygiene + remove SA-CTR-10 inventory truncation

### DIFF
--- a/scripts/security-audit.sh
+++ b/scripts/security-audit.sh
@@ -45,6 +45,10 @@ QUIET=false
 declare -a RESULTS=()
 SCORE=100
 
+# Audit run metadata — captured at start, emitted in run_meta JSON block
+STARTED_AT="$(date -Iseconds)"
+STARTED_EPOCH=$EPOCHSECONDS
+
 # Colors (disabled for JSON/quiet)
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -761,7 +765,7 @@ run_container_checks() {
             if (( age_days > 30 )); then
                 old_images="$old_images ${img_name##*/}:${age_days}d"
             fi
-        done < <(podman images --format json 2>/dev/null | jq -r '.[] | "\(.Names[0] // .Id)\t\(.Created)"' 2>/dev/null | head -30)
+        done < <(podman images --format json 2>/dev/null | jq -r '.[] | "\(.Names[0] // .Id)\t\(.Created)"' 2>/dev/null)
         if [[ -z "$old_images" ]]; then
             record_check "SA-CTR-10" 3 containers "PASS" "All container images <30 days old"
         else
@@ -1057,6 +1061,27 @@ generate_json() {
     timestamp=$(date -Iseconds)
     local total=0 pass=0 warn=0 fail=0
 
+    # Run metadata — computed once, emitted in the run_meta JSON block below
+    local completed_at duration_seconds host audit_script_version
+    local category_json compared_against_json
+    completed_at="$timestamp"
+    duration_seconds=$(( EPOCHSECONDS - STARTED_EPOCH ))
+    host="$(hostname -s 2>/dev/null || hostname)"
+    audit_script_version="$(git -C "$SCRIPT_DIR" rev-parse --short HEAD 2>/dev/null || echo "unknown")"
+    if [[ -n "$CATEGORY" ]]; then
+        category_json="\"$CATEGORY\""
+    else
+        category_json="null"
+    fi
+    compared_against_json="null"
+    if $COMPARE; then
+        local prev_file_for_meta
+        prev_file_for_meta=$(ls -t "$HISTORY_DIR"/audit-*.json 2>/dev/null | head -1 || echo "")
+        if [[ -f "$prev_file_for_meta" ]]; then
+            compared_against_json="\"$prev_file_for_meta\""
+        fi
+    fi
+
     # Category counters
     declare -A cat_pass cat_warn cat_fail
     for cat in auth network traefik containers monitoring secrets compliance; do
@@ -1158,7 +1183,18 @@ generate_json() {
   "timestamp": "$timestamp",
   "version": "2.0",
   "level": $LEVEL,
+  "score": $SCORE,
   "security_score": $SCORE,
+  "run_meta": {
+    "started_at": "$STARTED_AT",
+    "completed_at": "$completed_at",
+    "duration_seconds": $duration_seconds,
+    "host": "$host",
+    "audit_script_version": "$audit_script_version",
+    "level": $LEVEL,
+    "category": $category_json,
+    "compared_against": $compared_against_json
+  },
   "summary": {
     "total": $total,
     "pass": $pass,


### PR DESCRIPTION
## Summary

PR-2 of the audit-subsystem hardening initiative (PR-1: #209). Three coordinated changes to `scripts/security-audit.sh` that close #200's tactical part, #201, and #204.

## Changes

### 1. Remove `head -30` cap on SA-CTR-10 (#200, tactical)

The image-age check sampled only the first 30 entries returned by `podman images --format json`. With more than 30 images on the host, *which* old images got flagged depended on the order podman returned them — removing an orphan image changed the WARN population between consecutive runs.

Now processes every image (O(images), <100 on any realistic homelab).

**The pinned-image exemption part of #200 is intentionally left to #205** (the exemptions registry). This PR closes only the inventory-shape determinism part.

### 2. Add `score` alias of `security_score` (#201)

`security_score` already existed and was populated (e.g. `85` in current runs). `jq '.score'` returned null because the key didn't exist — not because the script wrote null. See the [comment thread on #201](https://github.com/vonrobak/fedora-homelab-containers/issues/201#issuecomment-4479721539) for the misreading note.

This PR adds `"score": $SCORE` alongside `"security_score": $SCORE` so consumers can use either name. `autonomous-check.sh:723` still reads `security_score` — fully backwards compatible.

### 3. Add populated `run_meta` block (#204)

Same misreading as #201 — the `run_meta` field never existed; jq was returning null for a missing key. See the [comment on #204](https://github.com/vonrobak/fedora-homelab-containers/issues/204#issuecomment-4479721682).

The "or remove from schema" branch of the AC was technically already true (no field present). The operational case for adding it (reproducibility, duration trends) won, so this PR implements:

```json
"run_meta": {
  "started_at": "2026-05-18T18:33:09+02:00",
  "completed_at": "2026-05-18T18:34:12+02:00",
  "duration_seconds": 63,
  "host": "fedora-htpc",
  "audit_script_version": "8bc4748",
  "level": 3,
  "category": null,
  "compared_against": null
}
```

`audit_script_version` uses `git -C "$SCRIPT_DIR" rev-parse --short HEAD`, falling back to `"unknown"`. `compared_against` is populated only when `--compare` is active and a prior audit exists; otherwise null (reflects whether a real comparison happened).

## Test plan

- [x] `jq '.score'` returns a number (`85`), not null.
- [x] `jq '.security_score'` still returns the same number (backwards compat).
- [x] `jq '.run_meta'` returns a populated object with all eight fields.
- [x] Two consecutive `./scripts/security-audit.sh --level 3` runs produce identical `SA-CTR-10` messages (determinism: `diff` exit 0).
- [x] `--compare` populates `run_meta.compared_against` with the prior audit path; `trend` block continues to work as before.
- [x] `--category containers` populates `run_meta.category` with the category name.
- [x] Pre-commit Traefik check passes.

## Issue references

- Closes #201 (with misreading note in comment)
- Closes #204 (with misreading note in comment)
- Closes the inventory-truncation part of #200; the pinned-image exemption is deferred to #205.

🤖 Generated with [Claude Code](https://claude.com/claude-code)