### PR TITLE
feat(monitoring): SLO & alert coverage (Plan B) — Traefik burn, Immich uploads, Navidrome 5xx, Nextcloud latency

### DIFF
--- a/config/grafana/provisioning/dashboards/json/slo-dashboard.json
+++ b/config/grafana/provisioning/dashboards/json/slo-dashboard.json
@@ -884,6 +884,94 @@
       ],
       "title": "Error Budget Consumption (7-day trend)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${ds_prometheus}"
+      },
+      "description": "Immich upload SLO (SLO-004): 30-day upload success rate and remaining upload error budget. Uploads are user-data-loss-adjacent. Alerted by SLOBurnRateTier1/2_ImmichUploads.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 25
+              },
+              {
+                "color": "yellow",
+                "value": 50
+              },
+              {
+                "color": "green",
+                "value": 75
+              }
+            ]
+          },
+          "unit": "percent"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 24,
+        "x": 0,
+        "y": 31
+      },
+      "id": 7,
+      "options": {
+        "displayMode": "gradient",
+        "maxVizHeight": 300,
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "namePlacement": "auto",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "sizing": "auto",
+        "valueMode": "color"
+      },
+      "pluginVersion": "11.3.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "error_budget:immich:uploads:budget_remaining * 100",
+          "legendFormat": "Upload Error Budget Remaining",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${ds_prometheus}"
+          },
+          "expr": "slo:immich:uploads:actual * 100",
+          "legendFormat": "30-day Upload Success",
+          "refId": "B"
+        }
+      ],
+      "title": "Immich Upload SLO (SLO-004)",
+      "type": "bargauge"
     }
   ],
   "refresh": "30s",

--- a/config/prometheus/alerts/slo-multiwindow-alerts.yml
+++ b/config/prometheus/alerts/slo-multiwindow-alerts.yml
@@ -271,6 +271,92 @@ groups:
           description: "Long-term trend - review in monthly report."
 
   # ===========================================================================
+  # IMMICH UPLOADS - Burn Rate Alerts (G3, added 2026-05-25)
+  # SLO-004: 99.5% of upload (POST/PUT/PATCH) operations succeed. Failing uploads
+  # are user-data-loss-adjacent. Each alert carries a MINIMUM-ATTEMPT GUARD
+  # (>10 upload attempts in the window): at this service's very low upload volume
+  # (~a few/week), a single failed upload would otherwise read as 100% failure and
+  # trip a burn-rate alert. The guard restricts firing to an active upload session
+  # that is genuinely failing.
+  #
+  # Severity is warning/info, NOT critical/page (a deliberate deviation from the
+  # plan's "page"): the upload SLI counts only 2xx as success, so a client-side
+  # disconnect (499) mid-upload counts as a failure. Paging on a user's flaky
+  # network would be false-positive paging. To escalate later, raise Tier 1 to
+  # critical AND add 499 to the success criteria in the recording rules.
+  # ===========================================================================
+  - name: slo_multiwindow_immich_uploads
+    interval: 1m
+    rules:
+      # TIER 1: WARNING - Fast Burn during an active, failing upload session
+      - alert: SLOBurnRateTier1_ImmichUploads
+        expr: |
+          (
+            burn_rate:immich:uploads:1h > 14.4
+            and
+            burn_rate:immich:uploads:5m > 14.4
+          )
+          and
+          sum(increase(traefik_service_requests_total{exported_service="immich@file", method=~"POST|PUT|PATCH"}[1h])) > 10
+          and
+          (time() - process_start_time_seconds{job="prometheus"} > 3600)
+        for: 5m
+        labels:
+          severity: warning
+          component: slo
+          service: immich
+          slo: uploads
+          tier: "1"
+          burn_rate: "fast"
+        annotations:
+          summary: "⚠️ Immich photo uploads are failing during active use"
+          description: |
+            **Photo uploads are failing right now**
+
+            More than 10 upload attempts in the last hour and the upload error budget
+            is burning at >14.4x. Photos the user is uploading may not be saved.
+
+            - Upload burn rate (1h): {{ $value | humanize }}x normal
+            - Upload burn rate (5m): {{ query "burn_rate:immich:uploads:5m" | first | value | humanize }}x normal
+            - Upload budget remaining: {{ query "error_budget:immich:uploads:budget_remaining * 100" | first | value | humanize }}%
+
+            Note: the upload SLI counts only 2xx as success, so heavy client-side
+            disconnects (499) can also raise this. Confirm server health before assuming data loss.
+
+            Action: systemctl --user status immich.service immich-postgres.service
+                    podman logs immich --tail 100
+                    Check Traefik access logs in Loki:
+                      {container_name="traefik"} |= "immich" | json | method =~ "POST|PUT|PATCH" | status >= 400
+
+      # TIER 2: INFO - Sustained elevated upload failure rate
+      - alert: SLOBurnRateTier2_ImmichUploads
+        expr: |
+          (
+            burn_rate:immich:uploads:6h > 6
+            and
+            burn_rate:immich:uploads:30m > 6
+          )
+          and
+          sum(increase(traefik_service_requests_total{exported_service="immich@file", method=~"POST|PUT|PATCH"}[6h])) > 10
+          and
+          (time() - process_start_time_seconds{job="prometheus"} > 21600)
+        for: 30m
+        labels:
+          severity: info
+          component: slo
+          service: immich
+          slo: uploads
+          tier: "2"
+          burn_rate: "medium"
+        annotations:
+          summary: "ℹ️ Immich upload failure rate elevated over several hours"
+          description: |
+            Upload error budget burning at >6x over a 6h window with >10 attempts.
+            Investigate when convenient.
+
+            - Upload budget remaining: {{ query "error_budget:immich:uploads:budget_remaining * 100" | first | value | humanize }}%
+
+  # ===========================================================================
   # AUTHELIA - Multi-Window Burn Rate Alerts (Critical SSO service)
   # ===========================================================================
   - name: slo_multiwindow_authelia
