### PR TITLE
chore(monitoring): metric diet — drop ~14k unconsumed series + stack hygiene

### DIFF
--- a/config/loki/loki-config.yml
+++ b/config/loki/loki-config.yml
@@ -53,7 +53,9 @@ compactor:
   compaction_interval: 10m
   retention_enabled: true
   retention_delete_delay: 2h
-  retention_delete_worker_count: 150
+  # 20 workers is ample for a single-node, 7-day-retention store; 150 spiked CPU
+  # during the 10-min compaction window with no throughput benefit (metric diet, 2026-05-25).
+  retention_delete_worker_count: 20
   delete_request_store: filesystem
 
 # Limits configuration

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -45,6 +45,14 @@ scrape_configs:
         labels:
           instance: 'fedora-htpc'
           service: 'grafana'
+    # Metric diet — drop grafana_feature_toggles_info (346 unused series, one per
+    # feature flag). No dashboard/rule consumes any grafana_* metric; operational
+    # series (grafana_http_request_*, grafana_build_info, datasource health) are kept
+    # for ad-hoc debugging. Audited 2026-05-25; see plan / deep-dive report §3.
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'grafana_feature_toggles_info'
+        action: drop
 
   # Traefik monitoring (metrics enabled 2025-11-06)
   - job_name: 'traefik'
@@ -93,6 +101,17 @@ scrape_configs:
         labels:
           instance: 'fedora-htpc'
           service: 'cadvisor'
+    # Metric diet (allowlist) — keep ONLY the container_/machine_ series consumed by a
+    # dashboard or rule. cAdvisor emits ~16.5k series; this retains ~3k and drops ~13.6k
+    # unreferenced series (container_tasks_state, *_memory_failures_total,
+    # *_blkio_device_usage_total, per-device *_fs_reads/writes_total, *_pressure_io_*, …).
+    # Allowlist (not denylist) so future cAdvisor metric additions stay dropped by default.
+    # Keep-list audited 2026-05-25 against all dashboards + alert/recording rules.
+    # See docs/97-plans/2026-05-25-monitoring-metric-diet.md + deep-dive report §3.
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'container_(cpu_usage_seconds_total|memory_usage_bytes|memory_working_set_bytes|spec_memory_limit_bytes|network_receive_bytes_total|network_transmit_bytes_total|fs_reads_bytes_total|fs_writes_bytes_total|last_seen|start_time_seconds)|machine_(memory_bytes|cpu_cores)|cadvisor_version_info|container_scrape_error'
+        action: keep
 
   # Unpoller - UniFi Network metrics exporter
   - job_name: 'unpoller'
@@ -134,6 +153,13 @@ scrape_configs:
         labels:
           instance: 'fedora-htpc'
           service: 'redis-authelia'
+    # Metric diet — drop the unused per-command latency histogram (~632 series:
+    # _bucket/_sum/_count). Dashboards use redis_commands_duration_seconds_total /
+    # redis_command_calls_total, which are kept. Audited 2026-05-25 (plan / report §3).
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'redis_commands_latencies_usec_(bucket|sum|count)'
+        action: drop
 
   # Redis exporter — redis-immich (Valkey, Redis-protocol-compatible)
   - job_name: 'redis-immich'
@@ -142,6 +168,11 @@ scrape_configs:
         labels:
           instance: 'fedora-htpc'
           service: 'redis-immich'
+    # Metric diet — drop the unused per-command latency histogram (see redis-authelia).
+    metric_relabel_configs:
+      - source_labels: [__name__]
+        regex: 'redis_commands_latencies_usec_(bucket|sum|count)'
+        action: drop
 
   # PostgreSQL exporter — postgresql-immich
   - job_name: 'postgres-immich'

--- a/docs/97-plans/2026-05-25-monitoring-metric-diet.md
+++ b/docs/97-plans/2026-05-25-monitoring-metric-diet.md
@@ -1,7 +1,7 @@
 # Plan A: Monitoring Metric Diet & Stack Hygiene
 
 **Date Created:** 2026-05-25
-**Status:** Proposed
+**Status:** Implemented (2026-05-25) — core metric diet live; postgres trim deferred (see log)
 **Last Updated:** 2026-05-25
 **Implements:** Report [2026-05-25 Monitoring Stack Deep-Dive](../99-reports/2026-05-25-monitoring-stack-deep-dive.md) §3, §7
 **Reconciles with:** ADR-003 (Monitoring Stack), ADR-030 (Supply-Chain Trust Model — `:latest` pin)
@@ -129,3 +129,43 @@ reverts to `:latest` if a bad digest is chosen.
 ## Progress Log
 
 - 2026-05-25 — Plan drafted from deep-dive report. Status: Proposed.
