### PR TITLE
feat(monitoring): backup & dump observability (Plan C)

### DIFF
--- a/config/grafana/provisioning/dashboards/json/backup-health.json
+++ b/config/grafana/provisioning/dashboards/json/backup-health.json
@@ -537,7 +537,7 @@
             "type": "prometheus",
             "uid": "prometheus"
           },
-          "expr": "ALERTS{alertname=~\"Backup.*|RestoreTest.*\"}",
+          "expr": "ALERTS{category=~\"backup|disaster-recovery\"}",
           "format": "table",
           "instant": true,
           "legendFormat": "__auto",
@@ -870,6 +870,310 @@
       ],
       "title": "Last Full Send Size (per subvolume)",
       "type": "barchart"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Free space as a fraction of pool capacity. The offsite destination drive is only visible via Urd metrics (node_exporter excludes /run/media, ADR-023). Populates after the next `urd backup` run emits backup_pool_total_bytes (PR #145).",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.07
+              },
+              {
+                "color": "green",
+                "value": 0.15
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 40
+      },
+      "id": 9,
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "backup_pool_free_bytes / backup_pool_total_bytes",
+          "legendFormat": "{{label}} ({{role}})",
+          "refId": "A"
+        }
+      ],
+      "title": "BTRFS Pool Free %",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "BTRFS metadata allocation ratio. Can ENOSPC even with free data space — a silent killer. Alert BackupPoolMetadataExhaustion fires >0.95.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "min": 0,
+          "max": 1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 0.85
+              },
+              {
+                "color": "red",
+                "value": 0.95
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 40
+      },
+      "id": 10,
+      "options": {
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "orientation": "auto",
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "backup_pool_metadata_utilization_ratio",
+          "legendFormat": "{{label}} ({{role}})",
+          "refId": "A"
+        }
+      ],
+      "title": "BTRFS Pool Metadata Utilization",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Age of each DB's last successful ephemeral restore test. Surfacing freshness guards against silent producer death (cf. the May 2026 dead-metric incident). DbRestoreTestOverdue fires at 10d.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "yellow",
+                "value": 604800
+              },
+              {
+                "color": "red",
+                "value": 864000
+              }
+            ]
+          },
+          "unit": "dtdurations"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 40
+      },
+      "id": 11,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "values": false,
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": ""
+        },
+        "showPercentChange": false,
+        "textMode": "value_and_name",
+        "wideLayout": true
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "time() - db_restore_test_last_timestamp",
+          "legendFormat": "{{database}}",
+          "refId": "A"
+        }
+      ],
+      "title": "DB Restore-Test Recency",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Per-DB dump size over time (log scale so the ~1.6 GB prometheus dump doesn't flatten the others). Makes DbDumpSizeAnomaly (>2x 14-day median) visually verifiable; prometheus is excluded from that alert.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "log",
+              "log": 2
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 48
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "db_dump_size_bytes",
+          "legendFormat": "{{database}}",
+          "refId": "A"
+        }
+      ],
+      "title": "DB Dump Size Trend (per database)",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",
@@ -890,6 +1194,6 @@
   "timezone": "browser",
   "title": "Backup Health Dashboard",
   "uid": "backup-health",
-  "version": 2,
+  "version": 3,
   "weekStart": ""
 }

--- a/config/prometheus/alerts/backup-alerts.yml
+++ b/config/prometheus/alerts/backup-alerts.yml
@@ -69,7 +69,12 @@ groups:
           description: "Restore test hasn't run in {{ $value | humanizeDuration }}. Should run monthly (last Sunday)."
 
       # Warning: Low snapshot count (may indicate cleanup issues)
-      # DISABLED: User monitors this via Grafana dashboard, Discord alerts not needed
+      # DISABLED BY DESIGN (reaffirmed 2026-05-25, Plan C B4): the owner watches
+      # snapshot counts on the `backup-health` Grafana dashboard ("Snapshot Counts
+      # (Local vs External)" + "Snapshot Count Trends Over Time" panels). A Discord
+      # page adds no value over that panel for a slow-moving, eyeballed signal.
+      # Per-subvolume counts are also available as backup_subvolume_local_snapshot_count.
+      # Keep disabled; if ever re-enabled, gate on a long `for:` to avoid prune churn.
       # - alert: LowSnapshotCount
       #   expr: backup_snapshot_count{location="local"} < 2
       #   for: 1h
