### PR TITLE
docs(monitoring): deep-dive plans — metric diet, SLO coverage, backup observability

### DIFF
--- a/docs/97-plans/2026-05-25-backup-observability.md
+++ b/docs/97-plans/2026-05-25-backup-observability.md
@@ -1,0 +1,116 @@
+# Plan C: Backup & Dump Observability
+
+**Date Created:** 2026-05-25
+**Status:** Proposed
+**Last Updated:** 2026-05-25
+**Implements:** Report [2026-05-25 Monitoring Stack Deep-Dive](../99-reports/2026-05-25-monitoring-stack-deep-dive.md) §6
+**Reconciles with:** ADR-029 (Three-Tier DB Storage + Dump Backup), ADR-021 (Urd), `backup-alerts.yml`,
+`db-dump-alerts.yml`, `scripts/btrfs-snapshot-backup.sh`, `scripts/db-dump.sh`, `~/projects/urd`
+
+## Objective
+
+Raise the **signal quality** of backup observability without adding bulk. Backups are already
+well-instrumented (11 alerts + restore tests); this plan fixes the one noisy alert, closes two real
+coverage gaps (pool capacity, dump growth), and tidies the dashboard. Per owner decision, the **1.5 GB
+nightly Prometheus dump is kept as-is** — effort goes to the items below instead.
+
+## Background (verified 2026-05-25)
+
+- The **only firing alert** in the whole stack is `ExternalBackupMissing{subvolume="subvol6-tmp"}`
+  (`backup_snapshot_count{location="external"} == 0`, `for: 12h`, warning). `subvol6-tmp` is
+  scratch/temp data; the alert has no concept of "not expected to be external."
+- Urd already emits `backup_pool_free_bytes` and `backup_pool_metadata_utilization_ratio` (UPI-043),
+  but **it is unconfirmed whether Prometheus scrapes them** and there is **no pool-capacity alert**.
+- `db_dump_size_bytes` is collected (Prometheus dump 1.55 GB, Immich 82.6 MB, …) but **never alerted**.
+- `LowSnapshotCount` is intentionally disabled (owner watches the Grafana panel).
+- Context: the `backup_restore_test_*` producer was silently dead until **2026-05-24** (a `set -e` +
+  `((var++))` footgun) — the alerts were correct but received no data. Reinforces "verify the signal
+  arrives, not just that the alert exists."
+
+## Approach
+
+### 1. Fix `ExternalBackupMissing` noise (highest priority — it's the live false-positive)
+
+First **confirm intent**: read `scripts/btrfs-snapshot-backup.sh` to determine whether `subvol6-tmp`
+is *supposed* to be sent externally.
+
+- **If tmp is intentionally local-only:** make the alert ignore non-external subvolumes. Cleanest:
+  have the backup script emit a label/metric marking which subvolumes are expected-external (e.g.
+  `backup_external_expected{subvolume=...} 1`), and gate the alert:
+  `backup_snapshot_count{location="external"} == 0 and on(subvolume) backup_external_expected == 1`.
+  Fallback (no script change): add `subvolume!="subvol6-tmp"` to the alert expr with a comment.
+- **If tmp *should* be external and genuinely isn't:** this is a real miss — fix the send schedule in
+  the script; keep the alert. (Determine which case before writing the fix.)
+
+### 2. BTRFS pool free-space alert (B2)
+
+- **Verify scrape first:** query `backup_pool_free_bytes` / `backup_pool_metadata_utilization_ratio`
+  in Prometheus. If empty, Urd's pool metrics aren't reaching the textfile collector / scrape — wire
+  that up (confirm Urd writes them to the node_exporter textfile dir, or add a scrape) **before**
+  adding the alert.
+- Then add to `backup-alerts.yml`:
+  - `BtrfsPoolSpaceWarning` — free below ~15% (warning).
+  - `BtrfsPoolSpaceCritical` — free below ~7% (critical) — a full pool breaks snapshots *and* dumps.
+  - `BtrfsPoolMetadataExhaustion` — `backup_pool_metadata_utilization_ratio > 0.95` (BTRFS metadata
+    exhaustion can ENOSPC even with data space free — a classic silent killer).
+- Use slow repeat intervals (capacity is slow-moving; match the existing `DiskSpaceCritical` 24h cadence).
+
+### 3. Dump-size-growth alert (B3)
+
+Add `DbDumpSizeAnomaly` to `db-dump-alerts.yml`: fire when a dump exceeds, e.g., **2× its own 14-day
+median** (`db_dump_size_bytes > 2 * quantile_over_time(0.5, db_dump_size_bytes[14d])`), warning,
+per-`database`. Catches a runaway DB or a misconfigured dump before it pressures the 4.6 GB dump set.
+Exclude/relax for `prometheus` (its size tracks TSDB, addressed by Plan A's diet).
+
+### 4. `LowSnapshotCount` + documentation (B4)
+
+- Leave `LowSnapshotCount` disabled, but add an in-rule comment stating the decision and that the
+  signal lives on the `backup-health` dashboard.
+- Confirm the `backup-health.json` dashboard actually has a per-subvolume snapshot-count panel.
+
+### 5. backup-health dashboard polish
+
+Promote the new signals to first-class panels on `backup-health.json`:
+- BTRFS pool free-space + metadata-utilization gauges (from B2).
+- `db_dump_size_bytes` trend per database (makes B3 visually verifiable).
+- Restore-test recency (`time() - db_restore_test_last_timestamp`) — given the May 2026 dead-metric
+  incident, surfacing freshness guards against silent producer failure.
+
+## Success Criteria
+
+- `ExternalBackupMissing` no longer fires for scratch subvolumes; firing-alert count returns to **0**
+  in steady state.
+- `backup_pool_free_bytes` confirmed present in Prometheus; pool warning/critical/metadata alerts load
+  and `promtool check rules` passes.
+- `DbDumpSizeAnomaly` loads and does not false-fire against current 14-day-stable dump sizes.
+- `backup-health` dashboard shows pool space, dump-size trend, and restore-test recency.
+
+## Verification
+
+```bash
+podman exec prometheus promtool check rules /etc/prometheus/alerts/backup-alerts.yml \
+  /etc/prometheus/alerts/db-dump-alerts.yml
+# confirm the metrics the new alerts depend on actually exist:
+for q in backup_pool_free_bytes backup_pool_metadata_utilization_ratio db_dump_size_bytes backup_external_expected; do
+  podman exec prometheus wget -qO- "http://localhost:9090/api/v1/query?query=$q" | head -c 200; echo
+done
+# confirm ExternalBackupMissing is no longer firing:
+podman exec prometheus wget -qO- 'http://localhost:9090/api/v1/query?query=ALERTS%7Balertname%3D%22ExternalBackupMissing%22,alertstate%3D%22firing%22%7D'
+# backup-health dashboard: pool + dump-size + restore-recency panels populate
+```
+
+## Rollback
+
+`git revert` the alert-file and dashboard-JSON changes. If Plan C touches `btrfs-snapshot-backup.sh`
+(expected-external label), revert it separately; the script keeps emitting existing metrics regardless.
+
+## Notes
+
+- Cross-repo: pool-metric wiring may require a change in `~/projects/urd` (textfile output) rather than
+  this repo — flag and coordinate if so (see `reference_urd_project`).
+- This plan deliberately does **not** touch the Prometheus dump, retention, or the dump schedule.
+
+## Progress Log
+
+- 2026-05-25 — Plan drafted from deep-dive report. Status: Proposed. Item 1 is the only live
+  false-positive and should ship first.

--- a/docs/97-plans/2026-05-25-monitoring-metric-diet.md
+++ b/docs/97-plans/2026-05-25-monitoring-metric-diet.md
@@ -1,0 +1,131 @@
+# Plan A: Monitoring Metric Diet & Stack Hygiene
+
+**Date Created:** 2026-05-25
+**Status:** Proposed
+**Last Updated:** 2026-05-25
+**Implements:** Report [2026-05-25 Monitoring Stack Deep-Dive](../99-reports/2026-05-25-monitoring-stack-deep-dive.md) §3, §7
+**Reconciles with:** ADR-003 (Monitoring Stack), ADR-030 (Supply-Chain Trust Model — `:latest` pin)
+
+## Objective
+
+Cut Prometheus active series ~40–45% by dropping data that **no dashboard and no rule consumes**,
+then fix three small hygiene items. This is the highest-ROI, lowest-risk change in the deep-dive:
+pure subtraction, fully reversible, with zero loss of any metric currently used.
+
+## Background (verified 2026-05-25)
+
+- **33,745 active series**; **cAdvisor = 17,660 (52%)**; Grafana self-metrics 2,631; postgres-immich
+  2,330; node_exporter 1,873.
+- **`config/prometheus/prometheus.yml` contains zero `metric_relabel_configs`** — nothing is dropped.
+- TSDB on disk = 4.0 GB (15d retention); ingest ~1,850 samples/s.
+- Blast-radius grep (this session) proved the top cardinality drivers have **no consumer**:
+  `container_tasks_state`, `container_memory_failures_total`, `container_blkio_device_usage_total`,
+  per-device `container_fs_reads_total`/`container_fs_writes_total`,
+  `container_pressure_io_stalled_seconds_total`, `grafana_feature_toggles_info`,
+  `redis_commands_latencies_usec_bucket`.
+- The complete cAdvisor keep-list (union of all dashboard + alert + recording-rule references):
+
+  ```
+  container_cpu_usage_seconds_total      container_network_receive_bytes_total
+  container_memory_usage_bytes           container_network_transmit_bytes_total
+  container_memory_working_set_bytes     container_fs_reads_bytes_total
+  container_spec_memory_limit_bytes      container_fs_writes_bytes_total
+  container_last_seen                    container_start_time_seconds
+  machine_memory_bytes                   machine_cpu_cores
+  ```
+
+  `container_fs_*_bytes_total` **must be preserved** (used by `container-metrics.json` +
+  `service-health.json`); everything outside the list is unreferenced.
+
+## Approach
+
+### 1. cAdvisor allowlist (the big lever)
+
+Add a `metric_relabel_configs` keep-filter to the **`cadvisor` job only** in
+`config/prometheus/prometheus.yml`. Allowlist (keep) approach, not denylist, so future cAdvisor
+metric additions stay dropped by default:
+
+```yaml
+  - job_name: cadvisor
+    # ... existing static_configs / labels ...
+    metric_relabel_configs:
+      # Keep only the container_/machine_ series consumed by dashboards + rules.
+      # Audited 2026-05-25 (see Plan A / deep-dive report §3). Drops ~14k unused series.
+      - source_labels: [__name__]
+        regex: 'container_(cpu_usage_seconds_total|memory_usage_bytes|memory_working_set_bytes|spec_memory_limit_bytes|network_receive_bytes_total|network_transmit_bytes_total|fs_reads_bytes_total|fs_writes_bytes_total|last_seen|start_time_seconds)|machine_(memory_bytes|cpu_cores)|cadvisor_version_info|container_scrape_error'
+        action: keep
+```
+
+- Keep the `cadvisor_version_info` and `container_scrape_error` series (tiny, useful for self-health).
+- Document the keep-list inline with a comment pointing at this plan + the report, so the rationale
+  survives.
+
+### 2. Exporter trims (secondary)
+
+- **Grafana job:** drop `grafana_feature_toggles_info` (346 unused series) and other unused
+  `grafana_*_info` families via a small drop rule on the grafana job. Keep
+  `grafana_http_request_*`, datasource health, and build/version series.
+- **Redis jobs** (`redis-authelia`, `redis-immich`): drop `redis_commands_latencies_usec_bucket`
+  (518 unused histogram series). Dashboards use `redis_commands_duration_seconds_total` /
+  `redis_command_calls_total`, which stay.
+- **postgres-immich (lower priority):** `datname=immich` carries ~2,330 series from per-table
+  `pg_stat_*`. Evaluate dropping per-relation stats not used by `postgres-exporter.json`; defer if it
+  risks a dashboard panel — confirm with a grep of `postgres-exporter.json` first.
+
+### 3. Dashboard verification (no rewrites expected)
+
+- `container-metrics.json` and `service-health.json` reference only `container_fs_*_bytes_total`
+  (preserved) plus the kept CPU/memory/network metrics — **no panel should break.**
+- After applying, open both dashboards (+ `homelab-overview`) and confirm all panels render. If any
+  panel goes empty, fix the query *in the same PR* (do not widen the keep-list to paper over it).
+
+### 4. Stack hygiene
+
+- **Loki delete-workers:** `config/loki/loki-config.yml` `retention_delete_worker_count: 150` → `20`.
+- **Loki healthcheck:** add a TCP-probe `HealthCmd` to `quadlets/loki.container` mirroring promtail's
+  `/dev/tcp` `GET /ready` pattern (distroless-safe; no shell/curl needed in image). Keeps systemd
+  restart-on-unhealthy instead of relying solely on `up{job="loki"}`.
+- **Pin `alert-discord-relay`:** resolve `localhost/...:latest` to a digest (or, since it is a
+  locally-built image, pin the base + record the build digest per ADR-030 Tier-2). Brings the last
+  unpinned image into supply-chain compliance.
+
+## Success Criteria
+
+- `prometheus_tsdb_head_series` drops from ~33,745 to **~19–20k** within one scrape cycle.
+- `seriesCountByMetricName` no longer lists `container_tasks_state`, `container_blkio_device_usage_total`,
+  `container_memory_failures_total`, `grafana_feature_toggles_info`, `redis_commands_latencies_usec_bucket`.
+- TSDB on disk trends toward **~2.2 GB** over the next 15-day retention cycle; nightly Prometheus dump
+  shrinks proportionally.
+- All Grafana dashboards still render every panel.
+- Loki shows a healthy systemd healthcheck; `alert-discord-relay` is digest-pinned.
+
+## Verification
+
+```bash
+# Before
+podman exec prometheus wget -qO- 'http://localhost:9090/api/v1/query?query=prometheus_tsdb_head_series'
+# Validate config, then hot-reload
+podman exec prometheus promtool check config /etc/prometheus/prometheus.yml
+curl -s -X POST http://localhost:9090/-/reload   # or: systemctl --user restart prometheus
+# After (give it a scrape interval)
+podman exec prometheus wget -qO- 'http://localhost:9090/api/v1/status/tsdb'
+# Dashboards: load container-metrics, service-health, homelab-overview in Grafana — all panels populated
+# Loki health
+systemctl --user restart loki && systemctl --user status loki   # healthy
+```
+
+## Rollback
+
+`git revert` the `prometheus.yml` change (metric_relabel only affects ingestion going forward; no
+historical data is mutated). Loki worker count and healthcheck are independent reverts. The relay pin
+reverts to `:latest` if a bad digest is chosen.
+
+## Notes / future
+
+- If the cAdvisor allowlist proves durable, consider promoting "ingest only consumed metrics" to a
+  standing convention — possibly a short ADR — so new exporters get a keep-list at deploy time. **Not**
+  authored in this plan; flagged only.
+
+## Progress Log
+
+- 2026-05-25 — Plan drafted from deep-dive report. Status: Proposed.

--- a/docs/97-plans/2026-05-25-slo-alert-coverage.md
+++ b/docs/97-plans/2026-05-25-slo-alert-coverage.md
@@ -1,0 +1,115 @@
+# Plan B: SLO & Alert Coverage
+
+**Date Created:** 2026-05-25
+**Status:** Proposed
+**Last Updated:** 2026-05-25
+**Implements:** Report [2026-05-25 Monitoring Stack Deep-Dive](../99-reports/2026-05-25-monitoring-stack-deep-dive.md) §4, §5
+**Reconciles with:** `slo-framework.md`, `slo-based-alerting.md`, ADR-003
+
+## Objective
+
+Close the alerting gaps on the owner's **most-valued surface** — the SLO dashboard — so that the
+things it *charts* are also things it *alerts on*. Every change here reuses recording rules that
+**already exist**; we are adding alert rules and a few thin recording rules, not new pipelines.
+
+## Background (verified 2026-05-25)
+
+- Burn-rate alerts live in `config/prometheus/alerts/slo-multiwindow-alerts.yml`, 4-tier pattern
+  (`SLOBurnRateTier{1..4}_<Service>`, thresholds 14.4× / 6× / 3× / 1.5× over paired windows).
+- Recording rules live in `config/prometheus/rules/slo-recording-rules.yml` +
+  `slo-burn-rate-extended.yml`.
+- **G1 (🔴):** `burn_rate:traefik:availability:{1h,5m,6h,30m,1d,2h,3d}` rules exist, the SLO dashboard
+  charts Traefik, the monthly report includes it — but there is **no `SLOBurnRateTier*_Traefik` alert**.
+- **G2 (🟡):** `sli:<svc>:latency:p95` rules exist for ~6 services, charted in panel 5, **no alert**.
+- **G3 (🟡):** `sli:immich:uploads:success_ratio` exists, but no target / error-budget / burn-rate / alert.
+- **G4 (🟡):** `NextcloudSustained5xxLowVolume` + `HomeAssistantSustained5xxLowVolume` exist; Navidrome
+  (similar low traffic) has no equivalent.
+- `slo_compliance` rule group evaluates in 0.364 s every 30 s (10× the next group).
+
+## Approach
+
+### 1. Traefik SLO burn-rate alerts (G1 — highest priority)
+
+Add `SLOBurnRateTier1_Traefik … Tier4_Traefik` to `slo-multiwindow-alerts.yml`, copying the existing
+service blocks and substituting the already-present `burn_rate:traefik:availability:*` series. Traefik
+uses the `up`-based SLI (no NaN risk), so the expressions are the simplest of the set.
+
+- Target 99.95%, 21-min monthly budget (per `slo-framework.md`).
+- Tier 1 → critical (page); Tiers 2–3 → warning; Tier 4 → info, matching the other services' routing.
+- Rationale comment: gateway failure is the only single point that fails *every* downstream SLO.
+
+### 2. Latency burn alerts (G2)
+
+Add latency alerts for the latency-sensitive services where slow ≈ broken — start with **Authelia**
+(200 ms target), **Traefik** (p99 100 ms), **Jellyfin** (500 ms). Two tiers each:
+
+- Tier 1 (critical): `sli:<svc>:latency:p95 > <target>` sustained over a short+long window pair.
+- Tier 2 (warning): same metric, longer window / smaller multiple.
+
+Keep it deliberately small (3 services × 2 tiers) — latency alerts are easy to over-add. HA/Nextcloud
+latency stays dashboard-only (WebSocket-heavy, 1 s budget already lenient).
+
+### 3. Immich-upload SLO (G3)
+
+Extend the framework for uploads (SLI already exists):
+
+- Add to `slo-recording-rules.yml`: `slo:immich:uploads:target` (0.995),
+  `error_budget:immich:uploads:{total,consumed,remaining}` mirroring the availability budget rules.
+- Add to `slo-burn-rate-extended.yml`: `burn_rate:immich:uploads:*` for the four window pairs.
+- Add `SLOBurnRateTier1_ImmichUploads` + `Tier2` alerts (uploads are user-data-loss-adjacent → at
+  least page + ticket; Tier 3/4 optional).
+- Add the upload error budget to the SLO dashboard (one panel row) so the new alert has a visual home.
+
+### 4. Navidrome low-volume 5xx (G4)
+
+Add `NavidromeSustained5xxLowVolume` to `slo-multiwindow-alerts.yml`, mirroring the Nextcloud/HA
+compensating alerts (threshold scaled to Navidrome's actual request rate — measure first, then set
+e.g. ">N 5xx in 6h at <0.5 req/s"). Closes the last instance of the 2026-04-21 incident class.
+
+### 5. `slo_compliance` eval cost
+
+Lower-priority tuning. Options (pick one in implementation):
+- Move the 30-day rolling-compliance rules into their own group with a **longer eval interval**
+  (e.g. 1–2 min) — compliance does not need 30 s freshness.
+- Or split the heaviest expressions out so they don't serialize behind cheaper SLI rules.
+Document the trade-off (slightly staler compliance %, much cheaper eval) in the rule file.
+
+### 6. Documentation
+
+- Update `slo-framework.md`: mark Traefik availability, the three latency SLOs, and Immich-upload as
+  **now alerted** (today they read as monitored-only).
+- Add an inline comment in `slo-recording-rules.yml` near the Immich block citing the calibration
+  rationale (99.9% → 99.5% at ~50 req/day) currently isolated to the guide.
+
+## Success Criteria
+
+- `promtool check rules` passes on all changed files; `amtool config check` passes.
+- New alerts visible in Prometheus `/rules` and Alertmanager routing dry-run hits the right receivers
+  (critical → discord-critical, warning → discord-warnings, etc.).
+- A synthetic burn (temporary low threshold in a scratch copy) fires `SLOBurnRateTier1_Traefik` and
+  `SLOBurnRateTier1_ImmichUploads` as expected.
+- SLO dashboard gains the Immich-upload budget panel; all existing panels unchanged.
+- `slo_compliance` group eval time drops (or its interval lengthens) with no loss of dashboard data.
+
+## Verification
+
+```bash
+podman exec prometheus promtool check rules /etc/prometheus/alerts/slo-multiwindow-alerts.yml \
+  /etc/prometheus/rules/slo-recording-rules.yml /etc/prometheus/rules/slo-burn-rate-extended.yml
+podman exec alertmanager amtool check-config /etc/alertmanager/alertmanager.yml   # if amtool present
+# confirm the recording rules the new alerts depend on actually return data:
+for q in burn_rate:traefik:availability:1h sli:authelia:latency:p95 sli:immich:uploads:success_ratio; do
+  podman exec prometheus wget -qO- "http://localhost:9090/api/v1/query?query=$q" | head -c 200; echo
+done
+# optional: promtool test rules with a unit-test fixture for the new burn-rate alerts
+```
+
+## Rollback
+
+Each addition is isolated; `git revert` the alert/rule file. New recording rules only add series
+(no mutation). Removing the new alerts cannot affect existing alerting.
+
+## Progress Log
+
+- 2026-05-25 — Plan drafted from deep-dive report. Status: Proposed. Sequence after Plan A (smaller
+  TSDB makes burn-rate queries cheaper) but independent of it.


### PR DESCRIPTION
## Summary

Three `Status: Proposed` implementation plans produced by a monitoring-stack deep-dive. The authoritative report lives locally in `docs/99-reports/2026-05-25-monitoring-stack-deep-dive.md` (that directory is gitignored by repo convention); these plans are the actionable, reviewable output.

**Theme:** the stack is healthy and well-architected — the work is *pruning noise* and *closing a few high-value alert gaps*, in line with the "less is more" goal. Findings are backed by live runtime telemetry captured this session, not just config review.

### Plan A — Metric Diet & Stack Hygiene (`2026-05-25-monitoring-metric-diet.md`)
- **33,745 active series; cAdvisor = 52%; zero `metric_relabel_configs` anywhere.** ~14,000 series have no dashboard/rule consumer.
- cAdvisor allowlist (10-metric keep-list, verified against every dashboard + rule), plus grafana/redis exporter trims.
- Loki `retention_delete_worker_count` 150→20, add distroless-safe TCP healthcheck; pin `alert-discord-relay` (only un-pinned image, ADR-030).
- Projected: **TSDB 4.0 GB → ~2.2 GB**, no data loss.

### Plan B — SLO & Alert Coverage (`2026-05-25-slo-alert-coverage.md`)
- 🔴 **Traefik SLO recorded + charted but never alerted** — add 4-tier burn-rate alerts (gateway = tightest SLO, fails all services).
- 🟡 Latency SLOs (Authelia/Traefik/Jellyfin) and Immich-upload SLO: visualized but not enforced — add alerts.
- 🟡 Navidrome low-volume 5xx compensating alert (closes last 2026-04-21-pattern gap).
- `slo_compliance` rule-group eval-cost tuning (0.36 s every 30 s).

### Plan C — Backup & Dump Observability (`2026-05-25-backup-observability.md`)
- Fix the **only firing alert** (noisy `ExternalBackupMissing` on scratch `subvol6-tmp`).
- Add BTRFS pool free-space + metadata-exhaustion alerts (verify Urd's UPI-043 metrics are scraped first).
- Add `db_dump_size_bytes` growth alert; backup-health dashboard polish.
- Prometheus 1.5 GB nightly dump kept as-is (owner decision).

## Scope / Notes

- **Docs only** — no changes to `prometheus.yml`, alert/rule files, quadlets, dashboards, or scripts. Each plan proposes those changes with verification + rollback sections.
- Unrelated auto-generated `AUTO-*.md` changes and a pre-existing journal in the working tree were intentionally left out of this commit.

## Test Plan

- [ ] Review the three plans for accuracy against current config
- [ ] Confirm Plan C item 1 question (is `subvol6-tmp` meant to be external?) before implementing
- [ ] Confirm Plan C item 2 (Urd `backup_pool_free_bytes` actually scraped) — may need a `~/projects/urd` change
- [ ] Sequence execution A → B → C (A shrinks TSDB, making burn-rate queries cheaper)

🤖 Generated with [Claude Code](https://claude.com/claude-code)