### PR TITLE
feat(monitoring): pihole-session-sweeper — mitigate exporter session leak (GH#246)

### DIFF
--- a/config/prometheus/alerts/pihole-session-alerts.yml
+++ b/config/prometheus/alerts/pihole-session-alerts.yml
@@ -1,0 +1,47 @@
+# Pi-hole API session-pool alerts (GH#246 — exporter session-leak mitigation).
+#
+# Backing metric: pihole-sessions.prom textfile, emitted by the
+# pihole-session-sweeper.timer (hourly). Watches the only failure mode the
+# sweeper does NOT self-heal: the sweeper itself failing or being unable to
+# keep up with a regression in upstream pihole-exporter behavior.
+
+groups:
+  - name: pihole-sessions
+    rules:
+      - alert: PiHoleSessionPoolNearExhaustion
+        expr: pihole_sessions_active / pihole_sessions_max > 0.75
+        for: 30m
+        labels:
+          severity: warning
+          service: pihole
+          component: exporter
+        annotations:
+          summary: "Pi-hole session pool {{ $value | humanizePercentage }} full"
+          description: |
+            The Pi-hole API session pool is filling faster than the sweeper
+            can drain it (active/max > 75% for 30m). Likely causes: the
+            pihole-session-sweeper.timer is failing, or upstream
+            ekofr/pihole-exporter behavior has changed and is leaking faster
+            than once per session-timeout window.
+
+            Inspect:
+              systemctl --user status pihole-session-sweeper.timer
+              journalctl --user -u pihole-session-sweeper.service --since '6 hours ago'
+              curl -sS -X POST http://192.168.1.69/api/auth -d "..." | jq
+
+            Context: GH#246, eko/pihole-exporter#318.
+
+      - alert: PiHoleSessionSweeperStale
+        expr: time() - pihole_session_sweeper_last_success_timestamp_seconds > 7200
+        for: 15m
+        labels:
+          severity: warning
+          service: pihole
+          component: sweeper
+        annotations:
+          summary: "Pi-hole session sweeper has not succeeded in {{ $value | humanizeDuration }}"
+          description: |
+            pihole-session-sweeper.timer is hourly; no successful run in
+            >2h means the timer is broken or the script is erroring. The
+            session pool will start filling within a few session-timeout
+            cycles. Check journalctl --user -u pihole-session-sweeper.service.

--- a/scripts/pihole-session-sweeper.sh
+++ b/scripts/pihole-session-sweeper.sh
@@ -1,0 +1,130 @@
+#!/bin/bash
+################################################################################
+# pihole-session-sweeper.sh — Mitigate ekofr/pihole-exporter session leak
+#
+# Context (GH#246):
+#   The Pi-hole exporter (docker.io/ekofr/pihole-exporter) re-authenticates
+#   when its session expires but never calls DELETE /api/auth on the previous
+#   one. Pi-hole v6 does not garbage-collect expired sessions from the visible
+#   pool, so abandoned sessions accumulate against api.max_sessions (16),
+#   eventually rejecting new admin-UI logins with "too many requests".
+#
+#   Source confirmation: ensureAuth() at
+#   github.com/eko/pihole-exporter internal/pihole/api_client.go — calls
+#   c.Authenticate() (new session) without c.Logout() (does not exist).
+#   Same root cause underlies upstream eko/pihole-exporter#318
+#   ("endpoint gets slow until it stalls").
+#
+# Companion (already applied): Pi-hole webserver.session.timeout 1800 → 86400.
+#   That alone drops the leak rate from 48/day to 1/day; this sweeper makes
+#   the pool self-healing regardless of upstream-exporter behavior.
+#
+# Behavior:
+#   1. Auth with the app-password from Podman secret pihole_api_token.
+#   2. GET /api/auth/sessions; find any session where valid_until < now.
+#   3. DELETE each expired session by id.
+#   4. Log out the sweeper's own session (so this script never adds to the
+#      problem it solves).
+#   5. Emit a textfile metric for node_exporter so Prometheus can alert
+#      before exhaustion regardless of whether sweeping keeps up.
+#
+# Idempotent. Safe to run as often as you like; defaults to hourly via
+# pihole-session-sweeper.timer.
+################################################################################
+
+set -euo pipefail
+
+PIHOLE_HOST="${PIHOLE_HOST:-192.168.1.69}"
+SECRET_NAME="${PIHOLE_SECRET_NAME:-pihole_api_token}"
+METRICS_DIR="${HOME}/containers/data/backup-metrics"
+METRICS_FILE="${METRICS_DIR}/pihole-sessions.prom"
+PIHOLE_MAX_SESSIONS="${PIHOLE_MAX_SESSIONS:-16}"
+
+# systemd-cron environment (consistent with sibling scripts)
+export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+export DBUS_SESSION_BUS_ADDRESS="unix:path=${XDG_RUNTIME_DIR}/bus"
+
+log() { printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"; }
+die() { log "FATAL: $*" >&2; exit 1; }
+
+token=$(podman secret inspect --showsecret "$SECRET_NAME" --format '{{.SecretData}}' 2>/dev/null) \
+    || die "Failed to read podman secret $SECRET_NAME"
+[[ -n "$token" ]] || die "Empty token from $SECRET_NAME"
+
+sid=""
+cleanup() {
+    local rc=$?
+    if [[ -n "$sid" ]]; then
+        curl -sS --max-time 5 -X DELETE \
+            "http://${PIHOLE_HOST}/api/auth" \
+            -H "X-FTL-SID: $sid" >/dev/null 2>&1 || true
+    fi
+    return $rc
+}
+trap cleanup EXIT
+
+auth_resp=$(curl -sSf --max-time 10 -X POST "http://${PIHOLE_HOST}/api/auth" \
+    -H "Content-Type: application/json" \
+    -d "$(printf '{"password":"%s"}' "$token")") \
+    || die "Auth POST failed"
+sid=$(echo "$auth_resp" | python3 -c 'import json,sys; print(json.load(sys.stdin)["session"]["sid"])')
+[[ -n "$sid" ]] || die "Auth response missing sid"
+
+sessions_json=$(curl -sSf --max-time 10 \
+    "http://${PIHOLE_HOST}/api/auth/sessions" \
+    -H "X-FTL-SID: $sid") \
+    || die "GET /api/auth/sessions failed"
+
+now=$(date +%s)
+read -r total expired_ids_csv < <(python3 -c '
+import json, sys
+j = json.load(sys.stdin)
+sessions = j.get("sessions", [])
+now = '"$now"'
+my_sid = "'"$sid"'"
+expired = [s["id"] for s in sessions
+           if s.get("valid_until", 0) < now and s.get("sid","") != my_sid]
+print(len(sessions), ",".join(str(i) for i in expired))
+' <<<"$sessions_json")
+
+deleted=0
+failed=0
+if [[ -n "${expired_ids_csv:-}" ]]; then
+    IFS=',' read -ra ids <<<"$expired_ids_csv"
+    for id in "${ids[@]}"; do
+        if curl -sSf --max-time 5 -X DELETE \
+            "http://${PIHOLE_HOST}/api/auth/session/${id}" \
+            -H "X-FTL-SID: $sid" >/dev/null; then
+            deleted=$((deleted + 1))
+        else
+            failed=$((failed + 1))
+        fi
+    done
+fi
+
+active_after=$((total - deleted))
+log "sessions_before=$total expired_deleted=$deleted delete_failures=$failed sessions_after=$active_after max=$PIHOLE_MAX_SESSIONS"
+
+# Emit textfile metric (atomic, in-dir tmp → inherits container_file_t).
+# Same pattern as db-dump.sh per project_platform_gotchas.
+mkdir -p "$METRICS_DIR"
+out=$(cat <<EOF
+# HELP pihole_sessions_active Active Pi-hole API sessions after the last sweep.
+# TYPE pihole_sessions_active gauge
+pihole_sessions_active $active_after
+# HELP pihole_sessions_max Maximum allowed Pi-hole API sessions (Pi-hole config).
+# TYPE pihole_sessions_max gauge
+pihole_sessions_max $PIHOLE_MAX_SESSIONS
+# HELP pihole_session_sweeper_deleted Sessions deleted by the sweeper in the most recent run.
+# TYPE pihole_session_sweeper_deleted gauge
+pihole_session_sweeper_deleted $deleted
+# HELP pihole_session_sweeper_delete_failures Sweep delete attempts that failed in the most recent run.
+# TYPE pihole_session_sweeper_delete_failures gauge
+pihole_session_sweeper_delete_failures $failed
+# HELP pihole_session_sweeper_last_success_timestamp_seconds Unix timestamp of last successful sweep.
+# TYPE pihole_session_sweeper_last_success_timestamp_seconds gauge
+pihole_session_sweeper_last_success_timestamp_seconds $now
+EOF
+)
+printf '%s\n' "$out" > "${METRICS_FILE}.tmp"
+mv "${METRICS_FILE}.tmp" "$METRICS_FILE"

--- a/systemd/pihole-session-sweeper.service
+++ b/systemd/pihole-session-sweeper.service
@@ -1,0 +1,23 @@
+[Unit]
+# GH#246 — sweep expired Pi-hole API sessions left behind by the leak in
+# ekofr/pihole-exporter (ensureAuth re-auths without DELETE /api/auth).
+# Companion to the Pi-hole webserver.session.timeout bump (1800 → 86400)
+# applied via the admin UI on 2026-05-28.
+Description=Pi-hole session sweeper (GH#246 exporter session-leak mitigation)
+Documentation=file:/home/patriark/containers/scripts/pihole-session-sweeper.sh
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/containers/scripts/pihole-session-sweeper.sh
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=60s
+
+# PrivateTmp intentionally NOT set — rootless podman's pause-process needs
+# access to the user's real /tmp namespace (see project_platform_gotchas).
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=default.target

--- a/systemd/pihole-session-sweeper.timer
+++ b/systemd/pihole-session-sweeper.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=Pi-hole session sweeper timer (hourly)
+Documentation=file:/home/patriark/containers/scripts/pihole-session-sweeper.sh
+Requires=pihole-session-sweeper.service
+
+[Timer]
+# Hourly. With session.timeout=86400 (24h), the exporter creates ~1 new
+# session/day, so hourly is overkill in steady state — kept hourly anyway so
+# the pool also recovers within ~1h from any transient burst (e.g. exporter
+# crash-loop, Pi-hole restart, debugging curl spam).
+OnBootSec=5min
+OnUnitActiveSec=1h
+RandomizedDelaySec=2min
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Closes the operational pain from GH#246 ("too many requests" in Pi-hole admin UI) with a two-part mitigation. Change A (Pi-hole `webserver.session.timeout` 1800 → 86400) was applied directly via the Pi-hole admin UI on 2026-05-28 — this PR is change B, the self-healing safety net.

## Root cause (recap)

`ekofr/pihole-exporter` re-authenticates when its session expires but never calls `DELETE /api/auth` on the previous one. Pi-hole v6 doesn't garbage-collect expired sessions from the visible pool, so they accumulate against `api.max_sessions = 16` and eventually reject admin-UI logins. Source confirmed in `internal/pihole/api_client.go` — `ensureAuth()` calls `c.Authenticate()` without a corresponding logout. Same root cause underlies upstream eko/pihole-exporter#318.

## What this PR adds

| File | Role |
|---|---|
| `scripts/pihole-session-sweeper.sh` | Auth → list sessions → DELETE expired → logout. Emits textfile metric. |
| `systemd/pihole-session-sweeper.{service,timer}` | Hourly oneshot. |
| `config/prometheus/alerts/pihole-session-alerts.yml` | `PiHoleSessionPoolNearExhaustion`, `PiHoleSessionSweeperStale`. |

Together with change A, this drops the exporter's leak rate from 48 sessions/day to ~1/day, and the hourly sweep guarantees the pool can never fill — even if upstream behavior regresses.

## Design notes

- **Sweeper never adds to the leak it solves**: `trap` always calls `DELETE /api/auth` on its own session, on every exit path.
- **`PrivateTmp` deliberately unset** in the service unit. Rootless podman's pause-process namespace can't be re-entered from a private /tmp (`Error: ... cannot re-exec process to join the existing user namespace`). Caught + documented during testing.
- **Atomic, in-dir tmp + 0644** for the metric file, matching the established pattern in `db-dump.sh` per `project_platform_gotchas` (textfile context+mode preservation).
- **Alert thresholds intentionally lenient**: pool >75% for 30m, sweeper stale >2h. The sweeper is hourly and the leak is now 1/day — anything tighter would be noise.

## Verification (live)

- First manual sweep: `sessions_before=5 expired_deleted=1 delete_failures=0 sessions_after=4 max=16`
- Service via systemd: `Result=success, ExecMainStatus=0`
- `promtool check rules` + `promtool check config`: SUCCESS
- Prometheus picked up new alert file via `/-/reload`
- Both alerts evaluating `inactive` (ratio 0.25, sweeper last-success 76s ago)
- Timer scheduled: next at 13:33 CEST, then hourly

## What's deferred

- **Upstream fix**: forking ekofr/pihole-exporter to add proper `DELETE /api/auth` on re-auth + PR upstream. The right long-term move but not blocking — the sweeper makes this a maintenance issue, not an outage.

## Test plan

- [x] `promtool check config` passes
- [x] Sweeper runs cleanly via systemd
- [x] Metric file emitted with correct content + SELinux context
- [x] `pihole_sessions_active` queryable in Prometheus
- [x] Alerts loaded + evaluating inactive
- [ ] Confirm timer fires at 13:33 CEST (first hourly tick after enable)
- [ ] Watch over 24h: confirm `pihole_sessions_active` stays ≤2 in steady state