### PR TITLE
feat(security): ADR-030 Tier 3 — deliberate-path signature verification (P6)

### DIFF
--- a/config/prometheus/alerts/supply-chain-alerts.yml
+++ b/config/prometheus/alerts/supply-chain-alerts.yml
@@ -1,0 +1,31 @@
+groups:
+  - name: supply_chain_alerts
+    interval: 60s
+    rules:
+      # Critical: a KNOWN signer's image failed signature verification on the
+      # deliberate-update path (ADR-030 P6). A signer that should verify but does not
+      # is a tamper / wrong-identity signal — the pin was refused; investigate before
+      # any adopt. Inert until the metric exists (absent => no fire).
+      - alert: SupplyChainSignatureFailed
+        expr: supply_chain_signature_verify == 0
+        for: 5m
+        labels:
+          severity: critical
+          category: security
+          component: supply-chain
+        annotations:
+          summary: "Image signature verification FAILED for {{ $labels.service }}"
+          description: "{{ $labels.service }} ({{ $labels.repo }}) failed cosign verification against its known signer identity (ADR-030 P6). Possible tampering or a changed publisher identity. The pin was refused. Do NOT adopt; investigate `scripts/verify-image-signature.sh`."
+
+      # Warning: a signer's pin hasn't been re-verified in 90+ days (P3 drift — a
+      # deliberately-pinned signed image has gone stale and unre-checked).
+      - alert: SupplyChainSignatureStale
+        expr: (time() - supply_chain_signature_last_verify_timestamp) > (86400 * 90)
+        for: 6h
+        labels:
+          severity: warning
+          category: security
+          component: supply-chain
+        annotations:
+          summary: "Signed image not re-verified in 90+ days: {{ $labels.service }}"
+          description: "{{ $labels.service }} last had its signature verified {{ $value | humanizeDuration }} ago. Re-check for an available signed update (`scripts/check-image-updates.sh`) and adopt deliberately if appropriate (ADR-030 P3)."

--- a/config/supply-chain/known-unsigned.md
+++ b/config/supply-chain/known-unsigned.md
@@ -1,0 +1,79 @@
+# Known-Unsigned Images (ADR-030 P6 — tracked, not silently trusted)
+
+**Survey date:** 2026-05-24 · **Tool:** containerized cosign v3.0.6 (`cosign tree`)
++ skopeo tag-scheme probe + `gh attestation verify` (GHCR app images).
+
+ADR-030 P6 enforces authenticity *where publishers support it* and **tracks** the
+publishers who do not — rather than silently trusting them. This is that record. Of
+32 external image references, **1 is signed** (`ghcr.io/home-assistant/home-assistant`,
+verified on the deliberate-update path via `signers.yaml`); the rest are listed below.
+
+This is a point-in-time snapshot. Re-run the survey when adding a service or when a
+publisher may have started signing; promote any new signer into `signers.yaml`.
+
+## Signed (enforced via deliberate-path cosign gate)
+
+| Repository | Mechanism |
+|---|---|
+| `ghcr.io/home-assistant/home-assistant` | keyless GitHub-Actions cosign signature (Rekor-logged) — see `signers.yaml` |
+
+## Unsigned — no registry-attached sigstore signature (31 refs)
+
+No `cosign tree` artifacts and no tag-scheme `.sig`/`.att`. Trusted by **digest pin
+(P2) + bake (P3) + containment (P7)** only; authenticity not verifiable today.
+
+### docker.io
+- `docker.io/authelia/authelia`
+- `docker.io/crowdsecurity/crowdsec`
+- `docker.io/library/postgres`
+- `docker.io/library/mongo`
+- `docker.io/library/mariadb`
+- `docker.io/library/redis`
+- `docker.io/library/nextcloud`
+- `docker.io/library/traefik`
+- `docker.io/grafana/grafana`
+- `docker.io/grafana/loki`
+- `docker.io/grafana/promtail`
+- `docker.io/jellyfin/jellyfin`
+- `docker.io/deluan/navidrome`
+- `docker.io/valkey/valkey`
+- `docker.io/linuxserver/qbittorrent`
+- `docker.io/linuxserver/syslog-ng`
+- `docker.io/vaultwarden/server`
+
+### ghcr.io
+- `ghcr.io/advplyr/audiobookshelf`
+- `ghcr.io/lowercasename/gathio`
+- `ghcr.io/gethomepage/homepage`
+- `ghcr.io/immich-app/immich-server`
+- `ghcr.io/immich-app/immich-machine-learning`
+- `ghcr.io/immich-app/postgres`
+- `ghcr.io/unpoller/unpoller`
+
+### quay.io
+- `quay.io/prometheus/alertmanager`
+- `quay.io/prometheus/node-exporter`
+- `quay.io/prometheus/prometheus`
+- `quay.io/prometheuscommunity/postgres-exporter`
+- `quay.io/oliver006/redis_exporter`
+
+### gcr.io
+- `gcr.io/cadvisor/cadvisor`
+
+### codeberg.org
+- `codeberg.org/forgejo/forgejo`
+
+## GHCR build-provenance probe (separate finding)
+
+`gh attestation verify` against the GHCR application images returned **no GitHub
+build-provenance attestations** for any of: `immich-server`, `immich-machine-learning`,
+`immich/postgres`, `gethomepage/homepage`, `lowercasename/gathio`,
+`advplyr/audiobookshelf`, `unpoller/unpoller`. The outline expected "GHCR OIDC-built
+images" to be the most likely first signers; that assumption is **falsified** for this
+fleet's GHCR publishers.
+
+## Local builds (Tier 2, not registry-signed)
+
+`localhost/alert-discord-relay`, `localhost/proton-bridge` — accountability is via
+Tier 2 build-input pinning (base digest + hash-locked deps / GPG+SHA-verified RPM),
+not a registry signature. Signing our own builds is noted as a future, out of Tier 3 scope.

--- a/config/supply-chain/signers.yaml
+++ b/config/supply-chain/signers.yaml
@@ -1,0 +1,27 @@
+# ADR-030 P6 — Tier 3 signer registry (deliberate-path authenticity verification).
+#
+# Maps an image repository to the keyless cosign identity that MUST have signed it.
+# `scripts/verify-image-signature.sh` consults this file. A repository NOT listed
+# here is treated as "unsigned-but-tracked" (verifier exit 3) — NOT a failure; that
+# is ADR-030 P6's graduated, per-publisher trust by design. Adding a new signer is a
+# single entry. The verifier verifies with cosign because podman 5.8.2's policy.json
+# cannot express a workflow-URI identity (see the Tier 3 plan).
+#
+# Fields:
+#   repo             exact image repository (no tag, no digest)
+#   oidc_issuer      expected OIDC issuer   -> cosign --certificate-oidc-issuer
+#   identity_regexp  regexp for the cert SAN -> cosign --certificate-identity-regexp
+#   note             human context
+#
+# To add an email-identity signer (e.g. a publisher using user-OAuth keyless), the
+# same shape works — identity_regexp matches the email SAN instead of a workflow URI.
+
+signers:
+  - repo: ghcr.io/home-assistant/home-assistant
+    oidc_issuer: https://token.actions.githubusercontent.com
+    identity_regexp: '^https://github\.com/home-assistant/core/\.github/workflows/builder\.yml@refs/tags/.*$'
+    note: >-
+      Home Assistant Core — keyless GitHub-Actions cosign signature, Rekor-logged.
+      Survey 2026-05-24: the ONLY signed image in the fleet (1/32). Identity is a
+      workflow URI SAN, not an email, so it is NOT expressible in podman 5.8.2
+      policy.json (subjectEmail mandatory) — verified here on the deliberate path.

--- a/docs/97-plans/2026-05-23-tier3-4-signatures-and-egress-detection-outline.md
+++ b/docs/97-plans/2026-05-23-tier3-4-signatures-and-egress-detection-outline.md
@@ -14,6 +14,18 @@
 
 ## Tier 3 — Signature / Provenance Enforcement (P6) *(authenticity axis)*
 
