### PR TITLE
feat(dns): ADR-031 Phase 1 — Pi-hole resolver first-class (SSO admin, config-as-code, backup)

### DIFF
--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,89 @@
+# Ansible — Pi-hole resolver provisioning (ADR-031)
+
+Config-as-code for the LAN DNS resolver(s): Pi-hole v6 + unbound (DNSSEC) + node_exporter +
+keepalived (installed, **not** activated until Phase 3) + log2ram + SSH hardening + nightly backup.
+
+This is the **non-quadlet** half of the homelab's "in Git, reproducible" contract (ADR-031 D3).
+It makes node A rebuildable from a dead SD card and lets Phase 3 clone node B as an exact twin.
+
+> **Target is Pi-hole v6** (confirmed Core 6.4.2 / Web 6.5 / FTL 6.6.2, 2026-05-26).
+> v5 uses different tooling (setupVars/lighttpd, `pihole -a -t`) — do not run this against a v5 node.
+
+## ⚠️ This touches the LIVE sole resolver — read before running
+
+The Pi at `192.168.1.69` answers DNS for the whole LAN. A bad change = LAN-wide DNS outage.
+Mitigations built in: the `unbound` role **validates resolution before** the `pihole` role switches
+the upstream to it; all other roles are additive. Still:
+
+1. **Always dry-run first:** `ansible-playbook playbooks/pihole-resolver.yml --check --diff`
+2. **Roll out by tag**, additive roles first, resolution-affecting roles last:
+   ```
+   # additive / low-risk:
+   ansible-playbook playbooks/pihole-resolver.yml --tags common,ssh,node_exporter,log2ram,keepalived,backup
+   # resolution path (unbound validated, THEN pihole upstream switch):
+   ansible-playbook playbooks/pihole-resolver.yml --tags unbound
+   ansible-playbook playbooks/pihole-resolver.yml --tags pihole
+   ```
+3. Keep a second terminal with `dig @192.168.1.69 example.com` running during the resolver-path tags.
+
+## Access (you cannot drive the Pi from a Claude session — FIDO2 touch)
+
+SSH to the Pi uses a passphrase-protected, YubiKey-backed (ED25519-SK) key. Two consequences:
+the agent (gcr/Keychain) can't sign SK keys (`IdentityAgent=none`), AND ansible has no TTY to type
+the key passphrase (it falls back to the missing `ssh-askpass` → `Permission denied`). The fix is to
+**pre-open one master SSH connection by hand** (passphrase + one touch) that ansible then reuses.
+
+- The Pi's SSH user is **`patriark`** (not `pi`).
+- `inventory.ini` uses `~/.ssh/id_ed25519_sk_yk5c-li` (the always-connected YubiKey). Its pubkey must
+  be in the Pi's `~patriark/.ssh/authorized_keys`.
+- If `sudo` on the Pi prompts for a password, add `-K` (`--ask-become-pass`).
+
+```bash
+# 1. Open ONE persistent master connection (enter passphrase + touch the YubiKey once).
+#    ControlPath MUST match ansible.cfg's control_path so ansible reuses this connection.
+ssh -F /dev/null -o IdentityAgent=none -o IdentitiesOnly=yes -i ~/.ssh/id_ed25519_sk_yk5c-li \
+    -o ControlMaster=auto -o ControlPersist=1800s -o ControlPath=~/.ssh/ansible-cm-%h-%p-%r \
+    -fN patriark@192.168.1.69
+ssh -O check -o ControlPath=~/.ssh/ansible-cm-%h-%p-%r patriark@192.168.1.69   # "Master running"
+
+# 2. Now ansible reuses the master — no per-task auth, no passphrase prompt.
+cd ~/containers/ansible
+ansible -m ping resolvers                                      # "pong"
+ansible-playbook playbooks/pihole-resolver.yml --check --diff  # dry run
+```
+
+If the master expires (30 min idle), just re-run step 1. To close it early:
+`ssh -O exit -o ControlPath=~/.ssh/ansible-cm-%h-%p-%r patriark@192.168.1.69`.
+
+## Secrets
+
+Phase 1 needs none in Git. Phase 3's keepalived VRRP `auth_pass` is a secret — supply it via
+`ansible-vault` (e.g. `group_vars/resolvers/vault.yml`), never commit it. The placeholder in
+`keepalived.conf.j2` is inert because the service is stopped in Phase 1.
+
+## D8 backup — one manual step after the first run
+
+The `pihole_backup` role generates a passwordless rsync key **on the Pi** and prints its public key.
+The Pi *pushes* nightly (a cron/timer can't do a FIDO2 touch to pull). On the backup host
+(`fedora-htpc`) install the `rrsync` binary, then authorize that pubkey **restricted** to the dir:
+
+```bash
+sudo dnf install -y rsync-rrsync     # provides /usr/bin/rrsync
+# append to ~patriark/.ssh/authorized_keys (absolute rrsync path — forced commands get a minimal PATH):
+from="192.168.1.69",command="/usr/bin/rrsync -wo /home/patriark/containers/data/pihole-backups/raspberrypi",no-agent-forwarding,no-port-forwarding,no-pty,no-X11-forwarding <PASTE pihole-backup pubkey>
+```
+
+The target dir already lives in Urd's `htpc-home` backup set (priority 1, both drives), so each
+nightly export is snapshotted with retention automatically. The timer fires at 03:30, before Urd's
+04:00 run, so the fresh export is captured the same night.
+
+## Layout
+
+```
+ansible.cfg              defaults (ControlMaster = one touch per run)
+inventory.ini            resolvers group; node A = raspberrypi (192.168.1.69)
+group_vars/resolvers.yml sanitised settings (committed)
+host_vars/raspberrypi.yml node-A specifics (keepalived MASTER/priority)
+playbooks/pihole-resolver.yml  main play (roles + tags)
+roles/  common ssh_hardening unbound pihole node_exporter log2ram keepalived pihole_backup
+```

--- a/ansible/ansible.cfg
+++ b/ansible/ansible.cfg
@@ -1,0 +1,23 @@
+[defaults]
+inventory = inventory.ini
+roles_path = roles
+host_key_checking = True
+retry_files_enabled = False
+interpreter_python = auto_silent
+forks = 5
+
+[ssh_connection]
+# ControlMaster persists the connection so ONE YubiKey touch covers the whole run.
+# IdentityAgent=none + IdentitiesOnly=yes: the gcr/Keychain agent can't sign ED25519-SK keys;
+# force ssh to use the key file directly. The key itself is set per-host in inventory.ini.
+# -F /dev/null: ignore ~/.ssh/config — its global `Host *` block injects the three UDM YubiKey
+# keys into every connection, which trips the Pi's MaxAuthTries ("Too many authentication
+# failures") before the resolver key is tried. With the config ignored, only the inventory's
+# ansible_ssh_private_key_file (+ IdentitiesOnly) is offered. known_hosts default (~/.ssh/known_hosts)
+# still applies, so host-key checking stays on.
+ssh_args = -F /dev/null -o ControlMaster=auto -o ControlPersist=1800s -o IdentityAgent=none -o IdentitiesOnly=yes
+# The SK key is passphrase-protected and ansible has no TTY to type it (falls back to the missing
+# ssh-askpass). Workaround: pre-open ONE master connection in your terminal (passphrase + touch),
+# then ansible reuses it via this matching ControlPath — no per-task auth. See README "Access".
+control_path = ~/.ssh/ansible-cm-%%h-%%p-%%r
+pipelining = True

--- a/ansible/group_vars/resolvers.yml
+++ b/ansible/group_vars/resolvers.yml
@@ -1,0 +1,43 @@
+---
+# Sanitised resolver settings (committed). Secrets go in an ansible-vault file, never here.
+
+# --- Identity / topology ---
+resolver_admin_domain: pihole.patriark.org
+reverse_proxy_host: 192.168.1.70          # Traefik host (D4 admin plane)
+
+# --- unbound (recursive resolver, DNSSEC) ---
+unbound_listen: 127.0.0.1
+unbound_port: 5335
+unbound_ipv6: false                       # flip to true only if the LAN runs IPv6
+
+# --- Pi-hole v6 settings to converge (idempotent via `pihole-FTL --config`) ---
+pihole_upstream: "127.0.0.1#{{ unbound_port }}"   # point Pi-hole at unbound
+pihole_dnssec: false                      # unbound validates; avoid double-validation
+pihole_webserver_domain: pihole.patriark.org      # needed behind the Traefik reverse proxy
+pihole_local_record: "192.168.1.70 pihole.patriark.org"  # split-horizon admin record (D4)
+
+# --- node_exporter (scraped by Prometheus on .70 — the scrape JOB is Phase 2 / D5) ---
+node_exporter_listen: "{{ ansible_host }}:9100"   # LAN-bound, not 0.0.0.0
+prometheus_host: 192.168.1.70
+
+# --- log2ram (reduce SD-card write wear) ---
+log2ram_enabled: true                     # adds the azlux apt repo — see README
+
+# --- keepalived (Phase 3 — INSTALLED ONLY here, NOT started) ---
+keepalived_enabled: false                 # Phase 3 sets true on both nodes
+vip_address: 192.168.1.53                 # VRRP Virtual IP (port-53 mnemonic)
+keepalived_interface: eth0
+keepalived_auth_pass: "CHANGE_ME_IN_VAULT"   # inert in Phase 1 (service stopped)
+
+# --- SSH hardening ---
+ssh_allow_users:
+  - patriark
+
+# --- D8 backup (Pi pushes nightly to the Urd-snapshotted host) ---
+pihole_backup_dir: /var/backups/pihole
+pihole_backup_retention: 7
+backup_ssh_key_path: /root/.ssh/id_ed25519_pihole_backup
+backup_remote_user: patriark
+backup_remote_host: 192.168.1.70
+backup_remote_path: /home/patriark/containers/data/pihole-backups/raspberrypi
+backup_oncalendar: "*-*-* 03:30:00"       # before Urd's 04:00 snapshot

--- a/ansible/host_vars/raspberrypi.yml
+++ b/ansible/host_vars/raspberrypi.yml
@@ -1,0 +1,4 @@
+---
+# Node A (existing resolver). Phase 3 adds node B (192.168.1.68) as BACKUP with lower priority.
+keepalived_state: MASTER
+keepalived_priority: 200

--- a/ansible/inventory.ini
+++ b/ansible/inventory.ini
@@ -1,0 +1,11 @@
+# Resolver nodes (ADR-031). Node A exists; node B (192.168.1.68) is added in Phase 3.
+[resolvers]
+raspberrypi ansible_host=192.168.1.69
+
+[resolvers:vars]
+ansible_user=patriark
+ansible_python_interpreter=/usr/bin/python3
+# The Pi's SSH user is patriark (NOT pi). Uses the always-connected YubiKey (yk5c-li) so
+# ansible runs need no YubiKey swap. Its pubkey (id_ed25519_sk_yk5c-li.pub) must be in the
+# Pi's ~patriark/.ssh/authorized_keys (authorize once from a working Pi session).
+ansible_ssh_private_key_file=~/.ssh/id_ed25519_sk_yk5c-li

--- a/ansible/playbooks/pihole-resolver.yml
+++ b/ansible/playbooks/pihole-resolver.yml
@@ -1,0 +1,26 @@
+---
+# ADR-031 Phase 1 — bring the existing resolver up to the homelab service contract.
+# Run order matters: unbound is installed + VALIDATED before pihole switches its upstream to it,
+# so a broken unbound can never take DNS down. Everything else is additive.
+# Always dry-run first:  ansible-playbook playbooks/pihole-resolver.yml --check --diff
+- name: Pi-hole resolver — first-class single node (ADR-031 Phase 1)
+  hosts: resolvers
+  become: true
+  gather_facts: true
+  roles:
+    - role: common          # base packages
+      tags: [common, base]
+    - role: ssh_hardening   # key-only auth (additive; we connected via pubkey so it's safe)
+      tags: [ssh, hardening]
+    - role: node_exporter   # host metrics endpoint (scrape job is Phase 2)
+      tags: [node_exporter, monitoring]
+    - role: log2ram         # SD-card write reduction
+      tags: [log2ram, sdcard]
+    - role: keepalived      # INSTALLED ONLY — Phase 3 activates
+      tags: [keepalived, ha]
+    - role: pihole_backup   # D8 nightly Teleporter export + rsync push
+      tags: [backup]
+    - role: unbound         # recursive resolver + DNSSEC (validated before pihole points at it)
+      tags: [unbound, dns]
+    - role: pihole          # converge v6 settings; switch upstream to unbound LAST
+      tags: [pihole, dns]

--- a/ansible/roles/common/tasks/main.yml
+++ b/ansible/roles/common/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Base packages (root hints/anchor for unbound, rsync for backups, dig for validation)
+  ansible.builtin.apt:
+    name:
+      - dns-root-data        # root hints + DNSSEC trust anchor, Debian-managed (unbound uses these)
+      - bind9-dnsutils       # provides `dig` (resolution/DNSSEC validation gate)
+      - rsync                # D8 backup push
+      - ca-certificates
+    state: present
+    update_cache: true
+    cache_valid_time: 3600

--- a/ansible/roles/keepalived/tasks/main.yml
+++ b/ansible/roles/keepalived/tasks/main.yml
@@ -1,0 +1,27 @@
+---
+# Phase 1 INSTALLS keepalived and lays down a (currently inert) config so Phase 3 can activate
+# HA by simply flipping `keepalived_enabled: true` on both nodes. It is NOT started here —
+# a single node holding a VIP buys nothing and a misconfigured VRRP could disrupt the LAN.
+- name: Install keepalived
+  ansible.builtin.apt:
+    name: keepalived
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Lay down keepalived config (inert until Phase 3)
+  ansible.builtin.template:
+    src: keepalived.conf.j2
+    dest: /etc/keepalived/keepalived.conf
+    owner: root
+    group: root
+    mode: "0644"
+  when: not ansible_check_mode    # /etc/keepalived exists only after the (real) package install
+  # Deliberately NO restart notify — Phase 1 must not start keepalived.
+
+- name: Keep keepalived stopped + disabled in Phase 1 (Phase 3 sets keepalived_enabled=true)
+  ansible.builtin.service:
+    name: keepalived
+    enabled: "{{ keepalived_enabled | bool }}"
+    state: "{{ 'started' if (keepalived_enabled | bool) else 'stopped' }}"
+  when: not ansible_check_mode    # service exists only after the (real) package install

--- a/ansible/roles/keepalived/templates/keepalived.conf.j2
+++ b/ansible/roles/keepalived/templates/keepalived.conf.j2
@@ -1,0 +1,31 @@
+# Managed by Ansible (ADR-031). PHASE 1: keepalived is INSTALLED but the service is STOPPED
+# and DISABLED, so this config is INERT. Phase 3 activates HA by setting keepalived_enabled=true
+# on both nodes (node A = MASTER/higher priority, node B = BACKUP/lower) and supplying a real
+# auth_pass via ansible-vault.
+
+# Health check: release the VIP if this node can no longer answer DNS locally.
+vrrp_script chk_dns {
+    script "/usr/bin/dig +short +time=1 +tries=1 @127.0.0.1 pi.hole"
+    interval 2
+    weight -40
+    fall 2
+    rise 2
+}
+
+vrrp_instance VI_DNS {
+    state {{ keepalived_state | default('BACKUP') }}
+    interface {{ keepalived_interface }}
+    virtual_router_id 53
+    priority {{ keepalived_priority | default(100) }}
+    advert_int 1
+    authentication {
+        auth_type PASS
+        auth_pass {{ keepalived_auth_pass }}   # Phase 3: supply via ansible-vault, never commit
+    }
+    virtual_ipaddress {
+        {{ vip_address }}/24
+    }
+    track_script {
+        chk_dns
+    }
+}

--- a/ansible/roles/log2ram/tasks/main.yml
+++ b/ansible/roles/log2ram/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+# log2ram mounts /var/log to a tmpfs and flushes to disk periodically — drastically reduces
+# SD-card write wear (the dominant Pi failure mode). Source: azlux third-party apt repo
+# (external dependency — gated by `log2ram_enabled`, documented in README).
+- name: log2ram (azlux repo + install)
+  when: log2ram_enabled | bool
+  block:
+    - name: Ensure keyrings directory exists
+      ansible.builtin.file:
+        path: /usr/share/keyrings
+        state: directory
+        mode: "0755"
+
+    - name: Add azlux apt signing key
+      ansible.builtin.get_url:
+        url: https://azlux.fr/repo.gpg
+        dest: /usr/share/keyrings/azlux-archive-keyring.gpg
+        mode: "0644"
+
+    - name: Add azlux apt repository
+      ansible.builtin.apt_repository:
+        repo: "deb [signed-by=/usr/share/keyrings/azlux-archive-keyring.gpg] http://packages.azlux.fr/debian/ stable main"
+        filename: azlux
+        state: present
+        update_cache: true
+
+    - name: Install log2ram
+      ansible.builtin.apt:
+        name: log2ram
+        state: present
+      when: not ansible_check_mode    # azlux repo isn't really added in --check, so the pkg isn't yet visible
+
+    # Enable only — the /var/log → tmpfs switch applies cleanly on the next reboot,
+    # avoiding moving the live log mount out from under running services mid-run.
+    - name: Enable log2ram (applies on next reboot)
+      ansible.builtin.service:
+        name: log2ram
+        enabled: true
+      when: not ansible_check_mode    # service exists only after the (real) package install

--- a/ansible/roles/node_exporter/handlers/main.yml
+++ b/ansible/roles/node_exporter/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: restart node_exporter
+  ansible.builtin.service:
+    name: prometheus-node-exporter
+    state: restarted
+  when: not ansible_check_mode    # service exists only after the real install; flush_handlers would trip --check

--- a/ansible/roles/node_exporter/tasks/main.yml
+++ b/ansible/roles/node_exporter/tasks/main.yml
@@ -1,0 +1,43 @@
+---
+- name: Install prometheus-node-exporter
+  ansible.builtin.apt:
+    name: prometheus-node-exporter
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+# Bind to the LAN address so Prometheus on .70 can scrape it (not 0.0.0.0).
+# The Prometheus scrape JOB is Phase 2 (D5) — this only stands up the endpoint.
+- name: Bind node_exporter to the LAN address
+  ansible.builtin.lineinfile:
+    path: /etc/default/prometheus-node-exporter
+    regexp: '^ARGS='
+    line: 'ARGS="--web.listen-address={{ node_exporter_listen }}"'
+    create: true
+    owner: root
+    group: root
+    mode: "0644"
+  notify: restart node_exporter
+
+- name: Ensure node_exporter is enabled and started
+  ansible.builtin.service:
+    name: prometheus-node-exporter
+    state: started
+    enabled: true
+  when: not ansible_check_mode    # service exists only after the (real) package install
+
+# The Pi runs ufw (default-deny incoming). Open 9100 to the Prometheus host ONLY, so the
+# Phase-2 scrape can reach node_exporter without widening the firewall. Outbound container
+# traffic from Prometheus is SNAT'd to the htpc host IP, so the Pi sees the scrape from .70.
+- name: Detect ufw
+  ansible.builtin.stat:
+    path: /usr/sbin/ufw
+  register: ufw_bin
+
+- name: Allow the Prometheus host to scrape node_exporter (ufw)
+  community.general.ufw:
+    rule: allow
+    proto: tcp
+    port: "9100"
+    from_ip: "{{ prometheus_host }}"
+  when: ufw_bin.stat.exists

--- a/ansible/roles/pihole/handlers/main.yml
+++ b/ansible/roles/pihole/handlers/main.yml
@@ -1,0 +1,9 @@
+---
+- name: reload pihole dns
+  ansible.builtin.command: pihole reloaddns
+  changed_when: true
+
+- name: restart pihole-FTL
+  ansible.builtin.service:
+    name: pihole-FTL
+    state: restarted

--- a/ansible/roles/pihole/tasks/main.yml
+++ b/ansible/roles/pihole/tasks/main.yml
@@ -1,0 +1,58 @@
+---
+# Pi-hole v6 settings, converged idempotently via `pihole-FTL --config` (reads pihole.toml).
+# READ tasks force check_mode:false so they populate registers even during --check, letting the
+# SET tasks stay conditional (and show as "would change" in a dry run).
+
+- name: Read current Pi-hole upstreams
+  ansible.builtin.command: pihole-FTL --config dns.upstreams
+  register: ph_upstreams
+  changed_when: false
+  check_mode: false
+
+# Resolution-affecting: safe because the unbound role already VALIDATED unbound resolves.
+- name: Point Pi-hole upstream at unbound
+  ansible.builtin.command:
+    argv: [pihole-FTL, --config, dns.upstreams, '["{{ pihole_upstream }}"]']
+  when: pihole_upstream not in ph_upstreams.stdout
+  notify: reload pihole dns
+
+- name: Read current DNSSEC setting
+  ansible.builtin.command: pihole-FTL --config dns.dnssec
+  register: ph_dnssec
+  changed_when: false
+  check_mode: false
+
+- name: Set Pi-hole DNSSEC (false — unbound validates; avoid double-validation)
+  ansible.builtin.command:
+    argv: [pihole-FTL, --config, dns.dnssec, "{{ 'true' if pihole_dnssec else 'false' }}"]
+  when: (ph_dnssec.stdout | trim | lower) != (pihole_dnssec | string | lower)
+  notify: reload pihole dns
+
+- name: Read current webserver.domain
+  ansible.builtin.command: pihole-FTL --config webserver.domain
+  register: ph_wdomain
+  changed_when: false
+  check_mode: false
+
+# Required behind the Traefik reverse proxy (D4): otherwise FTL may reject the proxied
+# Host header / emit redirects to the wrong host.
+- name: Set webserver.domain for reverse-proxy access
+  ansible.builtin.command:
+    argv: [pihole-FTL, --config, webserver.domain, "{{ pihole_webserver_domain }}"]
+  when: (ph_wdomain.stdout | trim) != pihole_webserver_domain
+  notify: restart pihole-FTL
+
+- name: Read current local DNS records (dns.hosts)
+  ansible.builtin.command: pihole-FTL --config dns.hosts
+  register: ph_hosts
+  changed_when: false
+  check_mode: false
+
+# NOTE: pihole-FTL replaces the whole dns.hosts array. Our resolvers carry only this one
+# managed record, so set-only-if-absent is safe (no-op on node A, which already has it via
+# the UI; sets it on a fresh node B). For multiple records, manage the full list declaratively.
+- name: Ensure split-horizon admin record exists
+  ansible.builtin.command:
+    argv: [pihole-FTL, --config, dns.hosts, '["{{ pihole_local_record }}"]']
+  when: pihole_local_record not in ph_hosts.stdout
+  notify: reload pihole dns

--- a/ansible/roles/pihole_backup/tasks/main.yml
+++ b/ansible/roles/pihole_backup/tasks/main.yml
@@ -1,0 +1,65 @@
+---
+# D8 — nightly Pi-hole v6 Teleporter export, pushed via rsync to the Urd-snapshotted host.
+# The Pi PUSHES (a timer can't do a FIDO2 touch to pull). The push uses a dedicated
+# passwordless key, restricted on the receiving side to a forced rrsync command.
+
+- name: Ensure local backup directory exists
+  ansible.builtin.file:
+    path: "{{ pihole_backup_dir }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0750"
+
+- name: Generate passwordless rsync push key (if absent)
+  ansible.builtin.command: >-
+    ssh-keygen -t ed25519 -N "" -f {{ backup_ssh_key_path }}
+    -C "pihole-backup@{{ inventory_hostname }}"
+  args:
+    creates: "{{ backup_ssh_key_path }}"
+
+- name: Read the push public key (to authorize on the backup host)
+  ansible.builtin.slurp:
+    src: "{{ backup_ssh_key_path }}.pub"
+  register: backup_pub
+  when: not ansible_check_mode    # key is only generated in a real run, not in --check
+
+- name: ACTION REQUIRED — authorize this key on the backup host (restricted)
+  ansible.builtin.debug:
+    msg: >-
+      Add to {{ backup_remote_user }}@{{ backup_remote_host }}:~/.ssh/authorized_keys —
+      from="{{ ansible_host }}",command="rrsync -wo {{ backup_remote_path }}",no-agent-forwarding,no-port-forwarding,no-pty,no-X11-forwarding
+      {{ backup_pub.content | b64decode | trim }}
+  when: not ansible_check_mode
+
+- name: Install backup script
+  ansible.builtin.template:
+    src: pihole-backup.sh.j2
+    dest: /usr/local/sbin/pihole-backup.sh
+    owner: root
+    group: root
+    mode: "0750"
+
+- name: Install backup systemd service
+  ansible.builtin.template:
+    src: pihole-backup.service.j2
+    dest: /etc/systemd/system/pihole-backup.service
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Install backup systemd timer
+  ansible.builtin.template:
+    src: pihole-backup.timer.j2
+    dest: /etc/systemd/system/pihole-backup.timer
+    owner: root
+    group: root
+    mode: "0644"
+
+- name: Enable + start the nightly backup timer
+  ansible.builtin.systemd_service:
+    name: pihole-backup.timer
+    daemon_reload: true
+    enabled: true
+    state: started
+  when: not ansible_check_mode    # unit file is written by the (real) template tasks above

--- a/ansible/roles/pihole_backup/templates/pihole-backup.service.j2
+++ b/ansible/roles/pihole_backup/templates/pihole-backup.service.j2
@@ -1,0 +1,10 @@
+# Managed by Ansible (ADR-031 D8).
+[Unit]
+Description=Pi-hole Teleporter export + rsync push to Urd-backed host
+Wants=network-online.target
+After=network-online.target pihole-FTL.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/sbin/pihole-backup.sh
+# Surface failures: a missed backup should be visible (journal + systemd state).

--- a/ansible/roles/pihole_backup/templates/pihole-backup.sh.j2
+++ b/ansible/roles/pihole_backup/templates/pihole-backup.sh.j2
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Managed by Ansible (ADR-031 D8). Nightly Pi-hole v6 Teleporter export + rsync push.
+set -euo pipefail
+
+BACKUP_DIR="{{ pihole_backup_dir }}"
+RETENTION={{ pihole_backup_retention }}
+KEY="{{ backup_ssh_key_path }}"
+# The receiving key is locked to `rrsync -wo {{ backup_remote_path }}`, so THAT dir is the
+# rsync root — push to an empty remote path (an absolute path would be doubled under the root).
+REMOTE="{{ backup_remote_user }}@{{ backup_remote_host }}:"
+
+mkdir -p "$BACKUP_DIR"
+cd "$BACKUP_DIR"
+
+# 1. Teleporter export (v6) — full config archive, written to CWD.
+pihole-FTL --teleporter
+echo "$(date -Is) teleporter export complete"
+
+# 2. Prune local copies beyond the retention count (newest kept).
+#    (Urd snapshots the remote dir, so deep history lives there regardless.)
+ls -1t "$BACKUP_DIR"/*.zip 2>/dev/null | tail -n +$((RETENTION + 1)) | xargs -r rm -f
+
+# 3. Push to the Urd-snapshotted host. The receiving key is locked to a forced
+#    rrsync command, so this can only write into the designated backup dir.
+rsync -az --delete \
+  -e "ssh -i $KEY -o IdentitiesOnly=yes -o IdentityAgent=none -o BatchMode=yes -o StrictHostKeyChecking=accept-new" \
+  "$BACKUP_DIR"/ "$REMOTE"
+echo "$(date -Is) pushed to $REMOTE"

--- a/ansible/roles/pihole_backup/templates/pihole-backup.timer.j2
+++ b/ansible/roles/pihole_backup/templates/pihole-backup.timer.j2
@@ -1,0 +1,11 @@
+# Managed by Ansible (ADR-031 D8). Fires before Urd's 04:00 run so the fresh export is snapshotted.
+[Unit]
+Description=Nightly Pi-hole backup
+
+[Timer]
+OnCalendar={{ backup_oncalendar }}
+Persistent=true
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target

--- a/ansible/roles/ssh_hardening/handlers/main.yml
+++ b/ansible/roles/ssh_hardening/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: reload ssh
+  ansible.builtin.service:
+    name: ssh
+    state: reloaded

--- a/ansible/roles/ssh_hardening/tasks/main.yml
+++ b/ansible/roles/ssh_hardening/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+# Key-only SSH via a drop-in. Safe to apply: Ansible itself connected over pubkey, so disabling
+# password methods cannot lock us out. Recovery if ever needed: the Pi's physical console.
+# Mirrors the all-THREE-no's lesson from docs/99-reports/2026-04-12-udm-pro-yubikey-ssh-hardening.md.
+- name: Ensure sshd_config.d drop-in directory exists
+  ansible.builtin.file:
+    path: /etc/ssh/sshd_config.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+
+- name: Write SSH hardening drop-in
+  ansible.builtin.template:
+    src: 00-hardening.conf.j2
+    dest: /etc/ssh/sshd_config.d/00-hardening.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: reload ssh
+
+- name: Validate the assembled sshd config (incl. drop-in) BEFORE any reload
+  ansible.builtin.command: /usr/sbin/sshd -t
+  changed_when: false
+  # If this fails the play aborts here — the handler never reloads, so the running
+  # sshd keeps its old (working) config and access is preserved.

--- a/ansible/roles/ssh_hardening/templates/00-hardening.conf.j2
+++ b/ansible/roles/ssh_hardening/templates/00-hardening.conf.j2
@@ -1,0 +1,12 @@
+# Managed by Ansible (ADR-031 Phase 1). Do not edit by hand.
+# Key-only authentication. All THREE password-style methods must be disabled
+# (PasswordAuthentication alone is insufficient — keyboard-interactive routes
+# through PAM/pam_unix; see the 2026-04-12 UDM hardening report).
+PasswordAuthentication no
+KbdInteractiveAuthentication no
+ChallengeResponseAuthentication no
+PubkeyAuthentication yes
+PermitRootLogin prohibit-password
+{% if ssh_allow_users %}
+AllowUsers {{ ssh_allow_users | join(' ') }}
+{% endif %}

--- a/ansible/roles/unbound/handlers/main.yml
+++ b/ansible/roles/unbound/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: restart unbound
+  ansible.builtin.service:
+    name: unbound
+    state: restarted

--- a/ansible/roles/unbound/tasks/main.yml
+++ b/ansible/roles/unbound/tasks/main.yml
@@ -1,0 +1,42 @@
+---
+- name: Install unbound
+  ansible.builtin.apt:
+    name: unbound
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+
+- name: Pi-hole recursive resolver config for unbound
+  ansible.builtin.template:
+    src: pi-hole.conf.j2
+    dest: /etc/unbound/unbound.conf.d/pi-hole.conf
+    owner: root
+    group: root
+    mode: "0644"
+    validate: "/usr/sbin/unbound-checkconf %s"
+  notify: restart unbound
+
+- name: Ensure unbound is enabled and started
+  ansible.builtin.service:
+    name: unbound
+    state: started
+    enabled: true
+
+# Apply any pending restart NOW so the validation below tests the live config,
+# BEFORE the pihole role switches its upstream to this unbound.
+- name: Apply unbound restart before validation
+  ansible.builtin.meta: flush_handlers
+
+- name: Validate unbound actually resolves (gate — pihole must not point at a broken unbound)
+  ansible.builtin.command: dig +short +time=2 +tries=1 cloudflare.com @{{ unbound_listen }} -p {{ unbound_port }}
+  register: unbound_resolve
+  changed_when: false
+  retries: 5
+  delay: 3
+  until: unbound_resolve.rc == 0 and (unbound_resolve.stdout | length) > 0
+  when: not ansible_check_mode    # nothing to gate in a dry run (pihole won't switch upstream)
+
+- name: Show unbound resolution result
+  ansible.builtin.debug:
+    msg: "unbound at {{ unbound_listen }}#{{ unbound_port }} resolved cloudflare.com -> {{ unbound_resolve.stdout_lines }}"
+  when: not ansible_check_mode

--- a/ansible/roles/unbound/templates/pi-hole.conf.j2
+++ b/ansible/roles/unbound/templates/pi-hole.conf.j2
@@ -1,0 +1,31 @@
+# Managed by Ansible (ADR-031). Standard Pi-hole + unbound recursive resolver.
+# Root hints and the DNSSEC trust anchor come from the Debian `dns-root-data` package,
+# so they are intentionally NOT hard-coded here (Debian's unbound finds them automatically).
+server:
+    verbosity: 0
+    interface: {{ unbound_listen }}
+    port: {{ unbound_port }}
+    do-ip4: yes
+    do-udp: yes
+    do-tcp: yes
+    do-ip6: {{ 'yes' if unbound_ipv6 else 'no' }}
+    prefer-ip6: no
+
+    # Hardening
+    harden-glue: yes
+    harden-dnssec-stripped: yes
+    use-caps-for-id: no
+    edns-buffer-size: 1232
+
+    # Performance (sized for a Pi serving a home LAN)
+    prefetch: yes
+    num-threads: 1
+    so-rcvbuf: 1m
+
+    # Do not resolve RFC1918 / link-local upstream (rebinding protection)
+    private-address: 192.168.0.0/16
+    private-address: 169.254.0.0/16
+    private-address: 172.16.0.0/12
+    private-address: 10.0.0.0/8
+    private-address: fd00::/8
+    private-address: fe80::/10

--- a/config/authelia/configuration.yml
+++ b/config/authelia/configuration.yml
@@ -79,6 +79,7 @@ access_control:
         - 'home.patriark.org'
         - 'patriark.org'
         - 'torrent.patriark.org'
+        - 'pihole.patriark.org'   # DNS resolver admin (ADR-031 D4) — YubiKey + LAN/WG allowlist
       policy: two_factor
       subject:
         - 'group:admins'

--- a/config/traefik/dynamic/middleware.yml
+++ b/config/traefik/dynamic/middleware.yml
@@ -153,6 +153,25 @@ http:
           - "Remote-Email"
 
     # ═══════════════════════════════════════════════════════════
+    # IP ALLOWLIST - LAN + WireGuard only (internal admin planes)
+    # ═══════════════════════════════════════════════════════════
+    # Structural "internal-only" gate for admin UIs that must never be
+    # internet-reachable (Pi-hole resolver admin — ADR-031 D4). Sits in front
+    # of Authelia so a non-LAN/non-VPN client is rejected before the auth layer.
+    #
+    # This works ONLY because ADR-022 socket activation preserves the real
+    # client source IP at Traefik (rootlessport SNAT bypassed). Verified
+    # 2026-05-25: the access log shows real LAN/WAN client IPs, not a collapsed
+    # gateway IP. The default IPAllowList matches the direct connection IP, so
+    # no ipStrategy/X-Forwarded-For depth is needed for direct LAN/VPN clients.
+    ip-allowlist:
+      ipAllowList:
+        sourceRange:
+          - 192.168.1.0/24      # patriark-lan (trusted LAN)
+          - 192.168.100.0/24    # WireGuard VPN clients
+          # IoT VLAN (192.168.2.0/24) deliberately excluded — least-trusted segment.
+
+    # ═══════════════════════════════════════════════════════════
     # SECURITY HEADERS - Comprehensive
     # ═══════════════════════════════════════════════════════════
     security-headers:

--- a/config/traefik/dynamic/routers.yml
+++ b/config/traefik/dynamic/routers.yml
@@ -314,6 +314,32 @@ http:
       tls:
         certResolver: letsencrypt
 
+    # Pi-hole DNS resolver admin (ADR-031 D4) — INTERNAL ONLY (enforced by ip-allowlist)
+    # Replaces unauthenticated http://192.168.1.69/admin with SSO-gated HTTPS.
+    # NOTE: ADR-031 D4 envisioned "no public DNS record", but a pre-existing wildcard
+    # *.patriark.org -> WAN IP makes pihole.patriark.org publicly RESOLVABLE. So the
+    # enforcing "internal-only" control is the ip-allowlist (LAN+WG), NOT DNS hiding:
+    # a non-LAN/WG client reaches Traefik via the WAN and is 403'd at the allowlist
+    # before Authelia. Pi-hole also has a local DNS record pihole.patriark.org ->
+    # 192.168.1.70 so LAN/VPN clients hit this host directly. Cert via Cloudflare DNS-01.
+    # Requires an Authelia access_control rule (two_factor, group:admins) — added 2026-05-26.
+    # Chain (ADR-031 D4 / ADR-016 — routing here, not labels):
+    #   crowdsec -> rate-limit -> ip-allowlist (LAN+WG) -> authelia SSO -> headers
+    # Phase 3: repoint the `pihole` service at the keepalived VIP (192.168.1.53).
+    pihole-admin:
+      rule: "Host(`pihole.patriark.org`)"
+      service: "pihole"
+      entryPoints:
+        - websecure
+      middlewares:
+        - crowdsec-bouncer@file
+        - rate-limit@file
+        - ip-allowlist@file
+        - authelia@file
+        - security-headers@file
+      tls:
+        certResolver: letsencrypt
+
   services:
     homepage:
       loadBalancer:
@@ -391,6 +417,15 @@ http:
       loadBalancer:
         servers:
           - url: "http://qbittorrent:8085"
+
+    # Pi-hole resolver admin (ADR-031 D4). Literal LAN IP — no /etc/hosts (ADR-018)
+    # entry needed (that's only for podman aardvark-dns ordering of *container*
+    # names). Traefik reaches it via reverse_proxy LAN egress (same path Prometheus
+    # uses to scrape the Pi). Phase 3: change to the keepalived VIP http://192.168.1.53:80.
+    pihole:
+      loadBalancer:
+        servers:
+          - url: "http://192.168.1.69:80"
 
   middlewares:
     # CalDAV/.well-known redirects for Nextcloud


### PR DESCRIPTION
## ADR-031 Phase 1 — resolver first-class

Elevates the sole LAN resolver (Pi-hole + unbound @ 192.168.1.69) toward the homelab service contract. Applied and **verified end-to-end** against the live node.

### D4 — SSO admin plane (live)
- New `ip-allowlist` middleware (LAN + WireGuard; IoT excluded) + `pihole-admin` router/service in `config/traefik/dynamic/` (ADR-016: routing in dynamic config, not labels).
- Added the `pihole.patriark.org` rule to Authelia `access_control` (two_factor, group:admins).
- Verified: `pihole.patriark.org` → `302` → SSO; the `ip-allowlist` is the enforcing internal-only control (a pre-existing `*.patriark.org`→WAN wildcard means DNS hiding alone doesn't gate it).

### D3 — config-as-code (`ansible/`)
- Role-based, idempotent: Pi-hole v6 (`pihole-FTL --config`), unbound + DNSSEC (**validation-gated** before the upstream switch — a broken unbound can't take DNS down), node_exporter (+ a managed `ufw` allow from Prometheus), keepalived (installed, **not** activated — Phase 3), log2ram, key-only SSH hardening.
- `--check` clean; applied in 3 tagged waves (additive → unbound → pihole), all `failed=0`.

### D8 — backup
- Pi-side systemd timer (03:30, before Urd's 04:00): v6 Teleporter export → `rrsync` write-only push into the Urd-snapshotted `~/containers/data/pihole-backups/`.
- Verified: a real export zip landed on the backup host.

### Notes
- No secrets in Git (keepalived `auth_pass` is a vault placeholder; SSH keys are generated on the Pi).
- **D7** (UDM perimeter: block outbound 53 + DoH except the resolver) is drafted as a **private** runbook, owner-run — intentionally not in this PR.
- Phase 2 (scrape jobs + blackbox DNS probe + alerts + dashboard) and Phase 3 (HA node B + keepalived VIP + nebula-sync) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)