### PR TITLE
docs: AUTO doc regen + backup-observability session journal

### DIFF
--- a/docs/98-journals/2026-05-25-backup-observability-cross-repo-urd.md
+++ b/docs/98-journals/2026-05-25-backup-observability-cross-repo-urd.md
@@ -1,0 +1,109 @@
+# Backup & Dump Observability — Cross-Repo Session with Urd (Plan C)
+
+**Date:** 2026-05-25
+**Context:** Execute [Plan C: Backup & Dump Observability](../97-plans/2026-05-25-backup-observability.md) —
+raise the signal quality of backup monitoring without bloat. Backups are produced by **Urd**, a
+separate repo (`~/projects/urd`), so part of the work had to be verified and implemented there and
+handed back. Shipped as PR #237 (`f6492f8`), coordinated with Urd PR #145 (v0.21.0).
+
+## What Was Done
+
+- **Verified ground truth before writing anything**, which overturned three plan assumptions (see
+  Lessons). Then implemented against reality, not the plan's stale framing.
+- **Alerts:** gated `ExternalBackupMissing` on Urd's new `backup_external_expected` (removes the lone
+  live false positive, `subvol6-tmp`); fixed a *dead* `BtrfsPoolSpaceWarning`; added
+  `BtrfsPoolSpaceCritical`, `BackupPoolMetadataExhaustion`, `BackupDestinationPoolSpace{Warning,Critical}`,
+  and `DbDumpSizeAnomaly`.
+- **Dashboard:** added pool free-% + metadata gauges, dump-size trend (log), restore-test recency to
+  `backup-health.json`; fixed the "Active Backup Alerts" table to match on `category` labels (it was
+  silently missing `ExternalBackupMissing` and `DbDump*`).
+- **Cross-repo:** authored a structured verification prompt for the Urd session; Urd implemented and
+  returned two new metrics (`backup_external_expected`, `backup_pool_total_bytes`); cross-checked their
+  ADR draft against mine and completed the ADR-021 contract tables.
+- **Deployed in order:** waited for Urd v0.21.0 + a real `urd backup` run (#88) to emit the series →
+  confirmed scrape → hot-reloaded Prometheus → **firing-alert count went from 1 to 0**, no rule errors.
+
+## Lessons Learned
+
+### On the monitoring itself
+
+- **Verify the *producer*, not just the metric name.** The plan said "read `btrfs-snapshot-backup.sh`
+  and have the backup script emit a label." That script has been disabled since the Urd cutover
+  (ADR-021); the real emitter is Urd writing `data/backup-metrics/backup.prom`. Editing the obvious
+  file would have changed nothing. **Trace a metric to its actual emitter before touching "the obvious
+  source."**
+- **A dead alert is worse than no alert — it's invisible failure wearing a green badge.**
+  `BtrfsPoolSpaceWarning` queried `mountpoint="/mnt/btrfs-pool"`; the real mountpoint is `/mnt`, so the
+  selector returned **zero series** and the rule had silently never fired. It had been masking a data
+  pool sitting at ~80% used. This rhymes with the plan's own cautionary tale (the `restore_test_*`
+  producer was dead for weeks). **An alert is only real if its selector returns data — confirm the
+  series exists, don't assume the rule's presence means coverage.**
+- **`promtool` proves syntax, live queries prove behavior.** Every new expression was run as an instant
+  query against Prometheus to confirm it returned 0 (no false-fire) *and*, for the fixed warning, the
+  one intended true-positive. `promtool check rules` would have passed a rule that never matches
+  anything — exactly the dead-alert failure mode.
+- **Reason explicitly about absent-metric behavior.** Because `backup_external_expected` is emitted
+  *only* as `1` (absent otherwise), the gated `… and on(subvolume) backup_external_expected == 1`
+  returns nothing until the series exists — which **fully suppresses** the alert, real misses included.
+  An alert that depends on a not-yet-live metric isn't "inert" by default; it can be silently
+  *suppressing*. Know which.
+
+### On working efficiently across repos
+
+- **Hand the owning repo a structured prompt, not a question.** The effective pattern was: (1) state
+  *my* observed ground truth so they could confirm/correct, (2) ask falsifiable, specific questions,
+  (3) request a defined output format, (4) explicitly invite them to implement if cheap. The Urd
+  session came back with not just answers but two merged metrics and an ADR draft. A vague "can you
+  check backups?" would have produced a fraction of that.
+- **Let structural boundaries pick your asks.** node_exporter *cannot* see the offsite drive (excluded
+  per ADR-023), so a destination free-% alert *must* get its total from Urd. Recognizing "who can
+  physically see what" is what separated the genuine cross-repo asks from things I could do locally.
+  Don't ask the other repo for what your side already has.
+- **The contract has two homes; cross-check both.** The interface lives in ADR-021 (consumer) *and*
+  Urd ADR-105 / CHANGELOG (producer). My amendment recorded the change in prose but left the canonical
+  ADR-021 tables reading stale ("Not yet consumed"); the Urd session's draft caught exactly that.
+  **A cross-repo doc change needs a round-trip — each side spots the staleness the other can't see.**
+- **Pin concrete refs in the handoff.** "Urd PR #145", "v0.21.0", "run #88" made the deploy interlock
+  actionable and auditable, versus "the new Urd version."
+- **Sequencing is a correctness property across repos.** "Merge Urd → run a real backup → confirm the
+  series scraped → *then* reload Prometheus" wasn't politeness; reversing it would have blinded a
+  data-loss-critical alert. Cross-repo ordering deserves the same rigor as a migration.
+
+### Meta
+
+- **Memory paid for itself.** `project_backup_system` (Urd is sole producer) and `reference_urd_project`
+  immediately flagged the plan's stale "edit the shell script" framing — a verification that would
+  otherwise have cost several wrong turns.
+
+## What These Tools Now Enable (Future)
+
+The new metrics aren't just alerts — they're a small capacity/health telemetry surface to build on:
+
+1. **Capacity forecasting & proactive drive rotation.** With `backup_pool_total_bytes` + `free_bytes` +
+   the existing `backup_subvolume_churn_bytes_per_second`, a `predict_linear` panel can estimate the
+   WD-18TB exhaustion date and trigger the offsite swap / retention tuning *before* it's urgent.
+   WD-18TB is already at 84% used — this is the highest-value next build, not a hypothetical.
+2. **Scheduled BTRFS metadata balance.** `backup_pool_metadata_utilization_ratio` (/mnt at 0.86) gives
+   the early signal to run a targeted `btrfs balance -m` *ahead* of the metadata-ENOSPC cliff, instead
+   of discovering it when snapshots start failing.
+3. **"Backups are restorable" as a first-class SLO.** The restore-test recency panel + the
+   `DbRestoreTestOverdue` guard turn restore freshness into a measurable objective — the direct
+   antidote to the silent-producer-death failure mode that bit us in May.
+4. **Dump-size anomaly as a cross-domain data-health canary.** A ballooning dump usually means an app
+   problem (runaway table, DB-logged spam) *before* the app alerts on itself. `DbDumpSizeAnomaly` is
+   cheap early warning for application data health, not just backup hygiene.
+5. **Headroom-aware retention.** Urd already emits `backup_subvolume_estimated_local_pinned_delta_bytes`
+   (UPI 044 seed). The homelab could surface "you have room to keep N more snapshots of X" — retention
+   tuning driven by data instead of guesswork.
+6. **Converge on the pool metrics.** Migrate dashboards/alerts off the legacy unlabeled
+   `backup_external_free_bytes` onto the labeled `backup_pool_*` family, then deprecate the legacy
+   series (coordinated ADR-105 change). One consistent capacity model across source and destination.
+
+## Next Steps
+
+- **Watch items (live, not firing):** WD-18TB 16.6% free (warn 15%), /mnt 19.8% free (warn 15%),
+  /mnt metadata 0.86 (exhaustion 0.95). The nearest signals — the alerts now exist to catch them.
+- **Highest-value follow-up:** the capacity-forecast panel (#1 above) for the offsite drive.
+- **Deferred:** deprecate `backup_external_free_bytes` (coordinated with Urd, ADR-105).
+- **Open from the plan's siblings:** Plan A (Prometheus metric diet) is the natural next monitoring
+  workstream; the `loki` dump ghost-series noticed here is likely one of its inputs.

--- a/docs/AUTO-DEPENDENCY-GRAPH.md
+++ b/docs/AUTO-DEPENDENCY-GRAPH.md
@@ -1,6 +1,6 @@
 # Service Dependency Graph (Auto-Generated)
 
-**Generated:** 2026-05-23 15:02:13 UTC
+**Generated:** 2026-05-25 05:00:59 UTC
 **System:** fedora-htpc
 
 ---

--- a/docs/AUTO-DOCUMENTATION-INDEX.md
+++ b/docs/AUTO-DOCUMENTATION-INDEX.md
@@ -1,7 +1,7 @@
 # Documentation Index (Auto-Generated)
 
-**Generated:** 2026-05-23 15:02:14 UTC
-**Total Documents:** 422
+**Generated:** 2026-05-25 05:01:00 UTC
+**Total Documents:** 436
 
 ---
 
@@ -179,7 +179,7 @@
 
 ---
 
-### 97-plans/ (33 documents)
+### 97-plans/ (38 documents)
 
 **Strategic plans and forward-looking projects**
 - 📋 [2025-01-08-unpoller-with-advanced-networks-monitoring-plan.md](97-plans/2025-01-08-unpoller-with-advanced-networks-monitoring-plan.md)
@@ -197,6 +197,11 @@
 - 📋 [2026-05-23-tier1-digest-pinning-and-update-deautomation.md](97-plans/2026-05-23-tier1-digest-pinning-and-update-deautomation.md)
 - 📋 [2026-05-23-tier2-build-input-and-repo-hardening.md](97-plans/2026-05-23-tier2-build-input-and-repo-hardening.md)
 - 📋 [2026-05-23-tier3-4-signatures-and-egress-detection-outline.md](97-plans/2026-05-23-tier3-4-signatures-and-egress-detection-outline.md)
+- 📋 [2026-05-24-tier3-signature-verification-deliberate-path.md](97-plans/2026-05-24-tier3-signature-verification-deliberate-path.md)
+- 📋 [2026-05-24-tier4-egress-detection.md](97-plans/2026-05-24-tier4-egress-detection.md)
+- 📋 [2026-05-25-backup-observability.md](97-plans/2026-05-25-backup-observability.md)
+- 📋 [2026-05-25-monitoring-metric-diet.md](97-plans/2026-05-25-monitoring-metric-diet.md)
+- 📋 [2026-05-25-slo-alert-coverage.md](97-plans/2026-05-25-slo-alert-coverage.md)
 - 📋 [ADR-REORGANIZATION-PLAN.md](97-plans/ADR-REORGANIZATION-PLAN.md)
 - 📋 [MIGRATION-PLAN-FINAL.md](97-plans/MIGRATION-PLAN-FINAL.md)
 - ✅ [PLAN-1-AUTO-UPDATE-SAFETY-NET.md](97-plans/PLAN-1-AUTO-UPDATE-SAFETY-NET.md)
@@ -218,7 +223,7 @@
 
 ---
 
-### 98-journals/ (218 documents)
+### 98-journals/ (219 documents)
 
 **Chronological project history (append-only log)**
 
@@ -226,7 +231,7 @@ Complete dated entries documenting the homelab journey. See directory for full c
 
 ---
 
-### 99-reports/ (52 documents)
+### 99-reports/ (54 documents)
 
 **Automated system reports and point-in-time snapshots**
 
@@ -242,20 +247,20 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 - 2026-05-22: [2026-04-22-ADR-027-forward-nocow-workloads-subvol8-db.md](00-foundation/decisions/2026-04-22-ADR-027-forward-nocow-workloads-subvol8-db.md)
 - 2026-05-22: [2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md](00-foundation/decisions/2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md)
 - 2026-05-23: [2026-05-23-ADR-030-container-supply-chain-trust-model.md](00-foundation/decisions/2026-05-23-ADR-030-container-supply-chain-trust-model.md)
+- 2026-05-25: [slo-framework.md](40-monitoring-and-documentation/guides/slo-framework.md)
+- 2026-05-23: [2026-05-23-adr030-tier1-execution-lessons-private.md](90-archive/2026-05-23-adr030-tier1-execution-lessons-private.md)
+- 2026-05-24: [2026-05-23-adr030-tier2-execution-private.md](90-archive/2026-05-23-adr030-tier2-execution-private.md)
+- 2026-05-23: [2026-05-23-supply-chain-trust-model-adr030-private.md](90-archive/2026-05-23-supply-chain-trust-model-adr030-private.md)
+- 2026-05-24: [2026-05-24-adr030-tier3-execution-private.md](90-archive/2026-05-24-adr030-tier3-execution-private.md)
+- 2026-05-24: [2026-05-24-restore-test-tmpfs-and-dead-dr-metric.md](90-archive/2026-05-24-restore-test-tmpfs-and-dead-dr-metric.md)
 - 2026-05-23: [2026-05-23-tier1-digest-pinning-and-update-deautomation.md](97-plans/2026-05-23-tier1-digest-pinning-and-update-deautomation.md)
 - 2026-05-23: [2026-05-23-tier2-build-input-and-repo-hardening.md](97-plans/2026-05-23-tier2-build-input-and-repo-hardening.md)
-- 2026-05-23: [2026-05-23-tier3-4-signatures-and-egress-detection-outline.md](97-plans/2026-05-23-tier3-4-signatures-and-egress-detection-outline.md)
-- 2026-05-18: [2026-05-15-audit-backlog-drift-and-observability-deployment.md](98-journals/2026-05-15-audit-backlog-drift-and-observability-deployment.md)
-- 2026-05-18: [2026-05-18-audit-subsystem-hardening-private.md](98-journals/2026-05-18-audit-subsystem-hardening-private.md)
-- 2026-05-18: [2026-05-18-security-audit-and-drift-cleanup-private.md](98-journals/2026-05-18-security-audit-and-drift-cleanup-private.md)
-- 2026-05-21: [2026-05-21-pihole-dns-and-adr018-investigation-handoff.md](98-journals/2026-05-21-pihole-dns-and-adr018-investigation-handoff.md)
-- 2026-05-22: [2026-05-22-db-storage-three-tier-and-dump-backbone-phase-a.md](98-journals/2026-05-22-db-storage-three-tier-and-dump-backbone-phase-a.md)
-- 2026-05-23: [2026-05-23-supply-chain-trust-model-adr030-private.md](98-journals/2026-05-23-supply-chain-trust-model-adr030-private.md)
-- 2026-05-23: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
-- 2026-05-23: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
-- 2026-05-23: [AUTO-IMAGE-PIN-INDEX.md](AUTO-IMAGE-PIN-INDEX.md)
-- 2026-05-23: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
-- 2026-05-23: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
+- 2026-05-24: [2026-05-23-tier3-4-signatures-and-egress-detection-outline.md](97-plans/2026-05-23-tier3-4-signatures-and-egress-detection-outline.md)
+- 2026-05-24: [2026-05-24-tier3-signature-verification-deliberate-path.md](97-plans/2026-05-24-tier3-signature-verification-deliberate-path.md)
+- 2026-05-24: [2026-05-24-tier4-egress-detection.md](97-plans/2026-05-24-tier4-egress-detection.md)
+- 2026-05-25: [2026-05-25-backup-observability.md](97-plans/2026-05-25-backup-observability.md)
+- 2026-05-25: [2026-05-25-monitoring-metric-diet.md](97-plans/2026-05-25-monitoring-metric-diet.md)
+- 2026-05-25: [2026-05-25-slo-alert-coverage.md](97-plans/2026-05-25-slo-alert-coverage.md)
 
 ---
 

--- a/docs/AUTO-EGRESS-BASELINE-INDEX.md
+++ b/docs/AUTO-EGRESS-BASELINE-INDEX.md
@@ -1,6 +1,6 @@
 # Egress Observatory — Baseline Index (Auto-Generated)
 
-**Generated:** 2026-05-24 14:14:07 UTC
+**Generated:** 2026-05-25 05:01:01 UTC
 **Implements:** ADR-030 P7 (Tier 4) — egress detection. **Mode:** shadow (observe-only)
 
 Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers (attributable, rootless, scratch-safe, DNS-method-agnostic). Detection, not prevention. See `config/supply-chain/known-egress.md` for method and residual/evasion scope.
@@ -9,32 +9,32 @@ Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers
 
 | Component | Last run | Detail |
 |---|---|---|
-| Collector (`egress-collector.service`) | 27s ago | 21 services sampled |
-| Classifier (`egress-detect.timer`) | 2m ago | mode=shadow (observe-only); last window 3 dest(s) |
+| Collector (`egress-collector.service`) | 28s ago | 21 services sampled |
+| Classifier (`egress-detect.timer`) | 8m ago | mode=shadow (observe-only); last window 9 dest(s) |
 
 ## Per-service egress
 
 | Service | Mode | Public dests | Unexpected | Peers (swarm) |
 |---|---|---|---|---|
-| alert-discord-relay | classify | — | — | — |
+| alert-discord-relay | classify | 1 | 1 (unarmed) | — |
 | alertmanager | classify | — | — | — |
 | audiobookshelf | classify | — | — | — |
 | authelia | classify | — | — | — |
-| crowdsec | classify | — | — | — |
+| crowdsec | classify | 10 | 10 (unarmed) | — |
 | forgejo | classify | — | — | — |
 | gathio | classify | — | — | — |
-| grafana | classify | — | — | — |
-| home-assistant | classify | 3 | 3 (unarmed) | — |
+| grafana | classify | 1 | 1 (unarmed) | — |
+| home-assistant | classify | 12 | 12 (unarmed) | — |
 | homepage | classify | — | — | — |
-| immich-server | classify | — | — | — |
-| jellyfin | classify | — | — | — |
-| loki | classify | — | — | — |
-| navidrome | classify | — | — | — |
+| immich-server | classify | 2 | 2 (unarmed) | — |
+| jellyfin | classify | 4 | 4 (unarmed) | — |
+| loki | classify | 1 | 1 (unarmed) | — |
+| navidrome | classify | 1 | 1 (unarmed) | — |
 | nextcloud | classify | — | — | — |
 | prometheus | classify | — | — | — |
-| proton-bridge | classify | 1 | 1 (unarmed) | — |
-| qbittorrent | peer-swarm (count-only) | — | — | 136 |
-| traefik | classify | — | — | — |
+| proton-bridge | classify | 2 | 2 (unarmed) | — |
+| qbittorrent | peer-swarm (count-only) | — | — | 137 |
+| traefik | classify | 2 | 2 (unarmed) | — |
 | unpoller | classify | — | — | — |
 | vaultwarden | classify | — | — | — |
 
@@ -42,23 +42,95 @@ Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers
 
 Egress-tier services with **no observed public destination** over the window. Each is a candidate to move to an `Internal=true` network (shrinking the surface Tier 4 watches). **Not an automated change** — manual, per-service review (Feb-2026 21-container outage precedent). A short window will list services that simply hadn't egressed yet (e.g. proton-bridge in `TIME_WAIT`); confirm against a full ≥7-day baseline before acting.
 
-> alert-discord-relay, alertmanager, audiobookshelf, authelia, crowdsec, forgejo, gathio, grafana, homepage, immich-server, jellyfin, loki, navidrome, nextcloud, prometheus, traefik, unpoller, vaultwarden
+> alertmanager, audiobookshelf, authelia, forgejo, gathio, homepage, nextcloud, prometheus, unpoller, vaultwarden
 
 ## Observed destinations (durable state)
+
+### alert-discord-relay
+
+| Destination | Port | Class | First seen | Last seen | Obs |
+|---|---|---|---|---|---|
+| `162.159.135.232` | 443 | ⚠️ unexpected | 13h ago | 9h ago | 4 |
+
+### crowdsec
+
+| Destination | Port | Class | First seen | Last seen | Obs |
+|---|---|---|---|---|---|
+| `108.128.222.234` | 443 | ⚠️ unexpected | 12h ago | 8m ago | 48 |
+| `18.200.183.204` | 443 | ⚠️ unexpected | 14h ago | 92m ago | 56 |
+| `34.250.77.39` | 443 | ⚠️ unexpected | 13h ago | 3h ago | 47 |
+| `34.255.59.56` | 443 | ⚠️ unexpected | 9h ago | 2h ago | 20 |
+| `52.17.58.50` | 443 | ⚠️ unexpected | 71m ago | 71m ago | 5 |
+| `52.30.5.78` | 443 | ⚠️ unexpected | 8h ago | 2h ago | 27 |
+| `54.77.8.107` | 443 | ⚠️ unexpected | 10h ago | 29m ago | 44 |
+| `63.34.141.128` | 443 | ⚠️ unexpected | 10h ago | 2h ago | 12 |
+| `63.35.22.155` | 443 | ⚠️ unexpected | 14h ago | 8h ago | 15 |
+| `79.125.15.38` | 443 | ⚠️ unexpected | 13h ago | 2h ago | 30 |
+
+### grafana
+
+| Destination | Port | Class | First seen | Last seen | Obs |
+|---|---|---|---|---|---|
+| `34.120.177.193` | 443 | ⚠️ unexpected | 14h ago | 8m ago | 439 |
 
 ### home-assistant
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `18.184.210.208` | 8883 | ⚠️ unexpected | 6m ago | 2m ago | 10 |
-| `3.124.29.182` | 443 | ⚠️ unexpected | 2m ago | 2m ago | 1 |
-| `3.67.142.130` | 443 | ⚠️ unexpected | 6m ago | 6m ago | 1 |
+| `104.26.4.238` | 443 | ⚠️ unexpected | 11h ago | 5h ago | 2 |
+| `104.26.5.238` | 443 | ⚠️ unexpected | 14h ago | 2h ago | 3 |
+| `151.101.1.195` | 443 | ⚠️ unexpected | 8h ago | 8h ago | 3 |
+| `157.249.81.141` | 443 | ⚠️ unexpected | 10h ago | 29m ago | 5 |
+| `18.184.210.208` | 8883 | ⚠️ unexpected | 14h ago | 3h ago | 1297 |
+| `18.198.195.194` | 8883 | ⚠️ unexpected | 3h ago | 8m ago | 419 |
+| `3.124.29.182` | 443 | ⚠️ unexpected | 14h ago | 8m ago | 61 |
+| `3.125.66.145` | 443 | ⚠️ unexpected | 14h ago | 8m ago | 70 |
+| `3.67.142.130` | 443 | ⚠️ unexpected | 14h ago | 8m ago | 56 |
+| `52.29.210.73` | 443 | ⚠️ unexpected | 14h ago | 8m ago | 68 |
+| `52.57.174.242` | 443 | ⚠️ unexpected | 14h ago | 19m ago | 70 |
+| `63.181.74.73` | 443 | ⚠️ unexpected | 14h ago | 19m ago | 65 |
+
+### immich-server
+
+| Destination | Port | Class | First seen | Last seen | Obs |
+|---|---|---|---|---|---|
+| `104.21.71.92` | 443 | ⚠️ unexpected | 12h ago | 8m ago | 14 |
+| `172.67.170.79` | 443 | ⚠️ unexpected | 14h ago | 71m ago | 19 |
+
+### jellyfin
+
+| Destination | Port | Class | First seen | Last seen | Obs |
+|---|---|---|---|---|---|
+| `104.17.207.5` | 443 | ⚠️ unexpected | 13h ago | 13h ago | 5 |
+| `165.227.169.147` | 443 | ⚠️ unexpected | 13h ago | 13h ago | 5 |
+| `178.105.98.131` | 443 | ⚠️ unexpected | 13h ago | 13h ago | 3 |
+| `68.183.204.194` | 443 | ⚠️ unexpected | 13h ago | 13h ago | 1 |
+
+### loki
+
+| Destination | Port | Class | First seen | Last seen | Obs |
+|---|---|---|---|---|---|
+| `34.96.126.106` | 443 | ⚠️ unexpected | 14h ago | 2h ago | 19 |
+
+### navidrome
+
+| Destination | Port | Class | First seen | Last seen | Obs |
+|---|---|---|---|---|---|
+| `209.141.42.198` | 443 | ⚠️ unexpected | 13h ago | 13h ago | 3 |
 
 ### proton-bridge
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `185.70.42.41` | 443 | ⚠️ unexpected | 6m ago | 2m ago | 7 |
+| `185.70.42.41` | 443 | ⚠️ unexpected | 14h ago | 8m ago | 468 |
+| `185.70.42.45` | 443 | ⚠️ unexpected | 13h ago | 5h ago | 13 |
+
+### traefik
+
+| Destination | Port | Class | First seen | Last seen | Obs |
+|---|---|---|---|---|---|
+| `13.39.208.199` | 443 | ⚠️ unexpected | 14h ago | 14h ago | 3 |
+| `140.82.121.6` | 443 | ⚠️ unexpected | 14h ago | 14h ago | 1 |
 
 ---
 

--- a/docs/AUTO-IMAGE-PIN-INDEX.md
+++ b/docs/AUTO-IMAGE-PIN-INDEX.md
@@ -1,6 +1,6 @@
 # Container Image Pin Index (Auto-Generated)
 
-**Generated:** 2026-05-24 11:54:03 UTC
+**Generated:** 2026-05-25 05:01:00 UTC
 **Source:** `/home/patriark/containers/quadlets` — ADR-030 (Container Supply-Chain Trust Model)
 
 Pins live in each quadlet's `Image=` line (where Podman reads them); this is
@@ -32,7 +32,7 @@ For local builds the `Digest` column shows the **base image** pin (FROM …@sha2
 |---------|--------|--------|------------|-----|--------|------|-------------|
 | alert-discord-relay | yes | 🔨 base-pinned | `localhost/alert-discord-relay` | latest | `sha256:a3ab0b966bc4…` | no | n/a (Tier 2) |
 | alertmanager | yes | 🔒 pinned | `quay.io/prometheus/alertmanager` | latest | `sha256:51a825c2a40a…` | no | — unsigned |
-| audiobookshelf | yes | 🔒 pinned | `ghcr.io/advplyr/audiobookshelf` | latest | `sha256:4143292c530f…` | no | — unsigned |
+| audiobookshelf | yes | 🔒 pinned | `ghcr.io/advplyr/audiobookshelf` | 2.35.0 | `sha256:89276ff2e0b3…` | no | — unsigned |
 | authelia | yes | 🔒 pinned | `docker.io/authelia/authelia` | latest | `sha256:0c824dcab1ae…` | no | — unsigned |
 | cadvisor | no | 🔒 pinned | `gcr.io/cadvisor/cadvisor` | latest | `sha256:3de2bd520312…` | no | — unsigned |
 | crowdsec | yes | 🔒 pinned | `docker.io/crowdsecurity/crowdsec` | latest | `sha256:2f527c9bb8b3…` | no | — unsigned |

--- a/docs/AUTO-NETWORK-TOPOLOGY.md
+++ b/docs/AUTO-NETWORK-TOPOLOGY.md
@@ -1,6 +1,6 @@
 # Network Topology (Auto-Generated)
 
-**Generated:** 2026-05-23 15:02:08 UTC
+**Generated:** 2026-05-25 05:00:53 UTC
 **System:** fedora-htpc | **Networks:** 11 | **Containers:** 36
 
 ---

--- a/docs/AUTO-SERVICE-CATALOG.md
+++ b/docs/AUTO-SERVICE-CATALOG.md
@@ -1,6 +1,6 @@
 # Service Catalog (Auto-Generated)
 
-**Generated:** 2026-05-23 15:02:07 UTC
+**Generated:** 2026-05-25 05:00:53 UTC
 **System:** fedora-htpc | **Services:** 36/36 running | **Health:** 32/32 healthy (4 without healthcheck)
 
 ---
@@ -9,87 +9,87 @@
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| audiobookshelf | advplyr/audiobookshelf@sha256:4143292c530f6ac | ✅ healthy | 6m | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
-| forgejo | codeberg.org/forgejo/forgejo:15 | ✅ healthy | 42h | [git.patriark.org](https://git.patriark.org) | — |
-| forgejo-db | postgres:16-alpine | ✅ healthy | 42h | — | — |
-| navidrome | deluan/navidrome@sha256:9fa40b3d8dec43ceb2213 | ✅ healthy | 7m | [musikk.patriark.org](https://musikk.patriark.org) | — |
-| postgres-exporter | quay.io/prometheuscommunity/postgres-exporter | ✅ healthy | 11m | — | — |
-| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | 9d | — | — |
-| qbittorrent | linuxserver/qbittorrent@sha256:f76c4363cce083 | ✅ healthy | 5m | [torrent.patriark.org](https://torrent.patriark.org) | — |
-| redis-authelia-exporter | quay.io/oliver006/redis_exporter@sha256:e8c20 | — no check | 10m | — | — |
-| redis-immich-exporter | quay.io/oliver006/redis_exporter@sha256:e8c20 | — no check | 10m | — | — |
-| unifi-syslog | linuxserver/syslog-ng@sha256:0d164e438d1f9ee4 | ✅ healthy | 10m | — | — |
+| audiobookshelf | advplyr/audiobookshelf@sha256:89276ff2e0b3d2f | ✅ healthy | 10h | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
+| forgejo | codeberg.org/forgejo/forgejo:15 | ✅ healthy | 3d | [git.patriark.org](https://git.patriark.org) | — |
+| forgejo-db | postgres:16-alpine | ✅ healthy | 3d | — | — |
+| navidrome | deluan/navidrome@sha256:9fa40b3d8dec43ceb2213 | ✅ healthy | 38h | [musikk.patriark.org](https://musikk.patriark.org) | — |
+| postgres-exporter | quay.io/prometheuscommunity/postgres-exporter | ✅ healthy | 38h | — | — |
+| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | 13h | — | — |
+| qbittorrent | linuxserver/qbittorrent@sha256:f76c4363cce083 | ✅ healthy | 38h | [torrent.patriark.org](https://torrent.patriark.org) | — |
+| redis-authelia-exporter | quay.io/oliver006/redis_exporter@sha256:e8c20 | — no check | 38h | — | — |
+| redis-immich-exporter | quay.io/oliver006/redis_exporter@sha256:e8c20 | — no check | 38h | — | — |
+| unifi-syslog | linuxserver/syslog-ng@sha256:0d164e438d1f9ee4 | ✅ healthy | 38h | — | — |
 
 ## Core Infrastructure (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| authelia | authelia/authelia@sha256:0c824dcab1ae97c56bf6 | ✅ healthy | 41m | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
-| crowdsec | crowdsecurity/crowdsec@sha256:2f527c9bb8b3671 | ✅ healthy | 41m | — | [guide](10-services/guides/crowdsec.md) |
-| redis-authelia | redis:7-alpine | ✅ healthy | 9d | — | — |
-| traefik | traefik@sha256:6b9cbca6fac42ab0075f5437d8dc16 | ✅ healthy | 40m | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
+| authelia | authelia/authelia@sha256:0c824dcab1ae97c56bf6 | ✅ healthy | 39h | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
+| crowdsec | crowdsecurity/crowdsec@sha256:2f527c9bb8b3671 | ✅ healthy | 39h | — | [guide](10-services/guides/crowdsec.md) |
+| redis-authelia | redis:7-alpine | ✅ healthy | 11d | — | — |
+| traefik | traefik@sha256:6b9cbca6fac42ab0075f5437d8dc16 | ✅ healthy | 39h | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
 
 ## Nextcloud (3)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| nextcloud-db | mariadb:11 | ✅ healthy | 9d | — | [guide](10-services/guides/nextcloud.md) |
-| nextcloud | nextcloud:33 | ✅ healthy | 9d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
-| nextcloud-redis | redis:7-alpine | ✅ healthy | 8d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-db | mariadb:11 | ✅ healthy | 11d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud | nextcloud:33 | ✅ healthy | 11d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-redis | redis:7-alpine | ✅ healthy | 9d | — | [guide](10-services/guides/nextcloud.md) |
 
 ## Immich (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| immich-ml | immich-app/immich-machine-learning:v2.7.5 | ✅ healthy | 9d | — | [guide](10-services/guides/immich.md) |
-| immich-server | immich-app/immich-server:v2.7.5 | ✅ healthy | 9d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
-| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3-pgvec | ✅ healthy | 9d | — | — |
-| redis-immich | valkey/valkey:latest | ✅ healthy | 9d | — | — |
+| immich-ml | immich-app/immich-machine-learning:v2.7.5 | ✅ healthy | 11d | — | [guide](10-services/guides/immich.md) |
+| immich-server | immich-app/immich-server:v2.7.5 | ✅ healthy | 11d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
+| postgresql-immich | immich-app/postgres:14-vectorchord0.4.3-pgvec | ✅ healthy | 11d | — | — |
+| redis-immich | valkey/valkey:latest | ✅ healthy | 11d | — | — |
 
 ## Jellyfin (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| jellyfin | jellyfin/jellyfin@sha256:1694ff069f0c9dafb283 | ✅ healthy | 5m | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
+| jellyfin | jellyfin/jellyfin@sha256:1694ff069f0c9dafb283 | ✅ healthy | 38h | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
 
 ## Vaultwarden (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| vaultwarden | vaultwarden/server:latest | ✅ healthy | 9d | [vault.patriark.org](https://vault.patriark.org) | — |
+| vaultwarden | vaultwarden/server:latest | ✅ healthy | 11d | [vault.patriark.org](https://vault.patriark.org) | — |
 
 ## Home Automation (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 9d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
+| home-assistant | home-assistant/home-assistant:stable | ✅ healthy | 11d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
 
 ## Gathio (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| gathio-db | mongo:7 | ✅ healthy | 9d | — | — |
-| gathio | lowercasename/gathio:latest | ✅ healthy | 9d | [events.patriark.org](https://events.patriark.org) | — |
+| gathio-db | mongo:7 | ✅ healthy | 11d | — | — |
+| gathio | lowercasename/gathio:latest | ✅ healthy | 11d | [events.patriark.org](https://events.patriark.org) | — |
 
 ## Homepage (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| homepage | gethomepage/homepage@sha256:d8d784e5090111b6e | ✅ healthy | 9m | [patriark.org](https://patriark.org) | — |
+| homepage | gethomepage/homepage@sha256:d8d784e5090111b6e | ✅ healthy | 38h | [patriark.org](https://patriark.org) | — |
 
 ## Monitoring (9)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| alert-discord-relay | localhost/alert-discord-relay:latest | ✅ healthy | 9d | — | [guide](10-services/guides/alert-discord-relay.md) |
-| alertmanager | quay.io/prometheus/alertmanager@sha256:51a825 | ✅ healthy | 9m | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| cadvisor | gcr.io/cadvisor/cadvisor@sha256:3de2bd5203120 | ✅ healthy | 13m | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| grafana | grafana/grafana@sha256:2d1f9ae67c1778d33e291d | ✅ healthy | 8m | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| loki | grafana/loki:latest | — no check | 25h | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| node_exporter | quay.io/prometheus/node-exporter@sha256:0f422 | ✅ healthy | 12m | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| prometheus | quay.io/prometheus/prometheus:latest | ✅ healthy | 26h | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| promtail | grafana/promtail@sha256:6cfa64ec432b24a912d64 | ✅ healthy | 10m | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| unpoller | unpoller/unpoller@sha256:bf7bdcc59fcdaa469968 | — no check | 9m | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| alert-discord-relay | localhost/alert-discord-relay:2026-05-23 | ✅ healthy | 6h | — | [guide](10-services/guides/alert-discord-relay.md) |
+| alertmanager | quay.io/prometheus/alertmanager@sha256:51a825 | ✅ healthy | 38h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| cadvisor | gcr.io/cadvisor/cadvisor@sha256:3de2bd5203120 | ✅ healthy | 38h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| grafana | grafana/grafana@sha256:2d1f9ae67c1778d33e291d | ✅ healthy | 38h | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| loki | grafana/loki@sha256:191d4fdfb7264f16989f0a57f | — no check | 6h | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| node_exporter | quay.io/prometheus/node-exporter@sha256:0f422 | ✅ healthy | 38h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| prometheus | quay.io/prometheus/prometheus@sha256:c0b857ae | ✅ healthy | 6h | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| promtail | grafana/promtail@sha256:6cfa64ec432b24a912d64 | ✅ healthy | 38h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| unpoller | unpoller/unpoller@sha256:bf7bdcc59fcdaa469968 | — no check | 38h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
 
 ---
 
@@ -97,7 +97,7 @@
 
 - **Total Running:** 36
 - **Total Defined:** 36
-- **System Load:** 3,29, 2,31, 1,69
+- **System Load:** 2,27, 1,33, 1,38
 
 ---
 


### PR DESCRIPTION
Documentation-only follow-up to PR #237 (Plan C backup & dump observability).

## Contents
- **AUTO doc regeneration** — refreshes the auto-generated set to current state: service catalog, network topology, dependency graph, and the documentation / egress-baseline / image-pin indexes.
- **Session journal** — `docs/98-journals/2026-05-25-backup-observability-cross-repo-urd.md`. Records the Plan C work with emphasis on:
  - **Lessons learned** — verify the *producer* not the metric; a dead alert is invisible failure; promtool proves syntax, live queries prove behaviour; reason about absent-metric *suppression*.
  - **Cross-repo workflow** — structured verification prompts, letting structural boundaries pick the asks, two-homed contracts, pinning concrete refs, sequencing as a correctness property.
  - **Future directions** — capacity forecasting for the offsite drive, scheduled BTRFS metadata balance, a "backups are restorable" SLO, dump-size anomaly as a data-health canary.

No code or config changes; alerts/dashboard already shipped in #237.

🤖 Generated with [Claude Code](https://claude.com/claude-code)