### PR TITLE
feat(monitoring): backup churn-spike alert + local-pinned-delta panel

### DIFF
--- a/config/grafana/provisioning/dashboards/json/backup-health.json
+++ b/config/grafana/provisioning/dashboards/json/backup-health.json
@@ -1174,6 +1174,101 @@
       ],
       "title": "DB Dump Size Trend (per database)",
       "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "description": "Estimated local disk space pinned by snapshot retention per subvolume (mean in-window incremental wire_bytes x local snapshot count). A capacity/headroom signal: how much local space each subvolume is holding via retained snapshots. Some(0) when local snapshots are disabled or count is 0; absent in cold-start. Emitted by Urd (UPI 043; a UPI 044 retention-recommendation input). Added 2026-06-04.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisBorderShow": false,
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 10,
+            "gradientMode": "none",
+            "hideFrom": {
+              "tooltip": false,
+              "viz": false,
+              "legend": false
+            },
+            "insertNulls": false,
+            "lineInterpolation": "linear",
+            "lineWidth": 2,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "never",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          },
+          "unit": "bytes"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 56
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [
+            "lastNotNull",
+            "mean",
+            "max"
+          ],
+          "displayMode": "table",
+          "placement": "right",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "multi",
+          "sort": "desc"
+        }
+      },
+      "pluginVersion": "11.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+          },
+          "expr": "backup_subvolume_estimated_local_pinned_delta_bytes",
+          "legendFormat": "{{subvolume}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Estimated Local Pinned Delta (per subvolume)",
+      "type": "timeseries"
     }
   ],
   "refresh": "30s",
@@ -1194,6 +1289,6 @@
   "timezone": "browser",
   "title": "Backup Health Dashboard",
   "uid": "backup-health",
-  "version": 3,
+  "version": 4,
   "weekStart": ""
 }

--- a/config/prometheus/alerts/backup-alerts.yml
+++ b/config/prometheus/alerts/backup-alerts.yml
@@ -129,6 +129,32 @@ groups:
           summary: "Backup taking unusually long for {{ $labels.subvolume }}"
           description: "Last backup took {{ $value | humanizeDuration }}. May indicate performance issues. Alert auto-resolves after 1h for weekly/monthly backups."
 
+      # Warning: Anomalous churn spike — a subvolume's changed-data rate jumped far
+      # above its own recent baseline. NOT a failure signal; it's a capacity/anomaly
+      # canary (runaway growth, in-place rewrites, or a mass-rewrite event — doubles as
+      # a weak ransomware canary). churn = time-windowed bytes/sec from wire_bytes of
+      # recent incremental sends; refreshes at nightly backup cadence (hence the long for:).
+      #
+      # Calibration (2026-06-04, fleet at rest): busiest subvolumes churn ~25-30 KiB/s
+      # (htpc-root 27K, subvol7-containers 24K, htpc-home 15K); all others <1 KiB/s.
+      # The 256 KiB/s floor sits ~8x above any normal rate, so the RATIO test (>4x the
+      # 14d baseline, `offset 2d` to exclude the spike itself) provides sensitivity while
+      # the floor suppresses meaningless ratio-noise on near-idle subvolumes (e.g.
+      # subvol1-docs at ~5 B/s). Re-baseline the floor if fleet churn grows materially.
+      - alert: BackupChurnSpike
+        expr: |
+          backup_subvolume_churn_bytes_per_second
+            > 4 * avg_over_time(backup_subvolume_churn_bytes_per_second[14d] offset 2d)
+          and backup_subvolume_churn_bytes_per_second > 262144
+        for: 1h
+        labels:
+          severity: warning
+          category: backup
+          component: btrfs-snapshot-backup
+        annotations:
+          summary: "Anomalous backup churn on {{ $labels.subvolume }}"
+          description: "{{ $labels.subvolume }} is churning {{ $value | humanize }}B/s — over 4x its 14-day baseline and above the 256 KiB/s floor. Expected if you just imported or rewrote a lot of data; otherwise investigate runaway growth or in-place rewrites."
+
   # ==========================================================================
   # Pool-capacity alerts from Urd's btrfs pool metrics (backup_pool_*).
   # These cover what node_exporter cannot: BTRFS metadata exhaustion (a silent


### PR DESCRIPTION
Closes the two backup-health observability gaps surfaced in the metrics-consumption review: two Urd metrics were **emitted but consumed by nothing**. Both were deferred follow-ups in ADR-021.

## 1. `BackupChurnSpike` alert (`backup-alerts.yml`)

`backup_subvolume_churn_bytes_per_second` (live, 7 series) was dashboard-only; ADR-021 deferred thresholds "until ~2–4 weeks of data" (UPI 030 / Urd v0.16) — that window is long past (now on v0.24.0).

```promql
backup_subvolume_churn_bytes_per_second
  > 4 * avg_over_time(backup_subvolume_churn_bytes_per_second[14d] offset 2d)
and backup_subvolume_churn_bytes_per_second > 262144
```

- **Anomaly/capacity canary**, not a failure signal — catches runaway growth, in-place rewrites, or mass-rewrite events (a weak ransomware canary). Severity `warning`.
- **Dual-gated:** `> 4×` the subvolume's own 14-day baseline (`offset 2d` excludes the spike itself, so a sustained-1-day spike doesn't dampen its own baseline) **and** a `256 KiB/s` absolute floor.
- **Calibrated against live data** (2026-06-04, at rest): busiest subvolumes churn ~25–30 KiB/s (`htpc-root` 27K, `subvol7-containers` 24K, `htpc-home` 15K), rest <1 KiB/s. The floor sits ~8× above any normal rate, so the ratio test provides sensitivity while the floor kills ratio-noise on near-idle subvolumes (e.g. `subvol1-docs` at ~5 B/s). The comment block records this so the floor can be re-baselined if fleet churn grows.

## 2. "Estimated Local Pinned Delta" panel (`backup-health.json`, id 13)

Surfaces `backup_subvolume_estimated_local_pinned_delta_bytes` (live, 7 series; range 207 B → 5.7 GiB) — consumed by neither alert nor panel before this. Per-subvolume timeseries (unit `bytes`), cloned from the existing churn panel; new full-width row at `y=56` (no overlap). It's the "local space pinned by snapshot retention" headroom signal.

## Validation
- `promtool check rules` → SUCCESS, 11 rules (was 10).
- Dashboard JSON parses; 13 panels, non-overlapping gridPos.
- Live eval of the alert expr → **0 results** (correctly inactive; won't false-fire on deploy).

Both consume already-emitted Urd series — **no new metrics, no Urd-side changes.**

## Post-merge activation
Prometheus runs with `--web.enable-lifecycle`, so the new rule activates with a **hot reload** (no restart): `curl -X POST http://localhost:9090/-/reload` (via the container netns). Grafana re-provisions the dashboard on its provisioning interval (or restart). Happy to run the reload after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)