@@ -81,9 +86,23 @@ groups:
       #     summary: "Low snapshot count for {{ $labels.subvolume }}"
       #     description: "Only {{ $value }} local snapshots for {{ $labels.subvolume }}. Expected at least 3-7."
 
-      # Warning: External backup missing
+      # Warning: External backup missing — only for subvolumes SUPPOSED to go offsite.
+      # Gated on Urd's backup_external_expected (=1 only when an external destination is
+      # configured; line absent otherwise). subvol6-tmp is local-only by design
+      # (send_enabled=false) and is correctly excluded — it was the lone live false
+      # positive this gate removes (verified via Urd PR #145, 2026-05-25). htpc-root is
+      # external-only and stays covered (it IS expected-external).
+      #
+      # ⚠️ DEPLOY ORDERING: backup_external_expected exists only after Urd PR #145 is
+      # merged AND one `urd backup` run has emitted it. Until the series is live in
+      # Prometheus the join is empty and this alert is FULLY SUPPRESSED (real misses
+      # included) — deploy these rules only after first emission. Break-glass fallback
+      # if you must ship earlier (functional, hardcodes the single exception):
+      #   expr: backup_snapshot_count{location="external",subvolume!="subvol6-tmp"} == 0
       - alert: ExternalBackupMissing
-        expr: backup_snapshot_count{location="external"} == 0
+        expr: |
+          backup_snapshot_count{location="external"} == 0
+            and on(subvolume) backup_external_expected == 1
         for: 12h
         labels:
           severity: warning
@@ -91,7 +110,7 @@ groups:
           component: btrfs-snapshot-backup
         annotations:
           summary: "No external backups for {{ $labels.subvolume }}"
-          description: "External backup drive may not be mounted or backups failing."
+          description: "{{ $labels.subvolume }} is configured for offsite backup but has 0 external snapshots. External drive may not be mounted or sends are failing."
 
       # Warning: Backup taking too long
       # Auto-resolves after 1h to prevent persistent alerts on weekly/monthly backups
@@ -105,3 +124,56 @@ groups:
         annotations:
           summary: "Backup taking unusually long for {{ $labels.subvolume }}"
           description: "Last backup took {{ $value | humanizeDuration }}. May indicate performance issues. Alert auto-resolves after 1h for weekly/monthly backups."
+
+  # ==========================================================================
+  # Pool-capacity alerts from Urd's btrfs pool metrics (backup_pool_*).
+  # These cover what node_exporter cannot: BTRFS metadata exhaustion (a silent
+  # ENOSPC source even with free data space). The metrics carry {uuid,role,label}
+  # (NOT subvolume) and refresh at backup-run cadence (nightly) — hence the
+  # 5m group eval and long `for:`. Verified present in Prometheus 2026-05-25.
+  # ==========================================================================
+  - name: backup_pool_alerts
+    interval: 5m
+    rules:
+      # Critical: BTRFS can return ENOSPC even with free DATA space when METADATA
+      # is exhausted — a classic silent killer. Readings 2026-05-25: / 0.36,
+      # /mnt 0.86, WD-18TB 0.78 (/mnt is the one to watch). 0.95 leaves headroom
+      # while still firing before metadata blocks snapshots and dumps.
+      - alert: BackupPoolMetadataExhaustion
+        expr: backup_pool_metadata_utilization_ratio > 0.95
+        for: 1h
+        labels:
+          severity: critical
+          category: backup
+          component: btrfs-pool
+        annotations:
+          summary: "BTRFS metadata near exhaustion on {{ $labels.label }} ({{ $labels.role }})"
+          description: "Metadata utilization is {{ $value | humanizePercentage }} on pool {{ $labels.label }}. BTRFS can ENOSPC even with free data space — run a metadata balance before it blocks snapshots and dumps."
+
+      # Offsite destination drive capacity. node_exporter excludes /run/media (ADR-023),
+      # so these MUST come from Urd. backup_pool_total_bytes added in Urd PR #145
+      # (WD-18TB = 18.00 TB; ~16.6% free / 84% used at 2026-05-25 — warning is near).
+      # Source pools (/, /mnt) are instead covered LIVE by node_exporter
+      # (BtrfsPoolSpace{Warning,Critical}); Urd's once-daily snapshot is too coarse there.
+      # Inert until the new series emit (see DEPLOY ORDERING above) — absent total = no series.
+      - alert: BackupDestinationPoolSpaceWarning
+        expr: backup_pool_free_bytes{role="destination"} / backup_pool_total_bytes{role="destination"} < 0.15
+        for: 1h
+        labels:
+          severity: warning
+          category: backup
+          component: btrfs-pool
+        annotations:
+          summary: "Offsite backup drive {{ $labels.label }} low on space"
+          description: "{{ $labels.label }} is {{ $value | humanizePercentage }} free (<15%). Plan retention pruning or a larger drive before external sends start failing."
+
+      - alert: BackupDestinationPoolSpaceCritical
+        expr: backup_pool_free_bytes{role="destination"} / backup_pool_total_bytes{role="destination"} < 0.07
+        for: 1h
+        labels:
+          severity: critical
+          category: backup
+          component: btrfs-pool
+        annotations:
+          summary: "CRITICAL: offsite backup drive {{ $labels.label }} nearly full"
+          description: "{{ $labels.label }} is {{ $value | humanizePercentage }} free (<7%). External sends will fail soon — free space or swap drives now."

