### PR TITLE
chore(monitoring): stretch blackbox DNS probe cadence

### DIFF
--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -209,7 +209,11 @@ scrape_configs:
   # Blackbox DNS probes — *functional* signal (correctness > liveness).
   # dns_functional: resolver returns a real A record for patriark.org.
   # dns_blocked   : resolver sink-holes doubleclick.net to 0.0.0.0 (gravity health).
+  # Cadence: liveness-class probe — outages caught within one alert window (for: 3m).
+  # 30s is fast enough for that; 15s would just dirty Pi-hole's query log without
+  # earlier detection (real outages also show up in pihole-exporter query metrics).
   - job_name: 'blackbox-dns-functional'
+    scrape_interval: 30s
     metrics_path: /probe
     params:
       module: [dns_functional]
@@ -226,7 +230,13 @@ scrape_configs:
       - target_label: probe
         replacement: dns_functional
 
+  # Cadence: config-drift canary — gravity regressions are a slow signal (hours/days).
+  # Alert uses for: 10m, so 5m interval gives 2+ samples per window. Probing faster
+  # adds no detection speed and pollutes Pi-hole's query log (which the operator uses
+  # to investigate genuine network anomalies — see GH#TBD pihole-exporter session
+  # hygiene + 2026-05-28 conversation).
   - job_name: 'blackbox-dns-blocked'
+    scrape_interval: 5m
     metrics_path: /probe
     params:
       module: [dns_blocked]


### PR DESCRIPTION
## Summary

Per-job `scrape_interval` overrides on the two blackbox DNS probes in `config/prometheus/prometheus.yml`:

- `blackbox-dns-functional`: **15s → 30s** (liveness probe; alert `for: 3m`)
- `blackbox-dns-blocked`: **15s → 5m** (config-drift canary; alert `for: 10m`)

Both probes were inheriting the global 15s scrape interval, generating ~8 queries/min against Pi-hole. Net effect: **~8/min → ~2.2/min** (-72%) of blackbox-induced Pi-hole query-log noise. The operator uses that log to investigate real network anomalies, so reducing canary noise materially improves signal-to-noise.

## Why this is safe

| Probe | New interval | Alert `for:` | Samples in window |
|---|---|---|---|
| dns_functional | 30s | 3m | ~6 |
| dns_blocked | 5m | 10m | 2 |

Both alerts comfortably cover the new intervals. Real DNS outages also surface immediately via failing user queries and `pihole-exporter` metrics — the liveness probe was never the sole signal. Gravity regressions are slow (hours/days); probing every 15s offered no faster detection of any real failure mode.

## Validation

- `promtool check config /etc/prometheus/prometheus.yml` → SUCCESS
- Prometheus reloaded; `/api/v1/status/config` confirms new per-job intervals
- All 3 blackbox probes report `probe_success=1` post-change

## Context

Surfaced during a network-anomaly investigation (2026-05-28): operator noticed periodic `doubleclick.net` queries from fedora-htpc in Pi-hole logs every 15s, even with browsers closed. Source turned out to be our own gravity canary — exactly what ADR-031 Phase 2 (#241) intended, but probing faster than warranted.

## Related

- ADR-031 Phase 2 (#241) — introduced the dns_functional + dns_blocked probes
- #246 — separate `pihole-exporter` session-leak issue causing "too many requests" in admin UI (surfaced during the same investigation; not addressed here)

## Test plan

- [x] `promtool check config` passes
- [x] Prometheus picks up new config (`/api/v1/status/config`)
- [x] `probe_success{job=~"blackbox-dns-.*"} == 1`
- [ ] Visually confirm in Pi-hole query log: `doubleclick.net` queries drop to one every 5 minutes within ~10 minutes of merge
- [ ] Confirm `patriark.org` resolver-functional queries drop to one every 30 seconds