### PR TITLE
docs: ADR-030 container supply-chain trust model + tier plans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,17 +87,19 @@ Pattern-based deployment available via `homelab-deployment` skill (see `.claude/
 
 ### Update Strategy
 
-Most services use `:latest` tags. **Exceptions (pinned, manual upgrade only):**
+Governed by **ADR-030 (Container Supply-Chain Trust Model):** images move to immutable digest pins (`@sha256:…`) with deliberate, reviewed updates and a cooling-off interval — superseding ADR-015's `:latest`/auto-update trust model. **Migration is phased and currently proposed** (see `docs/97-plans/2026-05-23-tier1-…`); until executed, most services still ride `:latest` and 17 carry `AutoUpdate=registry`.
+
+**Exceptions today (pinned, manual upgrade only):**
 - **Databases:** PostgreSQL, MariaDB (major version migrations required)
 - **Immich:** Pinned to specific version (tight ML + postgres coupling)
 
-Rollback: BTRFS snapshots enable instant recovery if an update breaks a service.
+Rollback: BTRFS snapshots enable instant recovery; once pinned, `git revert` of a digest is a second rollback path.
 
-See ADR-015 for full rationale. Workflow: `scripts/update-before-reboot.sh` before DNF updates.
+See ADR-030 (trust model) and ADR-015 (superseded; its BTRFS rollback + health-validation mechanisms remain valid). Workflow: `scripts/update-before-reboot.sh` before DNF updates.
 
 ### Architecture Decision Records
 
-**20 ADRs documenting architectural decisions** (see `docs/*/decisions/` for full details)
+**Architectural decisions recorded as ADRs — latest is ADR-030** (see `docs/*/decisions/` for full details; number new ADRs sequentially from the latest)
 
 **Design-Guiding ADRs (affect future decisions):**
 - **ADR-001:** Rootless Containers — UID 1000, `:Z` SELinux labels on all mounts
@@ -111,6 +113,7 @@ See ADR-015 for full rationale. Workflow: `scripts/update-before-reboot.sh` befo
 - **ADR-018:** Static IP Multi-Network Services — /etc/hosts override for predictable routing
 - **ADR-019:** Filesystem Permission Model — POSIX ACLs for container access
 - **ADR-021:** Urd Backup Tool — Rust-based BTRFS Time Machine replaces shell script (supersedes ADR-020 implementation)
+- **ADR-030:** Container Supply-Chain Trust Model — digest pinning, deliberate (de-automated) updates, cooling-off interval, graduated signature verification (supersedes ADR-015 trust model)
 
 Check if an ADR exists before proposing changes. Reference the ADR and explain what changed if suggesting alternatives. New decisions get new ADRs (don't edit existing ones).
 

--- a/docs/00-foundation/decisions/2025-12-22-ADR-015-container-update-strategy.md
+++ b/docs/00-foundation/decisions/2025-12-22-ADR-015-container-update-strategy.md
@@ -1,6 +1,6 @@
 # ADR-015: Container Update Strategy for State-of-the-Art Homelab
 
-**Status:** Accepted
+**Status:** Superseded by ADR-030 (trust model; this ADR's BTRFS rollback + health-validation mechanisms remain valid)
 **Date:** 2025-12-22
 **Context:** Single-user homelab on Fedora Workstation with robust backup infrastructure
 

--- a/docs/00-foundation/decisions/2026-05-23-ADR-030-container-supply-chain-trust-model.md
+++ b/docs/00-foundation/decisions/2026-05-23-ADR-030-container-supply-chain-trust-model.md
@@ -1,0 +1,249 @@
+# ADR-030: Container Supply-Chain Trust Model
+
+**Date:** 2026-05-23
+**Status:** Accepted
+**Supersedes:** ADR-015 (the update *trust model* — see "Relationship to ADR-015". ADR-015's BTRFS rollback and health-validation mechanisms remain valid and are reused here.)
+
+---
+
+## Context
+
+Supply-chain attacks against software repositories and registries have escalated
+from occasional incidents to industrialised campaigns. The May 2026 "Megalodon"
+campaign injected malicious commits into ~5,561 GitHub repositories in a six-hour
+window using stolen tokens (push-to-master, no PR, forged `ci-bot`/`build-bot`
+identities); the payload fires inside the *downstream consumer's* build/CI and
+steals credentials. The transmission path to a homelab is indirect but real:
+*poisoned commit upstream → upstream's own CI builds and publishes a poisoned
+image under the **same moving tag** → we pull it on the next `podman pull`.* The
+mutable tag is the conveyor belt.
+
+This ADR exists because the homelab's current posture — established by ADR-015
+when the dominant risk was understood to be *running outdated software* — is
+optimised against the wrong threat for this class of attack. The exposure is
+**measured, not assumed** (verified 2026-05-23):
+
+- **0 of 37** image references are pinned by digest; **22 ride `:latest`**, the
+  rest ride floating major/minor tags (`:16`, `:7-alpine`, `:11`, `:33`, `:15`,
+  `:stable`). Only Immich (`v2.7.5`) and proton-bridge (`3.23.1`) carry specific
+  version tags — and even those are registry-mutable, not content-addressed.
+- **17 services carry `AutoUpdate=registry`** and pull unattended every Sunday at
+  03:00 via `podman-auto-update-weekly.service`. That set includes **`traefik`,
+  `crowdsec`, `jellyfin`, and `qbittorrent`** — i.e. the reverse proxy and the
+  IP-reputation engine, our highest-blast-radius, internet-facing components.
+- `policy.json` is `insecureAcceptAnything`: **no signature or provenance
+  verification** is enforced at pull time.
+- All ten internet-facing services reach the Internet via the `reverse_proxy`
+  network. A poisoned image among them has an open egress path.
+- Two locally-built images extend the supply chain to *build* inputs:
+  `alert-discord-relay` builds `FROM python:3.11-slim` (floating) with
+  transitive-unpinned, unhashed `pip` dependencies and is egress-capable;
+  `proton-bridge` installs a manually-downloaded RPM with no recorded
+  checksum/signature check (its Fedora base and repo packages are GPG-signed, so
+  that part is lower risk).
+
+Two important framings emerged from the analysis:
+
+1. **The existing update guard tracks the wrong axis for this threat.**
+   `audit-update-paths.sh` correctly keeps *stateful schema* services off the
+   auto-update path — but that guard exists for **availability** (the 2026-04-06
+   Nextcloud SLO collapse), keyed on *statefulness*. Supply-chain risk is keyed on
+   **blast radius / egress capability**, an orthogonal axis. That is precisely why
+   `traefik` and `crowdsec` — "stateless," so permitted by the availability guard —
+   sit on the unattended pull path despite being the worst things to silently
+   replace.
+
+2. **Cryptographic primitives are available but unused.** Podman 5.8.2 and skopeo
+   1.22.2 are installed; both digest pinning and sigstore `policy.json` are
+   supported today. `cosign` and `pip-tools` are **not** installed (prerequisites
+   for signature verification and hash-locked Python builds, respectively). The
+   repository has **no GitHub Actions workflows**, so Megalodon's *direct* CI-token
+   vector is low; our residual repo risk is branch-protection and token hygiene.
+
+The question this ADR answers is therefore not "pin or don't pin" but: **what is
+our trust model for accepting a container image — and its build inputs — into
+execution?**
+
+## Decision
+
+Adopt a **supply-chain trust model** governed by the principles below. This is a
+design contract, not a procedure; concrete sequencing lives in the Tier
+implementation plans under `docs/97-plans/` and is executed against these
+principles.
+
+The unifying idea: a supply-chain attack is **transitive trust failure**. Every
+durable defense reduces to one of six axes — *minimise* trust surface, verify
+*integrity*, verify *authenticity/provenance*, control the *time* trust is
+accepted, *contain* blast radius, and *detect* post-compromise. The principles map
+to those axes.
+
+### P1 — Trust is accepted deliberately, never ambiently *(minimise / time)*
+
+No service adopts a new image version without an explicit, reviewable, revertible
+action by the operator. Unattended `podman auto-update` of mutable tags is retired
+as the default acceptance mechanism. A *notify-only* feed of what is available is
+retained (the goal is no **unattended** trust acceptance, not going dark on
+patching).
+
+### P2 — Integrity by content address *(integrity)*
+
+Production image references resolve to immutable digests (`Image=…@sha256:…`). The
+human-readable tag is preserved as an adjacent comment for legibility. **Tags are
+for discovery; the digest is the execution contract.** A digest is the container
+equivalent of a lockfile hash: the registry cannot serve different bytes under the
+same digest, so a re-pointed tag or a poisoned upstream rebuild cannot silently
+change what runs.
+
+### P3 — A cooling-off interval precedes adoption *(time)*
+
+A new digest is adopted only after a bake interval during which no incident signal
+appears for that image. This trades CVE-patch *latency* (acceptable here: single
+user, no uptime SLA, instant BTRFS rollback) for the ecosystem's *detection*
+latency — most poisoned releases are caught within hours to days. Time is the
+cheapest control against a freshly-poisoned-but-validly-published artifact.
+
+### P4 — Blast radius defines update rigor, orthogonally to statefulness *(contain / minimise)*
+
+Update rigor is determined by what a compromised image could *do*, not only by
+whether it owns a schema. This ADR introduces an **egress/blast-radius axis**
+alongside the existing statefulness axis:
+
+- **Egress-capable / internet-facing tier** (the `reverse_proxy` members) gets the
+  strictest controls: digest-pinned, never on `AutoUpdate=registry`, longest bake.
+- **Internal-only tier** (`Internal=true` networks, no egress) may relax the bake
+  interval because exfiltration is already contained — though pinning still applies.
+
+The statefulness guard (`audit-update-paths.sh`) and this egress guard are
+complementary, not redundant.
+
+### P5 — First-party builds pin their inputs *(integrity / minimise)*
+
+Locally-built images are accountable for their build inputs to the same standard
+as runtime images: base images pinned by digest, and language/package
+dependencies locked by hash (including transitive dependencies, which are the
+actual gap). A build that resolves dependencies freshly at build time is a live
+instance of the very threat this ADR addresses.
+
+### P6 — Authenticity is verified where publishers support it; graduated, not all-or-nothing *(authenticity)*
+
+Integrity (P2) guarantees "the same bytes every time," not "the right bytes from
+the right publisher." Authenticity requires signatures/provenance. We move
+`policy.json` off `insecureAcceptAnything` toward sigstore enforcement **per
+publisher**, starting with provenance-bearing sources (e.g. GHCR images built via
+OIDC), while explicitly tolerating unsigned images from publishers who do not sign
+yet — tracked, not silently trusted. Blanket enforcement that breaks legitimate
+unsigned images is rejected as brittle.
+
+### P7 — Containment is a first-class supply-chain control *(contain / detect)*
+
+The existing rootless + SELinux + segmented-network posture is treated as a
+supply-chain control, because it bounds what a poisoned image can *do*. Egress is
+the residual exfiltration path and therefore the locus for future detection
+investment. This is the only line of defense against a **validly-signed but
+malicious** artifact from a legitimately-compromised maintainer — which no pin or
+signature can catch.
+
+### P8 — The project's own repository is part of the supply chain *(minimise / authenticity)*
+
+The repository that defines this infrastructure is itself an upstream of it.
+Branch protection (no direct push to `main`, PR required), short-lived scoped
+tokens (no long-lived write PATs), and signed merges are required controls — the
+direct lesson of Megalodon's push-to-master vector.
+
+### Architecture: where digests live
+
+Digests are written **in the quadlet** (where Podman reads them), with the tag as
+an adjacent comment, and a generated **audit index** aggregates every pin into a
+single reviewable document. This satisfies ADR-016's *intent* (one auditable view)
+without its literal centralisation: a central manifest feeding a quadlet generator
+would insert a fragile templating step into the boot-critical path, since Podman
+quadlets have no native external-variable substitution. We centralise the audit
+**view**, not the **write path**.
+
+### Non-goals
+
+This ADR does **not**: mandate same-day patching; require signatures from
+publishers who do not sign; replace BTRFS rollback or the health-validated update
+wrapper (PLAN-1) — both are retained and reused on the deliberate update path;
+require digest-pinning of the Fedora host (`dnf` already verifies GPG-signed RPMs;
+the host is not the weak link).
+
+## Consequences
+
+### Positive
+
+- The unattended "pull whatever the tag points to" path — the conveyor belt for a
+  poisoned upstream — is removed for the highest-risk services.
+- Updates become git diffs of digests: a reviewable, timestamped audit log and an
+  instant `git revert` rollback path complementing BTRFS snapshots.
+- The trust model is made explicit and axis-aligned, so future services inherit a
+  defined posture rather than an accidental one.
+- Build inputs gain the same accountability as runtime images, closing the one
+  live build-time exposure.
+
+### Negative
+
+- Manual digest bumps add friction to updating. (This friction *is* the control —
+  it is the human checkpoint and the time delay — but it is real ongoing effort.)
+- CVE patches land later than under continuous auto-update. Mitigated by the
+  notify-only feed (visibility), the single-user/no-SLA context, and rollback.
+- Signature enforcement (P6) has partial coverage by design and adds policy
+  surface that must be maintained as publishers' signing practices change.
+
+### Risks
+
+- **False confidence in pinning.** A digest pinned from an already-poisoned image
+  faithfully pins poison. P2 is necessary but not sufficient; it must travel with
+  P3 (bake) and, where possible, P6 (authenticity). This is called out so pinning
+  is never mistaken for completeness.
+- **Stale pins as a security debt.** Deliberate updates can become *no* updates.
+  The notify-only feed and a periodic review cadence exist to counter drift.
+- **The irreducible residual.** A validly-signed malicious artifact from a
+  compromised maintainer defeats P2 and P6. Only P3, P7, and detection bound it;
+  this risk is accepted and explicitly assigned to the containment/detection axis
+  rather than pretended away.
+
+## Alternatives Considered
+
+- **Keep ADR-015's auto-update model, rely on the PLAN-1 health wrapper.**
+  Rejected as the *security* control: PLAN-1 protects *availability* (rollback on a
+  broken image), not *integrity* (it would faithfully health-check a working but
+  malicious image). Its machinery is retained and repurposed, not relied on for
+  this threat.
+- **Stop all updates / pin and never move.** Rejected: trades supply-chain risk
+  for an accumulating CVE-staleness risk. The goal is *deliberate* acceptance, not
+  *no* acceptance — hence the notify-only feed and bake cadence.
+- **Central digest manifest + quadlet generator.** Rejected: a literal reading of
+  ADR-016 that adds a fragile generation step on the boot-critical path. Chose
+  in-quadlet pins + generated audit index instead.
+- **Digest pinning alone as sufficient.** Rejected: integrity ≠ authenticity (see
+  Risks). Pinning is the foundation, not the whole.
+- **Blanket signature enforcement.** Rejected: would block legitimate unsigned
+  images and create brittle breakage; P6 is graduated per publisher.
+
+## Relationship to ADR-015
+
+ADR-015's core thesis — *"the security risk of running outdated software outweighs
+the stability risk of automatic updates,"* therefore prefer `:latest` +
+auto-update — is **superseded** for the trust model. It was written against
+breakage/staleness risk and predates the supply-chain reframing; under this threat
+class, *unattended acceptance of mutable tags* is itself the dominant risk for
+high-blast-radius services. ADR-015's still-valid contributions — BTRFS snapshot
+rollback, the pre/post-update health-validation workflow, and the recognition that
+single-user/no-SLA context permits aggressive rollback — are preserved and reused
+here. ADR-015's status is updated to point forward to this ADR; its body is left
+intact per the repository's ADR-immutability convention.
+
+## Related
+
+- **ADR-015** — Container Update Strategy (superseded trust model; mechanisms reused)
+- **ADR-016** — Configuration Design Principles (single source of truth → audit index)
+- **ADR-001** — Rootless Containers (rootless + SELinux underpin P7 containment)
+- **ADR-021 / ADR-029** — BTRFS backup (Urd) and DB storage/rollback (underpin P3/P7)
+- **PLAN-1** — Auto-Update Safety Net (health-validation wrapper, reused on the deliberate path)
+- Implementation plans: `docs/97-plans/2026-05-23-tier1-…`, `…-tier2-…`, `…-tier3-4-…`
+
+---
+
+**Decision made by:** User (patriark) + Claude Code analysis
+**Trigger:** Escalation of registry/repository supply-chain campaigns (Megalodon, May 2026) against a homelab with unattended, unverified, mutable-tag update paths.

--- a/docs/97-plans/2026-05-23-tier1-digest-pinning-and-update-deautomation.md
+++ b/docs/97-plans/2026-05-23-tier1-digest-pinning-and-update-deautomation.md
@@ -1,0 +1,124 @@
+# Tier 1 Plan: Digest Pinning + Update De-Automation
+
+**Date Created:** 2026-05-23
+**Status:** Proposed
+**Last Updated:** 2026-05-23
+**Implements:** ADR-030 (P1, P2, P3, P4) — Container Supply-Chain Trust Model
+**Reconciles with:** PLAN-1 (Auto-Update Safety Net), `audit-update-paths.sh`
+
+## Objective
+
+Eliminate the unattended, unverified, mutable-tag pull path for high-blast-radius
+services, and establish content-addressed (digest) image references with a
+deliberate, reviewable update workflow. This is the highest-ROI tier: it closes
+the conveyor belt by which a poisoned upstream tag reaches execution.
+
+## Background (verified 2026-05-23)
+
+- **0 of 37** images are digest-pinned; **22 ride `:latest`**.
+- **17 services** carry `AutoUpdate=registry`; **`unpoller`** additionally has
+  `Pull=newer`. The auto-update set includes the egress/blast-radius tier:
+  `traefik`, `crowdsec`, `jellyfin`, `qbittorrent`, plus `grafana`, `homepage`,
+  `audiobookshelf`, `navidrome`, and the exporters.
+- Unattended pulls run via `~/.config/systemd/user/podman-auto-update-weekly.service`
+  (`ExecStart=/usr/bin/podman auto-update`, wrapped by
+  `scripts/pre-update-health-check.sh` and `scripts/post-update-health-check.sh`)
+  on `podman-auto-update-weekly.timer` (`Sun *-*-* 03:00:00`).
+- `scripts/check-image-updates.sh` already runs `podman auto-update --dry-run`
+  (notify-only) via `check-image-updates.timer` (`Sun *-*-* 10:00:00`).
+- `scripts/update-before-reboot.sh` Phase 3 pulls **every** image by its current
+  tag (`podman pull "$IMAGE"`), which would silently re-float any pin.
+- Tooling present: **skopeo 1.22.2**, **podman 5.8.2**. No central manifest tooling
+  needed (per ADR-030 architecture decision: in-quadlet pins + audit index).
+
+## Approach
+
+### 1. De-automate unattended pulls (P1, P4)
+
+- Remove `AutoUpdate=registry` (and `unpoller`'s `Pull=newer`) from the
+  **egress/blast-radius tier first** (`reverse_proxy` members), then the rest.
+- **Repurpose, don't delete, PLAN-1's safety net.** Keep
+  `pre/post-update-health-check.sh` and the rollback logic; convert
+  `podman-auto-update-weekly.service` from an unattended trigger into an
+  operator-invoked deliberate-update path that still runs digest changes through
+  the health checks. Decide explicitly whether to disable the *timer* while
+  keeping the *service* runnable on demand.
+- Keep `check-image-updates.sh` as the notify-only "what's available" feed (P1's
+  visibility half). Confirm its dry-run still reports usefully once images are
+  digest-pinned (auto-update dry-run keys off `AutoUpdate=registry`; if removing
+  that label blinds it, replace with a skopeo-based "newer digest available" check
+  — see open question).
+
+### 2. Digest-pin production images (P2)
+
+- For each service, resolve the current tag to a digest:
+  `skopeo inspect docker://<ref:tag> --format '{{.Digest}}'`.
+- Write `Image=<repo>@sha256:<digest>` with the tag retained as an adjacent
+  comment, e.g. `# tag: 16-alpine (resolved 2026-05-23)`.
+- **Sequence by blast radius:** (a) internet-facing/egress tier
+  (traefik, authelia, crowdsec, nextcloud, immich-server, vaultwarden, forgejo,
+  qbittorrent, alert-discord-relay, proton-bridge); (b) databases
+  (mariadb, postgres, mongo, redis/valkey, immich-postgres); (c) internal-only
+  monitoring/exporters.
+- `daemon-reload` + restart per service; verify health after each (do not batch
+  the whole fleet blind).
+
+### 3. Cooling-off cadence (P3)
+
+- Define the bake interval as an **operator checklist**, not automation: e.g. only
+  adopt a digest ≥N days old with no incident signal (advisories, upstream
+  issues, ecosystem chatter) for that image. Internal-only tier may use a shorter
+  interval (P4 — already contained).
+- Document where the operator checks for incident signal before bumping.
+
+### 4. Audit index (ADR-030 architecture)
+
+- Add a generator script (AUTO-* style, alongside the existing
+  `auto-doc-orchestrator.sh`) that parses every quadlet `Image=` line and emits a
+  single reviewable doc: service → repo → pinned digest → tag comment → resolved
+  date → mutability status (flag any still-floating reference). Centralises the
+  audit *view* without touching the write path.
+
+### 5. Guard extension (P4)
+
+- Add an **egress-axis guard** (sibling to `audit-update-paths.sh`) that fails if
+  any egress-tier service carries `AutoUpdate=registry`, or if any production
+  service is unpinned (still on a mutable tag). Wire it into the same checks
+  `audit-update-paths.sh` participates in.
+- **Reconcile `update-before-reboot.sh` Phase 3:** make the pull step digest-aware
+  so it no longer re-floats pinned images (a `podman pull` of a digest is a no-op
+  if present; ensure it does not pull tags for pinned services).
+
+## Critical files
+
+- `quadlets/*.container` — `Image=` lines (digest + tag comment); remove
+  `AutoUpdate=`/`Pull=` from the relevant set.
+- `~/.config/systemd/user/podman-auto-update-weekly.{service,timer}` — repurpose/disable.
+- `scripts/update-before-reboot.sh` — Phase 3 pull logic.
+- `scripts/check-image-updates.sh` — keep/adapt notify-only feed.
+- `scripts/audit-update-paths.sh` — model for the new egress guard.
+- New: digest-resolve helper + audit-index generator (naming per repo convention).
+
+## Open questions (resolve during execution)
+
+- Does removing `AutoUpdate=registry` blind `podman auto-update --dry-run`? If so,
+  the notify feed becomes a skopeo digest-diff check.
+- Disable `podman-auto-update-weekly.timer` outright, or keep it as a manual
+  `systemctl --user start` deliberate path?
+- Per-service rollback verification: confirm `git revert` of a digest + restart is
+  equivalent to BTRFS rollback for stateless services.
+
+## Success Criteria
+
+- 0 egress-tier services carry `AutoUpdate=registry` (or `Pull=newer`).
+- All production images are digest-pinned with a tag comment; audit index shows 0
+  unintended floating references.
+- Audit-index generator runs cleanly and is wired into the doc pipeline.
+- New egress guard is green and fails closed on a deliberately-introduced violation.
+- `update-before-reboot.sh` no longer silently re-floats pinned images.
+- A test digest bump flows through `pre/post-update-health-check.sh` and is
+  `git revert`-able.
+
+## Progress Log
+
+- 2026-05-23 — Plan created from ADR-030; grounded in verified system facts.

--- a/docs/97-plans/2026-05-23-tier2-build-input-and-repo-hardening.md
+++ b/docs/97-plans/2026-05-23-tier2-build-input-and-repo-hardening.md
@@ -1,0 +1,105 @@
+# Tier 2 Plan: First-Party Build Inputs + Repository Hardening
+
+**Date Created:** 2026-05-23
+**Status:** Proposed
+**Last Updated:** 2026-05-23
+**Implements:** ADR-030 (P5, P8) — Container Supply-Chain Trust Model
+
+## Objective
+
+Bring the homelab's *build-time* and *repository* supply chains up to the same
+trust standard as runtime images: pin and hash-lock the inputs of locally-built
+images, and protect the repository that defines the infrastructure.
+
+## Background (verified 2026-05-23)
+
+- **`alert-discord-relay` is a live build-time exposure.**
+  `config/alert-discord-relay/Dockerfile`:
+  - `FROM python:3.11-slim` — floating base tag.
+  - `RUN pip install --no-cache-dir -r requirements.txt`, where
+    `requirements.txt` pins only top-level versions (`Flask==3.0.0`,
+    `requests==2.31.0`, `gunicorn==21.2.0`) — **no hashes**, and **transitive
+    deps unpinned** (`urllib3`, `certifi`, `charset-normalizer`, `idna`, …
+    resolve to latest-compatible at build time).
+  - The container is **egress-capable** (on `reverse_proxy` first → default
+    route; posts to a Discord webhook), so a poisoned build can exfiltrate.
+- **`proton-bridge` has an unverified RPM input.**
+  `builds/proton-bridge/Containerfile`:
+  - `FROM registry.fedoraproject.org/fedora:43` — floating base (Fedora-signed
+    chain mitigates).
+  - `COPY protonmail-bridge-3.23.1-1.x86_64.rpm` then `dnf install -y` it — the
+    RPM is manually downloaded from proton.me, **gitignored (not committed)**,
+    with **no recorded checksum/signature-verification step**. Repo packages
+    (`nmap-ncat`, `pass`, `socat`) are Fedora-signed and fine.
+  - **Doc drift:** `builds/proton-bridge/README.md` says *"Status: Incomplete …
+    not suitable for automated quadlet deployment"*, but the unit is `active` and
+    `generated`. The README is stale.
+- **Tooling/CI:** `pip-tools` is **not installed**. The repo has a `.github/`
+  directory but **no `workflows/`** — no GitHub Actions, so no CI secrets to
+  steal. Server-side squash-merge signing is in use (no local GPG key).
+
+## Approach
+
+### 1. `alert-discord-relay` — pin base + hash-lock deps (P5)
+
+- Pin the base by digest: `FROM python:3.11-slim@sha256:<digest>` (resolve with
+  `skopeo inspect`), tag retained as a comment.
+- Generate a fully-resolved, **hash-locked** requirements file including
+  transitive deps. Two viable paths (decide during execution):
+  - **`pip-tools`** (`pip-compile --generate-hashes`) — requires installing
+    `pip-tools`.
+  - **`uv`** (`uv pip compile --generate-hashes`) — if preferred / present.
+- Switch the build to `pip install --require-hashes -r requirements.lock` so a
+  hash mismatch fails the build closed.
+- Rebuild, verify the relay still posts to Discord, re-pin the resulting
+  `localhost/alert-discord-relay` reference in its quadlet per Tier 1.
+
+### 2. `proton-bridge` — pin base + verify the RPM (P5)
+
+- Pin `fedora:43` by digest (tag as comment).
+- Record the **expected SHA-256** of the Proton RPM (from proton.me / a trusted
+  channel) in the build context, and add a verification step that fails the build
+  if the local RPM's hash does not match before `dnf install`.
+- Fix the stale `README.md` to reflect the actual `active` deployment state and
+  document the RPM provenance + expected hash.
+
+### 3. Repository hardening (P8)
+
+- Enable **branch protection on `main`**: no direct pushes, require PR. Mirror on
+  the self-hosted **Forgejo** repo if it is a push target.
+- **Token hygiene:** short-lived, narrowly-scoped tokens; no long-lived write
+  PATs/deploy keys. Inventory existing tokens and revoke over-scoped ones.
+- Keep server-side squash-merge signing (no change).
+- (No Actions workflows exist; this is branch/token *policy*, not CI hardening —
+  if workflows are added later, they inherit ADR-030's posture.)
+
+## Critical files
+
+- `config/alert-discord-relay/Dockerfile`, `config/alert-discord-relay/requirements.txt`
+  (+ new `requirements.lock`).
+- `builds/proton-bridge/Containerfile`, `builds/proton-bridge/README.md`
+  (+ recorded RPM hash).
+- Quadlets for both `localhost/*` images (re-pin per Tier 1 after rebuild).
+- Repository settings (GitHub `main`, Forgejo) — out-of-tree, document the change.
+
+## Open questions (resolve during execution)
+
+- `pip-tools` vs `uv` for hash generation — which to standardise on.
+- Where to record the Proton RPM expected hash so it is reviewable but the 81 MB
+  binary stays gitignored.
+- Whether the GitHub remote is canonical or a mirror of Forgejo (determines where
+  branch protection is primary).
+
+## Success Criteria
+
+- Both Containerfiles pin their base image by digest.
+- `alert-discord-relay` builds with `--require-hashes` against a transitive-complete
+  lock; a tampered hash fails the build.
+- `proton-bridge` build verifies the RPM against a recorded hash before install;
+  README reflects reality.
+- Branch protection enabled on `main`; token inventory complete with over-scoped
+  tokens revoked.
+
+## Progress Log
+
+- 2026-05-23 — Plan created from ADR-030; grounded in verified build-file audit.

--- a/docs/97-plans/2026-05-23-tier3-4-signatures-and-egress-detection-outline.md
+++ b/docs/97-plans/2026-05-23-tier3-4-signatures-and-egress-detection-outline.md
@@ -1,0 +1,87 @@
+# Tier 3 + Tier 4 Outline: Signature Enforcement & Egress Detection
+
+**Date Created:** 2026-05-23
+**Status:** Proposed (outline — not yet detailed for execution)
+**Last Updated:** 2026-05-23
+**Implements:** ADR-030 (P6, P7) — Container Supply-Chain Trust Model
+
+> These two tiers are intentionally outline-level. Tier 3 needs new tooling and a
+> publisher-by-publisher signing survey; Tier 4 is research-level with no committed
+> mechanism. They are documented now so the ADR has a forward path, and detailed
+> into full plans when Tier 1–2 are complete.
+
+---
+
+## Tier 3 — Signature / Provenance Enforcement (P6) *(authenticity axis)*
+
+**Why:** Digest pinning (Tier 1) guarantees *integrity* ("same bytes") but not
+*authenticity* ("right publisher"). Tier 3 is the only verifiable defense against a
+tag/registry account being used to publish a malicious image — short of source
+compromise (which is Tier 4's residual).
+
+**Verified starting state:**
+- `policy.json` (`/etc/containers/policy.json`) = `insecureAcceptAnything`; no
+  `~/.config/containers/policy.json`; no `~/.config/containers/registries.d/`.
+- **`cosign` is not installed** (prerequisite).
+- Podman 5.8.2 supports sigstore `sigstoreSigned` policy.
+
+**Outline approach:**
+1. **Signing survey** (its own task): for each registry/publisher in use
+   (docker.io library, ghcr.io/* incl. immich/homepage/gathio/unpoller/audiobookshelf,
+   quay.io/*, gcr.io, codeberg.org/forgejo, linuxserver, deluan), determine who
+   publishes sigstore signatures / OIDC provenance and who does not. GHCR
+   OIDC-built images are the most likely first candidates.
+2. Install `cosign`; build `registries.d` + a user `policy.json`.
+3. **Graduated enforcement:** `sigstoreSigned` for the signing subset (start with
+   provenance-bearing GHCR), explicit `insecureAcceptAnything` per-repo for
+   non-signers, tracked in a known-unsigned list (not silently trusted).
+4. Verify pulls/restarts still succeed under the new policy before making it the
+   default; ensure a signature failure fails closed and is observable.
+
+**Risks / why outline-only:** partial coverage by design; brittle if a publisher
+changes signing practices; misconfiguration can block legitimate images. Requires
+the survey before any enforcement is safe.
+
+**Success criteria (draft):** `policy.json` off blanket `insecureAcceptAnything`;
+signing subset enforced via sigstore; documented known-unsigned exceptions; no
+legitimate image blocked.
+
+---
+
+## Tier 4 — Egress Detection (P7) *(containment / detection axis)*
+
+**Why:** The irreducible residual. A **validly-signed but malicious** image from a
+legitimately-compromised maintainer defeats both pinning (Tier 1) and signatures
+(Tier 3). The only remaining controls are containment (already strong) and
+detecting/limiting what a compromised container does on the wire.
+
+**Verified starting state:**
+- Internal-only networks (`auth_services`, `monitoring`, `nextcloud`, `photos`,
+  `gathio`, `mail`, `media_services`, `syslog`, `home_automation`, `forgejo`) are
+  `Internal=true` — already no egress.
+- The `reverse_proxy` network has egress; all 10 internet-facing services reach
+  the Internet through it.
+- Inbound is monitored (CrowdSec, Loki/Promtail); **outbound/behavioral container
+  egress is not.**
+
+**Outline options to evaluate (no commitment yet):**
+- Per-container egress allow-listing (default-deny outbound, allow only known
+  destinations) for the `reverse_proxy` tier.
+- DNS egress logging (which domains containers resolve) as a low-cost detection
+  signal feeding Loki/alerts.
+- Flow/connection monitoring for anomalous outbound from the egress tier.
+
+**Risks / why outline-only:** legitimate egress destinations must be enumerated
+(false-positive risk); rootless networking constrains some host-level options;
+this is detection/limiting, not prevention. Needs a design spike before a plan.
+
+**Success criteria (draft):** a chosen mechanism gives visibility into (or
+allow-lists) outbound from the `reverse_proxy` tier, with anomalies surfaced in the
+existing monitoring stack.
+
+---
+
+## Progress Log
+
+- 2026-05-23 — Outline created from ADR-030; Tier 3/4 deferred pending Tier 1–2 and
+  the signing survey / egress design spike.

--- a/docs/AUTO-DEPENDENCY-GRAPH.md
+++ b/docs/AUTO-DEPENDENCY-GRAPH.md
@@ -1,6 +1,6 @@
 # Service Dependency Graph (Auto-Generated)
 
-**Generated:** 2026-05-21 20:54:09 UTC
+**Generated:** 2026-05-23 13:52:22 UTC
 **System:** fedora-htpc
 
 ---

--- a/docs/AUTO-DOCUMENTATION-INDEX.md
+++ b/docs/AUTO-DOCUMENTATION-INDEX.md
@@ -1,7 +1,7 @@
 # Documentation Index (Auto-Generated)
 
-**Generated:** 2026-05-21 20:54:10 UTC
-**Total Documents:** 413
+**Generated:** 2026-05-23 13:52:23 UTC
+**Total Documents:** 420
 
 ---
 
@@ -22,7 +22,7 @@
 
 ## Documentation by Category
 
-### 00-foundation/ (24 documents)
+### 00-foundation/ (26 documents)
 
 **Fundamentals and core concepts**
 
@@ -51,6 +51,8 @@
 - ADR-026: [2026-04-21-ADR-026-nextcloud-pinned-major-version](00-foundation/decisions/2026-04-21-ADR-026-nextcloud-pinned-major-version.md)
 - ADR-027: [2026-04-22-ADR-027-forward-nocow-workloads-subvol8-db](00-foundation/decisions/2026-04-22-ADR-027-forward-nocow-workloads-subvol8-db.md)
 - ADR-028: [2026-04-27-ADR-028-podman-secret-store-path-split](00-foundation/decisions/2026-04-27-ADR-028-podman-secret-store-path-split.md)
+- ADR-029: [2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup](00-foundation/decisions/2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md)
+- ADR-030: [2026-05-23-ADR-030-container-supply-chain-trust-model](00-foundation/decisions/2026-05-23-ADR-030-container-supply-chain-trust-model.md)
 - : [README](00-foundation/decisions/fixtures/README.md)
 - ADR-023: [2026-04-18-ADR-023-btrfs-storage-architecture-databases](00-foundation/decisions/withdrawn/2026-04-18-ADR-023-btrfs-storage-architecture-databases.md)
 
@@ -177,7 +179,7 @@
 
 ---
 
-### 97-plans/ (30 documents)
+### 97-plans/ (33 documents)
 
 **Strategic plans and forward-looking projects**
 - 📋 [2025-01-08-unpoller-with-advanced-networks-monitoring-plan.md](97-plans/2025-01-08-unpoller-with-advanced-networks-monitoring-plan.md)
@@ -192,6 +194,9 @@
 - 📋 [2026-03-19-fedora-coreos-rebuild-plan.md](97-plans/2026-03-19-fedora-coreos-rebuild-plan.md)
 - 📋 [2026-03-19-nixos-homelab-rebuild-plan.md](97-plans/2026-03-19-nixos-homelab-rebuild-plan.md)
 - 📋 [2026-03-22-urd-btrfs-time-machine-plan.md](97-plans/2026-03-22-urd-btrfs-time-machine-plan.md)
+- 📋 [2026-05-23-tier1-digest-pinning-and-update-deautomation.md](97-plans/2026-05-23-tier1-digest-pinning-and-update-deautomation.md)
+- 📋 [2026-05-23-tier2-build-input-and-repo-hardening.md](97-plans/2026-05-23-tier2-build-input-and-repo-hardening.md)
+- 📋 [2026-05-23-tier3-4-signatures-and-egress-detection-outline.md](97-plans/2026-05-23-tier3-4-signatures-and-egress-detection-outline.md)
 - 📋 [ADR-REORGANIZATION-PLAN.md](97-plans/ADR-REORGANIZATION-PLAN.md)
 - 📋 [MIGRATION-PLAN-FINAL.md](97-plans/MIGRATION-PLAN-FINAL.md)
 - ✅ [PLAN-1-AUTO-UPDATE-SAFETY-NET.md](97-plans/PLAN-1-AUTO-UPDATE-SAFETY-NET.md)
@@ -213,7 +218,7 @@
 
 ---
 
-### 98-journals/ (215 documents)
+### 98-journals/ (217 documents)
 
 **Chronological project history (append-only log)**
 
@@ -231,16 +236,24 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 
 ## Recently Updated (Last 7 Days)
 
-- 2026-05-16: [2026-03-28-ADR-021-urd-backup-tool.md](00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md)
-- 2026-05-16: [README.md](00-foundation/decisions/fixtures/README.md)
+- 2026-05-23: [2025-12-22-ADR-015-container-update-strategy.md](00-foundation/decisions/2025-12-22-ADR-015-container-update-strategy.md)
+- 2026-05-22: [2026-04-18-ADR-024-database-dump-backup.md](00-foundation/decisions/2026-04-18-ADR-024-database-dump-backup.md)
+- 2026-05-22: [2026-04-18-ADR-025-db-storage-migration-deferred.md](00-foundation/decisions/2026-04-18-ADR-025-db-storage-migration-deferred.md)
+- 2026-05-22: [2026-04-22-ADR-027-forward-nocow-workloads-subvol8-db.md](00-foundation/decisions/2026-04-22-ADR-027-forward-nocow-workloads-subvol8-db.md)
+- 2026-05-22: [2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md](00-foundation/decisions/2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md)
+- 2026-05-23: [2026-05-23-ADR-030-container-supply-chain-trust-model.md](00-foundation/decisions/2026-05-23-ADR-030-container-supply-chain-trust-model.md)
+- 2026-05-23: [2026-05-23-tier1-digest-pinning-and-update-deautomation.md](97-plans/2026-05-23-tier1-digest-pinning-and-update-deautomation.md)
+- 2026-05-23: [2026-05-23-tier2-build-input-and-repo-hardening.md](97-plans/2026-05-23-tier2-build-input-and-repo-hardening.md)
+- 2026-05-23: [2026-05-23-tier3-4-signatures-and-egress-detection-outline.md](97-plans/2026-05-23-tier3-4-signatures-and-egress-detection-outline.md)
 - 2026-05-18: [2026-05-15-audit-backlog-drift-and-observability-deployment.md](98-journals/2026-05-15-audit-backlog-drift-and-observability-deployment.md)
 - 2026-05-18: [2026-05-18-audit-subsystem-hardening-private.md](98-journals/2026-05-18-audit-subsystem-hardening-private.md)
 - 2026-05-18: [2026-05-18-security-audit-and-drift-cleanup-private.md](98-journals/2026-05-18-security-audit-and-drift-cleanup-private.md)
-- 2026-05-15: [security-audit-2026-05-15.md](99-reports/security-audit-2026-05-15.md)
-- 2026-05-21: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
-- 2026-05-21: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
-- 2026-05-21: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
-- 2026-05-21: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
+- 2026-05-21: [2026-05-21-pihole-dns-and-adr018-investigation-handoff.md](98-journals/2026-05-21-pihole-dns-and-adr018-investigation-handoff.md)
+- 2026-05-22: [2026-05-22-db-storage-three-tier-and-dump-backbone-phase-a.md](98-journals/2026-05-22-db-storage-three-tier-and-dump-backbone-phase-a.md)
+- 2026-05-23: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
+- 2026-05-23: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
+- 2026-05-23: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
+- 2026-05-23: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
 
 ---
 

--- a/docs/AUTO-NETWORK-TOPOLOGY.md
+++ b/docs/AUTO-NETWORK-TOPOLOGY.md
@@ -1,6 +1,6 @@
 # Network Topology (Auto-Generated)
 
-**Generated:** 2026-05-21 20:54:04 UTC
+**Generated:** 2026-05-23 13:52:17 UTC
 **System:** fedora-htpc | **Networks:** 11 | **Containers:** 36
 
 ---

--- a/docs/AUTO-SERVICE-CATALOG.md
+++ b/docs/AUTO-SERVICE-CATALOG.md
@@ -1,6 +1,6 @@
 # Service Catalog (Auto-Generated)
 
-**Generated:** 2026-05-21 20:54:03 UTC
+**Generated:** 2026-05-23 13:52:17 UTC
 **System:** fedora-htpc | **Services:** 36/36 running | **Health:** 32/32 healthy (4 without healthcheck)
 
 ---
@@ -9,87 +9,87 @@
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| audiobookshelf | advplyr/audiobookshelf:latest | ✅ healthy | 8d | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
-| forgejo | codeberg.org/forgejo/forgejo:15 | ✅ healthy | 8m | [git.patriark.org](https://git.patriark.org) | — |
-| forgejo-db | postgres:16-alpine | ✅ healthy | 12m | — | — |
-| navidrome | deluan/navidrome:latest | ✅ healthy | 8d | [musikk.patriark.org](https://musikk.patriark.org) | — |
-| postgres-exporter | quay.io/prometheuscommunity/postgres-exporter | ✅ healthy | 7d | — | — |
-| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | 8d | — | — |
-| qbittorrent | linuxserver/qbittorrent:latest | ✅ healthy | 8d | [torrent.patriark.org](https://torrent.patriark.org) | — |
-| redis-authelia-exporter | quay.io/oliver006/redis_exporter:latest | — no check | 7d | — | — |
-| redis-immich-exporter | quay.io/oliver006/redis_exporter:latest | — no check | 7d | — | — |
-| unifi-syslog | linuxserver/syslog-ng:latest | ✅ healthy | 4d | — | — |
+| audiobookshelf | advplyr/audiobookshelf:latest | ✅ healthy | 9d | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
+| forgejo | codeberg.org/forgejo/forgejo:15 | ✅ healthy | 41h | [git.patriark.org](https://git.patriark.org) | — |
+| forgejo-db | postgres:16-alpine | ✅ healthy | 41h | — | — |
+| navidrome | deluan/navidrome:latest | ✅ healthy | 9d | [musikk.patriark.org](https://musikk.patriark.org) | — |
+| postgres-exporter | quay.io/prometheuscommunity/postgres-exporter | ✅ healthy | 8d | — | — |
+| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | 9d | — | — |
+| qbittorrent | linuxserver/qbittorrent:latest | ✅ healthy | 9d | [torrent.patriark.org](https://torrent.patriark.org) | — |
+| redis-authelia-exporter | quay.io/oliver006/redis_exporter:latest | — no check | 8d | — | — |
+| redis-immich-exporter | quay.io/oliver006/redis_exporter:latest | — no check | 8d | — | — |
+| unifi-syslog | linuxserver/syslog-ng:latest | ✅ healthy | 18h | — | — |
 
 ## Core Infrastructure (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| authelia | authelia/authelia:latest | ✅ healthy | 7d | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
-| crowdsec | crowdsecurity/crowdsec:latest | ✅ healthy | 8d | — | [guide](10-services/guides/crowdsec.md) |
-| redis-authelia | redis:7-alpine | ✅ healthy | 8d | — | — |
-| traefik | traefik:latest | ✅ healthy | 3m | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
+| authelia | authelia/authelia:latest | ✅ healthy | 8d | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
+| crowdsec | crowdsecurity/crowdsec:latest | ✅ healthy | 9d | — | [guide](10-services/guides/crowdsec.md) |
+| redis-authelia | redis:7-alpine | ✅ healthy | 9d | — | — |
+| traefik | traefik:latest | ✅ healthy | 41h | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
 
 ## Nextcloud (3)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| nextcloud-db | mariadb:11 | ✅ healthy | 8d | — | [guide](10-services/guides/nextcloud.md) |
-| nextcloud | nextcloud:33 | ✅ healthy | 8d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
-| nextcloud-redis | redis:7-alpine | ✅ healthy | 6d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-db | mariadb:11 | ✅ healthy | 9d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud | nextcloud:33 | ✅ healthy | 9d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-redis | redis:7-alpine | ✅ healthy | 8d | — | [guide](10-services/guides/nextcloud.md) |
 
 ## Immich (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| immich-ml | immich-app/immich-machine-learning:v2.7.5 | ✅ healthy | 8d | — | [guide](10-services/guides/immich.md) |
-| immich-server | immich-app/immich-server:v2.7.5 | ✅ healthy | 8d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
-| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3-pgvec | ✅ healthy | 8d | — | — |
-| redis-immich | valkey/valkey:latest | ✅ healthy | 8d | — | — |
+| immich-ml | immich-app/immich-machine-learning:v2.7.5 | ✅ healthy | 9d | — | [guide](10-services/guides/immich.md) |
+| immich-server | immich-app/immich-server:v2.7.5 | ✅ healthy | 9d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
+| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3-pgvec | ✅ healthy | 9d | — | — |
+| redis-immich | valkey/valkey:latest | ✅ healthy | 9d | — | — |
 
 ## Jellyfin (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| jellyfin | jellyfin/jellyfin:latest | ✅ healthy | 8d | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
+| jellyfin | jellyfin/jellyfin:latest | ✅ healthy | 9d | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
 
 ## Vaultwarden (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| vaultwarden | vaultwarden/server:latest | ✅ healthy | 8d | [vault.patriark.org](https://vault.patriark.org) | — |
+| vaultwarden | vaultwarden/server:latest | ✅ healthy | 9d | [vault.patriark.org](https://vault.patriark.org) | — |
 
 ## Home Automation (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 8d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
+| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 9d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
 
 ## Gathio (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| gathio-db | mongo:7 | ✅ healthy | 8d | — | — |
-| gathio | lowercasename/gathio:latest | ✅ healthy | 8d | [events.patriark.org](https://events.patriark.org) | — |
+| gathio-db | mongo:7 | ✅ healthy | 9d | — | — |
+| gathio | lowercasename/gathio:latest | ✅ healthy | 9d | [events.patriark.org](https://events.patriark.org) | — |
 
 ## Homepage (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| homepage | gethomepage/homepage:latest | ✅ healthy | 8d | [patriark.org](https://patriark.org) | — |
+| homepage | gethomepage/homepage:latest | ✅ healthy | 9d | [patriark.org](https://patriark.org) | — |
 
 ## Monitoring (9)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| alert-discord-relay | localhost/alert-discord-relay:latest | ✅ healthy | 8d | — | [guide](10-services/guides/alert-discord-relay.md) |
-| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ healthy | 8d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ healthy | 8d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| grafana | grafana/grafana:latest | ✅ healthy | 8d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| loki | grafana/loki:latest | — no check | 8d | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| node_exporter | quay.io/prometheus/node-exporter:latest | ✅ healthy | 8d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 7d | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| promtail | grafana/promtail:latest | ✅ healthy | 4d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| unpoller | unpoller/unpoller:latest | — no check | 8d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| alert-discord-relay | localhost/alert-discord-relay:latest | ✅ healthy | 9d | — | [guide](10-services/guides/alert-discord-relay.md) |
+| alertmanager | quay.io/prometheus/alertmanager:latest | ✅ healthy | 9d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| cadvisor | gcr.io/cadvisor/cadvisor:latest | ✅ healthy | 9d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| grafana | grafana/grafana:latest | ✅ healthy | 9d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| loki | grafana/loki:latest | — no check | 24h | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| node_exporter | quay.io/prometheus/node-exporter:latest | ✅ healthy | 9d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 25h | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| promtail | grafana/promtail:latest | ✅ healthy | 18h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| unpoller | unpoller/unpoller:latest | — no check | 9d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
 
 ---
 
@@ -97,7 +97,7 @@
 
 - **Total Running:** 36
 - **Total Defined:** 36
-- **System Load:** 0,76, 1,04, 0,97
+- **System Load:** 2,93, 2,05, 1,48
 
 ---
 


### PR DESCRIPTION
## Summary

Establishes the homelab's **container supply-chain defense posture** in response to escalating registry/repository poisoning campaigns (e.g. the May 2026 "Megalodon" campaign — ~5,561 GitHub repos poisoned via stolen-token push-to-master). **Documentation/design only** — no quadlets, configs, services, or `policy.json` are modified by this PR.

### New
- **ADR-030 — Container Supply-Chain Trust Model** (`docs/00-foundation/decisions/`): design-level principles, not a how-to. Eight principles mapped to the trust axes (minimise / integrity / authenticity / time / contain / detect):
  - P1 deliberate-not-ambient updates · P2 digest pinning (`@sha256`) · P3 cooling-off interval · **P4 egress/blast-radius axis, distinct from statefulness** · P5 pinned build inputs · P6 graduated signature verification · P7 containment as a control · P8 protect the project's own repo.
  - Architecture: **in-quadlet pins + a generated audit index** (rejected a central manifest/generator as boot-path fragility).
  - **Supersedes ADR-015's trust model** (ADR-015's BTRFS rollback + health-validation mechanisms are retained and reused).
- **Tier plans** (`docs/97-plans/`): tier1 (digest pinning + update de-automation — full), tier2 (build-input + repo hardening — full), tier3-4 (signature enforcement + egress detection — outline). All `Proposed`.

### Changed
- **ADR-015**: status → `Superseded by ADR-030` (body untouched, per ADR-immutability convention).
- **CLAUDE.md**: Update Strategy section + ADR list now point to ADR-030, with status kept honest (proposed, **not yet executed**).
- **AUTO-* docs**: regenerated via `auto-doc-orchestrator.sh` (0 failures; indexes the new ADR/plans).

## Grounding (verified 2026-05-23, not assumed)

- **0 of 37** images digest-pinned; **22 ride `:latest`**.
- **17 services** carry `AutoUpdate=registry` and pull unattended Sun 03:00 — including egress-tier **traefik, crowdsec, jellyfin, qbittorrent**.
- `policy.json` = `insecureAcceptAnything` (no signature verification); all 10 internet-facing services have egress.
- Tooling: podman 5.8.2 + skopeo 1.22.2 present; **cosign + pip-tools absent** (Tier 3 / Tier 2 prerequisites).
- **Live build exposure found:** `alert-discord-relay` (floating `python:3.11-slim` base + unhashed, transitive-unpinned pip deps, egress-capable).
- No GitHub Actions workflows → Megalodon's direct CI-token vector is low; repo risk = branch-protection + token hygiene.

## Key design challenges recorded in the ADR

- The existing `audit-update-paths.sh` guard tracks **statefulness (availability)**, but supply-chain risk tracks **egress/blast-radius** — which is why traefik/crowdsec slipped onto the unattended path. ADR-030 P4 adds the missing axis.
- Digest pinning is **integrity, not authenticity** — pinning a poisoned image pins poison; hence P2 must travel with P3 (bake) and P6 (signatures). Called out explicitly as a Risk.
- "Stop auto-updates" reframed as "no *unattended* trust acceptance" (notify-only feed retained).

## Review checklist (docs-only)

- [ ] ADR-030 principles read as design guidance (not step-by-step)
- [ ] ADR-030 ↔ ADR-015 supersede relationship is correct and acceptable
- [ ] In-quadlet-pins + audit-index architecture decision endorsed
- [ ] Tier plan scope/sequencing matches intent (T1+T2 actionable, T3+T4 outline)
- [ ] CLAUDE.md status framing accurate (proposed, not executed)

## Not included
- Unrelated pre-existing `docs/98-journals/2026-05-21-pihole-dns-and-adr018-investigation-handoff.md` (left untracked for a separate change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)