### PR TITLE
chore(audiobookshelf): bump to 2.35.0, drop ACCESS_TOKEN_EXPIRY workaround

### DIFF
--- a/quadlets/audiobookshelf.container
+++ b/quadlets/audiobookshelf.container
@@ -16,9 +16,9 @@ Wants=network-online.target traefik.service
 # CONTAINER CONFIGURATION
 # ═══════════════════════════════════════════════════════════
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-23 (index digest, multi-arch)
+# ADR-030 P2: digest-pinned (integrity). tag: 2.35.0, resolved 2026-05-24 (index digest, multi-arch)
 # ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart.
-Image=ghcr.io/advplyr/audiobookshelf@sha256:4143292c530f6ac6700afd13360c04f477e4f1a81c1c97c4224b1c7e4330c5c4
+Image=ghcr.io/advplyr/audiobookshelf@sha256:89276ff2e0b3d2f07dd334b641f27a34ab7f02e1047c60b7b8a30126cb0813a5
 ContainerName=audiobookshelf
 HostName=audiobookshelf
 
@@ -29,11 +29,9 @@ Network=systemd-reverse_proxy:ip=10.89.2.74
 Environment=TZ=Europe/Oslo
 Environment=PORT=80
 
-# Auth token lifetimes — workaround for upstream bug #4630
-# Default 1h access token forces frequent refresh; rotation has no grace period,
-# so any lost refresh response (mobile network transition, app suspend) permanently
-# breaks the session. Longer access token = fewer refreshes = fewer broken sessions.
-Environment=ACCESS_TOKEN_EXPIRY=86400
+# NOTE: ACCESS_TOKEN_EXPIRY=86400 workaround (PR #185, bug #4630) removed in 2.35.0 bump —
+# upstream access-token refresh grace period (PR #5004) ships in this release. See issue #188.
+# Verify token refresh + Prologue session survival across the access-token boundary post-deploy.
 
 # Config & metadata (exclusive - NOCOW for SQLite)
 Volume=/mnt/btrfs-pool/subvol7-containers/audiobookshelf/config:/config:Z


### PR DESCRIPTION
## Summary

Bumps Audiobookshelf 2.34.0 → 2.35.0 and removes the `ACCESS_TOKEN_EXPIRY=86400` workaround (revert of #185), since the upstream fix it was compensating for now ships in this release.

## Why

- Upstream **PR #5004** (access-token refresh grace period) **merged 2026-05-17**.
- v2.35.0 release notes credit it explicitly: *"Access token refresh grace period (fixes frequently needing to re-login) #4630 by @nichwall in #5004"*.
- This is the exact fix tracked in #188.

## Changes

- `Image=` digest `4143292c` (2.34.0) → `89276ff2` (2.35.0, multi-arch index digest), per ADR-030.
- Remove `Environment=ACCESS_TOKEN_EXPIRY=86400`; replace with a NOTE documenting the removal + post-deploy verification step.

## Verification done

- PR #5004 merge confirmed via GitHub API.
- Image baked by digest; version label confirms `2.35.0`.
- ADR-030 supply-chain pre-commit gate passes (still digest-pinned).

## Post-merge follow-ups (per #188)

1. `daemon-reload` + restart `audiobookshelf.service`; confirm healthy + version 2.35.0.
2. Verify token refresh + Prologue session survives across the access-token boundary (back to 1h tokens + grace period).
3. Monitor 7 days for regression in `Session not found` rate, then close #188.

Refs #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)