### PR TITLE
deploy: Forgejo git forge (git.patriark.org)

### DIFF
--- a/config/traefik/dynamic/routers.yml
+++ b/config/traefik/dynamic/routers.yml
@@ -251,6 +251,21 @@ http:
       tls:
         certResolver: letsencrypt
 
+    # Forgejo - Git forge with native auth
+    # NO authelia@file: forward-auth breaks git CLI operations over HTTPS
+    forgejo-secure:
+      rule: "Host(`git.patriark.org`)"
+      service: "forgejo"
+      entryPoints:
+        - websecure
+      middlewares:
+        - crowdsec-bouncer@file
+        - rate-limit-public@file
+        - compression@file
+        - security-headers@file
+      tls:
+        certResolver: letsencrypt
+
     # Audiobookshelf - Uses native authentication (no Authelia SSO)
     # iOS app (abs) and web UI use Audiobookshelf's built-in auth
     audiobookshelf-secure:
@@ -351,6 +366,11 @@ http:
       loadBalancer:
         servers:
           - url: "http://gathio:3000"
+
+    forgejo:
+      loadBalancer:
+        servers:
+          - url: "http://forgejo:3000"
 
     home-assistant:
       loadBalancer:

--- a/config/traefik/hosts
+++ b/config/traefik/hosts
@@ -30,6 +30,9 @@
 10.89.2.80  immich-server
 10.89.2.84  gathio
 
+# Development
+10.89.2.89  forgejo
+
 # Monitoring & Logging
 10.89.2.83  loki
 

--- a/docs/AUTO-DEPENDENCY-GRAPH.md
+++ b/docs/AUTO-DEPENDENCY-GRAPH.md
@@ -1,6 +1,6 @@
 # Service Dependency Graph (Auto-Generated)
 
-**Generated:** 2026-05-18 05:02:05 UTC
+**Generated:** 2026-05-21 20:54:09 UTC
 **System:** fedora-htpc
 
 ---
@@ -47,8 +47,9 @@ graph TB
         alert_discord_relay[alert-discord-relay]
         audiobookshelf[audiobookshelf]
         cadvisor[cadvisor]
+        forgejo[forgejo]
+        forgejo_db[forgejo-db]
         immich_ml[immich-ml]
-        matter_server[matter-server]
         navidrome[navidrome]
         node_exporter[node_exporter]
         postgres_exporter[postgres-exporter]
@@ -63,6 +64,7 @@ graph TB
 
     %% Hard dependencies (from Requires= directives)
     authelia --> redis_authelia
+    forgejo --> forgejo_db
     gathio --> gathio_db
     immich_server --> postgresql_immich
     immich_server --> redis_immich
@@ -75,6 +77,7 @@ graph TB
     traefik -.-> alertmanager
     traefik -.-> audiobookshelf
     traefik -.-> authelia
+    traefik -.-> forgejo
     traefik -.-> gathio
     traefik -.-> grafana
     traefik -.-> home_assistant
@@ -153,8 +156,9 @@ graph TB
 | **alert-discord-relay** | — | 🟢 Service-specific impact |
 | **audiobookshelf** | — | 🟢 Service-specific impact |
 | **cadvisor** | — | 🟢 Service-specific impact |
+| **forgejo** | forgejo-db | 🟢 Service-specific impact |
+| **forgejo-db** | — | 🟢 Service-specific impact |
 | **immich-ml** | — | 🟢 Service-specific impact |
-| **matter-server** | — | 🟢 Service-specific impact |
 | **navidrome** | — | 🟢 Service-specific impact |
 | **node_exporter** | — | 🟢 Service-specific impact |
 | **postgres-exporter** | postgresql-immich | 🟢 Service-specific impact |
@@ -180,6 +184,8 @@ Derived from `After=` directives in quadlet files. systemd handles this automati
 | authelia | redis-authelia |
 | cadvisor | (no ordering constraints) |
 | crowdsec | (no ordering constraints) |
+| forgejo | forgejo-db |
+| forgejo-db | (no ordering constraints) |
 | gathio | gathio-db |
 | gathio-db | (no ordering constraints) |
 | grafana | (no ordering constraints) |
