### PR TITLE
fix(backup): restore-test selects latest snapshot by name, not mtime

### DIFF
--- a/scripts/test-backup-restore.sh
+++ b/scripts/test-backup-restore.sh
@@ -105,9 +105,13 @@ get_latest_snapshot() {
 
     log DEBUG "Looking for snapshots for $subvol"
 
-    # Strategy 1: Check local snapshots first (most recent, most reliable)
+    # Strategy 1: Check local snapshots first (most recent, most reliable).
+    # Select by the date in the NAME (YYYYMMDD[-HHMM] sorts lexically == chronologically),
+    # NOT by mtime: BTRFS read-only snapshots inherit the source subvolume's root-dir mtime,
+    # so `ls -t` ties across all of them and silently picks the OLDEST snapshot — the test
+    # would then validate a stale backup instead of the latest one.
     if [[ -d "$snapshot_dir" ]]; then
-        found_snapshot=$(ls -1td "$snapshot_dir"/* 2>/dev/null | head -1 || echo "")
+        found_snapshot=$(ls -1d "$snapshot_dir"/* 2>/dev/null | sort -r | head -1 || echo "")
         if [[ -n "$found_snapshot" && -d "$found_snapshot" ]]; then
             source="local"
             log DEBUG "Found local snapshot: $found_snapshot"
@@ -120,7 +124,7 @@ get_latest_snapshot() {
         # Try organized subfolder first
         local external_dir="$EXTERNAL_BACKUP_ROOT/$subvol"
         if [[ -d "$external_dir" ]]; then
-            found_snapshot=$(ls -1td "$external_dir"/* 2>/dev/null | head -1 || echo "")
+            found_snapshot=$(ls -1d "$external_dir"/* 2>/dev/null | sort -r | head -1 || echo "")
             if [[ -n "$found_snapshot" && -d "$found_snapshot" ]]; then
                 source="external"
                 log DEBUG "Found external snapshot (organized): $found_snapshot"
@@ -146,7 +150,7 @@ get_latest_snapshot() {
             esac
 
             if [[ -n "$search_pattern" ]]; then
-                found_snapshot=$(ls -1td "$EXTERNAL_BACKUP_ROOT"/$search_pattern 2>/dev/null | head -1 || echo "")
+                found_snapshot=$(ls -1d "$EXTERNAL_BACKUP_ROOT"/$search_pattern 2>/dev/null | sort -r | head -1 || echo "")
                 if [[ -n "$found_snapshot" && -d "$found_snapshot" ]]; then
                     source="external-scattered"
                     log WARNING "Found scattered external snapshot: $found_snapshot (may be old)"


### PR DESCRIPTION
## Summary

`get_latest_snapshot()` in `scripts/test-backup-restore.sh` chose the snapshot to validate with `ls -1td | head -1` (sort by **mtime**). BTRFS read-only snapshots inherit the source subvolume's root-dir mtime, so every snapshot of a subvolume whose root dir isn't touched between snapshots shares **one identical mtime** — and the `ls -t` tie-break then silently selects the alphabetically-first name = the **oldest** snapshot.

**Impact: 7 of 9 subvolumes were validating a stale snapshot** — the DR restore-test proved an *old* backup was restorable, not the current one, and the existing ">30 days old" staleness warning was checking the wrong snapshot. Surfaced when `subvol3-opptak` was seen testing `20260329` while `20260524` existed.

| Subvolume | Was validating | Latest |
|---|---|---|
| subvol3-opptak | 20260329 | **20260524** |
| subvol7-containers | 20260523 | **20260524** |
| htpc-home / htpc-root | 20260514 | **20260524** |
| subvol4-multimedia | 20260519 | **20260522** |
| subvol5-music | 20260330 | **20260403** |
| subvol6-tmp | 20260519 | **20260524** |

## Fix

Select by the date in the snapshot **name** (`YYYYMMDD[-HHMM]` sorts lexically == chronologically) via `ls -1d | sort -r | head -1`, at all three selection sites (local + two external-snapshot paths). Deterministic regardless of BTRFS mtime quirks; also makes the staleness warning a meaningful backup-freshness signal.

## Verification

Full suite **6/6 PASS**; each subvolume now selects its latest snapshot (cross-checked `Using snapshot:` against latest-by-name — all ✓). Scratch auto-cleaned, `/tmp` untouched.

Follow-up to #225 (which repaired the dead metric + tmpfs); same `get_latest_snapshot()` function touched there for the `Source` fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)