@@ -841,6 +927,177 @@ groups:
           description: "Long-term trend - review in monthly report."
 
   # ===========================================================================
+  # TRAEFIK GATEWAY - Multi-Window Burn Rate Alerts (G1, added 2026-05-25)
+  # The gateway has the tightest SLO (99.95%, 21-min monthly budget) precisely
+  # because a degraded Traefik fails EVERY downstream service — it is the only
+  # single point that breaks all other SLOs at once. Yet until now its burn-rate
+  # series were recorded (and charted) but never alerted, AND the recording rules
+  # were silently empty due to a label-match bug (see slo-recording-rules.yml).
+  # SLI is up{job="traefik"}-based, so there is no NaN/zero-traffic risk.
+  # ===========================================================================
+  - name: slo_multiwindow_traefik
+    interval: 1m
+    rules:
+      # TIER 1: CRITICAL - Fast Burn (Page immediately)
+      - alert: SLOBurnRateTier1_Traefik
+        expr: |
+          (
+            burn_rate:traefik:availability:1h > 14.4
+            and
+            burn_rate:traefik:availability:5m > 14.4
+          )
+          and
+          (time() - process_start_time_seconds{job="prometheus"} > 3600)
+        for: 2m
+        labels:
+          severity: critical
+          component: slo
+          service: traefik
+          slo: availability
+          tier: "1"
+          burn_rate: "fast"
+        annotations:
+          summary: "🚨 CRITICAL: Traefik gateway error budget burning at 14.4x normal rate"
+          description: |
+            **IMMEDIATE ACTION REQUIRED - THE GATEWAY IS DEGRADING**
+
+            Traefik availability is dropping fast. The gateway fronts every service, so
+            this degrades ALL of them. At this burn rate the 21-min monthly budget
+            (99.95% SLO) exhausts in less than 3 hours.
+
+            **Current State:**
+            - Burn Rate (1h): {{ $value | humanize }}x normal
+            - Burn Rate (5m): {{ query "burn_rate:traefik:availability:5m" | first | value | humanize }}x normal
+            - Error Budget Remaining: {{ query "error_budget:traefik:availability:budget_remaining * 100" | first | value | humanize }}%
+
+            **Impact:** Every internet-facing service is affected RIGHT NOW.
+
+            **Action:** Investigate and resolve immediately. Check:
+              systemctl --user status traefik.service
+              podman logs traefik --tail 100
+              ~/containers/scripts/homelab-intel.sh
+
+      # TIER 2: WARNING - Medium Burn (Create ticket)
+      - alert: SLOBurnRateTier2_Traefik
+        expr: |
+          (
+            burn_rate:traefik:availability:6h > 6
+            and
+            burn_rate:traefik:availability:30m > 6
+          )
+          and
+          (time() - process_start_time_seconds{job="prometheus"} > 21600)
+        for: 15m
+        labels:
+          severity: warning
+          component: slo
+          service: traefik
+          slo: availability
+          tier: "2"
+          burn_rate: "medium"
+        annotations:
+          summary: "⚠️ Traefik gateway error budget burning at 6x normal rate"
+          description: |
+            **Action needed within hours**
+
+            Traefik availability is degrading. At this burn rate the monthly budget
+            exhausts in less than 1 day. The gateway affects all services.
+
+            - Burn Rate (6h): {{ $value | humanize }}x normal
+            - Burn Rate (30m): {{ query "burn_rate:traefik:availability:30m" | first | value | humanize }}x normal
+            - Error Budget Remaining: {{ query "error_budget:traefik:availability:budget_remaining * 100" | first | value | humanize }}%
+
+      # TIER 3: WARNING - Slow Burn (Plan remediation)
+      - alert: SLOBurnRateTier3_Traefik
+        expr: |
+          (
+            burn_rate:traefik:availability:1d > 3
+            and
+            burn_rate:traefik:availability:2h > 3
+          )
+          and
+          (time() - process_start_time_seconds{job="prometheus"} > 86400)
+        for: 1h
+        labels:
+          severity: warning
+          component: slo
+          service: traefik
+          slo: availability
+          tier: "3"
+          burn_rate: "slow"
+        annotations:
+          summary: "📊 Traefik gateway error budget burning at 3x normal rate"
+          description: |
+            **Trend to monitor**
+
+            Traefik availability is slowly degrading. Budget exhausts in <1 week.
+
+            - Burn Rate (1d): {{ $value | humanize }}x normal
+            - Error Budget Remaining: {{ query "error_budget:traefik:availability:budget_remaining * 100" | first | value | humanize }}%
+
+      # TIER 4: INFO - Very Slow Burn (FYI only)
+      - alert: SLOBurnRateTier4_Traefik
+        expr: |
+          (
+            burn_rate:traefik:availability:3d > 1.5
+            and
+            burn_rate:traefik:availability:1d > 1.5
+          )
+          and
+          (time() - process_start_time_seconds{job="prometheus"} > 259200)
+        for: 6h
+        labels:
+          severity: info
+          component: slo
+          service: traefik
+          slo: availability
+          tier: "4"
+          burn_rate: "minimal"
+        annotations:
+          summary: "ℹ️ Traefik gateway error budget trending above baseline"
+          description: "Long-term trend - review in monthly report."
+
+  # ===========================================================================
+  # NEXTCLOUD LATENCY SLO (G2, added 2026-05-25)
+  # SLO-008: 95% of requests complete within 1s. Nextcloud is the only service with
+  # clean, high-volume, correctly-bucketed latency data (~28.8k req/7d, baseline
+  # ~99.7% under 1s — see slo-framework.md "Latency alerting status" for why the
+  # other candidate latency SLOs are not currently alertable). fast_ratio is NaN
+  # when idle (NaN < 0.95 is false), and a minimum-traffic guard prevents a single
+  # slow request during a lull from tripping the alert. Named outside the
+  # SLOBurnRateTier* convention so it does NOT hit the auto-remediation webhook —
+  # slow file sync warrants a notification, not an automated restart.
+  # ===========================================================================
+  - name: slo_latency_nextcloud
+    interval: 1m
+    rules:
+      - alert: NextcloudLatencySLOBreach
+        expr: |
+          sli:nextcloud:latency:fast_ratio < 0.95
+          and
+          sum(rate(traefik_service_request_duration_seconds_count{exported_service="nextcloud@file"}[5m])) > 0.05
+        for: 30m
+        labels:
+          severity: warning
+          component: slo
+          service: nextcloud
+          slo: latency
+        annotations:
+          summary: "⚠️ Nextcloud latency SLO breached (<95% of requests under 1s for 30m)"
+          description: |
+            Fewer than 95% of Nextcloud requests are completing within the 1s SLO target,
+            sustained for 30 minutes at meaningful traffic. File sync and web UI feel slow.
+
+            - Requests under 1s (5m): {{ $value | humanizePercentage }}
+            - p95 latency: {{ query "sli:nextcloud:latency:p95" | first | value | humanize }}s
+
+            Likely causes: MariaDB slowness, Redis pressure, PHP-FPM saturation, or a
+            large sync/scan. Check:
+              podman logs nextcloud --tail 100
+              podman exec -u www-data nextcloud php occ status
+              ~/containers/scripts/homelab-intel.sh
+
+  # ===========================================================================
   # COMPENSATING 4xx ALERTS for denylist services
   # Home Assistant, Nextcloud, Navidrome, and Audiobookshelf use code!~"5.." for SLO.
   # These alerts catch 4xx spikes that bypass burn rate detection:
