### PR TITLE
fix(traefik): give HA the rate-limit-public tier (Lovelace cold-load was 429ing)

### DIFF
--- a/config/traefik/dynamic/routers.yml
+++ b/config/traefik/dynamic/routers.yml
@@ -241,7 +241,11 @@ http:
         - websecure
       middlewares:
         - crowdsec-bouncer@file
-        - rate-limit@file
+        # rate-limit-public (200/min, burst 100) — Lovelace cold-load lazy-fetches
+        # 50+ JS chunks in parallel and overshoots the default rate-limit tier
+        # (100/min, burst 50) intended for Authelia-fronted services. Native-auth
+        # services follow rate-limit-public per CLAUDE.md convention.
+        - rate-limit-public@file
         # NO authelia@file - HA has robust built-in auth
         - security-headers-ha@file
       tls:


### PR DESCRIPTION
## Summary

User reported "too many requests" on `ha.patriark.org`. Traefik access log showed dozens of `/frontend_latest/*.js` chunks hitting **429** in a ~1 second window during HA's dashboard bootstrap.

**Cause:** `home-assistant-secure` was using `rate-limit@file` (**100/min, burst 50**), the default tier sized for *Authelia-fronted* services. But HA has no Authelia in front (native auth, per convention), and Lovelace lazy-loads 50+ JS modules on cold load — blowing the 50-burst budget instantly.

**Fix:** switch `home-assistant-secure` to `rate-limit-public@file` (**200/min, burst 100**). This matches the documented CLAUDE.md convention for native-auth services and mirrors what `jellyfin-secure` / `audiobookshelf-secure` / `navidrome-secure` already do.

## Diff

```yaml
# config/traefik/dynamic/routers.yml — home-assistant-secure middleware
   - crowdsec-bouncer@file
-  - rate-limit@file
+  - rate-limit-public@file
   - security-headers-ha@file
```

## Verification

- ✓ Traefik config validator passed (pre-commit hook)
- ✓ Traefik auto-reloaded the dynamic config
- ✓ 60 sequential requests to `/manifest.json`: **60/60 success, 0×429**
- ✓ User confirmed `ha.patriark.org` loads in browser after the change

## Evidence of original problem

```
21:14:43 GET /frontend_latest/1872.....js -> 499  ← client aborted
21:14:43 GET /favicon.ico                 -> 429  ← first hit
21:17:06 GET /frontend_latest/...js       -> 429  ×20 in ~1s (retry storm)
21:17:07 GET /?external_auth=1            -> 429
```

## Not addressed (out of scope, noted for follow-up)

1. **Compression middleware missing** from HA's chain per CLAUDE.md convention. Keeping this PR surgical — easy follow-up later.
2. **Source-IP collapse to UDM-Pro LAN IP (192.168.1.1)** in Traefik access logs — split-horizon DNS routes `patriark.org` via the gateway, causing all LAN clients to share one rate-limit bucket. Accepted by user given the network design; not pathological in current usage.

## Test plan

- [x] Pre-commit: Traefik config validator
- [x] Live test: 60 burst requests, zero 429s
- [x] Browser test: cold-load `ha.patriark.org`
- [ ] CI checks pass
- [ ] HA mobile app reconnect test (next time user opens the app)

## Related

- Not related to #212 (matter-server decommission) — shipped on a separate branch as the user requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)