@@ -189,7 +195,6 @@ Derived from `After=` directives in quadlet files. systemd handles this automati
 | immich-server | postgresql-immich,redis-immich |
 | jellyfin | (no ordering constraints) |
 | loki | (no ordering constraints) |
-| matter-server | (no ordering constraints) |
 | navidrome | traefik |
 | nextcloud | nextcloud-db,nextcloud-redis |
 | nextcloud-db | (no ordering constraints) |
@@ -218,9 +223,11 @@ Services on the same network can communicate:
 
 **auth_services:** authelia,redis-authelia,redis-authelia-exporter
 
+**forgejo:** forgejo,forgejo-db
+
 **gathio:** gathio,gathio-db
 
-**home_automation:** home-assistant,matter-server
+**home_automation:** home-assistant
 
 **mail:** authelia,proton-bridge
 
@@ -232,7 +239,7 @@ Services on the same network can communicate:
 
 **photos:** immich-ml,immich-server,postgres-exporter,postgresql-immich,redis-immich,redis-immich-exporter
 
-**reverse_proxy:** alert-discord-relay,alertmanager,audiobookshelf,authelia,crowdsec,gathio,grafana,home-assistant,homepage,immich-server,jellyfin,loki,navidrome,nextcloud,prometheus,proton-bridge,qbittorrent,traefik,unpoller,vaultwarden
+**reverse_proxy:** alert-discord-relay,alertmanager,audiobookshelf,authelia,crowdsec,forgejo,gathio,grafana,home-assistant,homepage,immich-server,jellyfin,loki,navidrome,nextcloud,prometheus,proton-bridge,qbittorrent,traefik,unpoller,vaultwarden
 
 **syslog:** unifi-syslog
 

--- a/docs/AUTO-DOCUMENTATION-INDEX.md
+++ b/docs/AUTO-DOCUMENTATION-INDEX.md
@@ -1,7 +1,7 @@
 # Documentation Index (Auto-Generated)
 
-**Generated:** 2026-05-18 05:02:06 UTC
-**Total Documents:** 411
+**Generated:** 2026-05-21 20:54:10 UTC
+**Total Documents:** 413
 
 ---
 
@@ -213,7 +213,7 @@
 
 ---
 
-### 98-journals/ (213 documents)
+### 98-journals/ (215 documents)
 
 **Chronological project history (append-only log)**
 
@@ -233,14 +233,14 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 
 - 2026-05-16: [2026-03-28-ADR-021-urd-backup-tool.md](00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md)
 - 2026-05-16: [README.md](00-foundation/decisions/fixtures/README.md)
-- 2026-05-13: [2026-05-13-udm-pro-threat-notifications-investigation-private.md](98-journals/2026-05-13-udm-pro-threat-notifications-investigation-private.md)
-- 2026-05-15: [2026-05-15-audit-backlog-drift-and-observability-deployment.md](98-journals/2026-05-15-audit-backlog-drift-and-observability-deployment.md)
-- 2026-05-13: [remediation-monthly-202604.md](99-reports/remediation-monthly-202604.md)
+- 2026-05-18: [2026-05-15-audit-backlog-drift-and-observability-deployment.md](98-journals/2026-05-15-audit-backlog-drift-and-observability-deployment.md)
+- 2026-05-18: [2026-05-18-audit-subsystem-hardening-private.md](98-journals/2026-05-18-audit-subsystem-hardening-private.md)
+- 2026-05-18: [2026-05-18-security-audit-and-drift-cleanup-private.md](98-journals/2026-05-18-security-audit-and-drift-cleanup-private.md)
 - 2026-05-15: [security-audit-2026-05-15.md](99-reports/security-audit-2026-05-15.md)
-- 2026-05-18: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
-- 2026-05-18: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
-- 2026-05-18: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
-- 2026-05-18: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
+- 2026-05-21: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
+- 2026-05-21: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
+- 2026-05-21: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
+- 2026-05-21: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
 
 ---
 

--- a/docs/AUTO-NETWORK-TOPOLOGY.md
+++ b/docs/AUTO-NETWORK-TOPOLOGY.md
@@ -1,7 +1,7 @@
 # Network Topology (Auto-Generated)
 