@@ -1029,3 +1286,33 @@ groups:
               systemctl --user status home-assistant.service
               podman logs home-assistant --tail 100
               curl -sf -o /dev/null -w '%{http_code}' https://home.patriark.org/
+
+      - alert: NavidromeSustained5xxLowVolume
+        # G4 (added 2026-05-25): closes the last instance of the 2026-04-21
+        # low-volume-5xx incident class. Navidrome is a personal music service that
+        # is frequently idle (0 requests in the trailing 7d at calibration time), so
+        # — like Home Assistant — its multi-window burn-rate alerts are blind to a
+        # stuck-5xx state at low traffic. Threshold mirrors HomeAssistantSustained5xx
+        # LowVolume (>20 5xx in 6h, <0.5 req/s guard); could not be scaled to live
+        # traffic because Navidrome was idle when this was written. Revisit once a
+        # real traffic floor accumulates.
+        expr: |
+          sum(increase(traefik_service_requests_total{exported_service="navidrome@file", code=~"5.."}[6h])) > 20
+          and
+          sum(rate(traefik_service_requests_total{exported_service="navidrome@file"}[6h])) < 0.5
+        for: 1h
+        labels:
+          severity: warning
+          component: slo
+          service: navidrome
+        annotations:
+          summary: "Navidrome sustained 5xx at low traffic (>20 5xx in 6h)"
+          description: |
+            Navidrome has returned more than 20 5xx responses over the last 6 hours
+            at low request rate. At this traffic level the standard burn-rate alerts
+            cannot distinguish a stuck-5xx state from normal idle traffic.
+
+            Check:
+              systemctl --user status navidrome.service
+              podman logs navidrome --tail 100
+              curl -sf -o /dev/null -w '%{http_code}' https://navidrome.patriark.org/