--- a/config/prometheus/alerts/backup-alerts.yml
+++ b/config/prometheus/alerts/backup-alerts.yml
@@ -74,7 +74,11 @@ groups:
       # (Local vs External)" + "Snapshot Count Trends Over Time" panels). A Discord
       # page adds no value over that panel for a slow-moving, eyeballed signal.
       # Per-subvolume counts are also available as backup_subvolume_local_snapshot_count.
-      # Keep disabled; if ever re-enabled, gate on a long `for:` to avoid prune churn.
+      # Keep disabled. If ever re-enabled: (1) gate on a long `for:` to avoid prune churn,
+      # and (2) EXCLUDE external-only subvolumes — htpc-root has local_snapshots=false
+      # (Urd config) so its local count is ~0 BY DESIGN and would false-fire. Prefer
+      # backup_subvolume_local_snapshot_count, whose line is ABSENT when local snapshots
+      # aren't configured, over backup_snapshot_count{location="local"} which reports 0.
       # - alert: LowSnapshotCount
       #   expr: backup_snapshot_count{location="local"} < 2
       #   for: 1h

--- a/config/prometheus/alerts/db-dump-alerts.yml
+++ b/config/prometheus/alerts/db-dump-alerts.yml
@@ -64,3 +64,27 @@ groups:
         annotations:
           summary: "DB restore test overdue for {{ $labels.database }}"
           description: "No restore test for {{ $labels.database }} in {{ $value | humanizeDuration }} (should run weekly)."
+
+      # Warning: a dump ballooned vs its own recent baseline — catches a runaway
+      # table/DB or a misconfigured dump before it pressures the offsite dump set.
+      # Guards against false positives:
+      #   (1) exclude prometheus — its dump tracks TSDB size (addressed by Plan A's
+      #       metric diet), not data health, and it dominates the set at ~1.6 GB;
+      #   (2) absolute floor (50 MiB) so tiny dumps (gathio ~16 KB, forgejo ~47 KB,
+      #       vaultwarden ~180 KB) can't trip on normal variance — only meaningfully
+      #       large dumps matter to the 4.6 GB offsite set.
+      # Baseline = 14-day median; only ~3 days of history exists today (2026-05-25),
+      # which widens automatically. Median (not avg) resists the nightly step shape.
+      - alert: DbDumpSizeAnomaly
+        expr: |
+          db_dump_size_bytes{database!="prometheus"}
+            > 2 * quantile_over_time(0.5, db_dump_size_bytes{database!="prometheus"}[14d])
+          and db_dump_size_bytes{database!="prometheus"} > 50 * 1024 * 1024
+        for: 30m
+        labels:
+          severity: warning
+          category: backup
+          component: db-dump
+        annotations:
+          summary: "DB dump for {{ $labels.database }} doubled vs its 14-day median"
+          description: "Latest {{ $labels.database }} dump is {{ $value | humanize1024 }}B — over 2x its 14-day median. Check for a runaway table or misconfigured dump before it pressures the offsite dump set."