-**Generated:** 2026-05-18 05:02:01 UTC
-**System:** fedora-htpc | **Networks:** 10 | **Containers:** 35
+**Generated:** 2026-05-21 20:54:04 UTC
+**System:** fedora-htpc | **Networks:** 11 | **Containers:** 36
 
 ---
 
@@ -31,6 +31,7 @@ graph TB
     CrowdSec -->|Rate Limit| alert_discord_relay[alert-discord-relay]
     CrowdSec -->|Rate Limit| alertmanager[alertmanager]
     CrowdSec -->|Rate Limit| audiobookshelf[audiobookshelf]
+    CrowdSec -->|Rate Limit| forgejo[forgejo]
     CrowdSec -->|Rate Limit| immich_server[immich-server]
     CrowdSec -->|Rate Limit| jellyfin[jellyfin]
     CrowdSec -->|Rate Limit| navidrome[navidrome]
@@ -66,6 +67,12 @@ graph TB
         auth_services_redis_authelia_exporter[redis-authelia-exporter]
     end
 
+    subgraph forgejo["forgejo<br/>10.89.8.0/24"]
+        direction LR
+        forgejo_forgejo[forgejo]
+        forgejo_forgejo_db[forgejo-db]
+    end
+
     subgraph gathio["gathio<br/>10.89.0.0/24"]
         direction LR
         gathio_gathio[gathio]
@@ -75,7 +82,6 @@ graph TB
     subgraph home_automation["home_automation<br/>10.89.6.0/24"]
         direction LR
         home_automation_home_assistant[home-assistant]
-        home_automation_matter_server[matter-server]
     end
 
     subgraph mail["mail<br/>10.89.9.0/24"]
@@ -129,6 +135,7 @@ graph TB
         reverse_proxy_audiobookshelf[audiobookshelf]
         reverse_proxy_authelia[authelia]
         reverse_proxy_crowdsec[crowdsec]
+        reverse_proxy_forgejo[forgejo]
         reverse_proxy_gathio[gathio]
         reverse_proxy_grafana[grafana]
         reverse_proxy_home_assistant[home-assistant]
@@ -167,47 +174,48 @@ graph TB
 
 Shows which services belong to which networks. Dynamically generated from running container state.
 
-| Service | auth_services | gathio | home_automation | mail | media_services | monitoring | nextcloud | photos | reverse_proxy | syslog |
-|---------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Service | auth_services | forgejo | gathio | home_automation | mail | media_services | monitoring | nextcloud | photos | reverse_proxy | syslog |
+|---------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **Gateway & Security** |
-| authelia | ✅ | - | - | ✅ | - | - | - | - | ✅ | - |
-| crowdsec | - | - | - | - | - | - | - | - | ✅ | - |
-| redis-authelia | ✅ | - | - | - | - | - | - | - | - | - |
-| traefik | - | - | - | - | - | - | - | - | ✅ | - |
+| authelia | ✅ | - | - | - | ✅ | - | - | - | - | ✅ | - |
+| crowdsec | - | - | - | - | - | - | - | - | - | ✅ | - |
+| redis-authelia | ✅ | - | - | - | - | - | - | - | - | - | - |
+| traefik | - | - | - | - | - | - | - | - | - | ✅ | - |
 | **Public Services** |