--- a/config/prometheus/rules/slo-burn-rate-extended.yml
+++ b/config/prometheus/rules/slo-burn-rate-extended.yml
@@ -88,6 +88,55 @@ groups:
           ) / error_budget:immich:availability:budget_total
 
       # ===========================================================================
+      # IMMICH UPLOADS - Burn rate windows (G3, added 2026-05-25)
+      # error = upload (POST/PUT/PATCH) NOT returning 2xx. NaN-safe via clamp_min:
+      # zero uploads in the window -> 0 burn. Paired with a minimum-attempt guard in
+      # the alert (slo-multiwindow-alerts.yml) so a single failed upload at this
+      # service's very low upload volume (~few/week) cannot trip the alert.
+      # Only Tier 1 (1h+5m) and Tier 2 (6h+30m) windows are recorded — uploads are
+      # bursty and low-volume, so the 1d/3d trend tiers add no signal.
+      # ===========================================================================
+      - record: burn_rate:immich:uploads:5m
+        expr: |
+          (
+            sum(rate(traefik_service_requests_total{exported_service="immich@file", method=~"POST|PUT|PATCH"}[5m]))
+            -
+            sum(rate(traefik_service_requests_total{exported_service="immich@file", method=~"POST|PUT|PATCH", code=~"2.."}[5m]))
+          )
+          / clamp_min(sum(rate(traefik_service_requests_total{exported_service="immich@file", method=~"POST|PUT|PATCH"}[5m])), 1e-10)
+          / error_budget:immich:uploads:budget_total
+
+      - record: burn_rate:immich:uploads:30m
+        expr: |
+          (
+            sum(rate(traefik_service_requests_total{exported_service="immich@file", method=~"POST|PUT|PATCH"}[30m]))
+            -
+            sum(rate(traefik_service_requests_total{exported_service="immich@file", method=~"POST|PUT|PATCH", code=~"2.."}[30m]))
+          )
+          / clamp_min(sum(rate(traefik_service_requests_total{exported_service="immich@file", method=~"POST|PUT|PATCH"}[30m])), 1e-10)
+          / error_budget:immich:uploads:budget_total
+
+      - record: burn_rate:immich:uploads:1h
+        expr: |
+          (
+            sum(rate(traefik_service_requests_total{exported_service="immich@file", method=~"POST|PUT|PATCH"}[1h]))
+            -
+            sum(rate(traefik_service_requests_total{exported_service="immich@file", method=~"POST|PUT|PATCH", code=~"2.."}[1h]))
+          )
+          / clamp_min(sum(rate(traefik_service_requests_total{exported_service="immich@file", method=~"POST|PUT|PATCH"}[1h])), 1e-10)
+          / error_budget:immich:uploads:budget_total
+
+      - record: burn_rate:immich:uploads:6h
+        expr: |
+          (
+            sum(rate(traefik_service_requests_total{exported_service="immich@file", method=~"POST|PUT|PATCH"}[6h]))
+            -
+            sum(rate(traefik_service_requests_total{exported_service="immich@file", method=~"POST|PUT|PATCH", code=~"2.."}[6h]))
+          )
+          / clamp_min(sum(rate(traefik_service_requests_total{exported_service="immich@file", method=~"POST|PUT|PATCH"}[6h])), 1e-10)
+          / error_budget:immich:uploads:budget_total
+
+      # ===========================================================================
       # HOME ASSISTANT - Extended burn rate windows (denylist: only 5xx = errors)
       # 404s at ~37 req/day via Traefik caused 4x budget overrun with allowlist criteria
       # ===========================================================================
@@ -220,19 +269,22 @@ groups:
       # TRAEFIK - Extended burn rate windows (using up metric)
       # ===========================================================================
 
+      # scalar() REQUIRED — see slo-recording-rules.yml Traefik burn-rate note:
+      # without it the labelled up{} series fails to match the label-less budget
+      # series and records nothing. (verified 2026-05-25)
       - record: burn_rate:traefik:availability:1d
         expr: |
-          (1 - avg_over_time(up{job="traefik"}[1d]))
+          scalar(1 - avg_over_time(up{job="traefik"}[1d]))
           / error_budget:traefik:availability:budget_total
 
       - record: burn_rate:traefik:availability:2h
         expr: |
