### PR TITLE
Forgejo loopback git-over-SSH (ADR-032) + *-private.md privacy hardening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,9 +61,10 @@ docs/99-reports/
 # but not version-controlled. See docs/CONTRIBUTING.md for archive conventions.
 docs/90-archive/
 
-# Private journal entries — suffix any journal filename with `-private.md`
-# to keep it local (not version-controlled)
-docs/98-journals/*-private.md
+# Private notes — suffix ANY filename with `-private.md` to keep it local
+# (not version-controlled), repo-wide. Originally journal-scoped; generalized
+# so guides/notes holding key handles, emails, or LAN details stay untracked.
+*-private.md
 
 # Active-probe posture script — tuned attack tool for this specific perimeter
 # (curated attack paths, CrowdSec burst logic, Region Block negative test).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ See ADR-030 (trust model) and ADR-015 (superseded; its BTRFS rollback + health-v
 
 ### Architecture Decision Records
 
-**Architectural decisions recorded as ADRs — latest is ADR-031** (see `docs/*/decisions/` for full details; number new ADRs sequentially from the latest)
+**Architectural decisions recorded as ADRs — latest is ADR-032** (see `docs/*/decisions/` for full details; number new ADRs sequentially from the latest)
 
 **Design-Guiding ADRs (affect future decisions):**
 - **ADR-001:** Rootless Containers — UID 1000, `:Z` SELinux labels on all mounts

--- a/docs/00-foundation/decisions/2026-06-05-ADR-032-forgejo-git-over-ssh-loopback.md
+++ b/docs/00-foundation/decisions/2026-06-05-ADR-032-forgejo-git-over-ssh-loopback.md
@@ -1,0 +1,128 @@
+# ADR-032: Forgejo Git-over-SSH — Loopback-Bound
+
+**Date:** 2026-06-05
+**Status:** Accepted (Implemented 2026-06-05)
+
+---
+
+## Context
+
+Forgejo (`git.patriark.org`) was deployed HTTPS-only — `DISABLE_SSH=true` +
+`START_SSH_SERVER=false` — with git-over-SSH **explicitly deferred** (see `project_forgejo`
+notes / original deployment). Auth and transport were Basic-over-HTTPS with a personal access
+token; commit-signature *verification* worked over HTTPS without SSH ever being enabled.
+
+A new requirement broke that posture's fit: **work on the repos from headless SSH sessions into
+fedora-htpc** (from fedora-jern / MacBook Air, including while away from home). That surfaced a
+credential problem the HTTPS-token model can't solve cleanly:
+
+- The HTTPS token now lives in the **GNOME keyring** (`git-credential-libsecret`), which is
+  **unlocked by the graphical login**. A non-graphical SSH session can't open it, and since SSH
+  login is key-based (FIDO2), PAM never sees a password to auto-unlock it. So the token is simply
+  **unavailable in headless SSH sessions.**
+- The fallbacks each fail the bar: plaintext `store` re-introduces an unencrypted token; podman
+  secrets' default `file` driver is base64 (not encrypted) and targets *containers*, not host
+  CLIs; `pass` needs a GPG key that doesn't exist.
+- SSH **agent forwarding** — the textbook "don't store a credential on the box" answer — was
+  blocked by the workstation's global `IdentityAgent none` (a workaround for a *believed*
+  gnome-keyring inability to sign sk/FIDO2 keys).
+
+The right tool for authenticating git operations *inside an SSH session on the box* is an SSH key,
+not an HTTPS token. Forgejo is the only remote that couldn't do that, because its SSH server was
+off.
+
+## Decision
+
+### D1 — Enable Forgejo's built-in SSH server, published to loopback only
+
+`START_SSH_SERVER=true`, `SSH_LISTEN_PORT=2222`, `SSH_PORT=2222`, `SSH_DOMAIN=localhost`,
+`DISABLE_SSH=false`, and crucially **`PublishPort=127.0.0.1:2222:2222`** — bound to the host
+loopback, not `0.0.0.0`. Only processes already on htpc (i.e. the owner's authenticated SSH
+sessions) can reach it. **No LAN exposure, no internet exposure, no firewall change, no Traefik
+involvement** (SSH is raw TCP, not HTTP). This reverses the "git-over-SSH deferred" posture, but in
+a contained way: the attack surface added to the network is *zero*.
+
+### D2 — Reuse the existing hardware key for auth; route via an ssh_config alias
+
+Forgejo authenticates SSH by matching the offered public key against keys on the account. The htpc
+FIDO2 signing key (already registered for verification) **doubles as the auth key** — no new key.
+The `forgejo` remote uses an `~/.ssh/config` alias (`forgejo-local` → `HostName 127.0.0.1`,
+`Port 2222`, `User git`) because the workstation's existing config aliases `localhost` to
+`fedora-htpc.lokal`. `git push/pull forgejo` is now **token-free** over SSH.
+
+### D3 — Remove the obsolete `IdentityAgent none` workaround (root-cause fix)
+
+Evidence (verified against the new Forgejo SSH endpoint): the gnome-keyring `gcr-ssh-agent`
+(**gcr 4.4**) **does** sign sk/FIDO2 keys — agent-based auth returns *"Authenticated"*, while
+*file-based* signing (forced by `IdentityAgent none`) fails silently in the auth path
+(`Server accepts key → No more authentication methods`). The workaround was therefore **obsolete
+and actively breaking** sk auth. It is removed from the global `Host *`. ssh now uses the
+persistent gcr agent, whose socket is exported in the **systemd `--user` environment** and kept
+alive by **lingering**, so it is reachable in headless SSH sessions. Validated: daily outbound SSH
+to UDM Pro and Pi-hole still authenticates cleanly.
+
+## Consequences
+
+### Positive
+
+- **The headless-SSH credential problem is solved without storing any secret** — git to Forgejo
+  authenticates with the always-present hardware key via the agent, from any on-htpc session.
+- Zero new network attack surface: loopback-only, key-based auth, closed instance
+  (`REQUIRE_SIGNIN_VIEW`, `DISABLE_REGISTRATION`).
+- The sk-auth fix is **global** — every SSH host benefits, and the ssh_config is simpler (a stale
+  workaround retired, documented inline).
+- The HTTPS path (Traefik routing, web UI, SSH-signed-commit *verification*) is **unaffected**;
+  both transports coexist.
+
+### Negative
+
+- Reverses a deliberate "no git-over-SSH" posture — one more enabled subsystem to reason about
+  (mitigated: loopback bind makes it equivalent-to-off from any other host's perspective).
+- Forgejo-SSH usability depends on the htpc graphical session keeping the agent populated
+  (acceptable on an always-on auto-login HTPC; loopback means no remote exposure regardless).
+- The htpc signing key now also serves **auth** (mild auth/signing reuse) — accepted: it's
+  hardware-backed and the endpoint is loopback-scoped.
+
+### Risks
+
+- **Re-binding the published port off loopback** would instantly expose an SSH service. Mitigated
+  by the explicit `127.0.0.1` bind and this ADR recording loopback as the invariant; widening to a
+  LAN bind must be a deliberate follow-up that also adds CrowdSec/fail2ban on the port.
+- **The global `IdentityAgent none` removal** is an outbound-SSH change affecting every host —
+  validated against UDM/Pi-hole/Forgejo; one-line revert (re-add `IdentityAgent none` to `Host *`)
+  if a host regresses. Inbound SSH into htpc is untouched.
+
+## Alternatives Considered
+
+- **HTTPS token in the GNOME keyring (libsecret).** The chosen store for *desktop* sessions, but
+  GUI-unlocked → unusable headless. Kept for graphical use; rejected for the SSH-session case.
+- **HTTPS token in podman secrets.** Default `file` driver is base64 (no encryption) and is built
+  to inject into *containers*, not feed host CLIs; doesn't cover `fj` either. Right tool only when a
+  *container* consumes the token (e.g. a future automated mirror job). Rejected here.
+- **HTTPS token in plaintext `store`.** Works headless but unencrypted at rest. Rejected as the end
+  state.
+- **`pass` (GPG-encrypted) token store.** Encrypted *and* headless-capable, and would also unlock
+  podman's `pass` secret driver — but requires generating a GPG key (none exists) and keeps Forgejo
+  on HTTPS. A viable path; **deferred**, not rejected.
+- **SSH agent forwarding from the laptops.** The canonical "no secret on the server" answer, but
+  blocked by the workstation's `IdentityAgent none` and unnecessary for a loopback service the htpc
+  key reaches directly. Superseded by D3 (which fixes the agent generally).
+- **LAN-bound (not loopback) Forgejo SSH.** Would let the laptops push to Forgejo *directly* without
+  first SSHing into htpc — but adds real LAN attack surface and demands brute-force protection on
+  the port. Rejected for now (loopback matches the stated SSH-into-htpc workflow); trivially
+  widenable later if the need appears.
+
+## Related
+
+- **`project_forgejo` deployment** — the HTTPS-only/native-auth posture this ADR amends.
+- **ADR-006** — YubiKey-First Authentication (the sk key now also serves git auth).
+- **ADR-016** — Configuration Design Principles (N/A to SSH: raw TCP, no Traefik route).
+- **ADR-030** — Container Supply-Chain Trust Model (image still digest-pinned; unaffected).
+- Session journal: `docs/98-journals/2026-06-04-forgejo-ssh-commit-signing-homelab-mirror-private.md`.
+
+---
+
+**Decision made by:** User (patriark) + Claude Code analysis
+**Trigger:** Owner request for a practical, best-practice way to authenticate git work from SSH
+sessions into the homelab (including while away) — the HTTPS token in the GUI-unlocked keyring is
+unavailable in headless sessions, so the credential model had to move from HTTPS-token to SSH-key.

--- a/docs/AUTO-DOCUMENTATION-INDEX.md
+++ b/docs/AUTO-DOCUMENTATION-INDEX.md
@@ -1,7 +1,7 @@
 # Documentation Index (Auto-Generated)
 
-**Generated:** 2026-06-04 15:10:34 UTC
-**Total Documents:** 446
+**Generated:** 2026-06-04 23:38:27 UTC
+**Total Documents:** 431
 
 ---
 
@@ -22,7 +22,7 @@
 
 ## Documentation by Category
 
-### 00-foundation/ (27 documents)
+### 00-foundation/ (28 documents)
 
 **Fundamentals and core concepts**
 
@@ -54,6 +54,7 @@
 - ADR-029: [2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup](00-foundation/decisions/2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md)
 - ADR-030: [2026-05-23-ADR-030-container-supply-chain-trust-model](00-foundation/decisions/2026-05-23-ADR-030-container-supply-chain-trust-model.md)
 - ADR-031: [2026-05-25-ADR-031-dns-resolver-first-class-and-ha](00-foundation/decisions/2026-05-25-ADR-031-dns-resolver-first-class-and-ha.md)
+- ADR-032: [2026-06-05-ADR-032-forgejo-git-over-ssh-loopback](00-foundation/decisions/2026-06-05-ADR-032-forgejo-git-over-ssh-loopback.md)
 - : [README](00-foundation/decisions/fixtures/README.md)
 - ADR-023: [2026-04-18-ADR-023-btrfs-storage-architecture-databases](00-foundation/decisions/withdrawn/2026-04-18-ADR-023-btrfs-storage-architecture-databases.md)
 
@@ -224,7 +225,7 @@
 
 ---
 
-### 98-journals/ (222 documents)
+### 98-journals/ (212 documents)
 
 **Chronological project history (append-only log)**
 
@@ -232,7 +233,7 @@ Complete dated entries documenting the homelab journey. See directory for full c
 
 ---
 
-### 99-reports/ (60 documents)
+### 99-reports/ (58 documents)
 
 **Automated system reports and point-in-time snapshots**
 
@@ -243,15 +244,17 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 ## Recently Updated (Last 7 Days)
 
 - 2026-06-04: [2026-03-28-ADR-021-urd-backup-tool.md](00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md)
+- 2026-06-05: [2026-06-05-ADR-032-forgejo-git-over-ssh-loopback.md](00-foundation/decisions/2026-06-05-ADR-032-forgejo-git-over-ssh-loopback.md)
+- 2026-06-04: [2026-06-04-branch-hygiene-adr021-cross-repo-and-churn-alert.md](98-journals/2026-06-04-branch-hygiene-adr021-cross-repo-and-churn-alert.md)
 - 2026-06-01: [2026-06-01-skill-usage-report.md](99-reports/2026-06-01-skill-usage-report.md)
 - 2026-06-01: [remediation-monthly-202605.md](99-reports/remediation-monthly-202605.md)
 - 2026-06-01: [security-audit-2026-06-01.md](99-reports/security-audit-2026-06-01.md)
-- 2026-06-04: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
-- 2026-06-04: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
-- 2026-06-04: [AUTO-EGRESS-BASELINE-INDEX.md](AUTO-EGRESS-BASELINE-INDEX.md)
-- 2026-06-04: [AUTO-IMAGE-PIN-INDEX.md](AUTO-IMAGE-PIN-INDEX.md)
-- 2026-06-04: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
-- 2026-06-04: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
+- 2026-06-05: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
+- 2026-06-05: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
+- 2026-06-05: [AUTO-EGRESS-BASELINE-INDEX.md](AUTO-EGRESS-BASELINE-INDEX.md)
+- 2026-06-05: [AUTO-IMAGE-PIN-INDEX.md](AUTO-IMAGE-PIN-INDEX.md)
+- 2026-06-05: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
+- 2026-06-05: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
 
 ---
 

--- a/quadlets/forgejo.container
+++ b/quadlets/forgejo.container
@@ -18,8 +18,14 @@ Environment=TZ=Europe/Oslo
 Environment=FORGEJO__server__DOMAIN=git.patriark.org
 Environment=FORGEJO__server__ROOT_URL=https://git.patriark.org/
 Environment=FORGEJO__server__HTTP_PORT=3000
-Environment=FORGEJO__server__DISABLE_SSH=true
-Environment=FORGEJO__server__START_SSH_SERVER=false
+# git-over-SSH: built-in server, published to loopback only (127.0.0.1:2222 below) so it's
+# reachable from on-htpc SSH sessions (agent-forwarded keys) with NO LAN/internet exposure.
+# Reverses the earlier "git-over-SSH deferred" decision; HTTPS path is unaffected.
+Environment=FORGEJO__server__DISABLE_SSH=false
+Environment=FORGEJO__server__START_SSH_SERVER=true
+Environment=FORGEJO__server__SSH_LISTEN_PORT=2222
+Environment=FORGEJO__server__SSH_PORT=2222
+Environment=FORGEJO__server__SSH_DOMAIN=localhost
 
 # Database (forgejo-db reached by container name on systemd-forgejo)
 Environment=FORGEJO__database__DB_TYPE=postgres
@@ -40,6 +46,9 @@ Volume=/mnt/btrfs-pool/subvol7-containers/forgejo:/data:Z
 # Networks (reverse_proxy FIRST = default route for internet; static IPs per ADR-018)
 Network=systemd-reverse_proxy:ip=10.89.2.89
 Network=systemd-forgejo:ip=10.89.8.89
+
+# git-over-SSH published to LOOPBACK ONLY — htpc-local; reached via agent-forwarded SSH sessions
+PublishPort=127.0.0.1:2222:2222
 
 DNS=192.168.1.69
 

--- a/scripts/generate-doc-index.sh
+++ b/scripts/generate-doc-index.sh
@@ -16,13 +16,13 @@ log() {
 
 # Get recently updated files (last 7 days)
 get_recent_files() {
-    find "$DOCS_DIR" -name "*.md" -mtime -7 -type f | sort
+    find "$DOCS_DIR" -name "*.md" ! -name "*-private.md" -mtime -7 -type f | sort
 }
 
 # Count files in directory
 count_files() {
     local dir=$1
-    find "$dir" -name "*.md" -type f 2>/dev/null | wc -l
+    find "$dir" -name "*.md" ! -name "*-private.md" -type f 2>/dev/null | wc -l
 }
 
 # Find all documentation related to a service
@@ -79,7 +79,7 @@ generate_index() {
     local timestamp
     timestamp=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
     local total_docs
-    total_docs=$(find "$DOCS_DIR" -name "*.md" -type f | wc -l)
+    total_docs=$(find "$DOCS_DIR" -name "*.md" ! -name "*-private.md" -type f | wc -l)
 
     log "Generating documentation index..."
 
@@ -116,7 +116,7 @@ generate_index() {
 EOF
 
     # Foundation guides
-    find "$DOCS_DIR/00-foundation/guides" -name "*.md" -type f 2>/dev/null | sort | while read -r file; do
+    find "$DOCS_DIR/00-foundation/guides" -name "*.md" ! -name "*-private.md" -type f 2>/dev/null | sort | while read -r file; do
         local basename
         basename=$(basename "$file")
         local relpath
@@ -129,7 +129,7 @@ EOF
 **Decisions (ADRs):**
 EOF
 
-    find "$DOCS_DIR/00-foundation/decisions" -name "*.md" -type f 2>/dev/null | sort | while read -r file; do
+    find "$DOCS_DIR/00-foundation/decisions" -name "*.md" ! -name "*-private.md" -type f 2>/dev/null | sort | while read -r file; do
         local basename
         basename=$(basename "$file" .md)
         local relpath
@@ -150,7 +150,7 @@ EOF
 **Service Guides:**
 EOF
 
-    find "$DOCS_DIR/10-services/guides" -name "*.md" -type f 2>/dev/null | sort | while read -r file; do
+    find "$DOCS_DIR/10-services/guides" -name "*.md" ! -name "*-private.md" -type f 2>/dev/null | sort | while read -r file; do
         local basename
         basename=$(basename "$file")
         local relpath
@@ -163,7 +163,7 @@ EOF
 **Service Decisions (ADRs):**
 EOF
 
-    find "$DOCS_DIR/10-services/decisions" -name "*.md" -type f 2>/dev/null | sort | while read -r file; do
+    find "$DOCS_DIR/10-services/decisions" -name "*.md" ! -name "*-private.md" -type f 2>/dev/null | sort | while read -r file; do
         local basename
         basename=$(basename "$file" .md)
         local relpath
@@ -184,7 +184,7 @@ EOF
 **Guides:**
 EOF
 
-    find "$DOCS_DIR/20-operations/guides" -name "*.md" -type f 2>/dev/null | sort | while read -r file; do
+    find "$DOCS_DIR/20-operations/guides" -name "*.md" ! -name "*-private.md" -type f 2>/dev/null | sort | while read -r file; do
         local basename
         basename=$(basename "$file")
         local relpath
@@ -197,7 +197,7 @@ EOF
 **Runbooks:**
 EOF
 
-    find "$DOCS_DIR/20-operations/runbooks" -name "*.md" -type f 2>/dev/null | sort | while read -r file; do
+    find "$DOCS_DIR/20-operations/runbooks" -name "*.md" ! -name "*-private.md" -type f 2>/dev/null | sort | while read -r file; do
         local basename
         basename=$(basename "$file" .md)
         local relpath
@@ -216,7 +216,7 @@ EOF
 **Guides:**
 EOF
 
-    find "$DOCS_DIR/30-security/guides" -name "*.md" -type f 2>/dev/null | sort | while read -r file; do
+    find "$DOCS_DIR/30-security/guides" -name "*.md" ! -name "*-private.md" -type f 2>/dev/null | sort | while read -r file; do
         local basename
         basename=$(basename "$file")
         local relpath
@@ -229,7 +229,7 @@ EOF
 **Security ADRs:**
 EOF
 
-    find "$DOCS_DIR/30-security/decisions" -name "*.md" -type f 2>/dev/null | sort | while read -r file; do
+    find "$DOCS_DIR/30-security/decisions" -name "*.md" ! -name "*-private.md" -type f 2>/dev/null | sort | while read -r file; do
         local basename
         basename=$(basename "$file" .md)
         local relpath
@@ -244,7 +244,7 @@ EOF
 **Runbooks:**
 EOF
 
-    find "$DOCS_DIR/30-security/runbooks" -name "*.md" -type f 2>/dev/null | sort | while read -r file; do
+    find "$DOCS_DIR/30-security/runbooks" -name "*.md" ! -name "*-private.md" -type f 2>/dev/null | sort | while read -r file; do
         local basename
         basename=$(basename "$file" .md)
         local relpath
@@ -263,7 +263,7 @@ EOF
 **Guides:**
 EOF
 
-    find "$DOCS_DIR/40-monitoring-and-documentation/guides" -name "*.md" -type f 2>/dev/null | sort | while read -r file; do
+    find "$DOCS_DIR/40-monitoring-and-documentation/guides" -name "*.md" ! -name "*-private.md" -type f 2>/dev/null | sort | while read -r file; do
         local basename
         basename=$(basename "$file")
         local relpath
@@ -280,7 +280,7 @@ EOF
 **Strategic plans and forward-looking projects**
 EOF
 
-    find "$DOCS_DIR/97-plans" -name "*.md" -type f 2>/dev/null | sort | while read -r file; do
+    find "$DOCS_DIR/97-plans" -name "*.md" ! -name "*-private.md" -type f 2>/dev/null | sort | while read -r file; do
         local basename
         basename=$(basename "$file")
         local relpath


### PR DESCRIPTION
## Summary

Enables **git-over-SSH for Forgejo**, loopback-bound, so repos can be worked on from **headless SSH sessions into htpc** (token-free, hardware-key auth) — the HTTPS token lives in the GUI-unlocked GNOME keyring and is unavailable in non-graphical SSH sessions. Plus hardening of the `*-private.md` privacy convention that surfaced during the work.

## Changes

**Forgejo git-over-SSH (ADR-032)**
- Built-in SSH server enabled, published to **`127.0.0.1:2222` only** — no LAN/internet exposure, no Traefik, no firewall change.
- `git push/pull forgejo` authenticates with the always-present htpc YubiKey over SSH (no token, no keyring unlock).
- Full context, alternatives, and the loopback security model in **ADR-032**.

**`*-private.md` privacy hardening**
- `.gitignore`: generalized the journal-scoped `*-private.md` rule to repo-wide.
- `generate-doc-index.sh`: excluded `*-private.md` from every `.md` enumeration — it was leaking gitignored private filenames into the **tracked** `AUTO-DOCUMENTATION-INDEX.md`.

## Not in this PR (by design)
- The companion `~/.ssh/config` change (removed the obsolete global `IdentityAgent none` so gcr-ssh-agent signs sk/FIDO2 keys) lives on the personal workstation config — documented in ADR-032. Validated: daily SSH to UDM Pro + Pi-hole intact.

## Verification
- `git push/pull forgejo` over SSH ✓ · Forgejo SSH bound loopback-only ✓ (`ss` → `127.0.0.1:2222`)
- Doc index regenerated: 0 private refs, ADR-032 indexed ✓
- Commits SSH-signed; pre-commit hooks (Traefik, secrets, ADR-030) pass ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)