+- 2026-05-25 — **Implemented on branch `chore/monitoring-metric-diet`.** Pre-flight grep re-verified
+  the keep-list (14 cAdvisor names kept / 102 dropped) and zero-consumer drop candidates.
+  - **cAdvisor allowlist** added to `config/prometheus/prometheus.yml`. Per-scrape proof:
+    `scrape_samples_post_metric_relabeling{job="cadvisor"}` **16,130 → 2,879** (−13,251).
+  - **Grafana** drop `grafana_feature_toggles_info`: 2,626 → 2,280 (−346).
+  - **Redis** drop `redis_commands_latencies_usec_*`: redis-immich 1,096 → 612 (−484);
+    redis-authelia emits none of that family (−0, rule harmless).
+  - **Loki** `retention_delete_worker_count` 150 → 20; quadlet healthcheck comment rewritten —
+    see below.
+  - **alert-discord-relay** moved off mutable `:latest` to immutable `:2026-05-23` (build date),
+    matching the proton-bridge local-build convention; build digest recorded in the quadlet.
+    Supply-chain gate stays green. (NB: `audit-egress-updates.sh` *exempts* `localhost/*` from
+    digest-pinning — the relay's integrity is already covered by the Tier-2 base-pin +
+    hash-locked `requirements.lock`, so a version tag, not a `@sha256`, is the correct fix.)
+  - **Dashboards verified:** every metric referenced by container-metrics / service-health /
+    homelab-overview returns data (CPU, memory, `fs_*_bytes_total`=603, last_seen, network,
+    start_time, node_*). No empty panels.
+  - **Plan deviations (verified before acting):**
+    1. **Loki healthcheck NOT added.** Plan said "mirror promtail's `/dev/tcp` probe
+       (distroless-safe, no shell needed)" — but Podman `HealthCmd` runs *inside* the container
+       and the grafana/loki image is genuinely distroless (no `sh`/`ls`/`wget`, only the loki
+       binary). promtail's probe works *only* because promtail is Debian-based and ships `bash`.
+       An in-container probe is therefore impossible. Documented why in `quadlets/loki.container`;
+       readiness stays covered by the existing `up{job="loki"} == 0` critical alert
+       (infrastructure-critical.yml) + homelab-intel.sh. (Owner-confirmed: skip.)
+    2. **Relay pinned by version tag, not `@sha256` digest** (plan's literal wording). A local
+       digest is fragile (breaks systemd start on prune/rebuild, not registry-verifiable) and the
+       repo's own tooling exempts `localhost/*` from digest-pinning. (Owner-confirmed: version tag.)
+    3. **postgres-immich trim DEFERRED.** The cAdvisor cut alone reaches the ~19–20k target; the
+       postgres dashboard consumes only cluster/`pg_stat_database_*`/`pg_settings_*` aggregates
+       (no per-table stats), so a trim is low-yield-for-risk here. Left for a follow-up if needed.
+  - **Operational note (cost me a cycle, worth recording):** `prometheus.yml` and `loki-config.yml`
+    are *single-file* bind mounts. Editing them with an atomic-write tool swaps the file inode,
+    but the bind mount stays pinned to the old inode — so `POST /-/reload` (HTTP 200, success=1)
+    read **stale** config and dropped nothing. Fix is a container **restart** (re-binds the mount
+    to the new inode), which the plan listed as the alternative; here it is *required*, not optional.
+  - **head_series** was still ~34k immediately after (stale series linger in the head until ~5 min
+    staleness + head truncation ~2h); the authoritative immediate signal is the per-scrape
+    `post_metric_relabeling` drop above. TSDB on disk shrinks over the 15-day retention cycle.
+  - **Not yet committed** — changes staged on the branch pending owner review.

--- a/quadlets/alert-discord-relay.container
+++ b/quadlets/alert-discord-relay.container
@@ -4,7 +4,11 @@ After=network-online.target reverse_proxy-network.service monitoring-network.ser
 Wants=monitoring-network.service network-online.target reverse_proxy-network.service
 
 [Container]
-Image=localhost/alert-discord-relay:latest
+# Local build, immutable tag (proton-bridge convention; ADR-030 P5 Tier-2). Tag = build date.
+# Build inputs are pinned in config/alert-discord-relay/Dockerfile (FROM @sha256 + hash-locked
+# requirements.lock). Recorded build digest: sha256:4df80f75b8100aca7eb699533ac72316759f22848a1b623129e9ed3c0f557e31
+# Bump = rebuild, retag with new date, update this line + digest, daemon-reload + restart.
+Image=localhost/alert-discord-relay:2026-05-23
 ContainerName=alert-discord-relay
 HostName=alert-discord-relay
 # reverse_proxy first for default route (Discord API access)

--- a/quadlets/loki.container
+++ b/quadlets/loki.container
@@ -21,8 +21,12 @@ Exec=-config.file=/etc/loki/local-config.yaml
 
 DNS=192.168.1.69
 
-# No container healthcheck possible - Loki uses a scratch/distroless image with no shell or tools
-# External monitoring via Prometheus up{job="loki"} and homelab-intel.sh (verifies via Promtail logs)
+# No in-container healthcheck possible — the grafana/loki image is distroless: no shell,
+# no busybox, no wget/curl, nothing but the loki binary (verified 2026-05-25). Podman
+# HealthCmd runs INSIDE the container, so even promtail's /dev/tcp probe is out — that one
+# only works because promtail is Debian-based and has `bash`. Loki readiness is covered
+# externally instead: the `up{job="loki"} == 0` critical alert (infrastructure-critical.yml)
+# and homelab-intel.sh (verifies via Promtail logs). See metric-diet plan, 2026-05-25.
 
 [Service]
 Slice=container.slice


### PR DESCRIPTION
## Summary

Cuts Prometheus cardinality ~40% by dropping metrics **no dashboard and no rule consumes**, plus three small hygiene items. Pure subtraction, fully reversible, zero loss of any metric currently used. Implements [`docs/97-plans/2026-05-25-monitoring-metric-diet.md`](docs/97-plans/2026-05-25-monitoring-metric-diet.md) (deep-dive report §3, §7).

- **cAdvisor allowlist** (`prometheus.yml`): `metric_relabel_configs` keep-filter retaining only the 14 `container_*`/`machine_*` series consumed by dashboards/rules; everything else dropped at ingestion. Allowlist (not denylist) so future cAdvisor additions stay dropped by default.
- **Exporter trims**: drop `grafana_feature_toggles_info` (grafana) and `redis_commands_latencies_usec_*` (both redis jobs) — all zero-consumer.
- **Loki**: `retention_delete_worker_count` 150 → 20 (single-node, 7-day retention); healthcheck comment rewritten to document why no in-container probe is possible.
- **alert-discord-relay**: moved off mutable `:latest` to immutable `:2026-05-23` (build date), matching the `proton-bridge` local-build convention; build digest recorded in the quadlet.

## Verification (live, this session)

Per-scrape `scrape_samples_post_metric_relabeling` (authoritative immediate signal):

| Job | scraped | kept | dropped |
|---|---|---|---|
| cadvisor | 16,130 | **2,879** | −13,251 |
| grafana | 2,626 | 2,280 | −346 |
| redis-immich | 1,096 | 612 | −484 |
| redis-authelia | 489 | 489 | 0 (family not emitted) |

- ✓ `promtool check config` valid; hot-path confirmed after restart (see note below)
- ✓ Dashboards **container-metrics / service-health / homelab-overview** — every referenced metric returns data, no empty panels
- ✓ ADR-030 supply-chain gate green; Loki active (`worker_count=20`); relay healthy on new tag
- `head_series` still ~34k immediately after — stale series linger in the head until ~5 min staleness + head truncation (~2h), then settle near ~19–20k; on-disk TSDB shrinks over the 15-day retention

## Deviations from the written plan (verified first)

1. **Loki healthcheck NOT added.** The plan's "promtail-style `/dev/tcp` probe (distroless-safe)" is impossible — Podman `HealthCmd` runs *inside* the container and the grafana/loki image is genuinely distroless (no shell/tools); promtail's probe works only because it ships `bash`. Documented in the quadlet; readiness stays on the existing `up{job="loki"}==0` critical alert + homelab-intel.sh. *(owner-confirmed: skip)*
2. **Relay pinned by version tag, not `@sha256`.** `audit-egress-updates.sh` explicitly exempts `localhost/*` from digest-pinning (integrity already covered by the Tier-2 base-pin + hash-locked `requirements.lock`); a local digest is fragile (breaks on prune/rebuild). *(owner-confirmed: version tag)*
3. **postgres-immich trim deferred** — the cAdvisor cut alone reaches the ~19–20k target; that dashboard uses only cluster-level aggregates, so a trim is low-yield-for-risk. Flagged for follow-up.

> **Operational note:** `prometheus.yml` / `loki-config.yml` are *single-file* bind mounts. Atomic-write edits swap the file inode, so `POST /-/reload` (HTTP 200) read **stale** config and dropped nothing — a container **restart** is required to re-bind the mount. Known recurring gotcha; called out so reviewers don't expect reload alone to suffice.

## Test Plan

- [ ] Grafana: confirm container-metrics, service-health, homelab-overview render every panel
- [ ] Prometheus: `prometheus_tsdb_head_series` trends to ~19–20k over the next ~2h
- [ ] Confirm `seriesCountByMetricName` no longer lists `container_tasks_state`, `container_blkio_device_usage_total`, `grafana_feature_toggles_info`, `redis_commands_latencies_usec_bucket`
- [ ] Loki: healthy after restart; deletion compaction CPU calmer
- [ ] Relay: still delivering Alertmanager → Discord on `:2026-05-23`

## Rollback

`git revert` the `prometheus.yml` change (metric_relabel only affects ingestion going forward; no historical data mutated). Loki worker count, healthcheck comment, and relay tag are independent reverts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)