-          (1 - avg_over_time(up{job="traefik"}[2h]))
+          scalar(1 - avg_over_time(up{job="traefik"}[2h]))
           / error_budget:traefik:availability:budget_total
 
       - record: burn_rate:traefik:availability:3d
         expr: |
-          (1 - avg_over_time(up{job="traefik"}[3d]))
+          scalar(1 - avg_over_time(up{job="traefik"}[3d]))
           / error_budget:traefik:availability:budget_total
 
       # ===========================================================================

--- a/config/prometheus/rules/slo-recording-rules.yml
+++ b/config/prometheus/rules/slo-recording-rules.yml
@@ -140,10 +140,14 @@ groups:
             sum(rate(traefik_service_request_duration_seconds_bucket{exported_service="jellyfin@file"}[5m])) by (le)
           )
 
-      # Jellyfin - Requests under 500ms target
+      # Jellyfin - Requests under ~500ms target
+      # NOTE (fixed 2026-05-25): was le="0.5", a bucket Traefik does NOT emit
+      # (buckets: 0.1, 0.3, 1.0, 3.0, 10.0), so this rule silently produced no data.
+      # Repointed to le="0.3" — the nearest available bucket to the 500ms SLO target.
+      # If a precise 500ms SLI is needed, add a 0.5 bucket to Traefik's histogram config.
       - record: sli:jellyfin:latency:fast_ratio
         expr: |
-          sum(rate(traefik_service_request_duration_seconds_bucket{exported_service="jellyfin@file", le="0.5"}[5m]))
+          sum(rate(traefik_service_request_duration_seconds_bucket{exported_service="jellyfin@file", le="0.3"}[5m]))
           /
           sum(rate(traefik_service_request_duration_seconds_count{exported_service="jellyfin@file"}[5m]))
 
@@ -154,10 +158,15 @@ groups:
             sum(rate(traefik_service_request_duration_seconds_bucket{exported_service="authelia@file"}[5m])) by (le)
           )
 
-      # Authelia - Requests under 200ms target
+      # Authelia - Requests under ~200ms target
+      # NOTE (fixed 2026-05-25): was le="0.2", a bucket Traefik does NOT emit
+      # (buckets: 0.1, 0.3, 1.0, 3.0, 10.0), so this rule silently produced no data.
+      # Repointed to le="0.3" — the nearest available bucket to the 200ms SLO target.
+      # (Authelia runs as forward-auth middleware and carries ~no routed traffic, so
+      # this SLI is mostly cosmetic; not alerted.)
       - record: sli:authelia:latency:fast_ratio
         expr: |
-          sum(rate(traefik_service_request_duration_seconds_bucket{exported_service="authelia@file", le="0.2"}[5m]))
+          sum(rate(traefik_service_request_duration_seconds_bucket{exported_service="authelia@file", le="0.3"}[5m]))
           /
           sum(rate(traefik_service_request_duration_seconds_count{exported_service="authelia@file"}[5m]))
 
@@ -271,6 +280,31 @@ groups:
       - record: slo:immich:availability:compliant
         expr: |
           slo:immich:availability:actual >= bool slo:immich:availability:target
+
+      # Immich - Upload success SLO (G3, added 2026-05-25). 99.5% of upload
+      # operations (POST/PUT/PATCH) return 2xx over 30 days. Failing photo uploads
+      # are user-data-loss-adjacent and were previously invisible unless a 5xx also
+      # spiked. NaN-safe: when no uploads occurred in the window, actual = 1.0
+      # (no failures), mirroring sli:immich:uploads:success_ratio. NOTE: only 2xx
+      # counts as success here — a client disconnect (499) mid-upload counts as a
+      # failure, which is why the paired alert is a warning, not a page.
+      - record: slo:immich:uploads:target
+        expr: 0.995
+
+      - record: slo:immich:uploads:actual
+        expr: |
+          clamp_max(
+            sum(increase(traefik_service_requests_total{exported_service="immich@file", method=~"POST|PUT|PATCH", code=~"2.."}[30d]))
+            /
+            clamp_min(sum(increase(traefik_service_requests_total{exported_service="immich@file", method=~"POST|PUT|PATCH"}[30d])), 1)
+            +
+            (sum(increase(traefik_service_requests_total{exported_service="immich@file", method=~"POST|PUT|PATCH"}[30d])) < bool 1),
+            1
+          )
+
+      - record: slo:immich:uploads:compliant
+        expr: |
+          slo:immich:uploads:actual >= bool slo:immich:uploads:target
 
       # Authelia - 99.9% availability target over 30 days
       - record: slo:authelia:availability:target
@@ -408,6 +442,21 @@ groups:
       - record: error_budget:immich:availability:budget_remaining
         expr: |
           clamp_max(1 - error_budget:immich:availability:budget_consumed, 1)