+> **⚠️ SUPERSEDED (2026-05-24) by**
+> `2026-05-24-tier3-signature-verification-deliberate-path.md`. The signing survey
+> found only **1/32** images signed (Home Assistant), and podman 5.8.2's `policy.json`
+> keyless `fulcio` block mandates `subjectEmail` — it **cannot express HA's workflow-URI
+> identity**, so pull-time enforceable coverage is **zero**. The approach below
+> (install cosign → write `policy.json` → enforce `sigstoreSigned` per publisher at
+> pull time) is therefore **not achievable** with the installed tooling and is replaced
+> by a **deliberate-path cosign gate** (verify at adopt time in `pin-container-image.sh`,
+> advisory in `check-image-updates.sh`), which is also better aligned with P1/P3. The
+> original outline text is retained below for the record. Tier 4 (next section) remains
+> outline-only.
+
 **Why:** Digest pinning (Tier 1) guarantees *integrity* ("same bytes") but not
 *authenticity* ("right publisher"). Tier 3 is the only verifiable defense against a
 tag/registry account being used to publish a malicious image — short of source

--- a/docs/97-plans/2026-05-24-tier3-signature-verification-deliberate-path.md
+++ b/docs/97-plans/2026-05-24-tier3-signature-verification-deliberate-path.md
@@ -1,0 +1,203 @@
+# Tier 3 Plan: Authenticity Verification on the Deliberate-Update Path
+
+**Date Created:** 2026-05-24
+**Status:** Approved (executable) — detailed from the 2026-05-23 outline after the signing survey
+**Implements:** ADR-030 (P6 authenticity; P1 deliberate-not-ambient; P3 cooling-off)
+**Supersedes:** the Tier 3 section of `2026-05-23-tier3-4-signatures-and-egress-detection-outline.md`
+(the pull-time `policy.json` approach — see "Why the approach changed")
+
+> Tier 4 (egress detection) remains outline-only in the original document.
+
+---
+
+## TL;DR
+
+The signing survey (2026-05-24) found that **podman's `policy.json` can enforce
+nothing on this fleet**, so Tier 3 enforces authenticity with **cosign on the
+deliberate-update path** instead — at the one moment a human deliberately adopts a
+new digest. This is *more* aligned with ADR-030's P1/P3 spine than pull-time
+enforcement would have been, and it keeps the boot/restart path untouched.
+
+---
+
+## What the survey found (verified 2026-05-24)
+
+Surveyed all 32 external image references with a digest-pinned containerized
+cosign v3.0.6 (`cosign tree`), a skopeo tag-scheme probe, and `gh attestation
+verify` for the GHCR app images.
+
+| Finding | Result |
+|---|---|
+| Images with a registry-attached sigstore signature | **1 / 32** — `ghcr.io/home-assistant/home-assistant` only |
+| Images with GitHub build-provenance attestations | **0** of the 6 GHCR app images (immich-server/-ml/postgres, homepage, gathio, unpoller, audiobookshelf) |
+| All other publishers (docker.io, quay.io, gcr.io, codeberg.org) | nothing |
+
+HA's signature is genuine and verifiable: keyless GitHub-Actions cosign signature,
+Rekor-logged, OIDC issuer `https://token.actions.githubusercontent.com`, certificate
+SAN `https://github.com/home-assistant/core/.github/workflows/builder.yml@refs/tags/<release>`.
+
+**The decisive limitation.** `man 5 containers-policy.json` (podman 5.8.2, installed)
+specifies that `sigstoreSigned.fulcio` requires **both `oidcIssuer` and `subjectEmail`**,
+and `pki` offers only `subjectEmail`/`subjectHostname`. There is **no URI-SAN /
+workflow-identity match field**. GitHub-Actions keyless certs carry a *URI SAN*, not an
+email — so podman 5.8.2 **cannot express HA's identity**. The one image that is signed
+is the one image `policy.json` cannot verify. Pull-time enforceable coverage = **0**.
+
+## Why the approach changed (outline → this plan)
+
+The outline assumed the standard play: install cosign, write `policy.json`, enforce
+`sigstoreSigned` per publisher at pull time. The survey invalidates that:
+
+1. **Coverage via stock `policy.json` is zero** (the limitation above).
+2. **Pull-time is the wrong checkpoint for this ADR.** ADR-030's spine is P1
+   (trust accepted deliberately, never ambiently) and P3 (cooling-off). Pull-time
+   `policy.json` enforces trust *ambiently* on every pull — including boot and the
+   reboot wrapper's Phase 3 — which is the boot-critical fragility ADR-030's
+   "where digests live" section deliberately avoided.
+3. **cosign already verifies what `policy.json` can't.** It validated HA cleanly
+   against the URI-SAN identity. Only the pull-time enforcement *surface* is broken,
+   not the verification capability.
+
+So Tier 3 verifies authenticity **at the moment of deliberate adoption** (where a
+human is already in the loop, after a bake), using cosign — and leaves `policy.json`
+permissive and documented.
+
+## Design
+
+### Components
+
+1. **Signers registry** — `config/supply-chain/signers.yaml`
+   One entry today (HA): repo, `certificate-identity-regexp`, `certificate-oidc-issuer`.
+   Schema documented so an email-identity (or future URI-SAN) signer is a one-line add.
+
+2. **Known-unsigned manifest** — `config/supply-chain/known-unsigned.md`
+   The 30 unsigned images + the "GHCR has no provenance" finding. This is P6's
+   "tracked, not silently trusted" artifact. Regenerable; surfaced in the pin index.
+
+3. **Verifier** — `scripts/verify-image-signature.sh <repo>@<digest>`
+   Runs the pinned containerized cosign against the signer entry for the repo.
+   **Exit codes (the load-bearing contract):**
+   - `0` — verified against a known identity
+   - `3` — no signer entry for this repo (unsigned-but-tracked; **not** a failure)
+   - `1` — a signer entry exists but verification **FAILED** (fail-closed)
+   - `2` — tooling/network error (cosign image missing, Rekor/registry unreachable) —
+     a transient signal, **not** fail-closed; the operator retries
+   Writes a Prometheus textfile metric (see Observability).
+
+4. **Enforcing gate** — in `scripts/pin-container-image.sh`
+   Before the `--apply` write, call the verifier on `${repo}@${D}`:
+   - exit `1` (FAILED) → **abort the pin** (a signature that should verify but doesn't
+     is a red alarm: possible key compromise or tampered artifact)
+   - exit `0` → proceed; record `# ADR-030 P6: signature verified <identity> (<date>)`
+     as an adjacent quadlet comment beside the existing P1/P2 comments
+   - exit `3` → proceed; optionally record `# ADR-030 P6: no publisher signature (tracked unsigned)`
+   - exit `2` → abort with a *retry* message (distinct from FAILED)
+   - `--skip-verify` — loud, logged escape hatch for the legitimate "HA changed its
+     workflow path and I reviewed the new SAN" case, so the gate can't deadlock.
+
+   *Rationale for this integration point:* pins move **only** through
+   `pin-container-image.sh` — the P1 deliberate-acceptance action. The gate fires once,
+   at a human's adoption, after a bake. It never touches boot/restart/reboot.
+   **Do not** gate `update-before-reboot.sh` (Phase 3 only *ensures pins present*; it
+   never moves one — gating it would reintroduce boot-path fragility).
+
+5. **Advisory check** — in `scripts/check-image-updates.sh`
+   The Sun-10:00 notify feed already resolves each image's available `current` digest.
+   For images with a signer entry, verify that available digest and annotate:
+   `✓ signature verified` / `✗ SIGNATURE FAILED — do not adopt`. Visibility only
+   (the script's "never changes anything" contract); front-loads the trust signal
+   *before* the bake interval. No `set -e` disruption.
+
+6. **Audit view** — `scripts/generate-image-pin-index.sh`
+   Add a **"Signed"** column: `✓ <identity>` / `— tracked-unsigned` / `✗ FAILED`,
+   making the 1/32 coverage (and its growth) explicit in the single reviewable doc.
+
+7. **cosign itself** — pinned `ghcr.io/sigstore/cosign/cosign:v3.0.6@sha256:de9c65…`,
+   run as a throwaway container. It is a supply-chain input; it appears in the pin index
+   like any other image.
+
+### Observability / fail-closed shape
+
+Reuse the existing rails: node_exporter textfile collector
+(`~/containers/data/backup-metrics/*.prom`, scraped by Prometheus) →
+Alertmanager → `alert-discord-relay`.
+
+- **Synchronous (primary):** the gate aborts with a loud stderr message naming the
+  expected identity and digest. A human is already at the keyboard.
+- **Durable:** `verify-image-signature.sh` writes
+  `~/containers/data/backup-metrics/supply-chain-signatures.prom`:
+  ```
+  supply_chain_signature_verify{service="home-assistant",repo="…",result="ok|failed"} 1|0
+  supply_chain_signature_last_verify_timestamp{service="home-assistant"} <epoch>
+  ```
+  Alertmanager rule: `supply_chain_signature_verify{result="failed"} == 1` → **critical**
+  Discord; optional `time() - …_last_verify_timestamp > 90d` → **warning** (stale pin / P3 drift).
+- **Passive:** the pin-index "Signed" column.
+
+**Three-way discrimination is the key detail:** verification-FAILED (critical,
+fail-closed, abort) ≠ no-signer-on-file (the 30, never alarms) ≠ cosign-unreachable
+(warn + retry, never hard-block on a network blip).
+
+### What stays out of scope (recorded as deferred)
+
+- **`policy.json` / `registries.d` enforcement** — blocked on podman gaining
+  URI-SAN / workflow-identity matching. `policy.json` stays `insecureAcceptAnything`,
+  with a justifying comment so it is not later misread as an oversight.
+- **Pull-time enforcement of any kind.**
+- **Signing our own local builds** (alert-discord-relay, proton-bridge) — a
+  Tier-2-adjacent future, not Tier 3's upstream-authenticity remit. Noted, not built.
+
+## Upstream dependency to revisit
+
+When podman/containers-image `sigstoreSigned` gains URI-SAN / workflow-identity
+matching, pull-time `policy.json` enforcement for HA-class keyless signers becomes
+expressible, and the cosign deliberate-path gate can be **promoted** to (or
+complemented by) pull-time policy. Exact constraint to recheck:
+`man 5 containers-policy.json` `sigstoreSigned.fulcio` mandates `oidcIssuer`+`subjectEmail`;
+`pki` offers only `subjectEmail`/`subjectHostname`; neither matches a URI SAN.
+
+## Execution order
+
+1. `config/supply-chain/signers.yaml` + `config/supply-chain/known-unsigned.md`
+2. `scripts/verify-image-signature.sh` — write, then **test end-to-end against HA**
+   (must verify) and a negative case (must fail-closed) before wiring anything.
+3. Gate into `pin-container-image.sh` (fail-closed, `--skip-verify`).
+4. Advisory into `check-image-updates.sh`.
+5. "Signed" column in `generate-image-pin-index.sh`; regenerate `AUTO-IMAGE-PIN-INDEX.md`.
+6. Alertmanager rule + route (existing Discord relay).
+7. Docs: mark the outline's Tier 3 superseded; update `project_supply_chain_hardening`
+   memory with the survey result + the podman URI-SAN upstream-dependency note.
+
+## Success criteria
+
+- `verify-image-signature.sh` verifies HA's current digest (exit 0) and fails closed
+  (exit 1) on a tampered/wrong identity — both demonstrated.
+- `pin-container-image.sh` aborts a pin on verification FAILURE and proceeds (with the
+  right comment) on verified / no-signer; `--skip-verify` works and is loud.
+- The pin index shows the "Signed" column with HA `✓` and the rest `tracked-unsigned`.
+- A verification failure surfaces in Discord via the existing relay; transient cosign
+  errors warn rather than block.
+- `policy.json` remains permissive **by documented decision**, with the upstream
+  dependency recorded.
+- No new code on the boot/restart/reboot path.
+
+## Risks
+
+- **HA changes its builder workflow path** → identity-regexp stops matching → gate
+  fails-closed on a legitimate update. *Mitigation:* identity stored as a regexp
+  (`builder.yml@refs/tags/.*`); loud `--skip-verify` after manual SAN review; a
+  blocking failure at adoption is the *correct* response to a changed signing identity.
+- **Sole signer looks like over-engineering.** *Mitigation:* framed as the extensible
+  P6 pilot — the second signer is a one-line config add; the pin-index column makes the
+  1/32 reality and its growth path explicit.
+- **Permissive `policy.json` misread as a gap later.** *Mitigation:* justifying comment
+  + the upstream-dependency note; the audit index shows authenticity *is* enforced, on
+  the deliberate-adoption axis.
+
+## Progress Log
+
+- 2026-05-24 — Plan created from the outline after the signing survey; approach changed
+  from pull-time `policy.json` to a deliberate-path cosign gate due to the podman 5.8.2
+  URI-SAN limitation. Direction approved (Option A).
+</content>
+</invoke>

--- a/docs/AUTO-IMAGE-PIN-INDEX.md
+++ b/docs/AUTO-IMAGE-PIN-INDEX.md
@@ -1,6 +1,6 @@
 # Container Image Pin Index (Auto-Generated)
 
-**Generated:** 2026-05-23 16:06:20 UTC
+**Generated:** 2026-05-24 11:54:03 UTC
 **Source:** `/home/patriark/containers/quadlets` — ADR-030 (Container Supply-Chain Trust Model)
 
 Pins live in each quadlet's `Image=` line (where Podman reads them); this is
@@ -19,50 +19,53 @@ For local builds the `Digest` column shows the **base image** pin (FROM …@sha2
 | 🔨 Local builds with FLOATING base | 0 |
 | Egress-tier still floating | 0 |
 | Egress-tier still auto-updating | 0 |
+| 🔏 P6 signers (authenticity-verified on adopt) | 1 |
+| ✗ P6 signature FAILED | 0 |
 
 > ✅ **Supply-chain invariant holds:** no reverse_proxy-tier service is floating
-> or auto-updating, and every local build pins its base image by digest.
+> or auto-updating, every local build pins its base image by digest, and no
+> known signer has a FAILED signature.
 
 ## Images
 
-| Service | Egress | Status | Repository | Tag | Digest | Auto |
-|---------|--------|--------|------------|-----|--------|------|
-| alert-discord-relay | yes | 🔨 base-pinned | `localhost/alert-discord-relay` | latest | `sha256:a3ab0b966bc4…` | no |
-| alertmanager | yes | 🔒 pinned | `quay.io/prometheus/alertmanager` | latest | `sha256:51a825c2a40a…` | no |
-| audiobookshelf | yes | 🔒 pinned | `ghcr.io/advplyr/audiobookshelf` | latest | `sha256:4143292c530f…` | no |
-| authelia | yes | 🔒 pinned | `docker.io/authelia/authelia` | latest | `sha256:0c824dcab1ae…` | no |
-| cadvisor | no | 🔒 pinned | `gcr.io/cadvisor/cadvisor` | latest | `sha256:3de2bd520312…` | no |
-| crowdsec | yes | 🔒 pinned | `docker.io/crowdsecurity/crowdsec` | latest | `sha256:2f527c9bb8b3…` | no |
-| forgejo-db | no | 🔒 pinned | `docker.io/library/postgres` | 16-alpine | `sha256:16bc17c64a57…` | no |
-| forgejo | yes | 🔒 pinned | `codeberg.org/forgejo/forgejo` | 15 | `sha256:db04c7114b65…` | no |
-| gathio-db | no | 🔒 pinned | `docker.io/library/mongo` | 7 | `sha256:32979a1189df…` | no |
-| gathio | yes | 🔒 pinned | `ghcr.io/lowercasename/gathio` | latest | `sha256:b7e9675d4e22…` | no |
-| grafana | yes | 🔒 pinned | `docker.io/grafana/grafana` | latest | `sha256:2d1f9ae67c17…` | no |
-| home-assistant | yes | 🔒 pinned | `ghcr.io/home-assistant/home-assistant` | stable | `sha256:d4fbec16196d…` | no |
-| homepage | yes | 🔒 pinned | `ghcr.io/gethomepage/homepage` | latest | `sha256:d8d784e50901…` | no |
-| immich-ml | no | 🔒 pinned | `ghcr.io/immich-app/immich-machine-learning` | v2.7.5 | `sha256:a2501141440f…` | no |
-| immich-server | yes | 🔒 pinned | `ghcr.io/immich-app/immich-server` | v2.7.5 | `sha256:c15bff75068e…` | no |
-| jellyfin | yes | 🔒 pinned | `docker.io/jellyfin/jellyfin` | latest | `sha256:1694ff069f0c…` | no |
-| loki | yes | 🔒 pinned | `docker.io/grafana/loki` | latest | `sha256:191d4fdfb726…` | no |
-| navidrome | yes | 🔒 pinned | `docker.io/deluan/navidrome` | latest | `sha256:9fa40b3d8dec…` | no |
-| nextcloud-db | no | 🔒 pinned | `docker.io/library/mariadb` | 11 | `sha256:78a5047d3ba3…` | no |
-| nextcloud-redis | no | 🔒 pinned | `docker.io/library/redis` | 7-alpine | `sha256:6ab0b6e73817…` | no |
-| nextcloud | yes | 🔒 pinned | `docker.io/library/nextcloud` | 33 | `sha256:b67959acacd5…` | no |
-| node_exporter | no | 🔒 pinned | `quay.io/prometheus/node-exporter` | latest | `sha256:0f422f62c15f…` | no |
-| postgres-exporter | no | 🔒 pinned | `quay.io/prometheuscommunity/postgres-exporter` | latest | `sha256:e96064f87622…` | no |
-| postgresql-immich | no | 🔒 pinned | `ghcr.io/immich-app/postgres` | 14-vectorchord0.4.3-pgvectors0.2.0 | `sha256:bcf63357191b…` | no |
-| prometheus | yes | 🔒 pinned | `quay.io/prometheus/prometheus` | latest | `sha256:c0b857aead0d…` | no |
-| promtail | no | 🔒 pinned | `docker.io/grafana/promtail` | latest | `sha256:6cfa64ec432b…` | no |
-| proton-bridge | yes | 🔨 base-pinned | `localhost/proton-bridge` | 3.23.1 | `sha256:747502f9190e…` | no |
-| qbittorrent | yes | 🔒 pinned | `docker.io/linuxserver/qbittorrent` | latest | `sha256:f76c4363cce0…` | no |
-| redis-authelia-exporter | no | 🔒 pinned | `quay.io/oliver006/redis_exporter` | latest | `sha256:e8c209894d4c…` | no |
-| redis-authelia | no | 🔒 pinned | `docker.io/library/redis` | 7-alpine | `sha256:6ab0b6e73817…` | no |
-| redis-immich-exporter | no | 🔒 pinned | `quay.io/oliver006/redis_exporter` | latest | `sha256:e8c209894d4c…` | no |
-| redis-immich | no | 🔒 pinned | `docker.io/valkey/valkey` | latest | `sha256:8436e10bc65c…` | no |
-| traefik | yes | 🔒 pinned | `docker.io/library/traefik` | latest | `sha256:6b9cbca6fac4…` | no |
-| unifi-syslog | no | 🔒 pinned | `docker.io/linuxserver/syslog-ng` | latest | `sha256:0d164e438d1f…` | no |
-| unpoller | yes | 🔒 pinned | `ghcr.io/unpoller/unpoller` | latest | `sha256:bf7bdcc59fcd…` | no |
-| vaultwarden | yes | 🔒 pinned | `docker.io/vaultwarden/server` | latest | `sha256:d626d04934cd…` | no |
+| Service | Egress | Status | Repository | Tag | Digest | Auto | Signed (P6) |
+|---------|--------|--------|------------|-----|--------|------|-------------|
+| alert-discord-relay | yes | 🔨 base-pinned | `localhost/alert-discord-relay` | latest | `sha256:a3ab0b966bc4…` | no | n/a (Tier 2) |
+| alertmanager | yes | 🔒 pinned | `quay.io/prometheus/alertmanager` | latest | `sha256:51a825c2a40a…` | no | — unsigned |
+| audiobookshelf | yes | 🔒 pinned | `ghcr.io/advplyr/audiobookshelf` | latest | `sha256:4143292c530f…` | no | — unsigned |
+| authelia | yes | 🔒 pinned | `docker.io/authelia/authelia` | latest | `sha256:0c824dcab1ae…` | no | — unsigned |
+| cadvisor | no | 🔒 pinned | `gcr.io/cadvisor/cadvisor` | latest | `sha256:3de2bd520312…` | no | — unsigned |
+| crowdsec | yes | 🔒 pinned | `docker.io/crowdsecurity/crowdsec` | latest | `sha256:2f527c9bb8b3…` | no | — unsigned |
+| forgejo-db | no | 🔒 pinned | `docker.io/library/postgres` | 16-alpine | `sha256:16bc17c64a57…` | no | — unsigned |
+| forgejo | yes | 🔒 pinned | `codeberg.org/forgejo/forgejo` | 15 | `sha256:db04c7114b65…` | no | — unsigned |
+| gathio-db | no | 🔒 pinned | `docker.io/library/mongo` | 7 | `sha256:32979a1189df…` | no | — unsigned |
+| gathio | yes | 🔒 pinned | `ghcr.io/lowercasename/gathio` | latest | `sha256:b7e9675d4e22…` | no | — unsigned |
+| grafana | yes | 🔒 pinned | `docker.io/grafana/grafana` | latest | `sha256:2d1f9ae67c17…` | no | — unsigned |
+| home-assistant | yes | 🔒 pinned | `ghcr.io/home-assistant/home-assistant` | stable | `sha256:d4fbec16196d…` | no | ✓ verified |
+| homepage | yes | 🔒 pinned | `ghcr.io/gethomepage/homepage` | latest | `sha256:d8d784e50901…` | no | — unsigned |
+| immich-ml | no | 🔒 pinned | `ghcr.io/immich-app/immich-machine-learning` | v2.7.5 | `sha256:a2501141440f…` | no | — unsigned |
+| immich-server | yes | 🔒 pinned | `ghcr.io/immich-app/immich-server` | v2.7.5 | `sha256:c15bff75068e…` | no | — unsigned |
+| jellyfin | yes | 🔒 pinned | `docker.io/jellyfin/jellyfin` | latest | `sha256:1694ff069f0c…` | no | — unsigned |
+| loki | yes | 🔒 pinned | `docker.io/grafana/loki` | latest | `sha256:191d4fdfb726…` | no | — unsigned |
+| navidrome | yes | 🔒 pinned | `docker.io/deluan/navidrome` | latest | `sha256:9fa40b3d8dec…` | no | — unsigned |
+| nextcloud-db | no | 🔒 pinned | `docker.io/library/mariadb` | 11 | `sha256:78a5047d3ba3…` | no | — unsigned |
+| nextcloud-redis | no | 🔒 pinned | `docker.io/library/redis` | 7-alpine | `sha256:6ab0b6e73817…` | no | — unsigned |
+| nextcloud | yes | 🔒 pinned | `docker.io/library/nextcloud` | 33 | `sha256:b67959acacd5…` | no | — unsigned |
+| node_exporter | no | 🔒 pinned | `quay.io/prometheus/node-exporter` | latest | `sha256:0f422f62c15f…` | no | — unsigned |
+| postgres-exporter | no | 🔒 pinned | `quay.io/prometheuscommunity/postgres-exporter` | latest | `sha256:e96064f87622…` | no | — unsigned |
+| postgresql-immich | no | 🔒 pinned | `ghcr.io/immich-app/postgres` | 14-vectorchord0.4.3-pgvectors0.2.0 | `sha256:bcf63357191b…` | no | — unsigned |
+| prometheus | yes | 🔒 pinned | `quay.io/prometheus/prometheus` | latest | `sha256:c0b857aead0d…` | no | — unsigned |
+| promtail | no | 🔒 pinned | `docker.io/grafana/promtail` | latest | `sha256:6cfa64ec432b…` | no | — unsigned |
+| proton-bridge | yes | 🔨 base-pinned | `localhost/proton-bridge` | 3.23.1 | `sha256:747502f9190e…` | no | n/a (Tier 2) |
+| qbittorrent | yes | 🔒 pinned | `docker.io/linuxserver/qbittorrent` | latest | `sha256:f76c4363cce0…` | no | — unsigned |
+| redis-authelia-exporter | no | 🔒 pinned | `quay.io/oliver006/redis_exporter` | latest | `sha256:e8c209894d4c…` | no | — unsigned |
+| redis-authelia | no | 🔒 pinned | `docker.io/library/redis` | 7-alpine | `sha256:6ab0b6e73817…` | no | — unsigned |
+| redis-immich-exporter | no | 🔒 pinned | `quay.io/oliver006/redis_exporter` | latest | `sha256:e8c209894d4c…` | no | — unsigned |
+| redis-immich | no | 🔒 pinned | `docker.io/valkey/valkey` | latest | `sha256:8436e10bc65c…` | no | — unsigned |
+| traefik | yes | 🔒 pinned | `docker.io/library/traefik` | latest | `sha256:6b9cbca6fac4…` | no | — unsigned |
+| unifi-syslog | no | 🔒 pinned | `docker.io/linuxserver/syslog-ng` | latest | `sha256:0d164e438d1f…` | no | — unsigned |
+| unpoller | yes | 🔒 pinned | `ghcr.io/unpoller/unpoller` | latest | `sha256:bf7bdcc59fcd…` | no | — unsigned |
+| vaultwarden | yes | 🔒 pinned | `docker.io/vaultwarden/server` | latest | `sha256:d626d04934cd…` | no | — unsigned |
 
 ---
 
@@ -71,3 +74,10 @@ reverse_proxy network member (ADR-030 P4). Local builds (`localhost/*`) are
 pinned via build inputs under Tier 2 — base image by digest, plus hash-locked
 deps (alert-discord-relay) / GPG+SHA-verified RPM (proton-bridge) — not by
 registry digest. The `Digest` column shows the base-image pin.*
+
+*`Signed (P6)` (Tier 3): `✓ verified` / `✗ FAILED` reflect the last
+deliberate-path cosign check (`signers.yaml` + the textfile metric), NOT a live
+verify. `— unsigned` = no publisher signature, tracked in `config/supply-chain/
+known-unsigned.md`. Survey 2026-05-24: 1/32 signed (Home Assistant). podman 5.8.2
+policy.json cannot enforce its workflow-URI identity, so authenticity is verified
+on the deliberate-update path — see the Tier 3 plan.*

--- a/scripts/check-image-updates.sh
+++ b/scripts/check-image-updates.sh
@@ -8,16 +8,27 @@
 # be deliberately bumped. It NEVER pulls or changes anything — visibility only,
 # preserving "trust is accepted deliberately" (P1).
 #
-# To adopt an available update: bake (P3), then
-#   scripts/pin-container-image.sh <svc> [--deautomate] --apply
+# To adopt an available update: bake (P3), then (the digest is verified at this step,
+# ADR-030 P6):
+#   scripts/pin-container-image.sh <svc> --adopt <new-digest> --apply
 #   systemctl --user daemon-reload && systemctl --user restart <svc>.service
 #
 # NOTE: no `set -e` — a single image's skopeo failure must not abort the sweep.
 set -uo pipefail
 
 QUADLET_DIR="${QUADLET_DIR:-$HOME/containers/quadlets}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SIGNERS_FILE="${SIGNERS_FILE:-$HOME/containers/config/supply-chain/signers.yaml}"
 REPORT_FILE="$HOME/containers/docs/99-reports/image-updates-$(date +%Y%m%d).txt"
 mkdir -p "$(dirname "$REPORT_FILE")"
+
+# ADR-030 P6 (Tier 3): pre-load repos that have a known signer so we can verify the
+# AVAILABLE digest and front-load the trust signal BEFORE a deliberate adopt (advisory).
+declare -A SIGNER_REPOS=()
+if [ -f "$SIGNERS_FILE" ]; then
+    while IFS= read -r r; do [ -n "$r" ] && SIGNER_REPOS["$r"]=1; done < <(
+        python3 -c "import yaml; d=yaml.safe_load(open('$SIGNERS_FILE')) or {}; [print(s.get('repo','')) for s in (d.get('signers') or [])]" 2>/dev/null)
+fi
 
 updates=(); failed=(); local_builds=(); uptodate=0
 
@@ -45,10 +56,23 @@ for f in "$QUADLET_DIR"/*.container; do
         failed+=("$name (${repo}:${tag})"); continue
     fi
     sleep 0.2  # be gentle on registries between checks
+
+    # ADR-030 P6 advisory: if this repo has a known signer, verify the AVAILABLE digest
+    signote=""
+    if [ -n "${SIGNER_REPOS[$repo]:-}" ]; then
+        "$SCRIPT_DIR/verify-image-signature.sh" "${repo}@${current}" --quiet >/dev/null 2>&1
+        case $? in
+            0) signote="  [✓ signature verified]" ;;
+            1) signote="  [✗ SIGNATURE FAILED — do not adopt]" ;;
+            *) signote="  [⚠ signature check error]" ;;
+        esac
+    fi
+
     if [ "$current" != "$pinned" ]; then
-        updates+=("$name | ${repo}:${tag} | pinned ${pinned:0:19}… → available ${current:0:19}…")
+        updates+=("$name | ${repo}:${tag} | pinned ${pinned:0:19}… → available ${current:0:19}…${signote}")
     else
         uptodate=$((uptodate+1))
+        [ -n "$signote" ] && updates+=("$name | ${repo}:${tag} | up-to-date${signote}")
     fi
 done
 
@@ -78,8 +102,9 @@ done
         echo ""
     fi
     echo "========================================"
-    echo "To adopt an update deliberately (after a bake interval, P3):"
-    echo "  scripts/pin-container-image.sh <svc> [--deautomate] --apply"
+    echo "To adopt an update deliberately (after a bake interval, P3; digest is"
+    echo "signature-verified at adopt time per ADR-030 P6):"
+    echo "  scripts/pin-container-image.sh <svc> --adopt <available-digest> --apply"
     echo "  systemctl --user daemon-reload && systemctl --user restart <svc>.service"
 } > "$REPORT_FILE"
 

--- a/scripts/generate-image-pin-index.sh
+++ b/scripts/generate-image-pin-index.sh
@@ -14,8 +14,28 @@ set -euo pipefail
 QUADLET_DIR="${QUADLET_DIR:-$HOME/containers/quadlets}"
 REPO_ROOT="${REPO_ROOT:-$HOME/containers}"
 OUTPUT_FILE="${OUTPUT_FILE:-$HOME/containers/docs/AUTO-IMAGE-PIN-INDEX.md}"
+SIGNERS_FILE="${SIGNERS_FILE:-$REPO_ROOT/config/supply-chain/signers.yaml}"
+METRIC_FILE="${METRIC_FILE:-$REPO_ROOT/data/backup-metrics/supply-chain-signatures.prom}"
 
 is_egress() { grep -qE '^Network=systemd-reverse_proxy' "$1"; }
+
+# ADR-030 P6 (Tier 3): the "Signed" column is derived from local state only (fast, no
+# network) — signer membership (signers.yaml) + last verify result (the .prom metric
+# written by verify-image-signature.sh at adopt time). It is NOT a live cosign check.
+declare -A SIGNER_REPOS=()
+if [ -f "$SIGNERS_FILE" ]; then
+    while IFS= read -r r; do [ -n "$r" ] && SIGNER_REPOS["$r"]=1; done < <(
+        python3 -c "import yaml; d=yaml.safe_load(open('$SIGNERS_FILE')) or {}; [print(s.get('repo','')) for s in (d.get('signers') or [])]" 2>/dev/null)
+fi
+declare -A VERIFY_RESULT=()
+if [ -f "$METRIC_FILE" ]; then
+    while IFS= read -r line; do
+        case "$line" in
+            supply_chain_signature_verify\{*)
+                rp="${line#*repo=\"}"; rp="${rp%%\"*}"; VERIFY_RESULT["$rp"]="${line##* }" ;;
+        esac
+    done < "$METRIC_FILE"
+fi
 
 # For a localhost build, find its build file and report base-pin state.
 # Echoes: "<pinned|floating|unknown> <full-base-digest-or-->"
@@ -38,7 +58,7 @@ localbuild_base() {
 
 rows=""
 pinned=0; floating=0; local_builds=0; egress_floating=0; egress_auto=0; total=0
-local_base_floating=0
+local_base_floating=0; signers_count=0; signers_failed=0
 
 for f in "$QUADLET_DIR"/*.container; do
     name="$(basename "$f" .container)"
@@ -73,9 +93,23 @@ for f in "$QUADLET_DIR"/*.container; do
 
     [ "$auto" != "no" ] && [ "$egress" = yes ] && egress_auto=$((egress_auto+1))
 
+    # ADR-030 P6 signed-state (local-derived: signer membership + last verify metric)
+    if [[ "$img" == localhost/* ]]; then
+        signed="n/a (Tier 2)"
+    elif [ -n "${SIGNER_REPOS[$repo]:-}" ]; then
+        signers_count=$((signers_count+1))
+        case "${VERIFY_RESULT[$repo]:-}" in
+            1) signed="✓ verified" ;;
+            0) signed="✗ FAILED"; signers_failed=$((signers_failed+1)) ;;
+            *) signed="signer (pending)" ;;
+        esac
+    else
+        signed="— unsigned"
+    fi
+
     short_digest="$digest"
     [ "$digest" != "—" ] && short_digest="${digest:0:19}…"
-    rows+="| ${name} | ${egress} | ${status} | \`${repo}\` | ${tag} | \`${short_digest}\` | ${auto} |"$'\n'
+    rows+="| ${name} | ${egress} | ${status} | \`${repo}\` | ${tag} | \`${short_digest}\` | ${auto} | ${signed} |"$'\n'
 done
 
 {
@@ -100,19 +134,23 @@ done
     echo "| 🔨 Local builds with FLOATING base | ${local_base_floating} |"
     echo "| Egress-tier still floating | ${egress_floating} |"
     echo "| Egress-tier still auto-updating | ${egress_auto} |"
+    echo "| 🔏 P6 signers (authenticity-verified on adopt) | ${signers_count} |"
+    echo "| ✗ P6 signature FAILED | ${signers_failed} |"
     echo ""
-    if [ "$egress_floating" -eq 0 ] && [ "$egress_auto" -eq 0 ] && [ "$local_base_floating" -eq 0 ]; then
+    if [ "$egress_floating" -eq 0 ] && [ "$egress_auto" -eq 0 ] && [ "$local_base_floating" -eq 0 ] && [ "$signers_failed" -eq 0 ]; then
         echo "> ✅ **Supply-chain invariant holds:** no reverse_proxy-tier service is floating"
-        echo "> or auto-updating, and every local build pins its base image by digest."
+        echo "> or auto-updating, every local build pins its base image by digest, and no"
+        echo "> known signer has a FAILED signature."
     else
-        echo "> ❌ **Invariant VIOLATED** — see \`scripts/audit-egress-updates.sh\` (egress) or pin"
-        echo "> the local build base(s) flagged above (\`FROM …@sha256:\`)."
+        echo "> ❌ **Invariant VIOLATED** — see \`scripts/audit-egress-updates.sh\` (egress), pin"
+        echo "> the local build base(s) flagged above (\`FROM …@sha256:\`), or investigate the"
+        echo "> ✗ P6 signature FAILED row (possible tampering — do not adopt)."
     fi
     echo ""
     echo "## Images"
     echo ""
-    echo "| Service | Egress | Status | Repository | Tag | Digest | Auto |"
-    echo "|---------|--------|--------|------------|-----|--------|------|"
+    echo "| Service | Egress | Status | Repository | Tag | Digest | Auto | Signed (P6) |"
+    echo "|---------|--------|--------|------------|-----|--------|------|-------------|"
     printf "%s" "$rows" | sort
     echo ""
     echo "---"
@@ -122,7 +160,14 @@ done
     echo "pinned via build inputs under Tier 2 — base image by digest, plus hash-locked"
     echo "deps (alert-discord-relay) / GPG+SHA-verified RPM (proton-bridge) — not by"
     echo "registry digest. The \`Digest\` column shows the base-image pin.*"
+    echo ""
+    echo "*\`Signed (P6)\` (Tier 3): \`✓ verified\` / \`✗ FAILED\` reflect the last"
+    echo "deliberate-path cosign check (\`signers.yaml\` + the textfile metric), NOT a live"
+    echo "verify. \`— unsigned\` = no publisher signature, tracked in \`config/supply-chain/"
+    echo "known-unsigned.md\`. Survey 2026-05-24: 1/32 signed (Home Assistant). podman 5.8.2"
+    echo "policy.json cannot enforce its workflow-URI identity, so authenticity is verified"
+    echo "on the deliberate-update path — see the Tier 3 plan.*"
 } > "$OUTPUT_FILE"
 
 echo "✓ Image pin index generated: $OUTPUT_FILE"
-echo "  pinned=$pinned floating=$floating local=$local_builds local_base_floating=$local_base_floating egress_floating=$egress_floating egress_auto=$egress_auto"
+echo "  pinned=$pinned floating=$floating local=$local_builds local_base_floating=$local_base_floating egress_floating=$egress_floating egress_auto=$egress_auto signers=$signers_count signers_failed=$signers_failed"

--- a/scripts/pin-container-image.sh
+++ b/scripts/pin-container-image.sh
@@ -9,24 +9,43 @@
 #
 # Optionally removes AutoUpdate=registry / Pull=newer (ADR-030 P1/P4 de-automation).
 #
-# Usage: pin-container-image.sh <container> [--deautomate] [--apply]
-#   no --apply  -> dry-run, prints the proposed change
-#   --deautomate -> also strip AutoUpdate=registry / Pull=newer lines
+# ADR-030 P6 (Tier 3): before applying a pin, the new digest is verified against the
+# publisher's known signing identity via scripts/verify-image-signature.sh. A signer
+# with a FAILED signature aborts the pin (fail-closed); an image with no signer entry
+# proceeds (unsigned-but-tracked). This is authenticity enforcement at the moment of
+# DELIBERATE adoption (P1) — see docs/97-plans/2026-05-24-tier3-…-deliberate-path.md.
 #
-# Exit: 0 ok/dry-run/already-pinned, 2 error, 3 local build (Tier 2, skipped)
+# Two modes:
+#   • first-pin (default): pin Image= to the running container's baked digest.
+#   • adopt (--adopt <digest>): deliberately move an ALREADY-pinned service to a new
+#     digest — the P1 "bump" path (resolve new digest → bake → adopt → restart). The
+#     P6 gate verifies the target digest before it is written; the restart pulls it.
+#
+# Usage: pin-container-image.sh <container> [--adopt <digest|repo@digest>] \
+#                               [--deautomate] [--apply] [--skip-verify]
+#   no --apply    -> dry-run, prints the proposed change (and the signature status)
+#   --adopt <d>   -> bump an already-pinned service to digest <d> (bare sha256:… or repo@sha256:…)
+#   --deautomate  -> also strip AutoUpdate=registry / Pull=newer lines
+#   --skip-verify -> bypass the P6 signature gate (LOUD, logged; for a reviewed
+#                    publisher identity change only)
+#
+# Exit: 0 ok/dry-run/already-pinned, 2 error or P6 gate refused, 3 local build (Tier 2, skipped)
 set -euo pipefail
 
 QUADLET_DIR="${QUADLET_DIR:-$HOME/containers/quadlets}"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TODAY="$(date +%Y-%m-%d)"
 
-c="${1:?usage: pin-container-image.sh <container> [--deautomate] [--apply]}"
+c="${1:?usage: pin-container-image.sh <container> [--adopt <digest>] [--deautomate] [--apply] [--skip-verify]}"
 shift || true
-DEAUTO=false; APPLY=false
-for a in "$@"; do
-    case "$a" in
-        --deautomate) DEAUTO=true ;;
-        --apply)      APPLY=true ;;
-        *) echo "unknown arg: $a" >&2; exit 2 ;;
+DEAUTO=false; APPLY=false; SKIPVERIFY=false; ADOPT=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --deautomate)  DEAUTO=true; shift ;;
+        --apply)       APPLY=true; shift ;;
+        --skip-verify) SKIPVERIFY=true; shift ;;
+        --adopt)       ADOPT="${2:?--adopt needs a digest or repo@digest}"; shift 2 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
     esac
 done
 
@@ -37,19 +56,36 @@ img="$(grep -m1 -E '^Image=' "$f" | sed 's/^Image=//' | tr -d '[:space:]')"
 [ -n "$img" ] || { echo "ERROR: no Image= in $f" >&2; exit 2; }
 
 case "$img" in
-    *@sha256:*)  echo "$c: already digest-pinned — skipping"; exit 0 ;;
     localhost/*) echo "$c: local build ($img) — Tier 2 (build inputs), skipping"; exit 3 ;;
 esac
 
-repo="${img%:*}"   # strip :tag (no registry ports in use)
-tag="${img##*:}"
-
-D="$(podman inspect "$c" --format '{{.ImageDigest}}' 2>/dev/null || true)"
-[ -n "$D" ] || { echo "ERROR: $c not running or no .ImageDigest" >&2; exit 2; }
+if [ -n "$ADOPT" ]; then
+    # ADOPT MODE — deliberate bump of an already-pinned (or floating) service.
+    repo="${img%@*}"; case "$repo" in *:*) repo="${repo%:*}";; esac
+    case "$ADOPT" in
+        *@sha256:*) D="${ADOPT##*@}"; adoptrepo="${ADOPT%@*}"
+                    [ "$adoptrepo" = "$repo" ] || { echo "ERROR: --adopt repo ($adoptrepo) != quadlet repo ($repo)" >&2; exit 2; } ;;
+        sha256:*)   D="$ADOPT" ;;
+        *) echo "ERROR: --adopt must be sha256:… or ${repo}@sha256:…" >&2; exit 2 ;;
+    esac
+    tag="$(grep -m1 -oE 'tag: [^,]+' "$f" | sed 's/tag: //')"; [ -n "$tag" ] || tag="${img##*:}"
+    case "$tag" in "$repo"|"$img") tag="latest" ;; esac
+    REQUIRE_LOCAL=false
+else
+    # FIRST-PIN MODE — freeze the running container's baked digest ("pin what's baked").
+    case "$img" in *@sha256:*) echo "$c: already digest-pinned — skipping (use --adopt <digest> to bump)"; exit 0 ;; esac
+    repo="${img%:*}"   # strip :tag (no registry ports in use)
+    tag="${img##*:}"
+    D="$(podman inspect "$c" --format '{{.ImageDigest}}' 2>/dev/null || true)"
+    [ -n "$D" ] || { echo "ERROR: $c not running or no .ImageDigest" >&2; exit 2; }
+    REQUIRE_LOCAL=true
+fi
 case "$D" in sha256:*) ;; *) echo "ERROR: unexpected digest for $c: '$D'" >&2; exit 2 ;; esac
 
 newref="${repo}@${D}"
-podman image exists "$newref" || { echo "ERROR: pinned ref not present locally: $newref" >&2; exit 2; }
+if $REQUIRE_LOCAL; then
+    podman image exists "$newref" || { echo "ERROR: pinned ref not present locally: $newref" >&2; exit 2; }
+fi
 
 echo "== $c =="
 echo "  was: Image=$img"
@@ -59,15 +95,47 @@ if $DEAUTO; then
     [ -n "$auto" ] && echo "  de-automate: removing [$auto]"
 fi
 
+# --- ADR-030 P6 signature gate (Tier 3, deliberate-path authenticity) ---------
+P6COMMENT=""
+if $SKIPVERIFY; then
+    echo "  ⚠️  P6 signature gate SKIPPED (--skip-verify) for $newref"
+    P6COMMENT="# ADR-030 P6: signature verification SKIPPED via --skip-verify ($TODAY)"
+else
+    vargs=("$newref" --service "$c")
+    $APPLY && vargs+=(--metric)
+    set +e
+    "$SCRIPT_DIR/verify-image-signature.sh" "${vargs[@]}"
+    vrc=$?
+    set -e
+    case "$vrc" in
+        0) P6COMMENT="# ADR-030 P6: publisher signature verified ($TODAY)" ;;
+        3) P6COMMENT="# ADR-030 P6: no publisher signature (tracked unsigned)" ;;
+        1) echo "  ❌ P6 GATE: signature verification FAILED for $newref — refusing to pin." >&2
+           echo "     Review the publisher's signing identity; use --skip-verify only after manual verification." >&2
+           exit 2 ;;
+        2) echo "  ⚠️  P6 GATE: signature check could not complete (tooling/network) for $newref — not pinning." >&2
+           echo "     Retry, or pass --skip-verify to override deliberately." >&2
+           exit 2 ;;
+        *) echo "  ⚠️  P6 GATE: unexpected verifier exit ($vrc) — not pinning." >&2; exit 2 ;;
+    esac
+fi
+
 $APPLY || { echo "  (dry-run — pass --apply to write)"; exit 0; }
 
 cp "$f" "/tmp/$(basename "$f").bak.$(date +%s)"
+had_p14=0; grep -q '^# ADR-030 P1/P4:' "$f" && had_p14=1
 tmp="$(mktemp)"
-awk -v repo="$repo" -v digest="$D" -v tag="$tag" -v today="$TODAY" -v deauto="$DEAUTO" '
+awk -v repo="$repo" -v digest="$D" -v tag="$tag" -v today="$TODAY" -v deauto="$DEAUTO" \
+    -v p6="$P6COMMENT" -v had_p14="$had_p14" '
+    # drop any pre-existing ADR-030 pin comments so re-pin (--adopt) stays idempotent
+    /^# ADR-030 P2:/      { next }
+    /^# ADR-030 P1\/P4:/  { next }
+    /^# ADR-030 P6:/      { next }
     /^Image=/ && !done {
         print "# ADR-030 P2: digest-pinned (integrity). tag: " tag ", resolved " today " (index digest, multi-arch)"
-        if (deauto == "true")
-            print "# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart."
+        if (deauto == "true" || had_p14 == "1")
+            print "# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = adopt new digest (pin-container-image.sh --adopt), bake, restart."
+        if (p6 != "") print p6
         print "Image=" repo "@" digest
         done=1
         next

--- a/scripts/verify-image-signature.sh
+++ b/scripts/verify-image-signature.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# verify-image-signature.sh — ADR-030 P6 (Tier 3) deliberate-path authenticity gate.
+#
+# Verifies that a specific image digest was signed by the publisher's known keyless
+# identity, using cosign. This exists because podman 5.8.2's policy.json cannot match
+# a workflow-URI keyless identity (sigstoreSigned.fulcio mandates subjectEmail), so
+# authenticity is enforced here — at the moment of DELIBERATE adoption (P1), after a
+# bake (P3) — not at pull time. See docs/97-plans/2026-05-24-tier3-…-deliberate-path.md.
+#
+# cosign runs as a digest-pinned throwaway container (it is itself a supply-chain input).
+#
+# Usage: verify-image-signature.sh <repo@digest | repo:tag> [--service <name>] [--metric] [--quiet]
+#
+# Exit codes (the load-bearing contract — callers depend on these):
+#   0  verified against a known signer identity
+#   3  no signer entry for this repo  -> unsigned-but-tracked (NOT a failure; P6 graduated)
+#   1  signer entry exists but verification FAILED  -> fail-closed (tamper / wrong identity)
+#   2  tooling / network error (cosign image missing, registry/Rekor unreachable) -> retry, NOT fail-closed
+set -uo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$HOME/containers}"
+SIGNERS_FILE="${SIGNERS_FILE:-$REPO_ROOT/config/supply-chain/signers.yaml}"
+COSIGN_IMAGE="${COSIGN_IMAGE:-ghcr.io/sigstore/cosign/cosign:v3.0.6@sha256:de9c65609e6bde17e6b48de485ee788407c9502fa08b8f4459f595b21f56cd00}"
+METRIC_DIR="${METRIC_DIR:-$REPO_ROOT/data/backup-metrics}"
+METRIC_FILE="$METRIC_DIR/supply-chain-signatures.prom"
+
+ref="${1:?usage: verify-image-signature.sh <repo@digest|repo:tag> [--service <name>] [--metric] [--quiet]}"
+shift || true
+service=""; want_metric=false; quiet=false
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --service) service="${2:?}"; shift 2 ;;
+        --metric)  want_metric=true; shift ;;
+        --quiet)   quiet=true; shift ;;
+        *) echo "verify-image-signature: unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+# repo = ref with any @digest or :tag stripped
+repo="$ref"; repo="${repo%@*}"; case "$repo" in *:*) repo="${repo%:*}";; esac
+[ -n "$service" ] || service="$repo"
+
+log() { $quiet || echo "$*" >&2; }
+
+cosign() { podman run --rm --network=bridge "$COSIGN_IMAGE" "$@"; }
+
+write_metric() {  # $1=value (1 ok / 0 failed)
+    $want_metric || return 0
+    mkdir -p "$METRIC_DIR" || return 0
+    local tmp; tmp="$(mktemp)" || return 0
+    # drop this service's previous lines, preserve others (no stale series)
+    [ -f "$METRIC_FILE" ] && grep -v "service=\"$service\"" "$METRIC_FILE" > "$tmp" 2>/dev/null
+    {
+        echo "# HELP supply_chain_signature_verify ADR-030 P6 deliberate-path signature check (1=verified, 0=FAILED)."
+        echo "# TYPE supply_chain_signature_verify gauge"
+        echo "supply_chain_signature_verify{service=\"$service\",repo=\"$repo\"} $1"
+        echo "supply_chain_signature_last_verify_timestamp{service=\"$service\"} $(date +%s)"
+    } >> "$tmp"
+    mv "$tmp" "$METRIC_FILE" 2>/dev/null || rm -f "$tmp"
+}
+
+# --- look up signer entry (PyYAML) -------------------------------------------
+[ -f "$SIGNERS_FILE" ] || { echo "verify-image-signature: missing $SIGNERS_FILE" >&2; exit 2; }
+entry="$(python3 - "$SIGNERS_FILE" "$repo" <<'PY'
+import sys, yaml
+path, repo = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    doc = yaml.safe_load(f) or {}
+for s in (doc.get("signers") or []):
+    if s.get("repo") == repo:
+        print(s.get("oidc_issuer", "")); print(s.get("identity_regexp", "")); break
+PY
+)" || { echo "verify-image-signature: failed to parse $SIGNERS_FILE" >&2; exit 2; }
+
+if [ -z "$entry" ]; then
+    log "ℹ️  $repo: no signer entry — unsigned-but-tracked (ADR-030 P6)"
+    exit 3
+fi
+issuer="$(printf '%s\n' "$entry" | sed -n 1p)"
+identity="$(printf '%s\n' "$entry" | sed -n 2p)"
+[ -n "$issuer" ] && [ -n "$identity" ] || { echo "verify-image-signature: incomplete signer entry for $repo" >&2; exit 2; }
+
+# --- tooling + connectivity pre-checks (separate network errors from FAILURE) -
+podman image exists "$COSIGN_IMAGE" || {
+    echo "verify-image-signature: cosign image not present ($COSIGN_IMAGE) — run: podman pull $COSIGN_IMAGE" >&2; exit 2; }
+if ! skopeo inspect --raw "docker://$ref" >/dev/null 2>&1; then
+    echo "verify-image-signature: registry unreachable or ref unresolvable: $ref (retry)" >&2; exit 2
+fi
+
+# --- verify ------------------------------------------------------------------
+log "🔎 verifying $ref"
+log "   identity ~ $identity"
+log "   issuer     $issuer"
+out="$(cosign verify \
+        --certificate-identity-regexp "$identity" \
+        --certificate-oidc-issuer "$issuer" \
+        "$ref" 2>&1)"; rc=$?
+
+if [ $rc -eq 0 ]; then
+    log "✅ VERIFIED: $repo signed by expected identity"
+    write_metric 1
+    exit 0
+fi
+
+# Registry was reachable (pre-check passed) → a cosign failure is either a genuine
+# verification failure (fail-closed) or a transparency-log/transient error (retry).
+if printf '%s' "$out" | grep -qiE 'rekor|tlog|transparency|timeout|deadline exceeded|connection refused|no such host|tuf|fetch.*trust'; then
+    echo "verify-image-signature: transient verification error (Rekor/TUF/network), retry:" >&2
+    $quiet || printf '%s\n' "$out" | tail -5 >&2
+    exit 2
+fi
+
+echo "❌ SIGNATURE VERIFICATION FAILED for $ref" >&2
+echo "   expected identity ~ $identity (issuer $issuer)" >&2
+$quiet || printf '%s\n' "$out" | tail -8 >&2
+write_metric 0
+exit 1


### PR DESCRIPTION
## Summary

Implements **ADR-030 Tier 3** (P6 authenticity), the third tier of the container supply-chain trust model (after #222 Tier 1 and #223 Tier 2).

The signing survey reframed the tier. Surveying all 32 external image refs (containerized pinned cosign v3.0.6 `cosign tree` + skopeo tag probe + `gh attestation verify`) found **only 1 image signed**: `ghcr.io/home-assistant/home-assistant` (keyless GitHub-Actions, Rekor-logged). And `man 5 containers-policy.json` (podman 5.8.2) shows the keyless `fulcio` block **mandates `subjectEmail`** — it cannot express HA's workflow-URI identity. So **pull-time `policy.json` enforceable coverage is zero**, invalidating the original outline's approach.

**Pivot (infra-architect-reviewed):** enforce authenticity with **cosign on the deliberate-update path** — at the moment of deliberate adoption (P1), after a bake (P3) — not at pull time. This is *more* aligned with ADR-030's spine and keeps the boot/restart path untouched. `policy.json` stays `insecureAcceptAnything` by documented decision.

## What's in here

- **`scripts/verify-image-signature.sh`** — pinned containerized cosign verifier. Exit `0` verified / `3` no-signer-tracked / `1` FAILED (fail-closed) / `2` tooling-retry. Writes a `supply_chain_signature_verify` `.prom` textfile metric.
- **`scripts/pin-container-image.sh`** — fail-closed P6 gate before `--apply`, plus a new **`--adopt <digest>`** mode. This also **fixes a pre-existing bug**: the documented "adopt an update" command (`pin-container-image.sh <svc> --apply`) was a silent no-op on already-pinned services — i.e. the entire deliberate-bump workflow was broken fleet-wide. `--adopt` repairs it and is where the gate fires.
- **`scripts/check-image-updates.sh`** — advisory signature annotation of the *available* digest in the Sun-notify feed; adoption instructions corrected to `--adopt`.
- **`scripts/generate-image-pin-index.sh`** — new **Signed (P6)** column (local-derived from `signers.yaml` + the metric; not a live check), folded into the supply-chain invariant.
- **`config/supply-chain/signers.yaml`** — signer registry (HA today; one-line add for future signers).
- **`config/supply-chain/known-unsigned.md`** — the 30 tracked-unsigned + the GHCR no-provenance finding (P6 "tracked, not silently trusted").
- **`config/prometheus/alerts/supply-chain-alerts.yml`** — `SupplyChainSignatureFailed` (critical) + `SupplyChainSignatureStale` (warning) → existing Discord relay; promtool-validated.
- **Docs:** new Tier 3 plan; 2026-05-23 outline's Tier 3 section marked superseded; `AUTO-IMAGE-PIN-INDEX.md` regenerated.

## Testing

- Verifier: 4/4 cases (HA verified `exit 0`; redis no-signer `exit 3`; wrong-identity `exit 1`; unsigned-image `exit 1`).
- Pin gate: dry-run + `--apply` + comment idempotency on a throwaway copy; repo-mismatch and non-resolvable-digest guards; real quadlets untouched.
- Advisory: live full sweep annotated HA's available digest `[✓ signature verified]`.
- Pin-index Signed column renders (HA `✓ verified`, rest `— unsigned`, invariant holds).
- `promtool check rules` SUCCESS.

## Notes / follow-ups

- **Upstream dependency:** when podman/containers-image `sigstoreSigned` gains URI-SAN / workflow-identity matching, pull-time `policy.json` enforcement becomes viable and this gate can be promoted. Recorded in the plan.
- `policy.json` deliberately stays permissive (documented in the plan + pin-index footer).
- Tier 4 (egress detection) remains outline-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)