### PR TITLE
Vaultwarden dump, loki→Tier 3, filefrag baseline + session journal

### DIFF
--- a/docs/00-foundation/decisions/2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md
+++ b/docs/00-foundation/decisions/2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md
@@ -65,7 +65,7 @@ Backup coverage is observable: `db-dumps.prom` (node_exporter textfile) → `db_
 
 ## Phase B — Offline migration into subvol8-db (DEFERRED / gated)
 
-Move the four engines still in `subvol7` (`postgresql-immich`, `nextcloud-db/data`, `gathio-db`, `prometheus`) into `subvol8-db` (forgejo-db + loki are already there). **Gate:** the dump backbone must have a track record of passing restore tests first (it now exists); revisit with a `filefrag` baseline per ADR-025's criteria.
+Move the four engines still in `subvol7` (`postgresql-immich`, `nextcloud-db/data`, `gathio-db`, `prometheus`) into `subvol8-db` (forgejo-db + loki are already there). **Gate:** (a) restore-test track record (the job now exists — let it run a few Sundays); (b) **measurement — DONE 2026-05-22, justifies migration:** subvol7 DBs show heavy COW-in-snapshot fragmentation (nextcloud `oc_filecache.ibd` = 11,777 extents; gathio max 2,362; immich PG mean 6.3 / max 1,862) vs the subvol8 NOCOW reference (forgejo PG mean 0.9 / max 8, loki mean 1.0) — a near-controlled same-engine comparison (immich vs forgejo PostgreSQL). Baseline saved under `data/backup-logs/`, regenerate via `scripts/filefrag-baseline.sh`; (c) build `scripts/migrate-db-to-subvol8.sh` first.
 
 **The unlock — the clean offline window:** run `scripts/update-before-reboot.sh`, which calls `graceful-shutdown.sh`. With every container cleanly stopped, on-disk DB state is *cleanly consistent*, so the move is a plain offline `rsync` — not a live migration. This collapses the risk surface of the original ADR-025 plan (no initdb-in-container, no Prometheus observability-gap choreography).
 

--- a/docs/00-foundation/decisions/2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md
+++ b/docs/00-foundation/decisions/2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md
@@ -28,8 +28,8 @@ Every byte lands in a tier whose BTRFS treatment matches how it would actually b
 | Tier | BTRFS treatment | Backup mechanism | Members |
 |------|-----------------|------------------|---------|
 | **1 — Snapshot** | COW, Urd snapshot, sent offsite | btrfs snapshot + `btrfs send` | user data, configs, app state, **SQLite DBs, Redis** (subvol1–7, /home) |
-| **2 — Dump** | **NOCOW, excluded from snapshots** | application-consistent logical dump → lands in Tier 1 → rides Urd offsite | PostgreSQL (immich, forgejo), MariaDB (nextcloud), MongoDB (gathio), Prometheus, Loki (`subvol8-db`) |
-| **3 — Discard** | NOCOW, excluded, no backup | regenerable | *(currently empty)* |
+| **2 — Dump** | **NOCOW, excluded from snapshots** | application-consistent logical dump → lands in Tier 1 → rides Urd offsite | PostgreSQL (immich, forgejo), MariaDB (nextcloud), MongoDB (gathio), Prometheus (`subvol8-db`); SQLite (vaultwarden) dumped but stays Tier 1 |
+| **3 — Discard** | NOCOW, excluded, no backup | regenerable | **Loki** (`subvol8-db`) — see implementation note |
 
 NOCOW only behaves as NOCOW **because Tier 2 is excluded from snapshots** — with no snapshot to share extents, there is no copy-on-first-write, so fragmentation cannot accumulate. Live DB files get write-in-place performance on spinning disks; the *backup artifact* is a small, compressed, application-consistent, version-portable dump that is COW-snapshotted and replicated offsite. Performance and recoverability are decoupled and each is optimal.
 
@@ -50,18 +50,18 @@ NOCOW disables BTRFS data checksums, so it is only safe for engines that carry *
 | Nextcloud | `nextcloud-db` | `mariadb-dump --single-transaction` as the **app user** (root is locked down) |
 | Gathio | `gathio-db` | `mongodump --archive` |
 | Prometheus | `prometheus` | admin-API `tsdb/snapshot` + tar (retention 7, dump ≈1.5 GB) |
-| Loki | `loki` | `podman pause` + `podman cp` + unpause |
+| Vaultwarden | `vaultwarden` | host `sqlite3 .backup` (online) + `PRAGMA integrity_check` (stays Tier 1; dump is a bonus) |
 
 Backup coverage is observable: `db-dumps.prom` (node_exporter textfile) → `db_dump_*` series → `config/prometheus/alerts/db-dump-alerts.yml`. `scripts/db-restore-test.sh` (weekly, Sun 05:00) restores each latest dump into an ephemeral matching-version container and validates object counts (`db_restore_test_*` series).
 
 ### Implementation notes (discovered by testing — the non-obvious bits)
 
 - **Metric label is `database`, not `service`.** The node_exporter scrape job sets a static `service="node_exporter"` target label that clobbers any `service` label on textfile metrics (`honor_labels: false`). Urd uses `subvolume`, dependency-metrics use `homelab_service`, for the same reason. **Any textfile metric must avoid the bare `service` label.**
-- **Loki = `podman pause` + `podman cp`.** Loki is distroless (no shell/tar to exec) with 70k+ constantly-rotating files. Rejected: stop-rsync-start (~17 min downtime + WAL-rotation race), host-side tar (permission-denied on mode-600 WAL checkpoint files + slow), live `podman cp` (races on file rotation under load). Quadlet containers are *removed* on stop, so cp needs the container running or paused. `podman pause` (SIGSTOP) freezes the filesystem → consistent, complete copy in ~40 s; Promtail buffers during the freeze (Loki is regenerable, not a source of truth).
+- **Loki is Tier 3 (not dumped).** It was briefly dumped via `podman pause` + `podman cp` (distroless image → can't exec tar; quadlet containers are *removed* on stop → can't cp a stopped one; host-side tar hits mode-600 WAL perms; live cp races on rotation). But a nightly dump **froze loki ~15 min** on a cold cache — 70k small files read seek-bound from HDD after Prometheus's 1.5 GB dump evicts the page cache (the warm-cache "~40 s" was a fluke). For regenerable log data (Promtail re-ingests; the originating systems are the source of truth) that trade isn't worth it, so loki is excluded from backup. If ever wanted, a weekly cadence would amortize the freeze.
 - **Nextcloud MariaDB root is locked down** (no password, no socket auth). The dump uses the app account `MYSQL_USER`/`MYSQL_PASSWORD`, which has `ALL` on its own database — the entire contents of that instance.
 - **Secrets never leave the container.** Each dump runs *inside* the running container where the engine password already exists as env; nothing is passed as a host process arg or stored in the repo. Robust to the ADR-028 secret-store path split.
 - **`zstd -f` is required** (a failed run leaves an empty `.tmp` that would otherwise block the next run).
-- **Vaultwarden dump deferred.** Its image lacks `sqlite3` and the SQLite file is owned by a container subuid in the rootless namespace; a clean logical dump needs a sidecar-image decision. Vaultwarden is Tier-1 snapshot-protected meanwhile.
+- **Vaultwarden: host `sqlite3 .backup` (no sidecar needed).** Initially assumed to need a sidecar (no `sqlite3` in the image). Ground truth corrected it: the SQLite is host-owned (uid 1000, mode 644) and the host has `sqlite3`, so an online `.backup` (backup API — safe alongside the live writer) + `PRAGMA integrity_check` gives an application-consistent copy with no container involvement. Vaultwarden stays Tier 1 (snapshotted); the dump is an extra offsite, restore-tested safety net for the most security-critical store. *Lesson: re-check the assumption before engineering around it.*
 
 ## Phase B — Offline migration into subvol8-db (DEFERRED / gated)
 
@@ -85,15 +85,15 @@ A defensive tool (`scripts/migrate-db-to-subvol8.sh`, dry-run default, `--execut
 | Tenant | Workload | NOCOW | Backup |
 |--------|----------|-------|--------|
 | forgejo-db | PostgreSQL | yes | `pg_dump` (Phase A) |