+
+      # Immich - Upload error budget (G3, 0.5% allowed upload failure)
+      - record: error_budget:immich:uploads:budget_total
+        expr: 0.005
+
+      - record: error_budget:immich:uploads:budget_consumed
+        expr: |
+          clamp_min(
+            (1 - slo:immich:uploads:actual) / (1 - slo:immich:uploads:target),
+            0
+          )
+
+      - record: error_budget:immich:uploads:budget_remaining
+        expr: |
+          clamp_max(1 - error_budget:immich:uploads:budget_consumed, 1)
 
       # Authelia - Error budget (0.1% = 43 min/month)
       - record: error_budget:authelia:availability:budget_total
@@ -791,22 +840,27 @@ groups:
           / error_budget:audiobookshelf:availability:budget_total
 
       # Traefik - Burn rates (uses up metric, always has data, no NaN risk)
+      # scalar() is REQUIRED: up{job="traefik"} carries {instance,job,service} labels
+      # while error_budget:...:budget_total is label-less. Without scalar() the binary
+      # division finds no matching label set and records an EMPTY series (verified
+      # 2026-05-25 — the un-scalared rules produced no data, so the Traefik SLO panel
+      # and any Traefik burn-rate alert were silently dead). scalar() strips the labels.
       - record: burn_rate:traefik:availability:1h
         expr: |
-          (1 - avg_over_time(up{job="traefik"}[1h]))
+          scalar(1 - avg_over_time(up{job="traefik"}[1h]))
           / error_budget:traefik:availability:budget_total
 
       - record: burn_rate:traefik:availability:5m
         expr: |
-          (1 - avg_over_time(up{job="traefik"}[5m]))
+          scalar(1 - avg_over_time(up{job="traefik"}[5m]))
           / error_budget:traefik:availability:budget_total
 
       - record: burn_rate:traefik:availability:6h
         expr: |
-          (1 - avg_over_time(up{job="traefik"}[6h]))
+          scalar(1 - avg_over_time(up{job="traefik"}[6h]))
           / error_budget:traefik:availability:budget_total
 
       - record: burn_rate:traefik:availability:30m
         expr: |
-          (1 - avg_over_time(up{job="traefik"}[30m]))
+          scalar(1 - avg_over_time(up{job="traefik"}[30m]))
           / error_budget:traefik:availability:budget_total

--- a/docs/40-monitoring-and-documentation/guides/slo-framework.md
+++ b/docs/40-monitoring-and-documentation/guides/slo-framework.md
@@ -78,6 +78,13 @@ How fast we're consuming error budget:
 - **Target:** 99.5% of uploads succeed over 7 days
 - **SLI:** `(traefik_service_requests_total{exported_service="immich@file", method="POST|PUT", code=~"2.."} / traefik_service_requests_total{exported_service="immich@file", method="POST|PUT"}) * 100`
 - **Rationale:** Photos must reliably upload or they're lost
+- **Alerting (added 2026-05-25):** `SLOBurnRateTier1_ImmichUploads` (warning) + `Tier2` (info),
+  each gated by a minimum-attempt guard (>10 upload attempts in the window) so a single failed
+  upload at this service's low upload volume cannot trip the alert. Severity is warning/info, not
+  page, because the SLI counts only 2xx as success — a client disconnect (499) mid-upload counts
+  as a failure, so paging would risk false positives on a user's flaky network. Recording rules:
+  `slo:immich:uploads:{target,actual,compliant}`, `error_budget:immich:uploads:*`,
+  `burn_rate:immich:uploads:{5m,30m,1h,6h}`. Visualized on the SLO dashboard ("Immich Upload SLO").
 
 ---
 
@@ -88,6 +95,12 @@ How fast we're consuming error budget:
 - **SLI:** `avg_over_time(up{job="traefik"}[5m])`
 - **Error Budget:** 21 minutes/month
 - **Rationale:** Traefik is the gateway - it affects ALL services
+- **Alerting (added 2026-05-25):** `SLOBurnRateTier1-4_Traefik` (the 4-tier burn-rate pattern;
+  Tier 1 critical → page, Tiers 2-3 warning, Tier 4 info). Previously the only charted SLO with no
+  alert. Adding the alerts also required **fixing the underlying recording rules**: the
+  `burn_rate:traefik:availability:*` series were silently empty because the labelled
+  `up{job="traefik"}` vector could not match the label-less error-budget series in the division
+  (now wrapped in `scalar()`). Without that fix the alerts would never have fired.
 
 **SLO-006: Request Latency**
 - **Target:** 99% of requests <100ms over 24 hours
@@ -308,6 +321,44 @@ Access the SLO dashboard at: `https://grafana.patriark.org/d/slo-dashboard`
 
 **Implementation Date:** 2025-11-27
 **Status:** ✅ Production-ready