-| alert-discord-relay | - | - | - | - | - | ✅ | - | - | ✅ | - |
-| audiobookshelf | - | - | - | - | - | - | - | - | ✅ | - |
-| gathio | - | ✅ | - | - | - | - | - | - | ✅ | - |
-| home-assistant | - | - | ✅ | - | - | - | - | - | ✅ | - |
-| homepage | - | - | - | - | - | - | - | - | ✅ | - |
-| immich-server | - | - | - | - | - | - | - | ✅ | ✅ | - |
-| jellyfin | - | - | - | - | ✅ | - | - | - | ✅ | - |
-| navidrome | - | - | - | - | - | - | - | - | ✅ | - |
-| nextcloud | - | - | - | - | - | - | ✅ | - | ✅ | - |
-| proton-bridge | - | - | - | ✅ | - | - | - | - | ✅ | - |
-| qbittorrent | - | - | - | - | - | - | - | - | ✅ | - |
-| unpoller | - | - | - | - | - | ✅ | - | - | ✅ | - |
-| vaultwarden | - | - | - | - | - | - | - | - | ✅ | - |
+| alert-discord-relay | - | - | - | - | - | - | ✅ | - | - | ✅ | - |
+| audiobookshelf | - | - | - | - | - | - | - | - | - | ✅ | - |
+| forgejo | - | ✅ | - | - | - | - | - | - | - | ✅ | - |
+| gathio | - | - | ✅ | - | - | - | - | - | - | ✅ | - |
+| home-assistant | - | - | - | ✅ | - | - | - | - | - | ✅ | - |
+| homepage | - | - | - | - | - | - | - | - | - | ✅ | - |
+| immich-server | - | - | - | - | - | - | - | - | ✅ | ✅ | - |
+| jellyfin | - | - | - | - | - | ✅ | - | - | - | ✅ | - |
+| navidrome | - | - | - | - | - | - | - | - | - | ✅ | - |
+| nextcloud | - | - | - | - | - | - | - | ✅ | - | ✅ | - |
+| proton-bridge | - | - | - | - | ✅ | - | - | - | - | ✅ | - |
+| qbittorrent | - | - | - | - | - | - | - | - | - | ✅ | - |
+| unpoller | - | - | - | - | - | - | ✅ | - | - | ✅ | - |
+| vaultwarden | - | - | - | - | - | - | - | - | - | ✅ | - |
 | **Monitoring** |
-| alertmanager | - | - | - | - | - | ✅ | - | - | ✅ | - |
-| cadvisor | - | - | - | - | - | ✅ | - | - | - | - |
-| grafana | - | - | - | - | - | ✅ | - | - | ✅ | - |
-| loki | - | - | - | - | - | ✅ | - | - | ✅ | - |
-| node_exporter | - | - | - | - | - | ✅ | - | - | - | - |
-| prometheus | - | - | - | - | - | ✅ | - | - | ✅ | - |
-| promtail | - | - | - | - | - | ✅ | - | - | - | - |
+| alertmanager | - | - | - | - | - | - | ✅ | - | - | ✅ | - |
+| cadvisor | - | - | - | - | - | - | ✅ | - | - | - | - |
+| grafana | - | - | - | - | - | - | ✅ | - | - | ✅ | - |
+| loki | - | - | - | - | - | - | ✅ | - | - | ✅ | - |
+| node_exporter | - | - | - | - | - | - | ✅ | - | - | - | - |
+| prometheus | - | - | - | - | - | - | ✅ | - | - | ✅ | - |
+| promtail | - | - | - | - | - | - | ✅ | - | - | - | - |
 | **Backend Services** |
-| gathio-db | - | ✅ | - | - | - | - | - | - | - | - |
-| immich-ml | - | - | - | - | - | - | - | ✅ | - | - |
-| matter-server | - | - | ✅ | - | - | - | - | - | - | - |
-| nextcloud-db | - | - | - | - | - | - | ✅ | - | - | - |
-| nextcloud-redis | - | - | - | - | - | - | ✅ | - | - | - |
-| postgres-exporter | - | - | - | - | - | ✅ | - | ✅ | - | - |
-| postgresql-immich | - | - | - | - | - | - | - | ✅ | - | - |
-| redis-authelia-exporter | ✅ | - | - | - | - | ✅ | - | - | - | - |
-| redis-immich-exporter | - | - | - | - | - | ✅ | - | ✅ | - | - |
-| redis-immich | - | - | - | - | - | - | - | ✅ | - | - |
-| unifi-syslog | - | - | - | - | - | - | - | - | - | ✅ |
+| forgejo-db | - | ✅ | - | - | - | - | - | - | - | - | - |
+| gathio-db | - | - | ✅ | - | - | - | - | - | - | - | - |
+| immich-ml | - | - | - | - | - | - | - | - | ✅ | - | - |
+| nextcloud-db | - | - | - | - | - | - | - | ✅ | - | - | - |
+| nextcloud-redis | - | - | - | - | - | - | - | ✅ | - | - | - |
+| postgres-exporter | - | - | - | - | - | - | ✅ | - | ✅ | - | - |
+| postgresql-immich | - | - | - | - | - | - | - | - | ✅ | - | - |
+| redis-authelia-exporter | ✅ | - | - | - | - | - | ✅ | - | - | - | - |
+| redis-immich-exporter | - | - | - | - | - | - | ✅ | - | ✅ | - | - |
+| redis-immich | - | - | - | - | - | - | - | - | ✅ | - | - |
+| unifi-syslog | - | - | - | - | - | - | - | - | - | - | ✅ |
 
 ---
 