--- a/config/prometheus/alerts/infrastructure-critical.yml
+++ b/config/prometheus/alerts/infrastructure-critical.yml
@@ -45,6 +45,24 @@ groups:
           description: "System SSD {{ $labels.instance }} has only {{ $value | humanizePercentage }} free space. Immediate cleanup required!"
 
       # ========================================================================
+      # ALERT 2b: BTRFS Data Pool Space Critical (/mnt)
+      # ========================================================================
+      # Added 2026-05-25 (Plan C). SystemDiskSpaceCritical covers "/" (system SSD)
+      # but the /mnt data pool — where all source subvolumes live — had only a
+      # warning (and that was dead until this commit). A full data pool breaks both
+      # snapshots and dumps. Currently ~19.8% free, so <10% leaves real headroom.
+      - alert: BtrfsPoolSpaceCritical
+        expr: (node_filesystem_avail_bytes{mountpoint="/mnt"} / node_filesystem_size_bytes{mountpoint="/mnt"}) < 0.10
+        for: 5m
+        labels:
+          severity: critical
+          category: capacity
+          component: storage
+        annotations:
+          summary: "CRITICAL: BTRFS data pool (/mnt) space dangerously low"
+          description: "Data pool /mnt on {{ $labels.instance }} has only {{ $value | humanizePercentage }} free. A full pool blocks snapshots AND db dumps — free space immediately."
+
+      # ========================================================================
       # ALERT 3: TLS Certificate Expiring Soon
       # ========================================================================
       # Only check the NEWEST certificate per domain (Traefik keeps old certs in metrics after renewal)

--- a/config/prometheus/alerts/infrastructure-warnings.yml
+++ b/config/prometheus/alerts/infrastructure-warnings.yml
@@ -36,8 +36,15 @@ groups:
       # ========================================================================
       # ALERT 2: BTRFS Pool Space Warning
       # ========================================================================
+      # FIX 2026-05-25 (Plan C): mountpoint was "/mnt/btrfs-pool", which node_exporter
+      # never reports (the data pool is mounted at "/mnt"; "btrfs-pool" is only a path
+      # component). The alert returned 0 series and was a silent DEAD alert. Corrected
+      # to mountpoint="/mnt". Threshold lowered 0.20 -> 0.15 (owner decision 2026-05-25):
+      # the pool sits at ~19.8% free / ~80% used (~3.1 TB absolute), and the dead alert
+      # had masked that. 15% keeps the signal without paging on today's steady state;
+      # BtrfsPoolSpaceCritical (<10%) escalates. Revisit if /mnt usage keeps climbing.
       - alert: BtrfsPoolSpaceWarning
-        expr: (node_filesystem_avail_bytes{mountpoint="/mnt/btrfs-pool"} / node_filesystem_size_bytes{mountpoint="/mnt/btrfs-pool"}) < 0.20
+        expr: (node_filesystem_avail_bytes{mountpoint="/mnt"} / node_filesystem_size_bytes{mountpoint="/mnt"}) < 0.15
         for: 10m
         labels:
           severity: warning