+
+### Changelog
+
+**2026-05-25 — SLO & alert coverage (Plan B):**
+- **G1:** Added `SLOBurnRateTier1-4_Traefik` burn-rate alerts and **fixed** the previously-empty
+  `burn_rate:traefik:availability:*` recording rules (label-match bug; now `scalar()`-wrapped).
+  The gateway SLO is now both charted *and* alerted.
+- **G3:** Added the Immich-upload SLO (`slo:immich:uploads:*`, `error_budget:immich:uploads:*`,
+  `burn_rate:immich:uploads:*`), warning/info alerts with a minimum-attempt guard, and a dashboard panel.
+- **G4:** Added `NavidromeSustained5xxLowVolume` (mirrors the HA low-volume compensating alert).
+- **slo_compliance eval cost:** investigated and found **already mitigated** — the group has run at
+  `interval: 2m` since 2025-11-28 (0.33s/120s ≈ 0.3% duty cycle), not the 30s the deep-dive assumed.
+  No change needed.
+- **Latency alerting (G2):** see "Latency alerting status" below.
+
+### Latency alerting status (investigated 2026-05-25)
+
+Latency SLIs (`sli:*:latency:p95`/`p99` and `:fast_ratio`) are **recorded and charted** (dashboard
+panel 5) but **not alerted**. The deep-dive proposed adding latency alerts (Authelia 200ms, Traefik
+p99 100ms, Jellyfin 500ms); live verification found none of those three is currently alertable:
+
+| Candidate | Blocker (verified) |
+|---|---|
+| **Authelia** | Runs as forward-auth middleware, not a routed service — ~2 service-level requests in 7 days. No latency signal to alert on. Also its `fast_ratio` rule uses `le="0.2"`, a bucket Traefik does not emit. |
+| **Jellyfin** | ~1 request/7d. Its `fast_ratio` rule uses `le="0.5"`, also a non-existent bucket. |
+| **Traefik** | Entrypoint latency conflates streaming/WebSocket long-lived connections (p99 ≈ 2.6s; only ~76% of requests <100ms). The documented "99% <100ms" target reads as permanently breached → unusable as a threshold. |
+
+**Traefik histogram buckets are `[0.1, 0.3, 1.0, 3.0, 10.0]`** (+`+Inf`) — so any `fast_ratio` rule
+referencing `le="0.2"` or `le="0.5"` silently produced no data. This was a **latent bug** in
+`sli:authelia:latency:fast_ratio` and `sli:jellyfin:latency:fast_ratio`, **fixed 2026-05-25** by
+repointing both to `le="0.3"` (the nearest available bucket). If precise 200ms/500ms latency SLIs
+are wanted later, add `0.2`/`0.5` buckets to Traefik's histogram config.
+
+**Resolution (2026-05-25):** A latency alert was added for the one service with clean, high-volume,
+correctly-bucketed data — **Nextcloud** (`NextcloudLatencySLOBreach`: warning when <95% of requests
+complete under 1s for 30m, with a minimum-traffic guard; baseline ~99.7% gives ample headroom).
+Authelia/Jellyfin/Immich latency remain dashboard-only (insufficient traffic) and Traefik entrypoint
+latency remains dashboard-only (streaming-conflated; not a clean threshold signal).
 
 ## References
 

--- a/docs/97-plans/2026-05-25-slo-alert-coverage.md
+++ b/docs/97-plans/2026-05-25-slo-alert-coverage.md
@@ -113,3 +113,31 @@ Each addition is isolated; `git revert` the alert/rule file. New recording rules
 
 - 2026-05-25 — Plan drafted from deep-dive report. Status: Proposed. Sequence after Plan A (smaller
   TSDB makes burn-rate queries cheaper) but independent of it.
+- 2026-05-25 — **Implemented on branch `feat/slo-alert-coverage`.** Status: Implemented (G1–G4 + docs;
+  #5 needed no change). Live verification (Prometheus had 15d of data) surfaced corrections to the plan's premises:
+  - **G1 (done):** The plan assumed `burn_rate:traefik:availability:*` returned data; it did **not** —
+    a label-match bug (labelled `up{}` ÷ label-less budget) made the series silently empty, so the
+    Traefik dashboard panel was blank and any alert would never fire. Fixed all 7 Traefik burn-rate
+    rules with `scalar()` (in `slo-recording-rules.yml` + `slo-burn-rate-extended.yml`), then added
+    `SLOBurnRateTier1-4_Traefik`. promtool ✅, amtool routing ✅ (Tier1→critical, Tier2-3→warning,
+    Tier4→info).
+  - **G3 (done):** Added Immich-upload SLO recording rules (`slo:`/`error_budget:`/`burn_rate:immich:uploads:*`),
+    `SLOBurnRateTier1/2_ImmichUploads` (warning/info, **not** page — see below), and a dashboard panel.
+    Deviation: severity is warning/info with a `>10 attempts` volume guard, because uploads are very
+    low volume (~few/week) and the SLI counts only 2xx as success (499 client-disconnects would
+    otherwise false-page). Routing verified safe: the handler matches alertnames **exactly**, so
+    `_ImmichUploads` never hits the `_Immich` immich-server-restart playbook (it returns `no_route`).
+  - **G4 (done):** Added `NavidromeSustained5xxLowVolume`. Could not scale the threshold to live
+    traffic (Navidrome was idle — 0 req/7d), so it mirrors `HomeAssistantSustained5xxLowVolume`
+    (>20 5xx in 6h, <0.5 req/s). Documented to revisit once a traffic floor accrues.
+  - **#5 (no action — premise outdated):** `slo_compliance` already runs at `interval: 2m` (since
+    2025-11-28), 0.33s/120s. The deep-dive's "every 30s" was wrong; eval cost is already mitigated.
+  - **G2 (done — re-scoped from evidence):** All three of the plan's proposed latency targets were
+    unbuildable: Authelia is forward-auth (~2 req/7d, no signal); Jellyfin ~1 req/7d; both
+    `fast_ratio` rules also referenced non-existent histogram buckets (`le=0.2`/`le=0.5`; Traefik
+    emits `[0.1,0.3,1.0,3.0,10.0]`); Traefik entrypoint latency is streaming-conflated (p99≈2.6s,
+    ~76% <100ms). Owner chose "Nextcloud alert + fix bucket bugs": (1) fixed the two broken
+    `fast_ratio` bucket refs (`le=0.2`/`0.5` → `0.3`); (2) added `NextcloudLatencySLOBreach`
+    (warning, <95% under 1s for 30m, min-traffic guard) — the only service with clean alertable
+    latency data. Named outside the `SLOBurnRateTier*` convention so it does not hit auto-remediation.
+    See `slo-framework.md` "Latency alerting status".