@@ -272,6 +280,17 @@ sequenceDiagram
 - redis-authelia-exporter
 
 
+### forgejo
+
+- **Full Name:** `systemd-forgejo`
+- **Subnet:** 10.89.8.0/24
+- **Services:** 2
+
+**Members:**
+- forgejo
+- forgejo-db
+
+
 ### gathio
 
 - **Full Name:** `systemd-gathio`
@@ -287,11 +306,10 @@ sequenceDiagram
 
 - **Full Name:** `systemd-home_automation`
 - **Subnet:** 10.89.6.0/24
-- **Services:** 2
+- **Services:** 1
 
 **Members:**
 - home-assistant
-- matter-server
 
 
 ### mail
@@ -367,7 +385,7 @@ sequenceDiagram
 
 - **Full Name:** `systemd-reverse_proxy`
 - **Subnet:** 10.89.2.0/24
-- **Services:** 20
+- **Services:** 21
 
 **Members:**
 - alert-discord-relay
@@ -375,6 +393,7 @@ sequenceDiagram
 - audiobookshelf
 - authelia
 - crowdsec
+- forgejo
 - gathio
 - grafana
 - home-assistant

--- a/docs/AUTO-SERVICE-CATALOG.md
+++ b/docs/AUTO-SERVICE-CATALOG.md
@@ -1,102 +1,103 @@
 # Service Catalog (Auto-Generated)
 
-**Generated:** 2026-05-18 05:02:00 UTC
-**System:** fedora-htpc | **Services:** 35/35 running | **Health:** 31/31 healthy (4 without healthcheck)
+**Generated:** 2026-05-21 20:54:03 UTC
+**System:** fedora-htpc | **Services:** 36/36 running | **Health:** 32/32 healthy (4 without healthcheck)
 
 ---
 