--- a/docs/00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md
+++ b/docs/00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md
@@ -66,13 +66,17 @@ Key metrics consumed by homelab alerts (`config/prometheus/alerts/backup-alerts.
 | `backup_success` | gauge | `subvolume` | `BackupFailed` alert (== 0) |
 | `backup_last_success_timestamp` | gauge | `subvolume` | `BackupStale` alert (age > 2d) |
 | `backup_script_last_run_timestamp` | gauge | — | `BackupScriptNotRunning` alert (age > 2d) |
-| `backup_snapshot_count` | gauge | `subvolume`, `location` | `ExternalBackupMissing` alert (external == 0) |
+| `backup_snapshot_count` | gauge | `subvolume`, `location` | `ExternalBackupMissing` alert (external == 0, gated by `backup_external_expected`) |
 | `backup_duration_seconds` | gauge | `subvolume` | `BackupSlowDuration` alert (> 1h) |
 | `backup_send_type` | gauge | `subvolume` | Grafana dashboard |
 | `backup_external_drive_mounted` | gauge | — | Grafana dashboard |
 | `backup_external_free_bytes` | gauge | — | Grafana dashboard |
 | `backup_subvolume_churn_bytes_per_second` | gauge | `subvolume` | `backup-health` Grafana dashboard (added Urd v0.16, [UPI 030](https://github.com/vonrobak/urd/pull/108)) |
 | `backup_subvolume_last_full_send_bytes` | gauge | `subvolume` | `backup-health` Grafana dashboard (added Urd v0.16, [UPI 030](https://github.com/vonrobak/urd/pull/108)) |
+| `backup_external_expected` | gauge | `subvolume` | `ExternalBackupMissing` gate (== 1; line absent = local-only by design). Urd [PR #145](https://github.com/vonrobak/urd/pull/145) |
+| `backup_pool_free_bytes` | gauge | `uuid`, `role`, `label` | `BackupDestinationPoolSpace{Warning,Critical}` numerator (role=destination); pool gauges (UPI 043) |
+| `backup_pool_total_bytes` | gauge | `uuid`, `role`, `label` | `BackupDestinationPoolSpace{Warning,Critical}` denominator (role=destination). Urd [PR #145](https://github.com/vonrobak/urd/pull/145) |
+| `backup_pool_metadata_utilization_ratio` | gauge | `uuid`, `role`, `label` | `BackupPoolMetadataExhaustion` alert (> 0.95) (UPI 043) |
 
 **Drift telemetry (Urd v0.16+).** Urd computes a rolling time-windowed churn rate per
 subvolume from `wire_bytes` of recent successful sends, and emits two gauges:
@@ -174,8 +178,8 @@ unaffected — no alert or dashboard widget currently references these names.
 
 | Metric | Labels | Cadence / shape | Homelab use |
 |--------|--------|-----------------|-------------|
-| `backup_pool_free_bytes` | `uuid`, `role`, `label` | Snapshot per backup run. `role ∈ {source, destination}`. Identity is `uuid`; `label` is informational (drive label for destinations, canonical mountpoint for sources). | Available for a future "BTRFS pool health" Grafana panel. **Not yet consumed.** |
-| `backup_pool_metadata_utilization_ratio` | `uuid`, `role`, `label` | 0.0–1.0 from `/sys/fs/btrfs/<uuid>/allocation/metadata/`. Covers source and destination pools. | Available for the same panel. **Not yet consumed.** |
+| `backup_pool_free_bytes` | `uuid`, `role`, `label` | Snapshot per backup run. `role ∈ {source, destination}`. Identity is `uuid`; `label` is informational (drive label for destinations, canonical mountpoint for sources). | **Consumed since 2026-05-25 (PR #145 amendment, below):** numerator of `BackupDestinationPoolSpace*` (role=destination); also a `backup-health` pool gauge. |
+| `backup_pool_metadata_utilization_ratio` | `uuid`, `role`, `label` | 0.0–1.0 from `/sys/fs/btrfs/<uuid>/allocation/metadata/`. Covers source and destination pools. | **Consumed since 2026-05-25 (PR #145 amendment, below):** `BackupPoolMetadataExhaustion` (> 0.95); also a `backup-health` gauge. |
 | `backup_subvolume_local_snapshot_count` | `subvolume` | Line **absent** when local snapshots are not configured for the subvolume. Coexists with the legacy `backup_snapshot_count{subvolume,location="local"}` — same physical fact, different contract shape (`Option::None`-as-absent vs. always-present). | **Not yet consumed.** Existing dashboards continue to use `backup_snapshot_count{location="local"}`. |
 | `backup_subvolume_estimated_local_pinned_delta_bytes` | `subvolume` | Wire-bytes-derived estimate (mean over in-window incrementals × local snapshot count). Emit policy: `Some(0)` when local snapshots disabled or `local_snapshot_count == 0` (known zero, distinct from unknown); line **absent** in cold-start (`local_snapshot_count > 0` and `mean_incremental_bytes` unknown). | Primarily a UPI 044 input (headroom-aware retention recommendations, downstream Urd work). **Not yet consumed.** |
 
@@ -291,5 +295,6 @@ under UPI-043.
 - **Urd project:** `~/projects/urd/` — CLAUDE.md, ADRs 100–111, status.md
 - **Urd design plan:** `docs/00-foundation/decisions/2026-03-23-urd-btrfs-time-machine-design.md`
 - **Urd ADR-105 Amendment 2026-05-15 (UPI 043):** canonical pool-observability + heartbeat v4 contract text.
+- **Urd [PR #145](https://github.com/vonrobak/urd/pull/145):** canonical source for `backup_external_expected` + `backup_pool_total_bytes` (Urd CHANGELOG `[Unreleased]`).
 - **Backup alerts:** `config/prometheus/alerts/backup-alerts.yml`
 - **Node exporter integration:** `quadlets/node_exporter.container` (textfile collector mount)

--- a/docs/00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md
+++ b/docs/00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md
@@ -245,6 +245,47 @@ deciding whether to swap `backup_snapshot_count{location="local"}` for the new
 sit outside the contract change recorded by this amendment. Track as a separate
 follow-up issue.
 
+## Amendment 2026-05-25 (Urd PR #145): expected-external + pool-total metrics, now consumed
+
+Backup-observability Plan C (`docs/97-plans/2026-05-25-backup-observability.md`) needed two
+gaps closed that only Urd can fill. Urd PR #145 (`feat/external-expected-and-pool-total`) adds
+both as additive, ADR-105-safe gauges. This amendment registers them and records that several
+previously-"Not yet consumed" metrics now back live alerts.
+
+### New Prometheus metrics (additive; existing metrics unchanged)
+
+Both arrive in `backup.prom` at the **next `urd backup` run after PR #145 merges** — they do
+not exist until then (alerts that reference them are inert, returning no series, until first
+emission; see deploy-ordering note below).
+
+| Metric | Labels | Cadence / shape | Homelab use |
+|--------|--------|-----------------|-------------|
+| `backup_external_expected` | `subvolume` | `1` iff the subvolume has an external destination configured (`send_enabled` AND ≥1 drive in scope); **line absent otherwise**. Same `subvolume` key as `backup_snapshot_count`. | **Consumed** by `ExternalBackupMissing`, which now gates on `… and on(subvolume) backup_external_expected == 1`. Removes the `subvol6-tmp` false positive (local-only by design, `send_enabled=false`). |
+| `backup_pool_total_bytes` | `uuid`, `role`, `label` | Total capacity (statvfs), same key as `backup_pool_free_bytes`; free+total read in one statvfs pass so they never skew within a run. Snapshot per backup run. | **Consumed** by `BackupDestinationPoolSpace{Warning,Critical}` (`free/total` on `role="destination"`) — node_exporter cannot see the offsite drive (ADR-023), so the total must come from Urd. |
+
+### Consumption status change (UPI-043 metrics)
+
+`backup_pool_metadata_utilization_ratio` is now **consumed** by `BackupPoolMetadataExhaustion`
+(`> 0.95`, all roles). `backup_pool_free_bytes{role="destination"}` is consumed as the numerator
+above. Source-pool free-% (`/`, `/mnt`) is intentionally **not** taken from Urd — node_exporter
+covers those live and continuously, whereas Urd's pool gauges refresh only once per nightly run
+(`urd-sentinel` never writes `backup.prom`). Treat all `backup_pool_*` values as up to ~24h stale.
+
+### Deploy ordering (load-bearing)
+
+`ExternalBackupMissing`'s join is empty until `backup_external_expected` is live, which **fully
+suppresses the alert (real misses included)** in the interim. Deploy the homelab alert changes
+only after PR #145 is merged and one `urd backup` run has emitted the new series. A break-glass
+fallback (`backup_snapshot_count{location="external",subvolume!="subvol6-tmp"} == 0`) is recorded
+inline in `backup-alerts.yml` for shipping earlier.
+
+### Follow-up (not in this amendment)
+
+`backup_external_free_bytes` is legacy, superseded by `backup_pool_free_bytes{role="destination"}`
+(+ total) but still an ADR-105 backward-compat contract — its deprecation is a separate
+coordinated change. Dashboard surfacing (Plan C item 5) remains the deferred UX follow-up noted
+under UPI-043.
+
 ## Related
 - **ADR-020:** Daily external backups (strategy — still valid, implementation superseded)
 - **Urd project:** `~/projects/urd/` — CLAUDE.md, ADRs 100–111, status.md

--- a/docs/97-plans/2026-05-25-backup-observability.md
+++ b/docs/97-plans/2026-05-25-backup-observability.md
@@ -114,3 +114,46 @@ podman exec prometheus wget -qO- 'http://localhost:9090/api/v1/query?query=ALERT
 
 - 2026-05-25 — Plan drafted from deep-dive report. Status: Proposed. Item 1 is the only live
   false-positive and should ship first.
+- 2026-05-25 — **Ground-truth verification (branch `feat/backup-observability`).** Several plan
+  assumptions corrected against the live system:
+  - **Producer is Urd, not the shell script.** `scripts/btrfs-snapshot-backup.sh` is disabled
+    (ADR-021, sole backup = Urd since 2026-03-25). The "have the backup script emit a label" path in
+    item 1 / item 2 must target `~/projects/urd`, which writes `data/backup-metrics/backup.prom`
+    (scraped via node_exporter textfile collector).
+  - **Item 2 scrape already works.** `backup_pool_free_bytes` (3), `backup_pool_metadata_utilization_ratio`
+    (3), `db_dump_size_bytes` (6) all confirmed present in Prometheus — no wiring needed. Pool metrics
+    are keyed `{uuid,role,label}` (NOT `subvolume`): source `/`, source `/mnt`, destination `WD-18TB`.
+  - **Dead alert found:** `BtrfsPoolSpaceWarning` queried `mountpoint="/mnt/btrfs-pool"` (0 series) —
+    real mountpoint is `/mnt`. Fixed. **/mnt is at 19.8% free**, so the corrected warning fires on
+    reload (true positive, pool ~80% used / ~3.1 TB free; previously masked).
+  - **subvol6-tmp** is the only subvolume with `external==0` (send_type=2). Item 1 needs the
+    expected-external intent confirmed in Urd before the gate is written.
+  - **db_dump_size_bytes** has only ~3 days of history (14-day median widens over time). A stale
+    `loki` series appears in range queries but not instant (not in current dump).
+  - **Shipped this branch (no Urd dependency, promtool-clean, verified non-false-firing):**
+    fixed `BtrfsPoolSpaceWarning` (/mnt); added `BtrfsPoolSpaceCritical` (/mnt <10%);
+    `BackupPoolMetadataExhaustion` (>0.95, group `backup_pool_alerts`); `DbDumpSizeAnomaly`
+    (2× 14-day median AND >50 MiB, excl. prometheus); reaffirmed `LowSnapshotCount` disabled w/ note.
+  - **Gated on Urd handoff (2026-05-25):** (1) item 1 clean fix needs `backup_external_expected{subvolume}`;
+    (2) destination free-% alert needs `backup_pool_total_bytes` (node_exporter can't see the offsite
+    drive per ADR-023; WD-18TB ~18% free — highest-value gap). Dashboard polish (item 5) staged until
+    the final metric set lands.
+- 2026-05-25 — **Urd handoff received (PR #145, written, not yet run).** Both metrics implemented &
+  additive (ADR-105 safe). Confirmed: subvol6-tmp is local-only by design (`send_enabled=false`);
+  WD-18TB = 18.00 TB, **84% used / 16.6% free**; `backup_pool_*` refresh once per nightly run
+  (sentinel never writes `.prom`); `db_dump_*`/`db_restore_test_*` are homelab-owned (not Urd).
+  - **Implemented item 1 + item 2-destination:** `ExternalBackupMissing` now gates on
+    `and on(subvolume) backup_external_expected == 1`; added `BackupDestinationPoolSpaceWarning` (<15%)
+    + `BackupDestinationPoolSpaceCritical` (<7%). Both inert (return 0) until the new series emit.
+    Break-glass fallback for item 1 recorded inline.
+  - **ADR-021 amended** (2026-05-25, PR #145 section): registers both new series as consumed; records
+    deploy-ordering and the source-pool (node_exporter) vs destination-pool (Urd) split.
+  - ⚠️ **DEPLOY ORDERING:** merge Urd PR #145 + run `urd backup` (emit series) BEFORE deploying/reloading
+    these rules — the `backup_external_expected` join otherwise suppresses ExternalBackupMissing entirely.
+  - **Item 5 dashboard polish DONE:** added pool free-% + metadata gauges, dump-size trend (log scale),
+    and restore-test recency to `backup-health.json`; fixed the "Active Backup Alerts" table to match on
+    `category=~"backup|disaster-recovery"` (was a name regex missing `ExternalBackupMissing`/`DbDump*`).
+  - **Threshold decision (owner, 2026-05-25):** `BtrfsPoolSpaceWarning` set to 15% (not 20%) so it does
+    not page on today's steady 19.8% free; `BtrfsPoolSpaceCritical` (<10%) escalates. Revisit if /mnt
+    usage climbs. All other new alerts verified to return 0 against live data.
+  - **Status: COMPLETE pending Urd PR #145 merge + first run** (then deploy/reload, honoring ordering).


### PR DESCRIPTION
Implements [Plan C: Backup & Dump Observability](docs/97-plans/2026-05-25-backup-observability.md), verified against live ground truth and coordinated with **Urd PR #145** (`feat/external-expected-and-pool-total`).

## ⚠️ Deploy ordering (read first)
`ExternalBackupMissing` now joins on Urd's new `backup_external_expected`. That series exists only **after Urd PR #145 is merged AND one `urd backup` run emits it**. Until then the join is empty and the alert is *fully suppressed* (real misses included).

**Merge order:** Urd #145 → run `urd backup` (confirm `backup_external_expected` + `backup_pool_total_bytes` in Prometheus) → merge + reload this. A break-glass fallback (`subvolume!="subvol6-tmp"`) is documented inline in `backup-alerts.yml` if you must ship earlier.

## What changed
**Alerts**
- `ExternalBackupMissing` → gated on `and on(subvolume) backup_external_expected == 1` (removes the lone live false positive: `subvol6-tmp`, local-only by design).
- **Fixed a dead alert:** `BtrfsPoolSpaceWarning` queried `mountpoint="/mnt/btrfs-pool"` → 0 series. Real mount is `/mnt`. Threshold set to 15% (pool is at 19.8% free / ~80% used — previously masked).
- New: `BtrfsPoolSpaceCritical` (/mnt <10%), `BackupPoolMetadataExhaustion` (>0.95), `BackupDestinationPoolSpace{Warning<15%,Critical<7%}` (offsite drive — node_exporter can't see it per ADR-023; uses Urd `backup_pool_total_bytes`), `DbDumpSizeAnomaly` (2× 14-day median AND >50 MiB, excl. prometheus).

**Dashboard** (`backup-health.json`): pool free-% + metadata gauges, dump-size trend (log), restore-test recency; fixed the "Active Backup Alerts" table to match `category=~"backup|disaster-recovery"` (was missing `ExternalBackupMissing`/`DbDump*`).

**ADR-021**: amended to register the two new Urd metrics as *consumed* + record deploy ordering and the source(node_exporter)/destination(Urd) split.

## Verification
- `promtool check rules` passes on all 4 rule files (no duplicate names).
- New alerts return **0** against live data (no false-fires); inert ones correctly inert until Urd emits.
- Dashboard JSON validates; 12 panels.

## Notes
- After fixing the dead `/mnt` alert, the data pool's real ~80%-used state is now visible (threshold tuned to 15% per owner so it doesn't page on steady state).
- Follow-up: deprecate legacy `backup_external_free_bytes` (ADR-105 coordinated change) — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)