### PR TITLE
feat(dns): ADR-031 resolver first-class + HA — Phase 0 alert-path fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ See ADR-030 (trust model) and ADR-015 (superseded; its BTRFS rollback + health-v
 
 ### Architecture Decision Records
 
-**Architectural decisions recorded as ADRs — latest is ADR-030** (see `docs/*/decisions/` for full details; number new ADRs sequentially from the latest)
+**Architectural decisions recorded as ADRs — latest is ADR-031** (see `docs/*/decisions/` for full details; number new ADRs sequentially from the latest)
 
 **Design-Guiding ADRs (affect future decisions):**
 - **ADR-001:** Rootless Containers — UID 1000, `:Z` SELinux labels on all mounts
@@ -114,6 +114,7 @@ See ADR-030 (trust model) and ADR-015 (superseded; its BTRFS rollback + health-v
 - **ADR-019:** Filesystem Permission Model — POSIX ACLs for container access
 - **ADR-021:** Urd Backup Tool — Rust-based BTRFS Time Machine replaces shell script (supersedes ADR-020 implementation)
 - **ADR-030:** Container Supply-Chain Trust Model — digest pinning, deliberate (de-automated) updates, cooling-off interval, graduated signature verification (supersedes ADR-015 trust model)
+- **ADR-031:** DNS Resolver First-Class & HA — redundancy-before-monitoring, active/passive keepalived VIP, alert-path resolver must be independent of the monitored resolver, resolver managed-as-code + SSO admin (status: Accepted, implementation phased)
 
 Check if an ADR exists before proposing changes. Reference the ADR and explain what changed if suggesting alternatives. New decisions get new ADRs (don't edit existing ones).
 

--- a/docs/00-foundation/decisions/2026-05-25-ADR-031-dns-resolver-first-class-and-ha.md
+++ b/docs/00-foundation/decisions/2026-05-25-ADR-031-dns-resolver-first-class-and-ha.md
@@ -1,0 +1,215 @@
+# ADR-031: DNS Resolver — First-Class Integration & High Availability
+
+**Date:** 2026-05-25
+**Status:** Accepted (implementation phased — see `docs/97-plans/2026-05-25-pihole-resolver-first-class-and-ha.md`)
+
+---
+
+## Context
+
+The Raspberry Pi at `192.168.1.69` runs Pi-hole + unbound and is the **sole recursive
+resolver for the entire LAN**. It is simultaneously the most load-bearing device in the
+homelab and the least integrated into it:
+
+- Administered over **unauthenticated HTTP** (`http://192.168.1.69/admin`) — no TLS, no SSO.
+- Managed by **ad-hoc SSH** from whichever workstation is reachable (MacBook address drifts;
+  workhorse at `.71`).
+- **Not in Git** (no config-as-code), **not backed up by Urd**, **not scraped by Prometheus**,
+  **no redundancy**.
+
+It fails the implicit service contract that every containerised service in this homelab already
+meets. A "first-class citizen" here means meeting that contract across six dimensions:
+**redundancy, observability, managed-as-code, a secured admin plane, backed-up state, and
+deliberate updates.**
+
+### The finding that orders the work (recon 2026-05-25)
+
+The DNS resolver sits *beneath* the monitoring/alerting plane, so **its outage hides its own
+alarm.** Measured, not assumed:
+
+- `alertmanager` and `alert-discord-relay` resolve via `DNS=192.168.1.69` with **no fallback**.
+- The host `/etc/resolv.conf` and both container networks (`reverse_proxy`, `monitoring`) point
+  **only** at `.69`.
+- Therefore, if the Pi dies, Alertmanager **cannot resolve `discord.com`** to report that it died.
+  The failure is **self-masking** — the smoke detector is wired to the same fuse as the fire.
+
+This is why **redundancy must precede monitoring**: monitoring a self-masking single point of
+failure reports the outage at the same moment it causes it. Redundancy is the actual fix;
+monitoring then tells you "one node is down, fix it at leisure" while resolution continues.
+
+### Favourable constraints already in place
+
+- **Prometheus can already reach the Pi directly** — it sits on `reverse_proxy` (10.89.2.79, LAN
+  egress) *and* `monitoring`. No new scrape pathway is needed.
+- **UnPoller already establishes the pattern** for monitoring an external LAN device (dual-network:
+  `reverse_proxy` to reach the device, `monitoring` to be scraped by Prometheus).
+- **`blackbox_exporter` is already a documented monitoring gap** — its DNS probe is the natural
+  primary signal for this work.
+- **DHCP is served by the UDM Pro, not Pi-hole** — so the resolvers can be **DNS-only**, which
+  keeps high-availability failover simple (no DHCP failover to engineer).
+
+## Decision
+
+Elevate the LAN resolver to a first-class, redundant, observable, secured homelab service via the
+decisions below. Concrete sequencing lives in the implementation plan; this ADR is the contract.
+
+### D1 — Redundancy precedes monitoring; HA is active/passive, not load-balanced
+
+Two Pi-hole + unbound nodes with **identical config**, fronted by a **keepalived VRRP Virtual IP**
+(e.g. `192.168.1.53`). Whichever node is MASTER holds the VIP; on failure the BACKUP claims it
+within seconds, transparently to clients. DHCP (on the UDM) hands out the **VIP as primary DNS plus
+both real node IPs as secondaries** (defence in depth).
+
+Active/active load-balancing is **rejected**: at homelab query volumes it buys nothing while
+splitting query logs/stats across nodes and complicating the failure model. Active/passive with a
+fast VIP gives the "takes over duties" behaviour cleanly. Resolvers are **DNS-only** (DHCP stays on
+the UDM).
+
+### D2 — The alert/egress path must not depend on the monitored resolver
+
+The alert-delivery containers (`alertmanager`, `alert-discord-relay`), the host resolver, and the
+container network defaults are configured with a resolver fallback **independent of any single
+node**:
+
+- **End state:** VIP primary + both node IPs as secondaries (stays filtered *and* redundant).
+- **Interim** (before the second node exists): a public resolver (e.g. `9.9.9.9`) as
+  **secondary only** — removes the dead-man's-switch immediately while primary stays Pi-hole.
+
+A failure that takes out DNS must still be able to phone home.
+
+### D3 — The resolver is managed as code, not hand-administered
+
+Pi-hole, unbound, keepalived, and node-level settings are provisioned by an **idempotent Ansible
+playbook** — the non-quadlet equivalent of "in Git, reproducible." The playbook is the mechanism
+that makes the second node an *exact twin* and any node rebuildable from a dead SD card. Sanitised
+configs are committed; secrets stay out of Git.
+
+### D4 — The admin plane is secured and centralised — never raw HTTP, never internet-exposed
+
+The Pi-hole admin UI is fronted by **Traefik** (TLS termination + **Authelia SSO** + a
+**LAN/WireGuard IP-allowlist** middleware) with **no public DNS record** (split-horizon). Routing
+is defined in `config/traefik/dynamic/routers.yml` per **ADR-016**, never in container labels. This
+converts today's unauthenticated-over-HTTP admin into SSO-gated HTTPS while structurally preventing
+internet exposure.
+
+### D5 — Observability is layered, and the primary signal is functional, not liveness
+
+Three layers, reusing the UnPoller pattern:
+
+- **`node_exporter`** on each node — host/hardware health (temperature throttling, SD/disk wear,
+  uptime), scraped directly by Prometheus.
+- **`pihole-exporter`** (host-side container, dual-network like UnPoller; requires a Pi-hole v6 API
+  token) — query / block / client statistics.
+- **`blackbox_exporter`** with a **DNS probe module** — performs a *real* query against the VIP and
+  each node and validates the answer. **This is the primary alert source.** A wedged-but-running
+  resolver passes liveness and fails the functional probe: *"process up" ≠ "DNS answering
+  correctly."*
+
+Alerts: per-node down, blackbox DNS-probe failure (per node + VIP), VIP-failover event, node
+temperature/disk. Grafana dashboards added.
+
+### D6 — Config replication and log centralisation are distinct mechanisms
+
+The owner's "syncs configs and logs" requirement is satisfied by **two independent paths**, not one
+tool:
+
+- **Config** (adlists, allow/deny, local DNS records) replicates primary→replica via
+  **`nebula-sync`** — the Pi-hole **v6** successor to the now-defunct Gravity Sync. *(Confirm the
+  Pi-hole major version first; tooling differs for v5.)*
+- **Logs** centralise separately into **Loki** (Promtail/syslog from each node into the existing
+  `syslog` path), giving unified query history alongside every other service.
+
+### D7 — DNS is enforced at the perimeter
+
+The UDM blocks outbound port 53 and known DoH endpoints from all client VLANs **except the resolver
+nodes**, forcing all DNS through Pi-hole. This is both a security control and the **structural fix
+for the browser-DoH bypass class** that produced the 2026-05-21 "nothing blocked" symptom (resolved
+tactically via the Vivaldi secure-DNS toggle; this makes it un-bypassable).
+
+### D8 — The resolver inherits the homelab's backup and update discipline
+
+A nightly Pi-hole Teleporter/config export is rsynced into an **Urd-snapshotted** host directory,
+bringing the resolver into the existing backup system (ADR-021 / ADR-029). Pi-hole / unbound / OS
+updates follow the **deliberate, reviewed cadence** in the spirit of ADR-030 (no unattended upgrades
+on load-bearing infrastructure), documented as a runbook.
+
+### Hardware constraint
+
+A resolver must be on **wired Ethernet** with a DHCP reservation (or static IP). Wi-Fi is rejected
+for this role — the owner has already observed Wi-Fi address drift, and a resolver on Wi-Fi is a
+recurring-outage source. This rules out Wi-Fi-only boards (e.g. Pi Zero 2 W) for the second node
+unless given wired Ethernet via USB; a wired Pi (3B+/4/5) is preferred.
+
+## Consequences
+
+### Positive
+
+- The DNS single point of failure is removed; the alert path survives a resolver outage.
+- The resolver becomes reproducible (Ansible), observable (3-layer + functional probe), backed-up
+  (Urd), and SSO-secured (Traefik) — it finally meets the service contract.
+- The DoH bypass class is closed at the perimeter.
+- The second node also mitigates SD-card failure (the dominant Pi hardware failure mode).
+
+### Negative
+
+- Two devices to maintain instead of one; keepalived + nebula-sync are new moving parts.
+- The Ansible playbook is upfront effort before the redundancy payoff lands.
+- Perimeter DNS lockdown (D7) can break a device that hardcodes a public resolver — mitigated with a
+  scoped allow exception.
+
+### Risks
+
+- **VRRP split-brain** (both nodes claim the VIP) if priorities/auth are misconfigured — mitigated
+  with authenticated VRRP, correct MASTER/BACKUP priorities, and alerting on failover events.
+- **Silent nebula-sync drift** if replication fails unnoticed — mitigated by alerting on replication
+  staleness.
+- **Filtering weakened on the alert path** if a public tertiary resolver is used — accepted, scoped
+  to egress-only containers (`alertmanager`, `alert-discord-relay`).
+
+## Alternatives Considered
+
+- **Dual-DNS via DHCP only (no VIP).** Simplest, but client-side failover is slow and uneven
+  (multi-second resolver timeouts) and OS-dependent. Rejected as the *primary* mechanism; retained
+  as the secondary belt-and-suspenders alongside the VIP.
+- **Active/active load-balancing (dnsdist / anycast).** Overkill at homelab query volumes; splits
+  query logs/stats; complicates the failure model. Rejected.
+- **Govern DNS HA from the UDM as the single source of truth.** A sound instinct that conflates three
+  layers. *Assignment* ("which DNS address do clients use?") already lives on the UDM via DHCP and
+  stays there — it hands out the VIP. *Failover* and *resolution/filtering* should not move to the UDM:
+  it has no native health-checked-handout mechanism (custom scripting on a closed appliance gets wiped
+  by firmware updates and is gated behind FIDO2-touch SSH), and the only UDM-native option — hand out
+  primary + secondary IPs and let clients fail over — *is* the rejected dual-DNS model above. The
+  decisive inversion: the VIP yields **more** single-source-of-truth, not less — the UDM advertises one
+  stable address and clients never know two nodes exist, so failover is server-side and invisible.
+  Config replication (`nebula-sync`, D6) is also an irreducible Pi-to-Pi concern the UDM cannot own,
+  since it cannot hold Pi-hole's filtering config. The UDM remains the assignment authority; HA stays on
+  the nodes. *(The UDM being a hard SPOF for the whole LAN does not weaken this: the failures the second
+  node guards against — SD-card death, a bad Pi-hole/unbound update, a node reboot — are not UDM
+  failures, and the UDM cannot mitigate them.)* Rejected as the failover/resolution owner.
+- **Local TLS on the Pi (Caddy/nginx) instead of Traefik.** More moving parts on the node,
+  inconsistent with ADR-016's centralised routing. Rejected.
+- **Leave as-is and just add monitoring.** Rejected — monitoring a self-masking SPOF reports the
+  outage simultaneously with causing it. Redundancy is the fix; monitoring is the complement.
+
+## Adjacent, not bundled
+
+The **ADR-018** (`config/traefik/hosts` + static-IP) obsolescence review is **Traefik-internal and
+unrelated** to DNS HA. The static-IP / VIP work here is a natural moment to *revisit* ADR-018, but it
+must remain a **separate decision** — per the 2026-05-21 handoff, do not conflate the two.
+
+## Related
+
+- **ADR-016** — Configuration Design Principles (admin route lives in `routers.yml`, not labels)
+- **ADR-018** — Static IP Multi-Network Services (adjacent; reviewed separately)
+- **ADR-008** — CrowdSec Security Architecture (admin route reuses the middleware chain)
+- **ADR-003** — Monitoring Stack (observability layers plug into the existing stack)
+- **ADR-021 / ADR-029** — Urd backup + DB/storage (D8 backup integration)
+- **ADR-030** — Container Supply-Chain Trust Model (deliberate-update discipline extended to the Pi)
+- Implementation plan: `docs/97-plans/2026-05-25-pihole-resolver-first-class-and-ha.md`
+- Prior investigation: `docs/98-journals/2026-05-21-pihole-dns-and-adr018-investigation-handoff.md`
+
+---
+
+**Decision made by:** User (patriark) + Claude Code analysis
+**Trigger:** Owner request to elevate the Pi-hole resolver to a first-class, secured, observable,
+redundant homelab service; recon revealed a self-masking DNS dependency in the alert-delivery path.

--- a/docs/97-plans/2026-05-25-pihole-resolver-first-class-and-ha.md
+++ b/docs/97-plans/2026-05-25-pihole-resolver-first-class-and-ha.md
@@ -1,0 +1,187 @@
+# Plan: Pi-hole Resolver — First-Class Integration & High Availability
+
+**Date Created:** 2026-05-25
+**Status:** Proposed
+**Last Updated:** 2026-05-25 (Phase 0 container step implemented + verified)
+**Implements:** ADR-031 (`../00-foundation/decisions/2026-05-25-ADR-031-dns-resolver-first-class-and-ha.md`)
+**Prior context:** `../98-journals/2026-05-21-pihole-dns-and-adr018-investigation-handoff.md`
+
+## Objective
+
+Turn the sole LAN resolver (Pi-hole + unbound on the Pi at `192.168.1.69`) into a first-class
+homelab service: redundant, observable, managed-as-code, SSO-secured, backed-up, and deliberately
+updated — per ADR-031. Sequenced so the **self-masking DNS dependency in the alert path is removed
+first** and **redundancy lands before** the work that depends on it.
+
+## Background (verified 2026-05-25)
+
+- Prometheus is on `reverse_proxy` (10.89.2.79) + `monitoring` (10.89.4.79) → **can scrape the Pi
+  directly**; no new pathway needed.
+- UnPoller (`quadlets/unpoller.container`) is the **dual-network template** for monitoring a LAN
+  device: `Network=systemd-reverse_proxy:ip=…` (reach device) + `Network=systemd-monitoring` (be
+  scraped). Reuse it.
+- `blackbox_exporter` is **not deployed** (known gap in `99-reports/2026-04-17-service-configuration-review.md`).
+- `alertmanager` + `alert-discord-relay` resolve only via `192.168.1.69` (no fallback) → alert path
+  dies with the Pi.
+- DHCP is on the **UDM Pro**, not Pi-hole → resolvers can be DNS-only; HA stays simple.
+- IP plan: node A `192.168.1.69` (existing), node B `192.168.1.68` (new reservation),
+  **VIP `192.168.1.53`** (mnemonic: port 53). Adjust to taste.
+
+---
+
+## Approach
+
+### Phase 0 — De-risk the alert path *(small, do first — ADR-031 D2)*
+
+Stop the dead-man's-switch before any larger work.
+
+1. Add a **secondary resolver** to the egress-only alert containers:
+   - `quadlets/alertmanager.container`: `DNS=192.168.1.69` → keep, add `DNS=9.9.9.9` (interim).
+   - `quadlets/alert-discord-relay.container`: add explicit `DNS=192.168.1.69` + `DNS=9.9.9.9`.
+2. Give the **host** a fallback resolver (NetworkManager: secondary `dns=` entry, not replacing
+   Pi-hole as primary).
+3. `daemon-reload` + restart the two services; verify they still resolve with Pi-hole up, and still
+   resolve with Pi-hole simulated-down (block `.69` temporarily / stop Pi-hole briefly).
+
+> End state (after Phase 3) replaces `9.9.9.9` with the VIP + both node IPs so filtering is retained.
+
+### Phase 1 — First-class single node *(ADR-031 D3, D4, D7, D8 + hardening)*
+
+Bring the *existing* node up to contract before cloning it.
+
+1. **Config-as-code (D3).** Create `ansible/` (or `provisioning/pihole/`) with an idempotent
+   playbook for: Pi-hole install/config, unbound (recursive, DNSSEC on), `node_exporter`,
+   `keepalived` (installed but Phase-3-activated), `log2ram` (reduce SD writes), SSH hardening
+   (key-only, no passwords, LAN-restricted). Commit sanitised config; secrets via Ansible Vault or
+   out-of-band.
+2. **Wired + reserved (D3 hardware note).** Confirm the node is on **wired Ethernet** with a UDM
+   DHCP reservation. (A resolver on Wi-Fi is out — see ADR-031.)
+3. **SSO admin via Traefik (D4).** In `config/traefik/dynamic/`:
+   - Add an `ip-allowlist` middleware (private + WireGuard ranges) in `middleware.yml`.
+   - Add router `pihole` in `routers.yml`: `pihole.patriark.org` → `http://192.168.1.69:80`
+     (later: → the VIP), middleware chain
+     `crowdsec-bouncer@file, rate-limit@file, ip-allowlist@file, authelia@file, security-headers@file`.
+     **No public DNS record** — internal split-horizon only.
+   - Verify Traefik can reach the LAN IP (it's on `reverse_proxy`); apply ADR-018 `/etc/hosts`
+     handling only if a multi-network resolution issue actually appears (do **not** pre-emptively).
+4. **Backups (D8).** Cron on the node: nightly Teleporter/config export → `rsync` into an
+   Urd-snapshotted host directory. Confirm the path is within Urd's backup set.
+5. **Perimeter DNS enforcement (D7).** On the UDM: firewall rules blocking outbound 53 + known DoH
+   endpoints from client VLANs except the resolver node(s). Stage carefully; add allow-exceptions
+   for any device with a hardcoded public resolver. *(Hand the owner copy-paste UDM blocks — FIDO2
+   SSH can't be driven from here.)*
+   - **Sequencing caveat:** this lockdown blocks the homelab host's (.70) outbound 53 to `9.9.9.9`,
+     which would disable the Phase-0 alert-container fallback. Before enabling D7, either add a scoped
+     allow-exception for .70→9.9.9.9:53, or (cleaner) move the alert-container fallback off `9.9.9.9`
+     onto the second node's internal IP once Phase 3 exists.
+
+### Phase 2 — Observability *(ADR-031 D5)*
+
+1. **node_exporter scrape.** Add a `node-exporter-pi` job to `config/prometheus/prometheus.yml`
+   targeting `192.168.1.69:9100` (later add node B + VIP).
+2. **pihole-exporter.** New `quadlets/pihole-exporter.container` on the UnPoller dual-network
+   pattern; config points at the Pi v6 API (token via Podman secret). Add `pihole` scrape job
+   (`pihole-exporter:<port>` on the monitoring network).
+3. **blackbox_exporter (the primary signal).** New `quadlets/blackbox-exporter.container` +
+   `config/blackbox/blackbox.yml` with a `dns` probe module. Add a `blackbox-dns` scrape job using
+   the `__param_target` relabel pattern, targeting each node IP **and the VIP**.
+4. **Alerts** in `config/prometheus/alerts/` (new file, e.g. `dns-resolver-alerts.yml`):
+   per-node `up==0`, blackbox DNS-probe failure (per node + VIP), VIP-failover, Pi temp/disk.
+   Route critical (VIP probe failing = real outage) → discord-critical; single-node-down → warning.
+5. **Grafana dashboard** for resolver health (query rate, block rate, cache hit, per-node up,
+   probe latency, temp).
+
+### Phase 3 — High availability: second node *(ADR-031 D1, D6)*
+
+1. **Provision node B** with the **same Ansible playbook** (`192.168.1.68`, wired, reserved).
+2. **keepalived VIP (D1).** Activate VRRP on both nodes for VIP `192.168.1.53`; node A MASTER
+   (higher priority), node B BACKUP; **authenticated VRRP**; health-check script tied to Pi-hole/DNS
+   liveness so a wedged Pi-hole releases the VIP.
+3. **Config replication (D6).** Deploy `nebula-sync` (new `quadlets/nebula-sync.container` or on a
+   node) syncing node A → node B via the Pi-hole v6 Teleporter API on a schedule. *(Confirm Pi-hole
+   v6; v5 needs different tooling.)*
+4. **Log centralisation (D6).** Promtail/syslog on both nodes → existing Loki `syslog` path.
+5. **Cut clients over to the VIP.** UDM DHCP DNS = **VIP primary + node A + node B** secondaries.
+   Update `pihole.patriark.org` router target and the alert-path `DNS=` entries to **VIP + both node
+   IPs**, replacing the Phase-0 `9.9.9.9` interim.
+7. **Host fallback (deferred from Phase 0 per owner decision).** The host's immutable `/etc/resolv.conf`
+   stayed Pi-hole-only (fail-closed) through Phases 0–2 to avoid leaking to a public resolver. Now add
+   the **second node's internal IP** as secondary: `chattr -i /etc/resolv.conf`, append
+   `nameserver 192.168.1.68` (or the VIP), `chattr +i`. Still filtered, no public leak, and no D7
+   allow-exception needed since the fallback is internal.
+6. **Failover drill.** Stop Pi-hole on node A; confirm VIP migrates to node B within seconds,
+   resolution continues, the failover alert fires, and node-A-down alert fires.
+
+### Follow-up (separate decision, do not bundle)
+
+- **ADR-018 obsolescence review** per the 2026-05-21 handoff — adjacent to the static-IP/VIP work but
+  Traefik-internal and unrelated. Track as its own task/ADR.
+
+---
+
+## Success Criteria
+
+- **Phase 0:** alert containers + host resolve external names with Pi-hole *down*; no other change.
+- **Phase 1:** node rebuildable from the Ansible playbook; `pihole.patriark.org` serves HTTPS, gated
+  by Authelia, reachable only from LAN/WireGuard, absent from public DNS; nightly export lands in
+  Urd's set; client-VLAN DNS egress is blocked except the resolver.
+- **Phase 2:** Prometheus shows `up==1` for node + pihole + blackbox jobs; a deliberately wrong
+  upstream / stopped Pi-hole makes the **blackbox DNS probe fail** (proving functional > liveness);
+  alerts visible in `/rules`; dashboard populated.
+- **Phase 3:** killing the MASTER migrates the VIP to BACKUP in seconds with uninterrupted
+  resolution; `nebula-sync` shows node B config matching node A; both nodes' logs in Loki; DHCP hands
+  out VIP + both nodes.
+
+## Verification
+
+```bash
+# Phase 0 — alert path survives DNS loss (run on fedora-htpc)
+podman exec alertmanager getent hosts discord.com            # resolves with Pi-hole up
+systemctl --user stop pihole 2>/dev/null || true             # or block 192.168.1.69 at host fw
+podman exec alertmanager getent hosts discord.com            # still resolves via fallback
+# (restore Pi-hole afterward)
+
+# Phase 1 — admin plane
+curl -I https://pihole.patriark.org                          # 302 → Authelia, valid TLS
+dig +short pihole.patriark.org @1.1.1.1                      # empty (no public record)
+
+# Phase 2 — monitoring + functional probe
+podman exec prometheus promtool check rules /etc/prometheus/alerts/dns-resolver-alerts.yml
+podman exec prometheus wget -qO- \
+  'http://localhost:9090/api/v1/query?query=up{job=~"node-exporter-pi|pihole|blackbox-dns"}' | head -c 400
+podman exec prometheus wget -qO- \
+  'http://localhost:9090/api/v1/query?query=probe_success{job="blackbox-dns"}' | head -c 400
+
+# Phase 3 — failover drill + replication (run against the nodes)
+dig +short example.com @192.168.1.53                         # VIP answers
+# stop Pi-hole on MASTER, then re-query the VIP within a few seconds:
+dig +short example.com @192.168.1.53                         # BACKUP now answers via migrated VIP
+```
+
+## Rollback
+
+- **Phase 0:** revert the two quadlets + NM change; `daemon-reload` + restart. Pure addition of a
+  secondary resolver — removing it restores prior behaviour.
+- **Phase 1:** Traefik changes are `git revert` + Traefik restart (single-file `hosts` bind mount is
+  inode-bound — restart, don't just edit). Firewall rules are removable on the UDM. Ansible is
+  additive.
+- **Phase 2:** each exporter/job/alert is isolated; `git revert` the quadlet/scrape/alert file.
+  Removing them cannot affect existing alerting.
+- **Phase 3:** keepalived/nebula-sync are separate services — stop them and revert DHCP to the single
+  Pi IP to return to today's topology. BTRFS snapshots + `git revert` underneath.
+
+## Progress Log
+
+- 2026-05-25 — Plan drafted from ADR-031. Status: Proposed. Owner chose keepalived VIP (active/passive),
+  Traefik internal-only + SSO admin, and ADR + plan as the first deliverable. Sequence: Phase 0 → 1 →
+  2 → 3; ADR-018 review tracked separately.
+- 2026-05-25 — **Phase 0 container step DONE + verified.** Added `DNS=192.168.1.69` + `DNS=9.9.9.9` to
+  `alertmanager.container` and `alert-discord-relay.container` (the latter previously inherited
+  network DNS only). Both restarted healthy; `podman inspect` shows `[192.168.1.69 9.9.9.9]`; both
+  resolve external names; `9.9.9.9` reachable from the network. **Host step BLOCKED on a finding:**
+  `/etc/resolv.conf` is **immutable-pinned** (`chattr +i`) to Pi-hole only (deliberate fail-closed;
+  systemd-resolved disabled). NM applies DNS at device level but cannot rewrite the file. Host fallback
+  **deferred to Phase 3 per owner decision** — host stays fail-closed/Pi-hole-only now; the fallback
+  will be the *internal* second node (no public leak, no D7 exception needed). Critical alert path is
+  already protected at the container level regardless. **Phase 0 = COMPLETE** (host step intentionally
+  deferred, not skipped).

--- a/docs/98-journals/2026-05-21-pihole-dns-and-adr018-investigation-handoff.md
+++ b/docs/98-journals/2026-05-21-pihole-dns-and-adr018-investigation-handoff.md
@@ -1,0 +1,108 @@
+# Handoff: Pi-hole "nothing blocked" anomaly + ADR-018 workaround obsolescence review
+
+**Created:** 2026-05-21 (by Claude, end of Forgejo deployment session)
+**For:** a fresh session with no context from the originating conversation
+**Status:** OPEN — investigation not yet started
+**Type:** two related-but-distinct investigations. Keep them separate; do not conflate.
+
+---
+
+## Why this exists
+
+During a Forgejo deployment the owner raised two things:
+
+1. **Pi-hole anomaly:** Lots of DNS requests in the Pi-hole query log attributed to "this server" / many marked as `localhost` (or similar), and **zero queries being blocked** — despite the owner browsing the web heavily from `fedora-htpc` (.70), where Pi-hole "used to" reliably block trackers/ads. "Now zero."
+2. **A hunch:** that this is caused by "the custom DNS hack we made back in the day" (the ADR-018 `/etc/hosts` + static-IP workaround), and a request to determine **whether that workaround is even still needed**, or whether it was a remnant of a Podman multi-network DNS-ordering bug that may since be fixed.
+
+**Important framing for the investigator:** these are almost certainly TWO separate issues. The ADR-018 hack is internal to the Traefik container and cannot, by itself, stop the *host's web browsing* from being filtered by Pi-hole. Don't let the owner's (understandable) hunch anchor you — verify independently. The leading hypothesis for #1 is browser-level DoH bypass, which has nothing to do with #2.
+
+---
+
+## Confirmed topology & facts (gathered 2026-05-21, verify if stale)
+
+- **Pi-hole** runs on the **Raspberry Pi at `192.168.1.69`** (`raspberrypi`). This server is `fedora-htpc` at `192.168.1.70`. (`fedora-jern` = .71, MacBook = .11.)
+- Host `/etc/resolv.conf` on fedora-htpc: `nameserver 192.168.1.69`, `search lokal`, `options edns0 trust-ad`, NetworkManager-managed.
+- **No systemd-resolved stub** in use (`resolvectl status` returned empty) — so the OS resolves directly against Pi-hole, no 127.0.0.53 stub layer locally.
+- Container DNS: quadlets and `.network` files use `DNS=192.168.1.69` (Pi-hole directly).
+- Versions: `podman 5.8.2`, `aardvark-dns 1.17.1`, `netavark 1.17.2` (Fedora 44).
+- Rootless Podman NATs container egress to the host IP, so container→Pi-hole queries should appear in Pi-hole as coming from **.70**, not localhost.
+
+### The three mechanisms (do not conflate)
+
+| # | Mechanism | Scope | Relevant to |
+|---|-----------|-------|-------------|
+| A | **Split-horizon / NAT hairpin** for `*.patriark.org` | LAN clients reaching public hostnames | Minor cleanup only |
+| B | **ADR-018 `/etc/hosts` + static IPs** (`config/traefik/hosts`) | *Inside Traefik container*, backend name→network resolution | Thread B below |
+| C | **Pi-hole filtering of host/browser DNS** | OS + browser DNS path | Thread A below |
+
+A is `events.patriark.org` resolving to `.70` internally while `git.patriark.org` does not (inconsistent but harmless). Not the cause of anything here.
+
+---
+
+## Thread A — Pi-hole "nothing blocked"
+
+> **UPDATE 2026-05-21:** Tested — `dig doubleclick.net @192.168.1.69` → `0.0.0.0`, `flurry.com` → `0.0.0.0`, `example.com` → real IPs. **Pi-hole blocking is confirmed healthy** (hypothesis 2 below is OUT). The disambiguator is settled: the problem is **client-side** — the browser's queries aren't reaching Pi-hole. Focus on hypothesis 1 (Vivaldi DoH) + hypothesis 3 (localhost-client puzzle). Don't re-run the gravity/blocking check.
+
+### Hypotheses (ranked)
+
+1. **Browser DoH bypass (PRIME SUSPECT).** Firefox/Chrome may be using DNS-over-HTTPS directly to Cloudflare/Google/NextDNS, bypassing the OS resolver entirely. This perfectly explains "OS/container queries show in Pi-hole, but my web-browsing trackers are never blocked": those lookups never reach Pi-hole. Firefox enables DoH automatically in many setups.
+2. **Pi-hole blocking globally degraded.** Blocking toggled off, gravity/blocklists empty or failed to update, or Pi-hole running in a passthrough state. This would show as zero blocks for **all** clients, not just this workstation.
+3. **Client misattribution ("localhost").** Need to identify the real source of the `localhost`/127.0.0.1 queries in Pi-hole. Options: queries from the Pi itself (gravity updates, its own resolver), an upstream/conditional-forwarding setup masking real clients, or the owner reading the Top-Clients panel where `localhost` = the Pi.
+
+**Key disambiguator:** Is it zero blocks **globally** (→ hypothesis 2) or only for **this workstation's browsing** while other clients/devices still get blocks (→ hypothesis 1)? Establish this first.
+
+### Diagnostic steps
+
+- On a phone/another LAN device, browse to a known ad/tracker domain and check Pi-hole's live query log — is *anything* blocked for *any* client right now?
+- Pi-hole admin: check **blocking enabled**, **gravity domain count** (Tools → Update Gravity / `pihole -g` count), and the query-log breakdown by client + by status (blocked vs forwarded vs cached).
+- On fedora-htpc, test the OS path directly: `dig doubleclick.net @192.168.1.69` and `dig flurry.com @192.168.1.69` — if Pi-hole returns `0.0.0.0`/NXDOMAIN, OS-path blocking works and the gap is browser-side.
+- Firefox: `about:config` → `network.trr.mode` (0/2/3/5 — 2/3 = DoH active) and `network.trr.uri`. Or about:networking#dns. Chrome: Settings → Privacy → "Use secure DNS".
+- Network-level: check whether outbound DoH (443 to 1.1.1.1 / dns.google / mozilla.cloudflare-dns.com) is happening from .70. Consider whether to block/redirect DoH at the UDM to force clients onto Pi-hole.
+- Confirm the UDM isn't handing out an alternate/secondary DNS server via DHCP that clients fall back to.
+
+### Decision criteria
+
+- If DoH: decide policy — disable browser DoH, or point browser DoH at a Pi-hole DoH endpoint, or block external DoH at the UDM.
+- If gravity/blocking degraded: fix Pi-hole (re-enable, update gravity, check disk/health on the Pi).
+
+---
+
+## Thread B — Is the ADR-018 `/etc/hosts` + static-IP workaround still needed?
+
+### Background (READ BEFORE TOUCHING)
+
+- ADR: `docs/00-foundation/decisions/2026-02-04-ADR-018-static-ip-multi-network-services.md`
+- Root cause: `docs/98-journals/2026-02-02-ROOT-CAUSE-CONFIRMED-dns-resolution-order.md` (and the surrounding `2026-02-02-*` cluster — this was a **catastrophic network-failure incident**, with kernel-rollback tests and a symlink hypothesis).
+- Mechanism: `config/traefik/hosts` (bind-mounted to Traefik's `/etc/hosts`) pins each backend service name to its `reverse_proxy` static IP (10.89.2.x, .69+). Without it, aardvark-dns returned multi-network container IPs in **undefined order**, so Traefik sometimes routed via the wrong network (e.g. monitoring) → broke routing / violated segmentation.
+- **21 containers** currently carry `Network=systemd-reverse_proxy:ip=…` and depend on this: gathio, grafana, alertmanager, authelia, forgejo, nextcloud, home-assistant, prometheus, jellyfin, loki, audiobookshelf, immich-server, homepage, unpoller, traefik, proton-bridge, crowdsec, qbittorrent, vaultwarden, navidrome, alert-discord-relay.
+
+**This is load-bearing infrastructure born from a catastrophic outage. Treat removal as high-risk. Do NOT rip it out casually.**
+
+### What might have changed
+
+- aardvark-dns/netavark have had multi-network ordering fixes over time. Current = aardvark-dns 1.17.1 / netavark 1.17.2 / podman 5.8.2. Determine which versions were in play during the Feb 2026 incident and whether the relevant ordering fix landed since. Check aardvark-dns release notes / upstream issues on multi-network DNS result ordering.
+
+### Test methodology (safe, reversible)
+
+1. Confirm the bug still reproduces *today* before assuming the fix is needed: on a multi-network container, repeatedly resolve a backend name from inside Traefik and observe whether aardvark returns a stable, correct (reverse_proxy) IP or a varying/wrong-network one. e.g. `podman exec traefik getent hosts gathio` many times, and compare against the container's actual reverse_proxy IP.
+2. If aardvark now returns stable/correct ordering, pick ONE low-risk service (e.g. gathio) and test removing only its `/etc/hosts` entry — restart Traefik (remember: `config/traefik/hosts` is a **single-file bind mount**, inode-bound; edits require a Traefik restart to take effect, see platform gotchas) — and verify routing still hits the right network. Keep BTRFS snapshot / git revert ready.
+3. Only after a service-by-service validation would wholesale removal be justified. The static IPs themselves are cheap to keep even if `/etc/hosts` becomes unnecessary; consider decoupling the two questions.
+
+### Rollback safety
+
+- All changes are in `config/traefik/hosts` and quadlet `Network=` lines, both in git. Revert + Traefik restart restores prior behavior. BTRFS snapshots available (ADR-021/Urd).
+
+---
+
+## Side note — Thread A's red herring
+
+Be ready to explain to the owner *why* the ADR-018 hack (Thread B) does not cause the Pi-hole "nothing blocked" symptom (Thread A): it only affects the Traefik container's internal backend-name resolution; it does not sit in the path of the host's or browser's outbound DNS. They can be fixed/decided independently.
+
+---
+
+## References
+
+- `config/traefik/hosts` — the ADR-018 override
+- `docs/00-foundation/decisions/2026-02-04-ADR-018-static-ip-multi-network-services.md`
+- `docs/98-journals/2026-02-02-ROOT-CAUSE-CONFIRMED-dns-resolution-order.md`
+- Platform gotchas memory: single-file bind mounts are inode-bound (Traefik restart needed after editing `hosts`); static IPs use .69+ convention.

--- a/quadlets/alert-discord-relay.container
+++ b/quadlets/alert-discord-relay.container
@@ -11,6 +11,12 @@ HostName=alert-discord-relay
 Network=systemd-reverse_proxy:ip=10.89.2.86
 Network=systemd-monitoring
 
+# ADR-031 Phase 0 (D2): explicit resolvers with an independent fallback (previously inherited
+# reverse_proxy DNS=192.168.1.69 only). A Pi-hole outage must not stop alert delivery.
+# 9.9.9.9 is INTERIM — replace with the keepalived VIP + both node IPs in Phase 3.
+DNS=192.168.1.69
+DNS=9.9.9.9
+
 # Discord webhook URL
 Secret=discord_webhook_url,type=env,target=DISCORD_WEBHOOK_URL
 

--- a/quadlets/alertmanager.container
+++ b/quadlets/alertmanager.container
@@ -26,7 +26,10 @@ Secret=smtp_password
 # Command arguments
 Exec=--config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanager --log.level=info --web.external-url=https://alertmanager.patriark.org
 
+# ADR-031 Phase 0 (D2): independent fallback so a Pi-hole outage can't silence alerting.
+# 9.9.9.9 is INTERIM — replace with the keepalived VIP + both node IPs in Phase 3.
 DNS=192.168.1.69
+DNS=9.9.9.9
 
 # Health check
 HealthCmd=wget --no-verbose --tries=1 --spider http://localhost:9093/-/healthy || exit 1


### PR DESCRIPTION
## Summary

Elevates the LAN DNS resolver (Pi-hole + unbound on the Pi at `192.168.1.69`) from an
unmanaged, single point of failure into a first-class homelab service — and implements
**Phase 0**, which removes a self-masking failure in the alert path.

**Why now:** recon found the alerting path resolves DNS *only* through the Pi with no
fallback (`alertmanager`, `alert-discord-relay`, host `/etc/resolv.conf`, both container
networks). If the Pi died, Alertmanager could not resolve `discord.com` to report it — the
smoke detector wired to the same fuse as the fire.

## Documents

- **ADR-031** (Accepted) — `docs/00-foundation/decisions/2026-05-25-ADR-031-dns-resolver-first-class-and-ha.md`
  - Active/passive **keepalived VIP** for HA (not load-balanced); **UDM keeps DHCP/assignment**
    as the single source of truth.
  - Alert/egress path must use a resolver **independent** of the one it monitors.
  - Managed-as-code (Ansible), Traefik **internal-only + SSO** admin, Urd backup, 3-layer
    observability with a **functional blackbox DNS probe** as the primary signal, perimeter
    DoH/53 lockdown.
  - Alternatives incl. *"govern HA from the UDM"* evaluated and rejected.
- **Plan** — `docs/97-plans/2026-05-25-pihole-resolver-first-class-and-ha.md` (phased 0→3, with verification + rollback).
- Prior investigation journal (referenced by the ADR) brought into the tree.
- `CLAUDE.md` ADR pointer bumped to ADR-031.

## Phase 0 — implemented & verified

- `quadlets/alertmanager.container`: added `DNS=9.9.9.9` fallback alongside Pi-hole.
- `quadlets/alert-discord-relay.container`: set explicit `DNS=192.168.1.69` + `DNS=9.9.9.9`
  (previously inherited network DNS only).
- Host `/etc/resolv.conf` **left fail-closed** — discovered it is deliberately `chattr +i`
  pinned to Pi-hole; respected the pin. Host fallback deferred to Phase 3 (internal second
  node, no public leak).

**Verification (Pi-hole up):**
- ✅ both services restart healthy
- ✅ `podman inspect` shows upstreams `[192.168.1.69 9.9.9.9]` on both
- ✅ both resolve external names (primary path intact)
- ✅ `9.9.9.9` fallback reachable from the network

## Scope / risk

- Only additive `DNS=` lines on two quadlets; everything else is docs.
- Pre-commit ADR-030 supply-chain invariant gate passes (no image changes).
- Rollback: `git revert` the quadlets + `daemon-reload`; docs are inert.

## Test Plan

- [ ] Confirm `alertmanager` + `alert-discord-relay` resolve with Pi-hole **down** (block `.69` briefly)
- [ ] Confirm no regression in alert delivery to Discord with Pi-hole up
- [ ] Review ADR-031 decisions before starting Phase 1
- [ ] Note Phase-1 D7 caveat: perimeter 53 lockdown vs the `.70 → 9.9.9.9` fallback (allow-exception or move to internal node in Phase 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)