-## Other (8)
+## Other (10)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| audiobookshelf | advplyr/audiobookshelf:latest | ✅ healthy | 4d | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
-| navidrome | deluan/navidrome:latest | ✅ healthy | 4d | [musikk.patriark.org](https://musikk.patriark.org) | — |
-| postgres-exporter | quay.io/prometheuscommunity/postgres-exporter | ✅ healthy | 3d | — | — |
-| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | 4d | — | — |
-| qbittorrent | linuxserver/qbittorrent:latest | ✅ healthy | 4d | [torrent.patriark.org](https://torrent.patriark.org) | — |
-| redis-authelia-exporter | quay.io/oliver006/redis_exporter:latest | — no check | 3d | — | — |
-| redis-immich-exporter | quay.io/oliver006/redis_exporter:latest | — no check | 3d | — | — |
-| unifi-syslog | linuxserver/syslog-ng:latest | ✅ healthy | 28h | — | — |
+| audiobookshelf | advplyr/audiobookshelf:latest | ✅ healthy | 8d | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
+| forgejo | codeberg.org/forgejo/forgejo:15 | ✅ healthy | 8m | [git.patriark.org](https://git.patriark.org) | — |
+| forgejo-db | postgres:16-alpine | ✅ healthy | 12m | — | — |
+| navidrome | deluan/navidrome:latest | ✅ healthy | 8d | [musikk.patriark.org](https://musikk.patriark.org) | — |
+| postgres-exporter | quay.io/prometheuscommunity/postgres-exporter | ✅ healthy | 7d | — | — |
+| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | 8d | — | — |
+| qbittorrent | linuxserver/qbittorrent:latest | ✅ healthy | 8d | [torrent.patriark.org](https://torrent.patriark.org) | — |
+| redis-authelia-exporter | quay.io/oliver006/redis_exporter:latest | — no check | 7d | — | — |
+| redis-immich-exporter | quay.io/oliver006/redis_exporter:latest | — no check | 7d | — | — |
+| unifi-syslog | linuxserver/syslog-ng:latest | ✅ healthy | 4d | — | — |
 
 ## Core Infrastructure (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| authelia | authelia/authelia:latest | ✅ healthy | 3d | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
-| crowdsec | crowdsecurity/crowdsec:latest | ✅ healthy | 4d | — | [guide](10-services/guides/crowdsec.md) |
-| redis-authelia | redis:7-alpine | ✅ healthy | 4d | — | — |
-| traefik | traefik:latest | ✅ healthy | 4d | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
+| authelia | authelia/authelia:latest | ✅ healthy | 7d | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
+| crowdsec | crowdsecurity/crowdsec:latest | ✅ healthy | 8d | — | [guide](10-services/guides/crowdsec.md) |
+| redis-authelia | redis:7-alpine | ✅ healthy | 8d | — | — |
+| traefik | traefik:latest | ✅ healthy | 3m | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
 
 ## Nextcloud (3)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| nextcloud-db | mariadb:11 | ✅ healthy | 4d | — | [guide](10-services/guides/nextcloud.md) |
-| nextcloud | nextcloud:33 | ✅ healthy | 4d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
-| nextcloud-redis | redis:7-alpine | ✅ healthy | 2d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-db | mariadb:11 | ✅ healthy | 8d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud | nextcloud:33 | ✅ healthy | 8d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-redis | redis:7-alpine | ✅ healthy | 6d | — | [guide](10-services/guides/nextcloud.md) |
 
 ## Immich (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| immich-ml | immich-app/immich-machine-learning:v2.7.5 | ✅ healthy | 4d | — | [guide](10-services/guides/immich.md) |
-| immich-server | immich-app/immich-server:v2.7.5 | ✅ healthy | 4d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
-| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3-pgvec | ✅ healthy | 4d | — | — |
-| redis-immich | valkey/valkey:latest | ✅ healthy | 4d | — | — |
+| immich-ml | immich-app/immich-machine-learning:v2.7.5 | ✅ healthy | 8d | — | [guide](10-services/guides/immich.md) |
+| immich-server | immich-app/immich-server:v2.7.5 | ✅ healthy | 8d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
+| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3-pgvec | ✅ healthy | 8d | — | — |
+| redis-immich | valkey/valkey:latest | ✅ healthy | 8d | — | — |
 
 ## Jellyfin (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| jellyfin | jellyfin/jellyfin:latest | ✅ healthy | 4d | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
+| jellyfin | jellyfin/jellyfin:latest | ✅ healthy | 8d | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
 
 ## Vaultwarden (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| vaultwarden | vaultwarden/server:latest | ✅ healthy | 4d | [vault.patriark.org](https://vault.patriark.org) | — |
+| vaultwarden | vaultwarden/server:latest | ✅ healthy | 8d | [vault.patriark.org](https://vault.patriark.org) | — |
 
-## Home Automation (2)
+## Home Automation (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 4d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
-| matter-server | home-assistant-libs/python-matter-server:stab | ✅ healthy | 4d | — | [guide](10-services/guides/matter-server.md) |
+| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 8d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
 
 ## Gathio (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| gathio-db | mongo:7 | ✅ healthy | 4d | — | — |
-| gathio | lowercasename/gathio:latest | ✅ healthy | 4d | [events.patriark.org](https://events.patriark.org) | — |
+| gathio-db | mongo:7 | ✅ healthy | 8d | — | — |
+| gathio | lowercasename/gathio:latest | ✅ healthy | 8d | [events.patriark.org](https://events.patriark.org) | — |
 
 ## Homepage (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| homepage | gethomepage/homepage:latest | ✅ healthy | 4d | [patriark.org](https://patriark.org) | — |
+| homepage | gethomepage/homepage:latest | ✅ healthy | 8d | [patriark.org](https://patriark.org) | — |
 
 ## Monitoring (9)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| alert-discord-relay | localhost/alert-discord-relay:latest | ✅ healthy | 4d | — | [guide](10-services/guides/alert-discord-relay.md) |
-| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ healthy | 4d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ healthy | 4d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| grafana | grafana/grafana:latest | ✅ healthy | 4d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| loki | grafana/loki:latest | — no check | 4d | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| node_exporter | quay.io/prometheus/node-exporter:latest | ✅ healthy | 4d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 3d | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| promtail | grafana/promtail:latest | ✅ healthy | 28h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| unpoller | unpoller/unpoller:latest | — no check | 4d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| alert-discord-relay | localhost/alert-discord-relay:latest | ✅ healthy | 8d | — | [guide](10-services/guides/alert-discord-relay.md) |
+| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ healthy | 8d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ healthy | 8d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| grafana | grafana/grafana:latest | ✅ healthy | 8d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| loki | grafana/loki:latest | — no check | 8d | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| node_exporter | quay.io/prometheus/node-exporter:latest | ✅ healthy | 8d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 7d | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| promtail | grafana/promtail:latest | ✅ healthy | 4d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| unpoller | unpoller/unpoller:latest | — no check | 8d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
 
 ---
 
 ## Statistics
 
-- **Total Running:** 35
-- **Total Defined:** 35
-- **System Load:** 3,11, 2,24, 2,14
+- **Total Running:** 36
+- **Total Defined:** 36
+- **System Load:** 0,76, 1,04, 0,97
 
 ---
 

--- a/quadlets/forgejo-db.container
+++ b/quadlets/forgejo-db.container
@@ -1,0 +1,41 @@
+[Unit]
+Description=PostgreSQL Database for Forgejo
+After=network-online.target forgejo-network.service
+Wants=network-online.target forgejo-network.service
+
+[Container]
+Image=docker.io/library/postgres:16-alpine
+ContainerName=forgejo-db
+HostName=forgejo-db
+
+# Database configuration (podman secret, Pattern 2: type=env)
+Environment=POSTGRES_USER=forgejo
+Environment=POSTGRES_DB=forgejo
+Environment=POSTGRES_INITDB_ARGS=--data-checksums
+Secret=forgejo_db_password,type=env,target=POSTGRES_PASSWORD
+
+# Storage (subvol8-db, NOCOW set on dir before first use)
+Volume=/mnt/btrfs-pool/subvol8-db/forgejo-db:/var/lib/postgresql/data:Z
+
+# Network (dedicated Forgejo network, Internal=true)
+Network=systemd-forgejo
+
+# Health Check
+HealthCmd=pg_isready -U forgejo -d forgejo
+HealthInterval=10s
+HealthTimeout=5s
+HealthRetries=5
+
+[Service]
+Slice=container.slice
+Restart=on-failure
+TimeoutStartSec=300
+OOMPolicy=kill
+
+# Resource Limits
+MemoryHigh=384M
+MemoryMax=512M
+MemorySwapMax=16M
+
+[Install]
+WantedBy=default.target

--- a/quadlets/forgejo.container
+++ b/quadlets/forgejo.container
@@ -1,0 +1,62 @@
+[Unit]
+Description=Forgejo Git Forge
+After=network-online.target forgejo-db.service reverse_proxy-network.service forgejo-network.service
+Wants=network-online.target
+Requires=forgejo-db.service
+
+[Container]
+Image=codeberg.org/forgejo/forgejo:15
+ContainerName=forgejo
+HostName=forgejo
+
+Environment=USER_UID=1000
+Environment=USER_GID=1000
+Environment=TZ=Europe/Oslo
+
+# Server
+Environment=FORGEJO__server__DOMAIN=git.patriark.org
+Environment=FORGEJO__server__ROOT_URL=https://git.patriark.org/
+Environment=FORGEJO__server__HTTP_PORT=3000
+Environment=FORGEJO__server__DISABLE_SSH=true
+Environment=FORGEJO__server__START_SSH_SERVER=false
+
+# Database (forgejo-db reached by container name on systemd-forgejo)
+Environment=FORGEJO__database__DB_TYPE=postgres
+Environment=FORGEJO__database__HOST=forgejo-db:5432
+Environment=FORGEJO__database__NAME=forgejo
+Environment=FORGEJO__database__USER=forgejo
+Secret=forgejo_db_password,type=env,target=FORGEJO__database__PASSWD
+
+# Closed forge (HTTPS-only, native auth; installer locked)
+Environment=FORGEJO__security__INSTALL_LOCK=true
+Environment=FORGEJO__service__DISABLE_REGISTRATION=true
+Environment=FORGEJO__service__REQUIRE_SIGNIN_VIEW=true
+Environment=FORGEJO__session__COOKIE_SECURE=true
+
+# Storage (repos/LFS/data on container pool; not a DB, no NOCOW)
+Volume=/mnt/btrfs-pool/subvol7-containers/forgejo:/data:Z
+
+# Networks (reverse_proxy FIRST = default route for internet; static IPs per ADR-018)
+Network=systemd-reverse_proxy:ip=10.89.2.89
+Network=systemd-forgejo:ip=10.89.8.89
+
+DNS=192.168.1.69
+
+# Health Check
+HealthCmd=wget --quiet --tries=1 --spider http://localhost:3000/api/healthz || exit 1
+HealthInterval=30s
+HealthTimeout=10s
+HealthRetries=3
+HealthStartPeriod=60s
+
+[Service]
+Slice=container.slice
+Restart=on-failure
+TimeoutStartSec=300
+
+# Resource Limits
+MemoryHigh=1G
+MemoryMax=1536M
+
+[Install]
+WantedBy=default.target

--- a/quadlets/forgejo.network
+++ b/quadlets/forgejo.network
@@ -1,0 +1,15 @@
+[Unit]
+Description=Forgejo Application Network
+Documentation=man:podman-network(1)
+
+[Network]
+NetworkName=systemd-forgejo
+Driver=bridge
+Subnet=10.89.8.0/24
+Gateway=10.89.8.1
+IPRange=10.89.8.2-10.89.8.68
+DNS=192.168.1.69
+Internal=true
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

Deploys **Forgejo 15** as a self-hosted git forge at `git.patriark.org`, backed by a dedicated PostgreSQL 16 instance. Intended as the long-term home for all repos.

- **Quadlets:** `forgejo.network` (10.89.8.0/24, `Internal=true`), `forgejo-db.container` (postgres:16-alpine, data on `subvol8-db` with NOCOW), `forgejo.container` (codeberg forgejo:15, static IPs 10.89.2.89 / 10.89.8.89 per ADR-018)
- **Traefik:** native-auth route + service in `routers.yml` (`crowdsec-bouncer → rate-limit-public → compression → security-headers`) and a `/etc/hosts` backend entry. **No Authelia** — forward-auth would break `git clone/push` over HTTPS.
- **Posture:** HTTPS-only (SSH disabled), closed forge (`INSTALL_LOCK` + `DISABLE_REGISTRATION` + `REQUIRE_SIGNIN_VIEW`), dedicated Postgres per service (matches immich/gathio/nextcloud).

## Architecture notes

- One Postgres per service, not a shared instance. The user's incoming personal time-series DB will get its own instance (likely TimescaleDB) — different tuning, independent upgrade lifecycle (ADR-015), network isolation.
- DB data dirs now live under `subvol8-db` (NOCOW); app/repo data stays on `subvol7-containers`.

## Incidental fix (not in this diff)

While deploying, discovered the quadlet generator was failing its **entire** pass on an orphaned `matter-server.container` symlink left in `~/.config/containers/systemd/` by the #212 decommission (source removed, symlink not). Every quadlet unit was silently `LOAD=not-found` and a reboot would have started **nothing**. Removed the dangling symlink (runtime-only, not tracked in repo); generator now clean (47 units, EXIT=0).

## Verification

- ✓ `forgejo` + `forgejo-db` containers healthy
- ✓ `/api/healthz` → `database:ping: pass` (Postgres connectivity)
- ✓ Let's Encrypt cert issued for `git.patriark.org` (DNS-01)
- ✓ git smart-HTTP → `401 WWW-Authenticate: Basic realm="Gitea"` (not an SSO 302 — confirms git-over-HTTPS works)
- ✓ authenticated API → `200`
- ✓ admin account created; user has since added TOTP + 3 YubiKeys

## Test Plan

- [ ] Log in at https://git.patriark.org and create a repo
- [ ] `git clone` / `git push` over HTTPS
- [ ] Confirm in-browser file editor (Monaco) loads — if CSP blocks blob workers, add `security-headers-forgejo@file` with `worker-src blob:`
- [ ] (optional) add local DNS `git → 192.168.1.70` to avoid NAT hairpin internally

🤖 Generated with [Claude Code](https://claude.com/claude-code)