### PR TITLE
chore(security-audit): exempt Immich Postgres pin (ADR-015)

### DIFF
--- a/data/security-audit-exemptions.yml
+++ b/data/security-audit-exemptions.yml
@@ -108,6 +108,17 @@ exemptions:
 
   - check: SA-CTR-10
     match:
+      image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0
+    reason: |
+      Immich's Postgres pinned per ADR-015 — bundles vectorchord + pgvecto.rs
+      extensions matched to a specific Immich release. Must move in lockstep
+      with immich-server/ML; a stray pull breaks vector search.
+    documented_in: docs/00-foundation/decisions/2025-12-22-ADR-015-container-update-strategy.md
+    added: 2026-05-18
+    expires: 2027-01-01
+
+  - check: SA-CTR-10
+    match:
       image: localhost/proton-bridge:3.23.1
     reason: |
       Locally-built image with explicit version pin. Rebuilt manually when


### PR DESCRIPTION
## Summary

Adds an exemption registry entry for `ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0`, which was tripping SA-CTR-10 every audit run despite being deliberately pinned per ADR-015.

## Why

ADR-015 documents that Immich's Postgres must move in lockstep with `immich-server` and `immich-ml` because the image bundles `vectorchord` + `pgvecto.rs` extensions matched to a specific Immich release. A stray pull would break vector search.

The exemptions registry (added in #211) is the right home for this kind of "yes-it-looks-like-a-violation-but-here's-why" documentation.

## Diff

One block appended under `exemptions:` in `data/security-audit-exemptions.yml`:

```yaml
  - check: SA-CTR-10
    match:
      image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0
    reason: |
      Immich's Postgres pinned per ADR-015 — bundles vectorchord + pgvecto.rs
      extensions matched to a specific Immich release. Must move in lockstep
      with immich-server/ML; a stray pull breaks vector search.
    documented_in: docs/00-foundation/decisions/2025-12-22-ADR-015-container-update-strategy.md
    added: 2026-05-18
    expires: 2027-01-01
```

Expires 2027-01-01 to force periodic review.

## Test plan

- [ ] Next `scripts/security-audit.sh` run shows this image as `EXEMPT` instead of warn/fail
- [ ] Expired-exemption counter doesn't fire (expires > 1 year out)

🤖 Generated with [Claude Code](https://claude.com/claude-code)