### PR TITLE
Phase A: DB dump + restore-test backbone (ADR-029)

### DIFF
--- a/config/logrotate/unifi-syslog
+++ b/config/logrotate/unifi-syslog
@@ -8,7 +8,7 @@
 # Testing:
 #   sudo logrotate -d /etc/logrotate.d/unifi-syslog
 
-/mnt/btrfs-pool/subvol8-db/unifi-syslog/*.log {
+/mnt/btrfs-pool/subvol7-containers/unifi-syslog/*.log {
     daily
     rotate 14
     compress

--- a/config/prometheus/alerts/db-dump-alerts.yml
+++ b/config/prometheus/alerts/db-dump-alerts.yml
@@ -1,0 +1,66 @@
+groups:
+  - name: db_dump_alerts
+    interval: 60s
+    rules:
+      # Critical: an engine's application-consistent dump failed.
+      # Tier-2 DBs (subvol8-db) are NOT in the snapshot set, so a failed dump
+      # means that engine's offsite backup is stale until fixed.
+      - alert: DbDumpFailed
+        expr: db_dump_success == 0
+        for: 5m
+        labels:
+          severity: critical
+          category: backup
+          component: db-dump
+        annotations:
+          summary: "DB dump failed for {{ $labels.database }}"
+          description: "Last application-consistent dump for {{ $labels.database }} failed. Its Tier-2 offsite backup is stale. Check `journalctl --user -u db-dump.service`."
+
+      # Critical: no successful dump in 2+ days (last_success_timestamp is carried
+      # forward across failed runs, so this ages correctly).
+      - alert: DbDumpStale
+        expr: (time() - db_dump_last_success_timestamp) > (86400 * 2)
+        for: 1h
+        labels:
+          severity: critical
+          category: backup
+          component: db-dump
+        annotations:
+          summary: "DB dump stale for {{ $labels.database }}"
+          description: "No successful dump for {{ $labels.database }} in {{ $value | humanizeDuration }}."
+
+      # Warning: the dump job itself hasn't run (timer stopped / host down).
+      - alert: DbDumpJobNotRunning
+        expr: (time() - db_dump_last_run_timestamp) > (86400 * 2)
+        for: 6h
+        labels:
+          severity: warning
+          category: backup
+          component: db-dump
+        annotations:
+          summary: "db-dump job hasn't run in 2+ days"
+          description: "db-dump.sh last ran {{ $value | humanizeDuration }} ago. Check `systemctl --user status db-dump.timer`."
+
+      # --- The two rules below activate with the restore-test job (Phase A.4). ---
+      # They are inert until db_restore_test_* series exist (absent metric => no fire).
+      - alert: DbRestoreTestFailed
+        expr: db_restore_test_success == 0
+        for: 5m
+        labels:
+          severity: critical
+          category: disaster-recovery
+          component: db-restore-test
+        annotations:
+          summary: "DB restore test failed for {{ $labels.database }}"
+          description: "Ephemeral restore validation failed for {{ $labels.database }} — its dumps may be unrestorable."
+
+      - alert: DbRestoreTestOverdue
+        expr: (time() - db_restore_test_last_timestamp) > (86400 * 10)
+        for: 6h
+        labels:
+          severity: warning
+          category: disaster-recovery
+          component: db-restore-test
+        annotations:
+          summary: "DB restore test overdue for {{ $labels.database }}"
+          description: "No restore test for {{ $labels.database }} in {{ $value | humanizeDuration }} (should run weekly)."

--- a/docs/00-foundation/decisions/2026-04-18-ADR-024-database-dump-backup.md
+++ b/docs/00-foundation/decisions/2026-04-18-ADR-024-database-dump-backup.md
@@ -1,7 +1,7 @@
 # ADR-024: Application-Level Database Dump Backup
 
 **Date:** 2026-04-18
-**Status:** Proposed
+**Status:** Superseded by ADR-029 (2026-05-22) — dump backbone implemented there
 **Replaces (part 1 of 2):** ADR-023 (withdrawn)
 **Companion:** ADR-025 (deferred NOCOW migration)
 

--- a/docs/00-foundation/decisions/2026-04-18-ADR-025-db-storage-migration-deferred.md
+++ b/docs/00-foundation/decisions/2026-04-18-ADR-025-db-storage-migration-deferred.md
@@ -1,7 +1,7 @@
 # ADR-025: Database Storage Migration to NOCOW Subvolume (Deferred)
 
 **Date:** 2026-04-18
-**Status:** Deferred (conditional acceptance pending baseline measurements)
+**Status:** Superseded by ADR-029 (2026-05-22) — migration runbook consolidated there as Phase B (still gated)
 **Replaces (part 2 of 2):** ADR-023 (withdrawn)
 **Companion:** ADR-024 (dump-based backup — accepted and shipping first)
 **Earliest review for acceptance:** 2026-06-18 (60 days after ADR-024 begins running)

--- a/docs/00-foundation/decisions/2026-04-22-ADR-027-forward-nocow-workloads-subvol8-db.md
+++ b/docs/00-foundation/decisions/2026-04-22-ADR-027-forward-nocow-workloads-subvol8-db.md
@@ -1,7 +1,7 @@
 # ADR-027: Forward-Only NOCOW Placement on subvol8-db (Policy)
 
 **Date:** 2026-04-22
-**Status:** Accepted
+**Status:** Superseded by ADR-029 (2026-05-22) — NOCOW-candidate criteria + tenant table consolidated there as the Tier-2 growth rule
 **Companion:** ADR-025 (deferred DB migration — unchanged)
 **First tenant:** `unifi-syslog` (UDM Pro SIEM forensic log receiver)
 

--- a/docs/00-foundation/decisions/2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md
+++ b/docs/00-foundation/decisions/2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md
@@ -1,0 +1,111 @@
+# ADR-029: Three-Tier Database Storage + Dump Backup
+
+**Date:** 2026-05-22
+**Status:** Accepted (Phase A implemented); Phase B deferred/gated
+**Supersedes:** ADR-024 (dump-based backup), ADR-025 (deferred DB migration), ADR-027 (forward-only NOCOW placement)
+**Plan:** worked out 2026-05-22 (debate → plan → implementation)
+
+## Context
+
+The homelab's database storage was governed by three overlapping ADRs that had drifted from ground truth:
+
+- **ADR-024** (dump-based backup) was *accepted but never built*.
+- **ADR-027** (forward-only NOCOW placement) put new write-hot engines on `subvol8-db` and required DB tenants to be backed up "via ADR-024 dumps" — but those dumps didn't exist.
+- **ADR-025** (migrate the five existing DBs to `subvol8-db`) was deferred pending measurements.
+
+The net effect was a **live backup hole**: `forgejo-db` (PostgreSQL) and `loki` sat in the un-snapshotted `subvol8-db` with **no backup of any kind**. Meanwhile `gathio-db` and `prometheus` carried `chattr +C` (NOCOW) *inside the snapshotted `subvol7-containers`* — the COW-defeated-by-snapshots antipattern, live.
+
+This ADR consolidates the three into one coherent architecture, ships the missing backbone, and records the runbook for the gated migration.
+
+**Storage ground truth:** `htpc-btrfs-pool` is a 4-device BTRFS pool (`/dev/sd{a,b,c,d}`, 3.64 TiB each), Single data profile (no RAID). Offsite Urd sends to WD-18TB drives are the sole redundancy against disk failure.
+
+## Decision
+
+### Organize storage by *recovery model*, not data type
+
+Every byte lands in a tier whose BTRFS treatment matches how it would actually be recovered:
+
+| Tier | BTRFS treatment | Backup mechanism | Members |
+|------|-----------------|------------------|---------|
+| **1 — Snapshot** | COW, Urd snapshot, sent offsite | btrfs snapshot + `btrfs send` | user data, configs, app state, **SQLite DBs, Redis** (subvol1–7, /home) |
+| **2 — Dump** | **NOCOW, excluded from snapshots** | application-consistent logical dump → lands in Tier 1 → rides Urd offsite | PostgreSQL (immich, forgejo), MariaDB (nextcloud), MongoDB (gathio), Prometheus, Loki (`subvol8-db`) |
+| **3 — Discard** | NOCOW, excluded, no backup | regenerable | *(currently empty)* |
+
+NOCOW only behaves as NOCOW **because Tier 2 is excluded from snapshots** — with no snapshot to share extents, there is no copy-on-first-write, so fragmentation cannot accumulate. Live DB files get write-in-place performance on spinning disks; the *backup artifact* is a small, compressed, application-consistent, version-portable dump that is COW-snapshotted and replicated offsite. Performance and recoverability are decoupled and each is optimal.
+
+### The tier boundary: own-checksums + native dump tool
+
+NOCOW disables BTRFS data checksums, so it is only safe for engines that carry **their own** integrity checking — PostgreSQL (`data_checksums`), MariaDB/InnoDB (crc32), MongoDB/WiredTiger, Prometheus/Loki (per-chunk CRC32). **SQLite and Redis do not** self-checksum by default; under NOCOW they would lose their only integrity guarantee for zero fragmentation benefit (both are small / whole-file-rewrite / append patterns), and Vaultwarden would lose useful snapshot rollback. They stay in Tier 1.
+
+**Growth rule (one yes/no, for every future service):** *Does it run as its own engine with native page/chunk checksums and a native dump tool? → Tier 2 (`subvol8-db`) + add to the dump job. Otherwise (SQLite, Redis) → Tier 1 with its app.* (This is ADR-027's NOCOW-candidate criteria, restated as the durable rule.)
+
+## Phase A — Dump backbone (IMPLEMENTED 2026-05-22)
+
+`scripts/db-dump.sh` (nightly via `db-dump.timer` @ 01:30, before Urd's 04:00) dumps every Tier-2 engine to `subvol7-containers/db-dumps/<svc>/YYYY-MM-DD.<ext>.zst`, which Urd already snapshots and sends offsite. Per-engine failure isolation; idempotent per day; per-engine retention.
+
+| Engine | Container | Method |
+|--------|-----------|--------|
+| Immich PG | `postgresql-immich` | `pg_dump --format=custom --compress=0` |
+| Forgejo PG | `forgejo-db` | `pg_dump --format=custom --compress=0` |
+| Nextcloud | `nextcloud-db` | `mariadb-dump --single-transaction` as the **app user** (root is locked down) |
+| Gathio | `gathio-db` | `mongodump --archive` |
+| Prometheus | `prometheus` | admin-API `tsdb/snapshot` + tar (retention 7, dump ≈1.5 GB) |
+| Loki | `loki` | `podman pause` + `podman cp` + unpause |
+
+Backup coverage is observable: `db-dumps.prom` (node_exporter textfile) → `db_dump_*` series → `config/prometheus/alerts/db-dump-alerts.yml`. `scripts/db-restore-test.sh` (weekly, Sun 05:00) restores each latest dump into an ephemeral matching-version container and validates object counts (`db_restore_test_*` series).
+
+### Implementation notes (discovered by testing — the non-obvious bits)
+
+- **Metric label is `database`, not `service`.** The node_exporter scrape job sets a static `service="node_exporter"` target label that clobbers any `service` label on textfile metrics (`honor_labels: false`). Urd uses `subvolume`, dependency-metrics use `homelab_service`, for the same reason. **Any textfile metric must avoid the bare `service` label.**
+- **Loki = `podman pause` + `podman cp`.** Loki is distroless (no shell/tar to exec) with 70k+ constantly-rotating files. Rejected: stop-rsync-start (~17 min downtime + WAL-rotation race), host-side tar (permission-denied on mode-600 WAL checkpoint files + slow), live `podman cp` (races on file rotation under load). Quadlet containers are *removed* on stop, so cp needs the container running or paused. `podman pause` (SIGSTOP) freezes the filesystem → consistent, complete copy in ~40 s; Promtail buffers during the freeze (Loki is regenerable, not a source of truth).
+- **Nextcloud MariaDB root is locked down** (no password, no socket auth). The dump uses the app account `MYSQL_USER`/`MYSQL_PASSWORD`, which has `ALL` on its own database — the entire contents of that instance.
+- **Secrets never leave the container.** Each dump runs *inside* the running container where the engine password already exists as env; nothing is passed as a host process arg or stored in the repo. Robust to the ADR-028 secret-store path split.
+- **`zstd -f` is required** (a failed run leaves an empty `.tmp` that would otherwise block the next run).
+- **Vaultwarden dump deferred.** Its image lacks `sqlite3` and the SQLite file is owned by a container subuid in the rootless namespace; a clean logical dump needs a sidecar-image decision. Vaultwarden is Tier-1 snapshot-protected meanwhile.
+
+## Phase B — Offline migration into subvol8-db (DEFERRED / gated)
+
+Move the four engines still in `subvol7` (`postgresql-immich`, `nextcloud-db/data`, `gathio-db`, `prometheus`) into `subvol8-db` (forgejo-db + loki are already there). **Gate:** the dump backbone must have a track record of passing restore tests first (it now exists); revisit with a `filefrag` baseline per ADR-025's criteria.
+
+**The unlock — the clean offline window:** run `scripts/update-before-reboot.sh`, which calls `graceful-shutdown.sh`. With every container cleanly stopped, on-disk DB state is *cleanly consistent*, so the move is a plain offline `rsync` — not a live migration. This collapses the risk surface of the original ADR-025 plan (no initdb-in-container, no Prometheus observability-gap choreography).
+
+Per service, with all containers stopped:
+1. `mkdir` the empty target; **`chattr -m` then `chattr +C`** — the `m` (no-compress) flag inherited from the `compression=none` subvol root is mutually exclusive with `+C`, so a bare `chattr +C` returns EINVAL (ADR-027's documented workaround).
+2. `rsync -aHX --numeric-ids <src>/ <target>/` — **no `--reflink`, no `--inplace`** (reflink shares extents and silently defeats NOCOW).
+3. Assert `lsattr -d` shows `C` and `filefrag -v` shows no shared extents.
+4. Two-layer ACLs (ADR-019): parent-traversal `--x` for each container subuid + per-service `rwx` + default ACL.
+5. Update the quadlet `Volume=`, `daemon-reload`, start, healthcheck — **including the ADR-028 secret-mount check** (`podman run --rm --secret <name> alpine true`).
+6. PostgreSQL: verify checksums with `pg_controldata` (the quadlet sets `--data-checksums`, likely already on); only enable in place if off.
+7. Keep `<svc>.pre-migration-<DATE>` for 14 days. Per-service reversible (revert `Volume=`, restart); worst case restore from the prior night's dump.
+
+A defensive tool (`scripts/migrate-db-to-subvol8.sh`, dry-run default, `--execute` gate, rollback subcommand, hard-enforced no-reflink + post-copy NOCOW assertions) is to be built before Phase B executes.
+
+## subvol8-db tenant table (absorbed from ADR-027)
+
+| Tenant | Workload | NOCOW | Backup |
+|--------|----------|-------|--------|
+| forgejo-db | PostgreSQL | yes | `pg_dump` (Phase A) |
+| loki | TSDB / logs | yes | `podman pause`+`cp` tar (Phase A) |
+| ~~unifi-syslog~~ | append-only syslog | — | **moving to Tier 1** (subvol7, snapshot+offsite) — overrides ADR-027's placement; append-only forensic logs belong in the snapshot tier and the COW cost is negligible |
+| *(Phase B)* postgresql-immich, nextcloud-db, gathio-db, prometheus | server engines | yes | dumps (Phase A) + offline migration (Phase B) |
+
+New tenants follow the growth rule; update this table rather than writing a new ADR (unless the tier policy itself changes).
+
+## Consequences
+
+**Positive:** every database now has an application-consistent, offsite, restore-tested backup; the forgejo-db and loki holes are closed; NOCOW will actually work once Phase B completes; the architecture has a single durable growth rule.
+
+**Negative / accepted:** Prometheus dumps are full TSDB snapshots (~1.5 GB/night, no dedup) — local retention is shortened to 7 and offsite growth is governed by Urd's subvol7 retention; a future option is dumping Prometheus weekly rather than daily. `--web.enable-admin-api` exposes destructive TSDB endpoints to the unauthenticated monitoring network (accepted; external path is Authelia-fronted; only the snapshot endpoint is used). Live DB files in `subvol8-db` have no filesystem-snapshot rollback — recovery is via dumps, which is the intended model.
+
+## Follow-ups
+
+- Move `unifi-syslog` → subvol7 (quadlet + `config/logrotate/unifi-syslog` + verify promtail path).
+- `filefrag` baseline before deciding Phase B.
+- Vaultwarden sidecar dump.
+- Build `scripts/migrate-db-to-subvol8.sh` before Phase B.
+
+## Related
+
+- **ADR-024 / ADR-025 / ADR-027** — superseded by this ADR (content consolidated above).
+- **ADR-019** filesystem permission model (two-layer ACLs) · **ADR-021** Urd integration · **ADR-028** secret-store path split.
+- Implementation: `scripts/db-dump.sh`, `scripts/db-restore-test.sh`, `systemd/db-dump.*`, `systemd/db-restore-test.*`, `config/prometheus/alerts/db-dump-alerts.yml`.

--- a/quadlets/prometheus.container
+++ b/quadlets/prometheus.container
@@ -21,12 +21,19 @@ Volume=/mnt/btrfs-pool/subvol7-containers/prometheus:/prometheus:Z
 Secret=ha-prometheus-token,type=mount,target=/run/secrets/ha-prometheus-token
 
 # Prometheus command line arguments
+# --web.enable-admin-api exposes the TSDB snapshot endpoint used by db-dump.sh
+# (ADR-029 Tier-2 backup). It also exposes destructive endpoints
+# (/api/v1/admin/tsdb/delete_series, clean_tombstones) to the unauthenticated
+# systemd-monitoring network. Accepted for this homelab: the external path is
+# Authelia-fronted (routers.yml), only the snapshot endpoint is used, and the
+# dump job pre-cleans orphaned snapshots. See ADR-029.
 Exec=--config.file=/etc/prometheus/prometheus.yml \
      --storage.tsdb.path=/prometheus \
      --storage.tsdb.retention.time=15d \
      --web.console.libraries=/usr/share/prometheus/console_libraries \
      --web.console.templates=/usr/share/prometheus/consoles \
-     --web.enable-lifecycle
+     --web.enable-lifecycle \
+     --web.enable-admin-api
 
 DNS=192.168.1.69
 

--- a/quadlets/promtail.container
+++ b/quadlets/promtail.container
@@ -21,8 +21,8 @@ Volume=%h/containers/.claude/context/decision-log.jsonl:/var/log/remediation/dec
 # Traefik access logs
 Volume=/mnt/btrfs-pool/subvol7-containers/traefik-logs:/var/log/traefik:ro,z
 
-# UniFi UDM Pro syslog (written by unifi-syslog container)
-Volume=/mnt/btrfs-pool/subvol8-db/unifi-syslog:/var/log/unifi-syslog:ro,z
+# UniFi UDM Pro syslog (written by unifi-syslog container; moved to subvol7 per ADR-029)
+Volume=/mnt/btrfs-pool/subvol7-containers/unifi-syslog:/var/log/unifi-syslog:ro,z
 
 # Promtail command line arguments
 Exec=-config.file=/etc/promtail/promtail-config.yml

--- a/quadlets/unifi-syslog.container
+++ b/quadlets/unifi-syslog.container
@@ -23,7 +23,10 @@ Environment=PGID=0
 Environment=TZ=Europe/Oslo
 
 Volume=%h/containers/config/unifi-syslog/syslog-ng.conf:/config/syslog-ng.conf:ro,Z
-Volume=/mnt/btrfs-pool/subvol8-db/unifi-syslog:/var/log/unifi-syslog:Z
+# Tier 1 (subvol7): snapshotted + sent offsite by Urd. Moved off subvol8-db
+# (ADR-029): append-only forensic logs belong in the snapshot tier, and the
+# COW cost is negligible for append-only writes.
+Volume=/mnt/btrfs-pool/subvol7-containers/unifi-syslog:/var/log/unifi-syslog:Z
 
 DNS=192.168.1.69
 

--- a/scripts/db-dump.sh
+++ b/scripts/db-dump.sh
@@ -34,7 +34,11 @@ DUMP_ROOT="/mnt/btrfs-pool/subvol7-containers/db-dumps"
 METRICS_DIR="${HOME}/containers/data/backup-metrics"
 METRICS_FILE="${METRICS_DIR}/db-dumps.prom"
 LOG_DIR="${HOME}/containers/data/backup-logs"
-RETENTION="${DB_DUMP_RETENTION:-14}"        # daily dumps kept per service
+RETENTION="${DB_DUMP_RETENTION:-14}"        # default daily dumps kept per service
+# Per-engine overrides. Prometheus dumps are full TSDB snapshots (~1.5GB each);
+# a shorter local window keeps the footprint sane (the engine itself only
+# retains 15d of data, so old dumps have little marginal value).
+declare -A RETENTION_BY_DB=( [prometheus]=7 )
 ZSTD_LEVEL="${DB_DUMP_ZSTD_LEVEL:-10}"
 DATE="$(date +%Y-%m-%d)"
 RUN_TS="$(date +%s)"
@@ -172,10 +176,10 @@ run_engine() {  # run_engine <service> <fn> [extra args...]
     fi
 }
 
-prune() {  # keep newest $RETENTION dumps per service
-    local dir="${DUMP_ROOT}/$1" f
+prune() {  # keep newest N dumps per service (per-engine override, else default)
+    local dir="${DUMP_ROOT}/$1" keep="${RETENTION_BY_DB[$1]:-$RETENTION}" f
     [[ -d "$dir" ]] || return 0
-    ls -1t "$dir"/*.zst 2>/dev/null | tail -n +"$((RETENTION + 1))" | while read -r f; do
+    ls -1t "$dir"/*.zst 2>/dev/null | tail -n +"$((keep + 1))" | while read -r f; do
         rm -f "$f" && log INFO "[$1] pruned $(basename "$f")"
     done
 }

--- a/scripts/db-dump.sh
+++ b/scripts/db-dump.sh
@@ -1,0 +1,242 @@
+#!/bin/bash
+################################################################################
+# db-dump.sh — Application-consistent database dumps (Tier 2 backup)
+#
+# Part of the three-tier BTRFS storage architecture (ADR-029). Server database
+# engines live NOCOW on subvol8-db (excluded from snapshots); their backup is
+# an application-consistent logical dump written here, into subvol7-containers/
+# db-dumps/, which Urd snapshots nightly and sends offsite.
+#
+#   Snapshot tier  -> btrfs snapshot + send (configs, SQLite, Redis, user data)
+#   Dump tier      -> THIS SCRIPT (PostgreSQL, MariaDB, MongoDB, Prometheus, Loki)
+#
+# Design:
+#   - Per-engine isolation: one engine's failure never aborts the others
+#     (no `set -e`; each engine's result is captured independently).
+#   - Idempotent per day: output named YYYY-MM-DD, re-runs overwrite.
+#   - Secrets never touch host process args: the dump command runs INSIDE the
+#     running container, where the engine password already lives as env. Robust
+#     to the ADR-028 secret-store path split.
+#   - Observability mirrors Urd's backup_* series (db_dump_* in db-dumps.prom).
+#
+# Schedule: db-dump.timer @ 01:30 (before Urd's 04:00 send).
+# Usage:    db-dump.sh [--service <name>] [--help]
+################################################################################
+
+set -uo pipefail   # deliberately NOT -e: per-engine isolation
+
+# --- systemd/cron environment -------------------------------------------------
+export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+export DBUS_SESSION_BUS_ADDRESS="unix:path=${XDG_RUNTIME_DIR}/bus"
+
+# --- configuration ------------------------------------------------------------
+DUMP_ROOT="/mnt/btrfs-pool/subvol7-containers/db-dumps"
+METRICS_DIR="${HOME}/containers/data/backup-metrics"
+METRICS_FILE="${METRICS_DIR}/db-dumps.prom"
+LOG_DIR="${HOME}/containers/data/backup-logs"
+RETENTION="${DB_DUMP_RETENTION:-14}"        # daily dumps kept per service
+ZSTD_LEVEL="${DB_DUMP_ZSTD_LEVEL:-10}"
+DATE="$(date +%Y-%m-%d)"
+RUN_TS="$(date +%s)"
+
+# Engines handled by this job (service = container name = output subdir)
+ENGINES=(postgresql-immich forgejo-db nextcloud-db gathio-db prometheus loki)
+
+# --- argument parsing ---------------------------------------------------------
+ONLY_SERVICE=""
+SKIP_FLUSH=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --service) ONLY_SERVICE="${2:-}"; SKIP_FLUSH=1; shift 2 ;;   # test mode: don't clobber live metrics
+        --help)
+            echo "Usage: $(basename "$0") [--service <name>]"
+            echo "  --service <name>   dump only one engine, print metrics to stdout"
+            echo "  engines: ${ENGINES[*]}"
+            exit 0 ;;
+        *) echo "[ERROR] unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+# --- logging ------------------------------------------------------------------
+log() {
+    local level="$1"; shift
+    echo "[$(date '+%Y-%m-%d %H:%M:%S')] [${level}] $*" >&2
+}
+
+# --- result tracking ----------------------------------------------------------
+declare -A R_SUCCESS R_DURATION R_SIZE R_TS
+
+record() {  # record <service> <success 0|1> <duration_s> <size_bytes>
+    R_SUCCESS["$1"]="$2"; R_DURATION["$1"]="$3"; R_SIZE["$1"]="$4"
+    [[ "$2" == "1" ]] && R_TS["$1"]="$(date +%s)"
+}
+
+# Carry forward the previous last-success timestamp for engines that failed this
+# run, so DbDumpStale ages correctly instead of the series vanishing.
+# NOTE: label is `database`, not `service` — the node_exporter scrape job sets a
+# static service="node_exporter" target label that would clobber a `service`
+# label here (honor_labels=false). See ADR-029.
+prev_ts() {
+    [[ -f "$METRICS_FILE" ]] || return 0
+    grep -oP "db_dump_last_success_timestamp\{database=\"$1\"\} \K[0-9]+" "$METRICS_FILE" 2>/dev/null | tail -1
+}
+
+# --- engine dump functions ----------------------------------------------------
+# Each writes "$out_dir/$DATE.<ext>.zst" atomically (.tmp then mv) and returns
+# non-zero on any failure (pipefail propagates the in-container command's status).
+
+dump_pg() {  # args: svc out_dir container
+    local out="${2}/${DATE}.dump.zst" container="$3"
+    podman exec "$container" sh -c \
+        'PGPASSWORD="$POSTGRES_PASSWORD" pg_dump --format=custom --compress=0 --no-owner --no-acl -U "$POSTGRES_USER" -d "$POSTGRES_DB"' \
+        | zstd -q -f -T0 "-${ZSTD_LEVEL}" -o "${out}.tmp" \
+        && mv "${out}.tmp" "$out"
+}
+
+dump_mariadb() {  # args: svc out_dir
+    # root@localhost is locked down on this hardened Nextcloud MariaDB (no
+    # password and no socket auth). The app user has ALL on its own database,
+    # which is exactly what we dump.
+    local out="${2}/${DATE}.sql.zst"
+    podman exec nextcloud-db sh -c \
+        'mariadb-dump --single-transaction --routines --events -u "$MYSQL_USER" -p"$MYSQL_PASSWORD" "$MYSQL_DATABASE"' \
+        | zstd -q -f -T0 "-${ZSTD_LEVEL}" -o "${out}.tmp" \
+        && mv "${out}.tmp" "$out"
+}
+
+dump_mongo() {  # args: svc out_dir
+    local out="${2}/${DATE}.archive.zst"
+    podman exec gathio-db sh -c \
+        'mongodump --quiet --username "$MONGO_INITDB_ROOT_USERNAME" --password "$MONGO_INITDB_ROOT_PASSWORD" --authenticationDatabase admin --archive' \
+        | zstd -q -f -T0 "-${ZSTD_LEVEL}" -o "${out}.tmp" \
+        && mv "${out}.tmp" "$out"
+}
+
+dump_prometheus() {  # args: svc out_dir   (requires --web.enable-admin-api)
+    local out="${2}/${DATE}.tar.zst" snap rc
+    # Pre-clean orphaned snapshots >60min so a crashed run can't pin TSDB blocks.
+    podman exec prometheus sh -c \
+        'find /prometheus/snapshots -mindepth 1 -maxdepth 1 -type d -mmin +60 -exec rm -rf {} + 2>/dev/null' || true
+    snap="$(podman exec prometheus sh -c \
+        'wget -qO- --post-data="" "http://localhost:9090/api/v1/admin/tsdb/snapshot?skip_head=false"' \
+        | jq -r '.data.name // empty')"
+    if [[ -z "$snap" ]]; then
+        log ERROR "[prometheus] snapshot API returned no name — is --web.enable-admin-api set on the quadlet?"
+        return 1
+    fi
+    podman exec prometheus tar -C /prometheus/snapshots -cf - "$snap" \
+        | zstd -q -f -T0 "-${ZSTD_LEVEL}" -o "${out}.tmp" \
+        && mv "${out}.tmp" "$out"
+    rc=$?
+    podman exec prometheus rm -rf "/prometheus/snapshots/${snap}" 2>/dev/null || true
+    return "$rc"
+}
+
+dump_loki() {  # args: svc out_dir
+    # Loki is distroless (no shell/tar to exec) with 70k+ constantly-rotating
+    # files. Three approaches were measured and rejected: host-side tar/rsync
+    # hits permission-denied on mode-600 WAL checkpoint files and is slow (~140s);
+    # stop-and-copy fails because the quadlet removes the container on stop;
+    # a live `podman cp` races on file rotation under I/O load (rc=125).
+    # `podman pause` (SIGSTOP via the freezer cgroup) makes the filesystem static
+    # without removing the container, so `podman cp` reads a complete, consistent
+    # tree via the namespace in ~40s. Promtail buffers/retries during the freeze;
+    # Loki is regenerable, not a source of truth (ADR-027/029).
+    local out="${2}/${DATE}.tar.zst" rc
+    podman pause loki >/dev/null 2>&1 || { log ERROR "[loki] pause failed"; return 1; }
+    trap 'podman unpause loki >/dev/null 2>&1 || true; trap - RETURN' RETURN
+    podman cp loki:/loki - | zstd -q -f -T0 "-${ZSTD_LEVEL}" -o "${out}.tmp"
+    rc=$?
+    podman unpause loki >/dev/null 2>&1 || log WARNING "[loki] unpause returned non-zero"
+    trap - RETURN
+    [[ $rc -eq 0 ]] || { log ERROR "[loki] podman cp|zstd failed (rc=$rc)"; return 1; }
+    mv "${out}.tmp" "$out"
+}
+
+# --- engine runner ------------------------------------------------------------
+run_engine() {  # run_engine <service> <fn> [extra args...]
+    local svc="$1" fn="$2"; shift 2
+    local out_dir="${DUMP_ROOT}/${svc}" start now dur rc size
+    mkdir -p "$out_dir"
+    start="$(date +%s)"
+    log INFO "[$svc] dump starting"
+    if "$fn" "$svc" "$out_dir" "$@"; then rc=0; else rc=$?; fi
+    now="$(date +%s)"; dur=$((now - start))
+    if [[ $rc -eq 0 ]]; then
+        size="$(stat -c%s "${out_dir}/${DATE}".*.zst 2>/dev/null | head -1)"; size="${size:-0}"
+        log INFO "[$svc] OK in ${dur}s (${size} bytes)"
+        record "$svc" 1 "$dur" "$size"
+    else
+        log ERROR "[$svc] FAILED (rc=$rc) after ${dur}s"
+        record "$svc" 0 "$dur" 0
+    fi
+}
+
+prune() {  # keep newest $RETENTION dumps per service
+    local dir="${DUMP_ROOT}/$1" f
+    [[ -d "$dir" ]] || return 0
+    ls -1t "$dir"/*.zst 2>/dev/null | tail -n +"$((RETENTION + 1))" | while read -r f; do
+        rm -f "$f" && log INFO "[$1] pruned $(basename "$f")"
+    done
+}
+
+# --- metrics flush (atomic) ---------------------------------------------------
+flush_metrics() {
+    local out ts s
+    out="$( {
+        echo "# HELP db_dump_success Database dump result: 1=success, 0=failure"
+        echo "# TYPE db_dump_success gauge"
+        for s in "${!R_SUCCESS[@]}"; do echo "db_dump_success{database=\"$s\"} ${R_SUCCESS[$s]}"; done
+        echo "# HELP db_dump_last_success_timestamp Unix timestamp of last successful dump"
+        echo "# TYPE db_dump_last_success_timestamp gauge"
+        for s in "${!R_SUCCESS[@]}"; do
+            ts="${R_TS[$s]:-$(prev_ts "$s")}"
+            [[ -n "$ts" ]] && echo "db_dump_last_success_timestamp{database=\"$s\"} ${ts}"
+        done
+        echo "# HELP db_dump_duration_seconds Duration of the dump in seconds"
+        echo "# TYPE db_dump_duration_seconds gauge"
+        for s in "${!R_DURATION[@]}"; do echo "db_dump_duration_seconds{database=\"$s\"} ${R_DURATION[$s]}"; done
+        echo "# HELP db_dump_size_bytes Size of the produced dump in bytes"
+        echo "# TYPE db_dump_size_bytes gauge"
+        for s in "${!R_SIZE[@]}"; do echo "db_dump_size_bytes{database=\"$s\"} ${R_SIZE[$s]}"; done
+        echo "# HELP db_dump_last_run_timestamp Unix timestamp of last db-dump.sh run"
+        echo "# TYPE db_dump_last_run_timestamp gauge"
+        echo "db_dump_last_run_timestamp ${RUN_TS}"
+    } )"
+    if [[ $SKIP_FLUSH -eq 1 ]]; then
+        echo "--- metrics (test mode, not written) ---" >&2
+        echo "$out"
+        return 0
+    fi
+    mkdir -p "$METRICS_DIR"
+    printf '%s\n' "$out" > "${METRICS_FILE}.tmp"
+    mv "${METRICS_FILE}.tmp" "$METRICS_FILE"
+}
+
+# --- main ---------------------------------------------------------------------
+main() {
+    mkdir -p "$DUMP_ROOT" "$LOG_DIR"
+    log INFO "db-dump starting (date=${DATE}, retention=${RETENTION}${ONLY_SERVICE:+, only=${ONLY_SERVICE}})"
+
+    for svc in "${ENGINES[@]}"; do
+        [[ -n "$ONLY_SERVICE" && "$ONLY_SERVICE" != "$svc" ]] && continue
+        case "$svc" in
+            postgresql-immich) run_engine "$svc" dump_pg "$svc" ;;
+            forgejo-db)        run_engine "$svc" dump_pg "$svc" ;;
+            nextcloud-db)      run_engine "$svc" dump_mariadb ;;
+            gathio-db)         run_engine "$svc" dump_mongo ;;
+            prometheus)        run_engine "$svc" dump_prometheus ;;
+            loki)              run_engine "$svc" dump_loki ;;
+        esac
+        prune "$svc"
+    done
+
+    flush_metrics
+
+    local fails=0 total="${#R_SUCCESS[@]}"
+    for s in "${!R_SUCCESS[@]}"; do [[ "${R_SUCCESS[$s]}" == "1" ]] || fails=$((fails + 1)); done
+    log INFO "db-dump finished: $((total - fails))/${total} engines OK"
+    return 0   # never fail the unit; per-engine status is in metrics + alerts
+}
+
+main "$@"

--- a/scripts/db-restore-test.sh
+++ b/scripts/db-restore-test.sh
@@ -1,0 +1,174 @@
+#!/bin/bash
+################################################################################
+# db-restore-test.sh — Weekly per-engine restore validation (ADR-029)
+#
+# "A dump nobody has restored is a dump you don't have." For each engine, this
+# restores the LATEST dump from db-dump.sh into a throwaway, matching-version
+# container, validates that real objects came back, and tears the container
+# down. Result is exported as db_restore_test_* metrics (DbRestoreTest* alerts).
+#
+#   PG / MariaDB / Mongo : full ephemeral restore + object-count validation
+#   Prometheus / Loki    : archive integrity + structure check (full TSDB
+#                          restore is heavy; integrity is the weekly gate)
+#
+# Schedule: db-restore-test.timer @ Sun 05:00 (after Urd's 04:00 send).
+# Usage:    db-restore-test.sh [--service <name>] [--keep]
+################################################################################
+
+set -uo pipefail
+
+export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+export DBUS_SESSION_BUS_ADDRESS="unix:path=${XDG_RUNTIME_DIR}/bus"
+
+DUMP_ROOT="/mnt/btrfs-pool/subvol7-containers/db-dumps"
+METRICS_DIR="${HOME}/containers/data/backup-metrics"
+METRICS_FILE="${METRICS_DIR}/db-restore-test.prom"
+LOG_DIR="${HOME}/containers/data/backup-logs"
+TEST_PW="restoretest"               # ephemeral throwaway container password
+RUN_TS="$(date +%s)"
+
+# Matching images per engine (must match the source so extensions/format load)
+IMG_IMMICH="ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0"
+IMG_PG16="docker.io/library/postgres:16-alpine"
+IMG_MARIADB="docker.io/library/mariadb:11"
+IMG_MONGO="docker.io/library/mongo:7"
+
+ONLY_SERVICE=""
+KEEP=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --service) ONLY_SERVICE="${2:-}"; shift 2 ;;
+        --keep)    KEEP=1; shift ;;       # leave the live metrics file alone (test mode)
+        --help)    echo "Usage: $(basename "$0") [--service <name>] [--keep]"; exit 0 ;;
+        *) echo "[ERROR] unknown argument: $1" >&2; exit 2 ;;
+    esac
+done
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [$1] ${*:2}" >&2; }
+
+declare -A R_OK R_TS
+record() { R_OK["$1"]="$2"; [[ "$2" == "1" ]] && R_TS["$1"]="$(date +%s)"; }
+
+latest_dump() {  # echo newest dump path for a service, empty if none
+    ls -1t "${DUMP_ROOT}/$1/"*.zst 2>/dev/null | head -1
+}
+
+# Wait for a predicate (podman exec health probe) up to ~90s.
+wait_ready() {  # wait_ready <container> <probe-shell-cmd>
+    local c="$1" probe="$2" i
+    for i in $(seq 1 45); do
+        podman exec "$c" sh -c "$probe" >/dev/null 2>&1 && return 0
+        sleep 2
+    done
+    return 1
+}
+
+# --- engine restore tests -----------------------------------------------------
+test_pg() {  # args: svc image user db
+    local svc="$1" img="$2" user="$3" db="$4" c="dbrestoretest-${1}" dump n
+    dump="$(latest_dump "$svc")"; [[ -n "$dump" ]] || { log ERROR "[$svc] no dump found"; return 1; }
+    podman rm -f "$c" >/dev/null 2>&1 || true
+    trap 'podman rm -f "'"$c"'" >/dev/null 2>&1 || true; trap - RETURN' RETURN
+    podman run -d --rm --name "$c" --network none \
+        -e POSTGRES_PASSWORD="$TEST_PW" -e POSTGRES_USER="$user" -e POSTGRES_DB="$db" \
+        "$img" >/dev/null || { log ERROR "[$svc] could not start $img"; return 1; }
+    # Probe the DATABASE, not just the server: pg_isready passes as soon as the
+    # server accepts connections, but slow images (immich/vectorchord, ~40s)
+    # create POSTGRES_DB well after that — restoring too early gives 0 tables.
+    wait_ready "$c" "psql -U $user -d $db -tAc 'SELECT 1'" || { log ERROR "[$svc] ephemeral PG/db never ready"; return 1; }
+    zstd -dc "$dump" | podman exec -i "$c" pg_restore --no-owner --no-acl -U "$user" -d "$db" >/dev/null 2>&1 || true
+    n="$(podman exec "$c" psql -U "$user" -d "$db" -tAc \
+        "SELECT count(*) FROM information_schema.tables WHERE table_schema='public'" 2>/dev/null | tr -d '[:space:]')"
+    [[ "${n:-0}" -gt 0 ]] && { log SUCCESS "[$svc] restored, ${n} public tables"; return 0; }
+    log ERROR "[$svc] restore produced 0 tables"; return 1
+}
+
+test_mariadb() {  # args: svc db
+    local svc="$1" db="$2" c="dbrestoretest-${1}" dump n
+    dump="$(latest_dump "$svc")"; [[ -n "$dump" ]] || { log ERROR "[$svc] no dump found"; return 1; }
+    podman rm -f "$c" >/dev/null 2>&1 || true
+    trap 'podman rm -f "'"$c"'" >/dev/null 2>&1 || true; trap - RETURN' RETURN
+    podman run -d --rm --name "$c" --network none \
+        -e MARIADB_ROOT_PASSWORD="$TEST_PW" -e MARIADB_DATABASE="$db" \
+        "$IMG_MARIADB" >/dev/null || { log ERROR "[$svc] could not start mariadb"; return 1; }
+    wait_ready "$c" "mariadb -uroot -p${TEST_PW} ${db} -e 'SELECT 1'" || { log ERROR "[$svc] ephemeral MariaDB/db never ready"; return 1; }
+    zstd -dc "$dump" | podman exec -i "$c" mariadb -uroot -p"$TEST_PW" "$db" >/dev/null 2>&1 || { log ERROR "[$svc] import failed"; return 1; }
+    n="$(podman exec "$c" mariadb -uroot -p"$TEST_PW" -N -B -e \
+        "SELECT count(*) FROM information_schema.tables WHERE table_schema='$db'" 2>/dev/null | tr -d '[:space:]')"
+    [[ "${n:-0}" -gt 0 ]] && { log SUCCESS "[$svc] restored, ${n} tables"; return 0; }
+    log ERROR "[$svc] restore produced 0 tables"; return 1
+}
+
+test_mongo() {  # args: svc
+    local svc="$1" c="dbrestoretest-${1}" dump n
+    dump="$(latest_dump "$svc")"; [[ -n "$dump" ]] || { log ERROR "[$svc] no dump found"; return 1; }
+    podman rm -f "$c" >/dev/null 2>&1 || true
+    trap 'podman rm -f "'"$c"'" >/dev/null 2>&1 || true; trap - RETURN' RETURN
+    podman run -d --rm --name "$c" --network none \
+        -e MONGO_INITDB_ROOT_USERNAME=root -e MONGO_INITDB_ROOT_PASSWORD="$TEST_PW" \
+        "$IMG_MONGO" >/dev/null || { log ERROR "[$svc] could not start mongo"; return 1; }
+    wait_ready "$c" "mongosh --quiet -u root -p ${TEST_PW} --authenticationDatabase admin --eval 'db.adminCommand(\"ping\")'" \
+        || { log ERROR "[$svc] ephemeral Mongo never ready"; return 1; }
+    zstd -dc "$dump" | podman exec -i "$c" mongorestore --quiet \
+        -u root -p "$TEST_PW" --authenticationDatabase admin --archive >/dev/null 2>&1 || { log ERROR "[$svc] mongorestore failed"; return 1; }
+    n="$(podman exec "$c" mongosh --quiet -u root -p "$TEST_PW" --authenticationDatabase admin --eval \
+        'db.adminCommand("listDatabases").databases.filter(d=>!["admin","config","local"].includes(d.name)).length' 2>/dev/null | tr -d '[:space:]')"
+    [[ "${n:-0}" -gt 0 ]] && { log SUCCESS "[$svc] restored, ${n} user database(s)"; return 0; }
+    log ERROR "[$svc] restore produced 0 user databases"; return 1
+}
+
+test_archive() {  # args: svc   (integrity + structure only — for TSDB tarballs)
+    local svc="$1" dump
+    dump="$(latest_dump "$svc")"; [[ -n "$dump" ]] || { log ERROR "[$svc] no dump found"; return 1; }
+    zstd -t "$dump" >/dev/null 2>&1 || { log ERROR "[$svc] zstd integrity check failed"; return 1; }
+    zstd -dc "$dump" | tar -tf - >/dev/null 2>&1 || { log ERROR "[$svc] tar structure check failed"; return 1; }
+    log SUCCESS "[$svc] archive integrity + structure OK"; return 0
+}
+
+run_test() {  # run_test <svc> <fn> [args...]
+    local svc="$1" fn="$2"; shift 2
+    [[ -n "$ONLY_SERVICE" && "$ONLY_SERVICE" != "$svc" ]] && return 0
+    log INFO "[$svc] restore test starting"
+    if "$fn" "$svc" "$@"; then record "$svc" 1; else record "$svc" 0; fi
+}
+
+flush_metrics() {
+    local out s
+    out="$( {
+        echo "# HELP db_restore_test_success Restore test result: 1=restored+validated, 0=failed"
+        echo "# TYPE db_restore_test_success gauge"
+        for s in "${!R_OK[@]}"; do echo "db_restore_test_success{database=\"$s\"} ${R_OK[$s]}"; done
+        echo "# HELP db_restore_test_last_timestamp Unix timestamp of last successful restore test"
+        echo "# TYPE db_restore_test_last_timestamp gauge"
+        for s in "${!R_OK[@]}"; do
+            local ts="${R_TS[$s]:-}"
+            [[ -z "$ts" && -f "$METRICS_FILE" ]] && ts="$(grep -oP "db_restore_test_last_timestamp\{database=\"$s\"\} \K[0-9]+" "$METRICS_FILE" 2>/dev/null | tail -1)"
+            [[ -n "$ts" ]] && echo "db_restore_test_last_timestamp{database=\"$s\"} ${ts}"
+        done
+        echo "# HELP db_restore_test_last_run_timestamp Unix timestamp of last db-restore-test.sh run"
+        echo "# TYPE db_restore_test_last_run_timestamp gauge"
+        echo "db_restore_test_last_run_timestamp ${RUN_TS}"
+    } )"
+    if [[ $KEEP -eq 1 ]]; then echo "--- metrics (test mode, not written) ---" >&2; echo "$out"; return 0; fi
+    mkdir -p "$METRICS_DIR"
+    printf '%s\n' "$out" > "${METRICS_FILE}.tmp"
+    mv "${METRICS_FILE}.tmp" "$METRICS_FILE"
+}
+
+main() {
+    mkdir -p "$LOG_DIR"
+    log INFO "db-restore-test starting${ONLY_SERVICE:+ (only=${ONLY_SERVICE})}"
+    run_test postgresql-immich test_pg     "$IMG_IMMICH" immich  immich
+    run_test forgejo-db        test_pg     "$IMG_PG16"   forgejo forgejo
+    run_test nextcloud-db      test_mariadb nextcloud
+    run_test gathio-db         test_mongo
+    run_test prometheus        test_archive
+    run_test loki              test_archive
+    flush_metrics
+    local fails=0 total="${#R_OK[@]}"
+    for s in "${!R_OK[@]}"; do [[ "${R_OK[$s]}" == "1" ]] || fails=$((fails + 1)); done
+    log INFO "db-restore-test finished: $((total - fails))/${total} restored OK"
+    return 0
+}
+
+main "$@"

--- a/systemd/db-dump.service
+++ b/systemd/db-dump.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Database application-consistent dumps (Tier 2 backup, ADR-029)
+Documentation=file:///home/patriark/containers/docs/00-foundation/decisions
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/containers/scripts/db-dump.sh
+TimeoutStartSec=1h
+
+# Low priority — do not interfere with interactive use or other I/O
+Nice=19
+IOSchedulingClass=idle
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/systemd/db-dump.timer
+++ b/systemd/db-dump.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Nightly database dumps (runs before Urd's 04:00 send)
+
+[Timer]
+OnCalendar=*-*-* 01:30:00
+Persistent=true
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target

--- a/systemd/db-restore-test.service
+++ b/systemd/db-restore-test.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Weekly database restore-test validation (ADR-029)
+Documentation=file:///home/patriark/containers/docs/00-foundation/decisions
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/containers/scripts/db-restore-test.sh
+TimeoutStartSec=1h
+
+# Low priority — ephemeral restore containers must not disturb live services
+Nice=19
+IOSchedulingClass=idle
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/systemd/db-restore-test.timer
+++ b/systemd/db-restore-test.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Weekly DB restore-test (Sunday 05:00, after Urd's send)
+
+[Timer]
+OnCalendar=Sun *-*-* 05:00:00
+Persistent=true
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Phase A of the three-tier database storage architecture (ADR-029, supersedes ADR-024/025/027). Two commits:

## 1. Dump backbone
Application-consistent **logical dumps** for all six server DB engines → `subvol7-containers/db-dumps/` → Urd offsite. **Closes the forgejo-db and loki backup holes** (both were in the un-snapshotted subvol8-db).
- `scripts/db-dump.sh` — pg_dump / mariadb-dump (app user; root is locked down) / mongodump / Prometheus admin-API snapshot / Loki via `podman pause`+`cp`. Per-engine failure isolation; secrets stay inside the container; metrics use the `database` label (the `service` label is clobbered by node_exporter's scrape relabel).
- `systemd/db-dump.{service,timer}` (01:30), `config/prometheus/alerts/db-dump-alerts.yml`, Prometheus `--web.enable-admin-api`.

## 2. Restore-test + retention + ADR + unifi-syslog
- `scripts/db-restore-test.sh` + weekly timer (Sun 05:00): restores each dump into a throwaway matching-version container and validates object counts. **6/6 pass.** PG readiness probes the database (not `pg_isready`) — the immich/vectorchord image creates the DB ~30s late.
- Per-engine retention (prometheus=7) to cap the ~1.5 GB/night TSDB dump.
- **ADR-029** consolidates + supersedes ADR-024/025/027.
- **unifi-syslog moved** subvol8-db → subvol7 (Tier 1, snapshot+offsite); subvol8-db now holds only its NOCOW DB tenants.

## Verification
All six engines dump and restore successfully; Prometheus scrapes distinct `database`-labelled series with no alerts firing. Forgejo/immich/nextcloud/gathio restores validated by object count; prometheus/loki by archive integrity.

## Security
No real secrets in any file — dump commands run inside each container; the only credential literal is a throwaway password for the ephemeral, `--network none`, auto-removed restore-test containers. Pre-commit secret hook passes.

## Deferred (separate work)
Vaultwarden sidecar dump; `filefrag` baseline; Phase B offline migration (gated). Post-merge manual step (done): install the updated logrotate config to `/etc/logrotate.d/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)