-| loki | TSDB / logs | yes | `podman pause`+`cp` tar (Phase A) |
-| ~~unifi-syslog~~ | append-only syslog | — | **moving to Tier 1** (subvol7, snapshot+offsite) — overrides ADR-027's placement; append-only forensic logs belong in the snapshot tier and the COW cost is negligible |
+| loki | TSDB / logs | yes | **none — Tier 3, regenerable** (nightly dump froze it ~15 min on cold cache; dropped) |
+| ~~unifi-syslog~~ | append-only syslog | — | **moved to Tier 1** (subvol7, snapshot+offsite) — overrides ADR-027's placement; append-only forensic logs belong in the snapshot tier and the COW cost is negligible |
 | *(Phase B)* postgresql-immich, nextcloud-db, gathio-db, prometheus | server engines | yes | dumps (Phase A) + offline migration (Phase B) |
 
 New tenants follow the growth rule; update this table rather than writing a new ADR (unless the tier policy itself changes).
 
 ## Consequences
 
-**Positive:** every database now has an application-consistent, offsite, restore-tested backup; the forgejo-db and loki holes are closed; NOCOW will actually work once Phase B completes; the architecture has a single durable growth rule.
+**Positive:** every database (PostgreSQL, MariaDB, MongoDB, Prometheus, plus vaultwarden SQLite) now has an application-consistent, offsite, restore-tested backup; the forgejo-db hole is closed (loki is reclassified Tier 3 — regenerable, accepted no-backup); NOCOW will actually work once Phase B completes; the architecture has a single durable growth rule.
 
 **Negative / accepted:** Prometheus dumps are full TSDB snapshots (~1.5 GB/night, no dedup) — local retention is shortened to 7 and offsite growth is governed by Urd's subvol7 retention; a future option is dumping Prometheus weekly rather than daily. `--web.enable-admin-api` exposes destructive TSDB endpoints to the unauthenticated monitoring network (accepted; external path is Authelia-fronted; only the snapshot endpoint is used). Live DB files in `subvol8-db` have no filesystem-snapshot rollback — recovery is via dumps, which is the intended model.
 