### PR DESCRIPTION
Implements **Plan B** (`docs/97-plans/2026-05-25-slo-alert-coverage.md`), closing the alerting gaps from the [monitoring deep-dive](docs/99-reports/2026-05-25-monitoring-stack-deep-dive.md) §4–5. Live verification (Prometheus had 15d of data) corrected several of the plan's premises — see per-item notes.

## Changes

### G1 — Traefik SLO burn alerts 🔴 (+ recording-rule fix)
The plan assumed `burn_rate:traefik:availability:*` returned data. It **didn't**: a label-match bug (labelled `up{...}` ÷ label-less budget series never matched) made the series silently empty — the SLO dashboard panel was blank and any alert would never have fired. Fixed all 7 rules with `scalar()`, then added `SLOBurnRateTier1-4_Traefik` (Tier1 critical→page, 2–3 warning, 4 info). The fixed `3d` rule now returns a real value (`0.116`, historical gateway downtime).

### G3 — Immich-upload SLO 🟡
Added `slo:`/`error_budget:`/`burn_rate:immich:uploads:*` recording rules, `SLOBurnRateTier1/2_ImmichUploads`, and a dashboard panel. **Deviation:** warning/info (not page) with a `>10 attempts` volume guard — uploads are ~few/week and the SLI counts only 2xx as success, so paging would false-fire on a user's flaky network (499s). The remediation router matches alertnames **exactly**, so `_ImmichUploads` cannot trigger the `_Immich` server-restart playbook.

### G4 — Navidrome low-volume 5xx 🟡
Added `NavidromeSustained5xxLowVolume`, mirroring `HomeAssistantSustained5xxLowVolume`. Navidrome was idle at calibration time, so the threshold mirrors HA's; documented to revisit once a traffic floor accrues.

### G2 — Latency (re-scoped from evidence)
The plan's three targets were all unbuildable: Authelia is forward-auth (~2 req/7d, no signal), Jellyfin ~1 req/7d, **both `fast_ratio` rules referenced non-existent histogram buckets** (`le=0.2`/`0.5`; Traefik emits `[0.1,0.3,1.0,3.0,10.0]`), and Traefik entrypoint latency is streaming-conflated (p99 ≈ 2.6s). Per owner decision: fixed the two broken bucket refs (→ `le=0.3`) and added `NextcloudLatencySLOBreach` — the only service with clean, high-volume latency data (<95% under 1s for 30m, min-traffic guard, routes to **discord-warnings only**).

### #5 — `slo_compliance` eval cost
No change needed — already `interval: 2m` since 2025-11-28 (the deep-dive's "every 30s" was outdated; eval is 0.33s/120s ≈ 0.3% duty cycle).

## Verification
- `promtool check rules` ✅ on all changed files (42 alerts / 121 + 36 recording rules).
- `amtool check-config` ✅; routing dry-run confirms Tier1→critical, Tier2-3→warning, Tier4→info; `NextcloudLatencySLOBreach`→discord-warnings only.
- Prometheus reloaded live (`reload_successful=1`, no errors); **all 8 new alerts `inactive`/`health=ok`**, no spurious firing.
- Fixed Traefik + Immich-upload recording rules confirmed returning data.
- Non-invasive synthetic wiring test: relaxed Tier1 expressions resolve to a value (would fire under real burn).

## Rollback
Each addition is isolated; `git revert` the commit. New recording rules only add series (no mutation); removing the new alerts cannot affect existing alerting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)