### PR TITLE
feat(dns): ADR-031 Phase 2 — resolver observability + Nextcloud maintenance probe (closes #164)

### DIFF
--- a/config/blackbox-exporter/blackbox.yml
+++ b/config/blackbox-exporter/blackbox.yml
@@ -1,0 +1,59 @@
+# Blackbox Exporter — Probe Modules
+#
+# Phase 2 of ADR-031 (DNS Resolver First-Class & HA) + closes GH#164 (Nextcloud
+# maintenance state). PR B (closes GH#151) will append http_2xx + icmp_v4 modules.
+#
+# Functional > liveness: dns_functional verifies the resolver returns a non-empty
+# answer for a known-good name; dns_blocked verifies the gravity blocklist still
+# rewrites known-ad domains to 0.0.0.0. Both probes failing = real resolver outage;
+# only dns_blocked failing = gravity regression (Thread A class of bug —
+# see [[project_dns_investigation]]).
+
+modules:
+
+  # ADR-031 D5 — primary correctness signal for the resolver.
+  # Resolves a known-good name and FAILS unless the answer contains a real IPv4.
+  # Go's RE2 has no negative lookahead, so split into two checks:
+  #   1. must contain an A record   (catches NXDOMAIN / empty / SERVFAIL)
+  #   2. must NOT be 0.0.0.0        (catches accidental sink-holing of the apex)
+  dns_functional:
+    prober: dns
+    timeout: 5s
+    dns:
+      query_name: patriark.org
+      query_type: A
+      validate_answer_rrs:
+        fail_if_not_matches_regexp:
+          - 'patriark\.org\.\s+\d+\s+IN\s+A\s+\d+\.\d+\.\d+\.\d+'
+        fail_if_matches_regexp:
+          - 'patriark\.org\.\s+\d+\s+IN\s+A\s+0\.0\.0\.0'
+
+  # ADR-031 D5 — block-list health (gravity regression detector).
+  # Resolves a known-bad name and FAILS unless the answer is 0.0.0.0 (sink-holed).
+  # Detects the exact class of bug from the 2026-05-21 Pi-hole investigation
+  # (DoH-bypass / gravity-stale): blocking would silently stop working.
+  dns_blocked:
+    prober: dns
+    timeout: 5s
+    dns:
+      query_name: doubleclick.net
+      query_type: A
+      validate_answer_rrs:
+        fail_if_not_matches_regexp:
+          - 'doubleclick\.net\.\s+\d+\s+IN\s+A\s+0\.0\.0\.0'
+
+  # GH#164 — Nextcloud maintenance / DB-upgrade stuck-state alert.
+  # Probes /status.php (auth-free) and FAILS if maintenance or needsDbUpgrade is true.
+  # Blackbox cannot natively emit `nextcloud_maintenance{0|1}` gauges (GH#164 option 1
+  # was inaccurate on that point); the alert outcome is equivalent — probe_success=0
+  # + probe_failed_due_to_regexp=1 → NextcloudMaintenanceStuck.
+  nextcloud_status:
+    prober: http
+    timeout: 5s
+    http:
+      method: GET
+      valid_status_codes: [200]
+      preferred_ip_protocol: ip4
+      fail_if_body_matches_regexp:
+        - '"maintenance":true'
+        - '"needsDbUpgrade":true'

--- a/config/prometheus/alerts/dns-resolver-alerts.yml
+++ b/config/prometheus/alerts/dns-resolver-alerts.yml
@@ -1,0 +1,123 @@
+# DNS Resolver Alerts — ADR-031 Phase 2 + GH#164
+#
+# Three layers of signal for the LAN resolver (Pi-hole + unbound @ 192.168.1.69):
+#   1. Liveness  — node_exporter `up` for the Pi host.
+#   2. Liveness  — pihole-exporter `up` for the Pi-hole API.
+#   3. Functional — blackbox DNS probes (the *primary* signal per ADR-031 D5):
+#        - dns_functional : resolver returns a real A record for a known-good name.
+#        - dns_blocked    : resolver still sink-holes a known-bad name to 0.0.0.0.
+# Functional > liveness: the resolver can be UP and yet broken (gravity stale,
+# upstream wedged, DNSSEC failing). The blackbox probes catch those.
+#
+# Plus: NextcloudMaintenanceStuck (GH#164) — fires when /status.php reports
+# `maintenance:true` or `needsDbUpgrade:true` for >10m. Re-uses blackbox-exporter.
+
+groups:
+  - name: dns_resolver
+    interval: 30s
+    rules:
+
+      # --- Liveness ---------------------------------------------------------
+
+      - alert: PiHoleNodeDown
+        expr: up{job="node-exporter-pi"} == 0
+        for: 3m
+        labels:
+          severity: critical
+          category: availability
+          component: dns_resolver
+          service: pihole
+        annotations:
+          summary: "Pi-hole resolver host unreachable (node_exporter down)"
+          description: |
+            node_exporter on the Pi-hole resolver (raspberrypi @ 192.168.1.69) is
+            not responding for >3m. Either the Pi is down, ufw is blocking .70,
+            or node_exporter has crashed. Alert path has DNS=9.9.9.9 fallback
+            (ADR-031 Phase 0) so this notification should still arrive.
+          runbook: "ssh patriark@192.168.1.69 'systemctl status node_exporter ufw'"
+
+      - alert: PiHoleExporterDown
+        expr: up{job="pihole"} == 0
+        for: 5m
+        labels:
+          severity: warning
+          category: availability
+          component: dns_resolver
+          service: pihole
+        annotations:
+          summary: "Pi-hole exporter unreachable — query/block metrics blind"
+          description: |
+            pihole-exporter cannot reach the Pi-hole v6 API for >5m. DNS may still
+            work; we just lose visibility on query/block stats. Common causes:
+            invalid app password (PIHOLE_PASSWORD secret), API disabled, or web UI
+            stopped on the Pi.
+
+      # --- Functional (PRIMARY signal — ADR-031 D5) -------------------------
+
+      - alert: DnsResolverFunctionalFail
+        expr: probe_success{job="blackbox-dns-functional"} == 0
+        for: 3m
+        labels:
+          severity: critical
+          category: availability
+          component: dns_resolver
+          probe: dns_functional
+        annotations:
+          summary: "DNS resolver not returning answers for known-good names"
+          description: |
+            blackbox dns_functional probe failing for {{ $labels.instance }} (>3m).
+            Resolver is either down, returning SERVFAIL/empty, or sink-holing
+            patriark.org. This is the primary correctness signal — every internal
+            service that depends on DNS is affected.
+          runbook: |
+            dig +short patriark.org @{{ $labels.instance }}
+            ssh patriark@{{ $labels.instance }} 'systemctl status pihole-FTL unbound'
+
+      - alert: DnsResolverBlocklistRegression
+        expr: probe_success{job="blackbox-dns-blocked"} == 0
+        for: 10m
+        labels:
+          severity: warning
+          category: security
+          component: dns_resolver
+          probe: dns_blocked
+        annotations:
+          summary: "Pi-hole blocklist regression — known-bad name no longer sink-holed"
+          description: |
+            blackbox dns_blocked probe failing for {{ $labels.instance }} (>10m):
+            doubleclick.net is *not* being rewritten to 0.0.0.0. Detects the
+            class of bug from the 2026-05-21 Pi-hole investigation (gravity
+            stale / blocking disabled / upstream bypass). If DnsResolverFunctionalFail
+            is also firing, treat as full outage; alone = blocking-only regression.
+          runbook: |
+            dig +short doubleclick.net @{{ $labels.instance }}
+            ssh patriark@{{ $labels.instance }} 'pihole -g'   # rebuild gravity
+
+  - name: nextcloud_state
+    interval: 1m
+    rules:
+
+      # --- GH#164 — Nextcloud maintenance / DB-upgrade stuck-state ---------
+
+      - alert: NextcloudMaintenanceStuck
+        # Body-regex failure is the discriminator: any other probe failure (5xx,
+        # network) would not set probe_failed_due_to_regexp=1.
+        expr: probe_success{job="blackbox-nextcloud-status"} == 0
+              and probe_failed_due_to_regexp{job="blackbox-nextcloud-status"} == 1
+        for: 10m
+        labels:
+          severity: critical
+          category: availability
+          component: nextcloud
+          service: nextcloud
+        annotations:
+          summary: "Nextcloud stuck in maintenance / pending DB upgrade for >10m"
+          description: |
+            /status.php reports `maintenance:true` or `needsDbUpgrade:true` for
+            >10m. Planned maintenance windows are normally <10m; this indicates
+            a stuck upgrade or unfinished migration. Closes the gap from the
+            2026-04-21 SLO-collapse postmortem (rate-based alerts missed it).
+          runbook: |
+            podman exec -u www-data nextcloud php occ status
+            podman exec -u www-data nextcloud php occ upgrade
+            podman exec -u www-data nextcloud php occ maintenance:mode --off

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -181,3 +181,85 @@ scrape_configs:
         labels:
           instance: 'fedora-htpc'
           service: 'postgres-immich'
+
+  # ===========================================================================
+  # ADR-031 Phase 2 — DNS resolver observability
+  # ===========================================================================
+
+  # node_exporter on the Pi-hole resolver (raspberrypi @ 192.168.1.69)
+  # Reachable directly from Prometheus (reverse_proxy network has LAN egress).
+  # ufw on the Pi already allows .70 → 9100 (applied via Ansible role node_exporter).
+  - job_name: 'node-exporter-pi'
+    static_configs:
+      - targets: ['192.168.1.69:9100']
+        labels:
+          instance: 'raspberrypi'
+          service: 'node_exporter'
+          role: 'dns_resolver'
+
+  # Pi-hole exporter — query/block stats from the Pi-hole v6 API.
+  - job_name: 'pihole'
+    static_configs:
+      - targets: ['pihole-exporter:9617']
+        labels:
+          instance: 'raspberrypi'
+          service: 'pihole'
+          role: 'dns_resolver'
+
+  # Blackbox DNS probes — *functional* signal (correctness > liveness).
+  # dns_functional: resolver returns a real A record for patriark.org.
+  # dns_blocked   : resolver sink-holes doubleclick.net to 0.0.0.0 (gravity health).
+  - job_name: 'blackbox-dns-functional'
+    metrics_path: /probe
+    params:
+      module: [dns_functional]
+    static_configs:
+      - targets:
+          - 192.168.1.69  # node A (only resolver today; node B + VIP added in Phase 3)
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115
+      - target_label: probe
+        replacement: dns_functional
+
+  - job_name: 'blackbox-dns-blocked'
+    metrics_path: /probe
+    params:
+      module: [dns_blocked]
+    static_configs:
+      - targets:
+          - 192.168.1.69
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115
+      - target_label: probe
+        replacement: dns_blocked
+
+  # GH#164 — Nextcloud maintenance / DB-upgrade stuck-state probe.
+  # Probes nextcloud's reverse_proxy interface (same target Traefik uses).
+  - job_name: 'blackbox-nextcloud-status'
+    metrics_path: /probe
+    params:
+      module: [nextcloud_status]
+    static_configs:
+      - targets:
+          - http://10.89.2.82/status.php
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115
+      - target_label: service
+        replacement: nextcloud
+      - target_label: probe
+        replacement: nextcloud_status

--- a/quadlets/blackbox-exporter.container
+++ b/quadlets/blackbox-exporter.container
@@ -1,0 +1,43 @@
+[Unit]
+Description=Blackbox Exporter (Prometheus) - HTTP/DNS/ICMP/TCP probes
+Documentation=https://github.com/prometheus/blackbox_exporter
+After=network-online.target reverse_proxy-network.service monitoring-network.service
+Wants=network-online.target reverse_proxy-network.service monitoring-network.service
+
+[Container]
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-27 (multi-arch index digest).
+# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart.
+Image=quay.io/prometheus/blackbox-exporter@sha256:e753ff9f3fc458d02cca5eddab5a77e1c175eee484a8925ac7d524f04366c2fc
+ContainerName=blackbox-exporter
+HostName=blackbox-exporter
+
+# reverse_proxy first → default route (reach LAN .69 DNS, .1 ICMP, internet for external probes).
+# monitoring → scraped by Prometheus on :9115.
+Network=systemd-reverse_proxy:ip=10.89.2.90
+Network=systemd-monitoring:ip=10.89.4.95
+
+Volume=%h/containers/config/blackbox-exporter/blackbox.yml:/etc/blackbox_exporter/config.yml:Z,ro
+
+Exec=--config.file=/etc/blackbox_exporter/config.yml
+
+HealthCmd=wget --no-verbose --tries=1 -O /dev/null http://localhost:9115/-/healthy || exit 1
+HealthInterval=30s
+HealthTimeout=5s
+HealthRetries=3
+
+User=1000:1000
+NoNewPrivileges=true
+
+[Service]
+Slice=container.slice
+Restart=on-failure
+RestartSec=10s
+TimeoutStartSec=60s
+TimeoutStopSec=30s
+
+MemoryMax=128M
+MemoryHigh=115M
+CPUQuota=50%
+
+[Install]
+WantedBy=default.target

--- a/quadlets/pihole-exporter.container
+++ b/quadlets/pihole-exporter.container
@@ -1,0 +1,51 @@
+[Unit]
+Description=Pi-hole Exporter (Prometheus) — query/block metrics from the LAN resolver
+Documentation=https://github.com/eko/pihole-exporter
+After=network-online.target reverse_proxy-network.service monitoring-network.service
+Wants=network-online.target reverse_proxy-network.service monitoring-network.service
+
+[Container]
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-27.
+# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only.
+# Pi-hole v6: uses app-password auth, supplied via Podman secret PIHOLE_PASSWORD.
+Image=docker.io/ekofr/pihole-exporter@sha256:a890cc731a39da719ba19cfd717427d93366cd36307f069d495f37a1373ccffc
+ContainerName=pihole-exporter
+HostName=pihole-exporter
+
+# reverse_proxy first → default route to LAN (the Pi at 192.168.1.69).
+# monitoring → Prometheus scrapes :9617.
+Network=systemd-reverse_proxy:ip=10.89.2.91
+Network=systemd-monitoring:ip=10.89.4.96
+
+Environment=PIHOLE_HOSTNAME=192.168.1.69
+Environment=PIHOLE_PORT=80
+Environment=PIHOLE_PROTOCOL=http
+Environment=PORT=9617
+Environment=INTERVAL=30s
+Environment=TZ=Europe/Oslo
+
+# Pi-hole v6 app password — generate in Pi-hole UI (Settings → Web Interface / API → App passwords).
+# Create secret:  printf '<app-password>' | podman secret create pihole_api_token -
+Secret=pihole_api_token,type=env,target=PIHOLE_PASSWORD
+
+HealthCmd=wget --no-verbose --tries=1 -O /dev/null http://localhost:9617/metrics || exit 1
+HealthInterval=30s
+HealthTimeout=5s
+HealthRetries=3
+
+User=1000:1000
+NoNewPrivileges=true
+
+[Service]
+Slice=container.slice
+Restart=on-failure
+RestartSec=10s
+TimeoutStartSec=60s
+TimeoutStopSec=30s
+
+MemoryMax=64M
+MemoryHigh=56M
+CPUQuota=25%
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## ADR-031 Phase 2 — DNS resolver observability

Three layers of signal for the LAN resolver (Pi-hole + unbound @ 192.168.1.69), plus closes #164 (Nextcloud stuck-state alert) by re-using the same exporter. Phase 0 + 1 (#239, #240) already landed; this PR is the observability layer the ADR called for.

**Functional > liveness:** the resolver can be `up` and yet broken (gravity stale, upstream wedged, DNSSEC failing). The blackbox DNS probes catch those cases — the primary correctness signal per ADR-031 D5.

## What's in

**New services** (digest-pinned, AutoUpdate removed per ADR-030 P1/P2/P4):
- `blackbox-exporter` — dual-network (reverse_proxy + monitoring), Pi-hole/Nextcloud/UDM-reachable
- `pihole-exporter` — Pi-hole v6 app-password via Podman secret `pihole_api_token` → `PIHOLE_PASSWORD`

**Probe modules** (`config/blackbox-exporter/blackbox.yml`):
| Module | Purpose |
|---|---|
| `dns_functional` | Resolver returns a real A record for `patriark.org` (catches NXDOMAIN/empty/SERVFAIL/accidental apex sinkhole) |
| `dns_blocked` | Resolver still sink-holes `doubleclick.net` to `0.0.0.0` — detects the 2026-05-21-class gravity regression directly |
| `nextcloud_status` | `/status.php` has neither `maintenance:true` nor `needsDbUpgrade:true` |

**Scrape jobs** (`config/prometheus/prometheus.yml`):
`node-exporter-pi`, `pihole`, `blackbox-dns-functional`, `blackbox-dns-blocked`, `blackbox-nextcloud-status`.

**Alerts** (`config/prometheus/alerts/dns-resolver-alerts.yml`):
- `PiHoleNodeDown` / `PiHoleExporterDown` — liveness
- `DnsResolverFunctionalFail` (critical, 3m) — primary correctness signal
- `DnsResolverBlocklistRegression` (warning, 10m) — gravity health
- `NextcloudMaintenanceStuck` (critical, 10m) — **closes #164**

## Design choices worth flagging

- **#164 wanted a `nextcloud_maintenance{0|1}` gauge.** Blackbox can't natively emit JSON-parsed gauges — it emits `probe_success` + `probe_failed_due_to_regexp`. Alert outcome is equivalent; the literal metric name in #164 option 1 won't exist. Chose this over a small sidecar to keep one exporter for both ADR-031 and #164.
- **Go RE2 has no negative lookahead.** `dns_functional` uses paired `fail_if_not_matches_regexp` (must have an A) + `fail_if_matches_regexp` (mustn't be `0.0.0.0`) to express "non-empty, non-sinkholed answer."
- **Nextcloud probe targets the reverse_proxy IP directly** (`http://10.89.2.82/status.php`) — same path Traefik uses; decoupled from auth/CrowdSec/rate-limit middleware.
- **External reachability (true public probe of `patriark.org`)** is deferred — internal blackbox validates "Traefik responds + cert valid" only. Off-site prober is a future decision.

## Verification (live, on running stack)

```
promtool check config /etc/prometheus/prometheus.yml  → SUCCESS
promtool check rules  /etc/prometheus/alerts/dns-resolver-alerts.yml → SUCCESS (5 rules)
```

All 5 new scrape targets healthy:
| Job | Health | Signal |
|---|---|---|
| `node-exporter-pi` | up | Pi host metrics |
| `pihole` | up | 69 312 queries, 2 367 blocks today, 83 068 domains in blocklist, 20 clients |
| `blackbox-dns-functional` | up | `probe_success=1` |
| `blackbox-dns-blocked` | up | `probe_success=1` |
| `blackbox-nextcloud-status` | up | `probe_success=1` |

**Adversarial tests** (prove probes catch real failures, not just liveness):
- `dns_blocked @ 8.8.8.8` → `probe_success=0` ✓ (regex correctly fails when target isn't sink-holing)
- `dns_functional @ 0.0.0.0` → `probe_success=0` ✓

## Gotcha observed + handled

Prometheus's `prometheus.yml` is a single-file bind mount — `kill -HUP` / `/-/reload` re-reads the same stale inode after an external edit. Needed `systemctl --user restart prometheus.service` to pick up new scrape jobs. Documented in commit message; matches `project_platform_gotchas`.

## Test Plan

- [x] Pre-commit ADR-030 supply-chain gate passes
- [x] All 5 scrape targets healthy in Prometheus
- [x] All 3 probes return `probe_success=1` against current LAN
- [x] Adversarial probes correctly fail (regex actually works)
- [x] Alert rules loaded into Prometheus (`/api/v1/rules`)
- [ ] Force a regression in a maintenance window to fire one of the new alerts end-to-end (owner)
- [ ] Add a resolver-health Grafana dashboard (follow-up, not required for this PR)

## Follow-ups (separate PRs)

- **PR B** (closes #151) — `http_2xx` + `icmp_v4` modules + UDM probe + cert-expiry alerts
- **Phase 3** — node B (`192.168.1.68`) + keepalived VIP; add VIP + node B targets to the existing scrape jobs (no new exporter)
- D7 UDM perimeter lockdown — owner-run via `docs/99-reports/dns-perimeter-enforcement-udm-runbook.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)