--- a/docs/98-journals/2026-05-22-db-storage-three-tier-and-dump-backbone-phase-a.md
+++ b/docs/98-journals/2026-05-22-db-storage-three-tier-and-dump-backbone-phase-a.md
@@ -113,7 +113,18 @@ Secondary: secrets stay inside the container (dump runs via `podman exec`; nothi
 
 ### Gate — do not start until all hold
 1. **Dumps have a track record** of passing weekly restore-tests (they now exist; let `db-restore-test.timer` run a few Sundays and confirm `db_restore_test_success == 1` for all). The dumps are the migration's rollback safety net.
-2. **Measurement justifies it.** Run `sudo bash scripts/filefrag-baseline.sh` and read the latest `data/backup-logs/filefrag-baseline-*.txt`. Per ADR-025/029 criteria, migrate if subvol7 DB files show high/growing extent counts vs the subvol8 reference. If fragmentation is negligible, Phase B can stay deferred indefinitely — that's a legitimate outcome.
+2. **Measurement — DONE 2026-05-22, and it strongly justifies migration.** Baseline (`data/backup-logs/filefrag-baseline-2026-05-22-2245.txt`; regenerate with `sudo bash scripts/filefrag-baseline.sh`):
+
+   | Tier | DB | mean extents/file | max |
+   |------|----|------------------:|----:|
+   | subvol7 (COW-in-snapshot) | nextcloud — `oc_filecache.ibd` | 28.2 | **11,777** |
+   | subvol7 | gathio | 41.0 | 2,362 |
+   | subvol7 | immich PG | 6.3 | 1,862 |
+   | subvol7 | prometheus | 6.6 | 207 |
+   | subvol8 (NOCOW reference) | forgejo PG | **0.9** | 8 |
+   | subvol8 (NOCOW reference) | loki | **1.0** | 10 |
+
+   Near-controlled experiment: immich PG (COW) mean 6.3 / max 1,862 vs forgejo PG (NOCOW, same engine) mean 0.9 / max 8. The antipattern is real and material — nextcloud's hottest InnoDB table is in ~11.8k extents on spinning disks. **Phase B is evidence-justified;** only the operational gates (restore-test track record + the defensive tool) remain. Re-run the script post-migration for the before/after brag.
 3. **The defensive tool exists.** Build `scripts/migrate-db-to-subvol8.sh` (dry-run default, `--execute` gate, `rollback` subcommand) BEFORE migrating. Improvised shell is not acceptable here (this is the riskiest moment in the homelab's storage history).
 
 ### The window (the key unlock)

--- a/docs/98-journals/2026-05-22-db-storage-three-tier-and-dump-backbone-phase-a.md
+++ b/docs/98-journals/2026-05-22-db-storage-three-tier-and-dump-backbone-phase-a.md
@@ -1,0 +1,149 @@
+# Journal — Three-Tier DB Storage & Dump Backbone (Phase A)
+
+**Date:** 2026-05-22
+**Scope:** ADR-029 (supersedes ADR-024/025/027). Phase A built, tested, merged. Phase B specified + gated.
+**PRs:** #217 (Phase A backbone + restore-test + retention + ADR-029 + unifi-syslog move). A follow-up PR adds the vaultwarden dump + filefrag baseline.
+
+---
+
+## TL;DR
+
+A debate about whether `subvol8-db` should be a subvolume turned up two databases (`forgejo-db`, `loki`) with **zero backup**, and a backup convention (ADR-024 dumps) that had been *accepted but never built*. We designed and shipped a complete fix: a **three-tier, recovery-model storage architecture** with an application-consistent **dump backbone** for the six dumpable databases, **weekly restore-tests** that prove the dumps are restorable, observability + alerts, and a documented, gated **offline migration runbook** (Phase B). Loki was deliberately left as Tier 3 (no backup — regenerable). Testing caught ~8 real bugs before they could ever reach a 3am incident.
+
+State now: 6 databases dumped nightly → offsite via Urd; all 6 restore-tested; loki is Tier 3 (no backup); `subvol8-db` cleaned to match its own model; one ADR is the single source of truth.
+
+---
+
+## How this started
+
+The owner asked, essentially: "should `subvol8-db` be a subvolume or a plain NOCOW directory, and how should DB backups work?" Investigating ground truth (not the docs) revealed the docs had drifted from reality:
+
+- **ADR-024** (dump-based backup) — accepted, **never implemented**.
+- **ADR-027** (forward-only NOCOW placement) — accepted; put new write-hot engines on `subvol8-db` and *required* DB tenants to be backed up via ADR-024 dumps. Those dumps didn't exist → **`forgejo-db` and `loki` had no backup of any kind** (they live in `subvol8-db`, which is deliberately excluded from Urd snapshots).
+- **ADR-025** (migrate the 5 existing DBs to `subvol8-db`) — deferred pending measurements.
+- Meanwhile `gathio-db` and `prometheus` carried `chattr +C` (NOCOW) *inside the snapshotted `subvol7`* — the exact "COW defeated by snapshots" antipattern, live.
+
+So the real problem wasn't subvolume-vs-directory; it was a missing backbone and three drifted ADRs.
+
+---
+
+## The architecture (ADR-029)
+
+**Organize storage by *recovery model*, not data type.** Each tier's BTRFS treatment matches how the data is actually recovered:
+
+| Tier | BTRFS | Backup | Members |
+|------|-------|--------|---------|
+| 1 Snapshot | COW, snapshot, offsite | `btrfs send` | user data, configs, **SQLite, Redis** |
+| 2 Dump | **NOCOW, excluded from snapshots** | logical dump → Tier 1 → offsite | PostgreSQL, MariaDB, MongoDB, Prometheus, Loki |
+| 3 Discard | NOCOW, excluded | none | *(empty)* |
+
+**The tier boundary = the checksum question.** NOCOW disables BTRFS checksums, so it's only safe for engines that self-checksum (PG `data_checksums`, InnoDB, WiredTiger, TSDB CRC32). SQLite and Redis don't → they stay Tier 1 where BTRFS checksums + snapshot rollback protect them. **Growth rule:** *own checksums + native dump tool? → Tier 2 + dump job; else → Tier 1 with its app.*
+
+Why this is correct, not just tidy: NOCOW only *works* because Tier 2 is excluded from snapshots — no snapshot to share extents, so no copy-on-first-write, so no fragmentation. Live DB files get write-in-place speed; the backup artifact is a tiny, compressed, application-consistent, version-portable dump.
+
+---
+
+## What was built (Phase A)
+
+**`scripts/db-dump.sh`** (nightly `db-dump.timer` @ 01:30, before Urd's 04:00) — per-engine, failure-isolated, idempotent-per-day dumps to `subvol7-containers/db-dumps/<svc>/YYYY-MM-DD.<ext>.zst` (rides Urd offsite automatically):
+
+| Engine | Container | Method |
+|--------|-----------|--------|
+| Immich PG | postgresql-immich | `pg_dump --format=custom --compress=0` |
+| Forgejo PG | forgejo-db | `pg_dump --format=custom --compress=0` |
+| Nextcloud | nextcloud-db | `mariadb-dump --single-transaction` as the **app user** |
+| Gathio | gathio-db | `mongodump --archive` |
+| Prometheus | prometheus | admin-API `tsdb/snapshot` + tar (retention 7) |
+| Vaultwarden | vaultwarden | host `sqlite3 .backup` (online) + `PRAGMA integrity_check` |
+
+*(Loki is **not** dumped — Tier 3. See lesson 2.)*
+
+**`scripts/db-restore-test.sh`** (weekly `db-restore-test.timer` @ Sun 05:00) — restores each latest dump into a throwaway matching-version container (or `sqlite3`/archive check) and validates object counts: immich 61 tables, forgejo 128, nextcloud 162, gathio 1 db, prometheus archive integrity, vaultwarden 29 tables. **6/6** (loki excluded — Tier 3).
+
+**Observability:** `data/backup-metrics/db-dumps.prom` + `db-restore-test.prom` (node_exporter textfile) → `config/prometheus/alerts/db-dump-alerts.yml` (`DbDumpFailed`, `DbDumpStale`, `DbDumpJobNotRunning`, `DbRestoreTestFailed`, `DbRestoreTestOverdue`).
+
+**Other:** `--web.enable-admin-api` on `quadlets/prometheus.container`; per-engine retention (`prometheus=7`, default 14); `unifi-syslog` moved `subvol8-db → subvol7` (Tier 1); `scripts/filefrag-baseline.sh` for the Phase B fragmentation measurement; ADR-029 written, ADR-024/025/027 marked Superseded.
+
+After cleanup, **`subvol8-db` holds only its NOCOW DB tenants: `forgejo-db`, `loki`.**
+
+---
+
+## Lessons learned (testing earned its keep)
+
+1. **Prometheus textfile metrics must not use a `service` label.** The node_exporter scrape job sets a static `service="node_exporter"` target label that clobbers it (`honor_labels: false`), collapsing all per-engine series into one. Fix: label = `database`. (Urd uses `subvolume`, dependency-metrics use `homelab_service` — same reason.)
+2. **Loki ended up as Tier 3 (no backup) once the freeze cost showed itself.** It's distroless (no shell/tar to exec) with 70k+ rotating files. Rejected in order: stop-rsync-start (~17 min downtime + WAL race, rc=23); host-side tar (permission-denied on mode-600 WAL files + slow, 143 s); live `podman cp` (races on rotation, rc=125 — and containers are *removed* on stop, so cp needs them running/paused). `podman pause` + `cp` looked good in a warm-cache test (~40 s) — but the **first real nightly run froze loki ~15 min (936 s)**: cold-cache seek-bound reads of 70k small files after Prometheus's 1.5 GB dump evicts the page cache (the ~40 s was a fluke). For regenerable log data that trade isn't worth it → loki excluded from backup. *Lesson: measure on a cold cache / in the real pipeline, not in isolation.*
+3. **Nextcloud MariaDB `root` is locked down** (no password, no socket auth). Dump uses the app account, which has `ALL` on its own database — the whole instance.
+4. **`zstd -f` is required.** A failed run leaves an empty `.tmp` that blocks the next run otherwise.
+5. **Vaultwarden was *not* the hard case it looked like.** The deferral assumed a missing in-image `sqlite3` + subuid-owned data. Ground truth: the SQLite is **host-owned (uid 1000, mode 644)** and the **host has `sqlite3`** → a plain online `.backup` works, no sidecar. *Lesson: re-check the assumption before engineering around it.*
+6. **PG restore readiness must probe the DATABASE, not `pg_isready`.** `pg_isready` passes when the server accepts connections (~8 s), but the immich/vectorchord image creates `POSTGRES_DB` ~40 s in — restoring too early gave "0 tables." Probe `psql -d $db -c 'SELECT 1'`.
+7. **Never `pkill -f 'db-restore-test.sh'`** — the pattern self-matches the running shell's own command line and kills your command (exit 144). Lost a run to this.
+8. **`m` (no-compress) and `+C` (NOCOW) are mutually exclusive inodes.** `compression=none` on `subvol8-db` sets `m`, which inherits to children, so a bare `chattr +C` returns EINVAL. Must `chattr -m` then `chattr +C` (relevant to Phase B).
+
+Secondary: secrets stay inside the container (dump runs via `podman exec`; nothing in host `ps` args or the repo — robust to the ADR-028 secret-store path split). The only credential literal anywhere is a throwaway password for the ephemeral `--network none` restore-test containers.
+
+---
+
+## Trade-offs considered
+
+- **Phase A/B split (hybrid).** Ship the additive, low-risk dump backbone now; gate the higher-risk storage migration on measurement + a track record. The adversarial review of the original bundled ADR-023 demanded exactly this.
+- **Loki: not backed up (Tier 3).** The measured cost — a ~15 min nightly freeze on a cold cache — outweighed the value of backing up regenerable log data. Owner decision after the first real run; aligns with ADR-027's original stance. (Weekly cadence is the fallback if history ever matters.)
+- **Prometheus dump = full 1.5 GB TSDB nightly, no dedup.** Capped local retention at 7 (≈10 GB); offsite growth governed by Urd's subvol7 retention. Future option: dump Prometheus weekly instead of daily. Accepted for now.
+- **`--web.enable-admin-api`** exposes destructive TSDB endpoints to the unauthenticated monitoring network. Accepted: external path is Authelia-fronted, only the snapshot endpoint is used, the dump pre-cleans orphaned snapshots. Fallback would be a localhost-only second listener.
+- **unifi-syslog → Tier 1 (overrides ADR-027).** ADR-027 deliberately placed it on subvol8-db. The owner chose to move it: append-only forensic logs you want point-in-time recovery for belong in the snapshot tier, the COW cost is negligible for append-only, and snapshot-incrementals are more offsite-efficient than nightly tars.
+- **Vaultwarden stays Tier 1 + gets a bonus dump.** It's small, low-write, snapshot-rollback is valuable, and SQLite lacks self-checksums (NOCOW would *remove* its only integrity guarantee). The online `.backup` is an extra application-consistent, offsite, restore-tested copy of the most security-critical store.
+- **Per-engine local retention** rather than a single global value — small DBs keep 14, Prometheus keeps 7.
+
+---
+
+## Current state (verified)
+
+- 6 engines dumped (immich, forgejo, nextcloud, gathio, prometheus, vaultwarden); 6/6 restore-tests pass; Prometheus scrapes distinct `database`-labelled series; no db alerts firing. Loki = Tier 3 (no backup).
+- Timers armed: `db-dump.timer` (01:30 daily), `db-restore-test.timer` (Sun 05:00).
+- `subvol8-db` = `{forgejo-db (Tier 2, dumped), loki (Tier 3, no backup)}`.
+- Phase A merged (PR #217, squash, signed). Vaultwarden + filefrag baseline = follow-up PR.
+- Logrotate root copy for unifi-syslog's new path installed by the owner.
+
+---
+
+## HAND-OFF: Phase B (for a fresh Claude Code session)
+
+**Goal:** migrate the four databases still in `subvol7` into `subvol8-db` so NOCOW *actually works* (no snapshot defeating it): `postgresql-immich`, `nextcloud-db/data`, `gathio-db`, `prometheus`. **Do NOT touch `forgejo-db` (Tier 2) or `loki` (Tier 3) — both already live in `subvol8-db`; loki is not backed up and not migrated.**
+
+**Read first:** `docs/00-foundation/decisions/2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md` (Phase B section is the authoritative runbook) and memory `project_db_storage_architecture`.
+
+### Gate — do not start until all hold
+1. **Dumps have a track record** of passing weekly restore-tests (they now exist; let `db-restore-test.timer` run a few Sundays and confirm `db_restore_test_success == 1` for all). The dumps are the migration's rollback safety net.
+2. **Measurement justifies it.** Run `sudo bash scripts/filefrag-baseline.sh` and read the latest `data/backup-logs/filefrag-baseline-*.txt`. Per ADR-025/029 criteria, migrate if subvol7 DB files show high/growing extent counts vs the subvol8 reference. If fragmentation is negligible, Phase B can stay deferred indefinitely — that's a legitimate outcome.
+3. **The defensive tool exists.** Build `scripts/migrate-db-to-subvol8.sh` (dry-run default, `--execute` gate, `rollback` subcommand) BEFORE migrating. Improvised shell is not acceptable here (this is the riskiest moment in the homelab's storage history).
+
+### The window (the key unlock)
+Run `scripts/update-before-reboot.sh` → it calls `graceful-shutdown.sh`, stopping every container cleanly. With the DBs cleanly shut down, the move is a **plain offline `rsync`**, not a live migration — no initdb-in-container, no Prometheus observability-gap choreography. Then `dnf update` + reboot + `post-reboot-verify.sh`.
+
+### Per-service procedure (order small→large: gathio → nextcloud → prometheus → immich)
+1. `mkdir` the empty target in `subvol8-db/<svc>/`, then **`chattr -m` then `chattr +C`** (the inherited `m` no-compress flag is mutually exclusive with `+C`; bare `+C` → EINVAL — see Lesson 8).
+2. `rsync -aHX --numeric-ids <src>/ <target>/` — **NO `--reflink`, NO `--inplace`** (reflink shares extents and silently defeats NOCOW).
+3. Assert `sudo lsattr -d <target>` shows `C` and `sudo filefrag -v <file>` shows no shared extents.
+4. **Two-layer ACLs** (ADR-019): parent-traversal `setfacl -m u:<subuid>:--x /mnt/btrfs-pool/subvol8-db` + per-service `setfacl -R -m u:<subuid>:rwx <target>` + default ACL. **Verify each subuid first** via `/etc/subuid` + `podman inspect` — they differ: immich/nextcloud/gathio PG-family ≈ 100998, prometheus = 165533, and note forgejo-db is 100069 (different base) though it isn't migrating.
+5. Edit the quadlet `Volume=` → new path; `systemctl --user daemon-reload`; start; healthcheck.
+6. **Verify the secret still mounts** (ADR-028 lesson — a storage move once broke secret resolution silently): `podman run --rm --secret <name> alpine true`.
+7. **PostgreSQL only:** `pg_controldata | grep -i checksum` first (the quadlet sets `--data-checksums`, so likely already on → skip). Only if off, `pg_checksums --enable` in place (safe because cleanly stopped).
+8. Keep the source as `<svc>.pre-migration-<DATE>` for 14 days. **Rollback** = revert the quadlet `Volume=`, daemon-reload, restart; worst case restore from the prior night's dump.
+
+### After migration
+- Re-run `scripts/filefrag-baseline.sh` for the before/after fragmentation delta (the brag).
+- Confirm the dump job still works against the new paths (it reads via `podman exec`/`podman cp`, so paths don't matter to it — but verify).
+- Update ADR-029 status (Phase B done) + the tenant table; write a follow-up journal.
+- Partial migration is acceptable; forced completion is not. If one service can't migrate cleanly, leave it in subvol7 and stop.
+
+### Gotchas a fresh session must not relearn
+- Containers are **removed** on `systemctl --user stop` (quadlet) — `podman cp`/`exec` need them running or paused.
+- Don't `pkill -f` with a pattern matching your own command line.
+- The dump metrics label is `database`, not `service`.
+- Everything DB-related is documented in **ADR-029**; don't re-derive from the superseded ADR-024/025/027.
+
+---
+
+## Open / deferred (not blocking)
+- Phase B (above) — gated.
+- Optionally switch Prometheus to a weekly dump if the 1.5 GB/night offsite growth becomes a concern.
+- `data/backup-metrics/*.prom` for vaultwarden/restore-test populate fully on the next scheduled timer runs.

--- a/scripts/db-dump.sh
+++ b/scripts/db-dump.sh
@@ -43,8 +43,12 @@ ZSTD_LEVEL="${DB_DUMP_ZSTD_LEVEL:-10}"
 DATE="$(date +%Y-%m-%d)"
 RUN_TS="$(date +%s)"
 
-# Engines handled by this job (service = container name = output subdir)
-ENGINES=(postgresql-immich forgejo-db nextcloud-db gathio-db prometheus loki)
+# Engines handled by this job (service = container name = output subdir).
+# Loki is intentionally NOT here: it is Tier 3 (regenerable; Promtail re-ingests).
+# A nightly dump froze it ~15min on a cold cache (podman pause + cp of 70k files
+# after Prometheus evicts the page cache) — a bad trade for non-source-of-truth
+# log data. See ADR-029.
+ENGINES=(postgresql-immich forgejo-db nextcloud-db gathio-db prometheus vaultwarden)
 
 # --- argument parsing ---------------------------------------------------------
 ONLY_SERVICE=""
@@ -136,25 +140,28 @@ dump_prometheus() {  # args: svc out_dir   (requires --web.enable-admin-api)
     return "$rc"
 }
 
-dump_loki() {  # args: svc out_dir
-    # Loki is distroless (no shell/tar to exec) with 70k+ constantly-rotating
-    # files. Three approaches were measured and rejected: host-side tar/rsync
-    # hits permission-denied on mode-600 WAL checkpoint files and is slow (~140s);
-    # stop-and-copy fails because the quadlet removes the container on stop;
-    # a live `podman cp` races on file rotation under I/O load (rc=125).
-    # `podman pause` (SIGSTOP via the freezer cgroup) makes the filesystem static
-    # without removing the container, so `podman cp` reads a complete, consistent
-    # tree via the namespace in ~40s. Promtail buffers/retries during the freeze;
-    # Loki is regenerable, not a source of truth (ADR-027/029).
-    local out="${2}/${DATE}.tar.zst" rc
-    podman pause loki >/dev/null 2>&1 || { log ERROR "[loki] pause failed"; return 1; }
-    trap 'podman unpause loki >/dev/null 2>&1 || true; trap - RETURN' RETURN
-    podman cp loki:/loki - | zstd -q -f -T0 "-${ZSTD_LEVEL}" -o "${out}.tmp"
-    rc=$?
-    podman unpause loki >/dev/null 2>&1 || log WARNING "[loki] unpause returned non-zero"
-    trap - RETURN
-    [[ $rc -eq 0 ]] || { log ERROR "[loki] podman cp|zstd failed (rc=$rc)"; return 1; }
-    mv "${out}.tmp" "$out"
+# NOTE: Loki has no dump function by design (Tier 3 / discard — see ENGINES above
+# and ADR-029). If loki backup is ever wanted, the only workable method found was
+# `podman pause` + `podman cp` (distroless image; containers are removed on stop;
+# host-side tar hits mode-600 WAL perms; live cp races) — but it freezes loki for
+# the duration, which on a cold cache was ~15min. Prefer a weekly cadence if so.
+
+dump_vaultwarden() {  # args: svc out_dir
+    # Vaultwarden's SQLite is host-owned (uid 1000) with a live WAL, and the host
+    # has sqlite3 — so an online `.backup` (SQLite backup API; safe alongside the
+    # running writer) yields an application-consistent copy without touching the
+    # container. Vaultwarden stays Tier 1 (snapshotted); this dump is an extra
+    # restorable, offsite safety net for the most security-critical store.
+    # PRAGMA integrity_check guards against a torn copy before we keep it.
+    local out="${2}/${DATE}.sqlite3.zst" src="/mnt/btrfs-pool/subvol7-containers/vaultwarden/db.sqlite3" tmp
+    [[ -f "$src" ]] || { log ERROR "[vaultwarden] db.sqlite3 not found at $src"; return 1; }
+    tmp="$(mktemp "${DUMP_ROOT}/.vw.XXXXXX")" || return 1
+    if sqlite3 "$src" ".backup '$tmp'" >/dev/null 2>&1 \
+       && [[ "$(sqlite3 "$tmp" 'PRAGMA integrity_check' 2>/dev/null)" == "ok" ]] \
+       && zstd -q -f -T0 "-${ZSTD_LEVEL}" -o "${out}.tmp" "$tmp"; then
+        mv "${out}.tmp" "$out"; rm -f "$tmp"; return 0
+    fi
+    rm -f "$tmp" "${out}.tmp"; return 1
 }
 
 # --- engine runner ------------------------------------------------------------
@@ -230,7 +237,7 @@ main() {
             nextcloud-db)      run_engine "$svc" dump_mariadb ;;
             gathio-db)         run_engine "$svc" dump_mongo ;;
             prometheus)        run_engine "$svc" dump_prometheus ;;
-            loki)              run_engine "$svc" dump_loki ;;
+            vaultwarden)       run_engine "$svc" dump_vaultwarden ;;
         esac
         prune "$svc"
     done

--- a/scripts/db-restore-test.sh
+++ b/scripts/db-restore-test.sh
@@ -125,6 +125,20 @@ test_archive() {  # args: svc   (integrity + structure only — for TSDB tarball
     log SUCCESS "[$svc] archive integrity + structure OK"; return 0
 }
 
+test_sqlite() {  # args: svc   (decompress + integrity_check + table count, host sqlite3)
+    local svc="$1" dump tmp n
+    dump="$(latest_dump "$svc")"; [[ -n "$dump" ]] || { log ERROR "[$svc] no dump found"; return 1; }
+    tmp="$(mktemp)" || return 1
+    zstd -dc "$dump" > "$tmp" 2>/dev/null
+    if [[ "$(sqlite3 "$tmp" 'PRAGMA integrity_check' 2>/dev/null)" != "ok" ]]; then
+        log ERROR "[$svc] integrity_check failed"; rm -f "$tmp"; return 1
+    fi
+    n="$(sqlite3 "$tmp" "SELECT count(*) FROM sqlite_master WHERE type='table'" 2>/dev/null)"
+    rm -f "$tmp"
+    [[ "${n:-0}" -gt 0 ]] && { log SUCCESS "[$svc] integrity ok, ${n} tables"; return 0; }
+    log ERROR "[$svc] 0 tables"; return 1
+}
+
 run_test() {  # run_test <svc> <fn> [args...]
     local svc="$1" fn="$2"; shift 2
     [[ -n "$ONLY_SERVICE" && "$ONLY_SERVICE" != "$svc" ]] && return 0
@@ -163,7 +177,7 @@ main() {
     run_test nextcloud-db      test_mariadb nextcloud
     run_test gathio-db         test_mongo
     run_test prometheus        test_archive
-    run_test loki              test_archive
+    run_test vaultwarden       test_sqlite
     flush_metrics
     local fails=0 total="${#R_OK[@]}"
     for s in "${!R_OK[@]}"; do [[ "${R_OK[$s]}" == "1" ]] || fails=$((fails + 1)); done

--- a/scripts/filefrag-baseline.sh
+++ b/scripts/filefrag-baseline.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+################################################################################
+# filefrag-baseline.sh — BTRFS fragmentation baseline for DB workloads (ADR-029)
+#
+# Quantifies the "COW defeated by snapshots" antipattern. Run BEFORE and AFTER
+# the Phase B migration to measure the fragmentation delta:
+#   - subvol7 DBs (COW inside a snapshotted subvolume) = the antipattern; expect
+#     high/growing extent counts on hot DB files.
+#   - subvol8 DBs (NOCOW, excluded from snapshots) = the reference; expect low,
+#     stable extent counts.
+#
+# Needs root (DB data dirs are container-subuid-owned, mode 700).
+# Usage:  sudo bash scripts/filefrag-baseline.sh
+################################################################################
+set -uo pipefail
+
+TS="$(date +%Y-%m-%d-%H%M)"
+OUT="/home/patriark/containers/data/backup-logs/filefrag-baseline-${TS}.txt"
+
+# subvol7 = Phase B migration candidates (COW-in-snapshot); subvol8 = reference
+DIRS=(
+    "/mnt/btrfs-pool/subvol7-containers/postgresql-immich|subvol7 (candidate)"
+    "/mnt/btrfs-pool/subvol7-containers/nextcloud-db/data|subvol7 (candidate)"
+    "/mnt/btrfs-pool/subvol7-containers/gathio-db|subvol7 (candidate)"
+    "/mnt/btrfs-pool/subvol7-containers/prometheus|subvol7 (candidate)"
+    "/mnt/btrfs-pool/subvol8-db/forgejo-db|subvol8 (NOCOW reference)"
+    "/mnt/btrfs-pool/subvol8-db/loki|subvol8 (NOCOW reference)"
+)
+
+emit() {
+    echo "BTRFS fragmentation baseline — ${TS}"
+    echo "extents/file: higher = more fragmented. DB random-write files under"
+    echo "COW+snapshots accumulate extents; NOCOW (excluded from snapshots) stays flat."
+    echo
+    for entry in "${DIRS[@]}"; do
+        local dir="${entry%%|*}" label="${entry##*|}"
+        if [[ ! -d "$dir" ]]; then echo "## ${dir}  [${label}]  — ABSENT"; echo; continue; fi
+        # "<extents> <path>" per regular file
+        local frag
+        frag="$(find "$dir" -type f -print0 2>/dev/null \
+            | xargs -0 -r filefrag 2>/dev/null \
+            | sed -nE 's/^(.*): ([0-9]+) extents? found$/\2 \1/p')"
+        echo "## ${dir}  [${label}]"
+        if [[ -z "$frag" ]]; then echo "   (no regular files)"; echo; continue; fi
+        local nfiles total max
+        nfiles="$(echo "$frag" | wc -l)"
+        total="$(echo "$frag" | awk '{s+=$1} END{print s}')"
+        max="$(echo "$frag" | awk 'BEGIN{m=0} $1>m{m=$1} END{print m}')"
+        awk -v n="$nfiles" -v t="$total" -v m="$max" \
+            'BEGIN{printf "   files=%d  total_extents=%d  mean=%.1f  max=%d\n", n, t, (n>0)?t/n:0, m}'
+        echo "$frag" | sort -rn | head -5 | awk '{printf "   worst: %6d extents  %s\n", $1, $2}'
+        echo
+    done
+}
+
+mkdir -p "$(dirname "$OUT")"
+emit | tee "$OUT"
+chmod 644 "$OUT" 2>/dev/null || true
+echo "Saved: $OUT"


### PR DESCRIPTION
Follow-up to #217 (Phase A dump backbone). Completes the requested extras and records the session.

## Changes
- **Vaultwarden dump** (7th→6th engine; loki dropped): host `sqlite3 .backup` (online, safe with the live writer) + `PRAGMA integrity_check`. The earlier "needs a sidecar" assumption was wrong — the SQLite is host-owned (uid 1000, 644) and the host has `sqlite3`. Vaultwarden stays Tier 1 (snapshotted); the dump is a bonus offsite/restore-tested copy of the password store. Dump + restore-test both verified (29 tables, integrity ok).
- **Loki → Tier 3 (no backup).** The first real nightly run showed `podman pause`+`cp` froze loki **~15 min** on a cold cache (70k files, seek-bound after Prometheus's 1.5 GB dump evicts the page cache; the warm-cache ~40 s was a fluke). Not worth it for regenerable log data (Promtail re-ingests). Loki stays NOCOW in subvol8-db, just undumped. Removed from both scripts + live metrics; orphaned dump dir reclaimed (553 MB).
- **`scripts/filefrag-baseline.sh`** — measures BTRFS fragmentation for the Phase B gate (run with sudo: subvol7 migration candidates vs subvol8 NOCOW reference, before/after).
- **ADR-029** updated (loki Tier 3, vaultwarden host-backup, tenant table) and a comprehensive **session journal** with lessons, trade-offs, and a Phase B hand-off for a fresh session.

## State after this
6 databases dumped + restore-tested (immich, forgejo, nextcloud, gathio, prometheus, vaultwarden); loki Tier 3; no db alerts firing.

## Security
No secrets — vaultwarden dump runs host `sqlite3` on the host-owned DB; only credential literal is the throwaway restore-test password. Pre-commit secret hook passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)