### PR TITLE
feat(forgejo): instance SSH commit signing for server-side merges (ADR-034)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,7 +99,7 @@ See ADR-030 (trust model) and ADR-015 (superseded; its BTRFS rollback + health-v
 
 ### Architecture Decision Records
 
-**Architectural decisions recorded as ADRs — latest is ADR-032** (see `docs/*/decisions/` for full details; number new ADRs sequentially from the latest)
+**Architectural decisions recorded as ADRs — latest is ADR-034** (see `docs/*/decisions/` for full details; number new ADRs sequentially from the latest)
 
 **Design-Guiding ADRs (affect future decisions):**
 - **ADR-001:** Rootless Containers — UID 1000, `:Z` SELinux labels on all mounts

--- a/docs/00-foundation/decisions/2026-06-06-ADR-034-forgejo-instance-commit-signing-ssh.md
+++ b/docs/00-foundation/decisions/2026-06-06-ADR-034-forgejo-instance-commit-signing-ssh.md
@@ -1,0 +1,157 @@
+# ADR-034: Forgejo Instance Commit Signing (SSH)
+
+**Date:** 2026-06-06
+**Status:** Accepted (config staged on branch `feat/forgejo-instance-commit-signing`;
+activated once the instance key + podman secrets are created and Forgejo restarts)
+
+---
+
+## Context
+
+Commit signing on the homelab moved to **SSH-format signatures** backed by FIDO2
+hardware keys: authors sign their own commits with their YubiKeys, and the per-host
+touch/PIN policy is recorded in **ADR-033**. Verification is host-agnostic
+(`allowed_signers` carries no enforcing options) so any author's good signature
+verifies as `G`.
+
+That covers **author** commits. It does **not** cover commits the **forge itself**
+creates. When a PR is merged — and especially **squash-merged**, the homelab's
+preferred strategy for a clean linear `main` — Forgejo synthesises a *new* commit
+server-side. Its committer is `<name>@noreply.git.patriark.org` and, with no instance
+signing configured, that commit is **UNSIGNED**. So even though every author signs
+locally, `main` steadily accumulates unsigned merge/squash commits.
+
+This was verified on the sibling `jern-mgmt` project (2026-06-06): locally-authored
+commits show `Good` SSH signatures; every server-side merge/squash commit on the
+Forgejo instance is unsigned. The Forgejo instance was not configured to sign its own
+commits.
+
+This is the same class of gap GitHub solves by **re-signing merged `main` with its
+web-flow key** (ADR-033 §D4). Our self-hosted forge had no equivalent.
+
+### Constraints
+
+- **A server cannot tap a YubiKey.** Forgejo runs unattended; the instance signer
+  must be a **passphraseless software key**, not a FIDO2 credential. (This is a
+  *different* key from any author key — it signs *as the forge*, not as a person.)
+- **Forgejo / git / OpenSSH must support SSH signing.** Confirmed on the running
+  instance (see Decision): Forgejo `15.0.2`, git `2.52.0` (≥2.34), OpenSSH `10.2p1`
+  (≥8.2p1).
+- **Config is by environment variables**, matching every other Forgejo setting in
+  `quadlets/forgejo.container` (no `app.ini` is mounted). The `[repository.signing]`
+  section name contains a dot, which Forgejo's `environment-to-ini` escapes as
+  `_0X2E_`.
+- **The private key is a secret** and must follow the repo's podman-secrets
+  convention — never committed.
+
+## Decision
+
+Enable **instance commit signing** in **SSH format** on the Forgejo container, using a
+dedicated passphraseless `ed25519` software key owned by the forge. Squash-merge stays
+the default; every server-side merge/squash commit is now signed by the instance key
+and shows **Verified**.
+
+### D1 — `[repository.signing]` settings (env vars in the quadlet)
+
+| ini (`[repository.signing]`) | Value | Quadlet env var |
+|---|---|---|
+| `FORMAT`        | `ssh` | `FORGEJO__repository_0X2E_signing__FORMAT` |
+| `SIGNING_KEY`   | `/run/secrets/forgejo_signing_key.pub` | `…__SIGNING_KEY` |
+| `SIGNING_NAME`  | `patriark.org Forgejo` | `…__SIGNING_NAME` *(quoted — has a space)* |
+| `SIGNING_EMAIL` | `forgejo@git.patriark.org` | `…__SIGNING_EMAIL` |
+| `MERGES`        | `always` | `…__MERGES` |
+
+- `SIGNING_KEY` points at the **public** key. git invokes
+  `ssh-keygen -Y sign -f <path>`, and ssh-keygen locates the **private** key by
+  stripping `.pub` — so both files must sit at sibling paths. *(Empirically verified:
+  signing `-f key.pub` with no agent and a passphraseless key succeeds, and the result
+  verifies via `allowed_signers`.)*
+- `SIGNING_EMAIL` becomes the signer **principal**. Author hosts add this principal +
+  the instance public key to `~/.config/git/allowed_signers` so forge-created commits
+  also verify **locally** (not just in the Forgejo UI).
+- `SIGNING_NAME` contains a space, so the whole `Environment=` assignment is
+  double-quoted — systemd splits unquoted `Environment=` values on whitespace.
+
+### D2 — Key delivery via podman secrets (uid/gid-mapped, never committed)
+
+The keypair is delivered as **two podman file secrets** mounted into the container,
+matching the repo's secrets convention (cf. `gathio`, `prometheus`):
+
+```
+Secret=forgejo_signing_key,    type=mount,target=/run/secrets/forgejo_signing_key,    uid=1000,gid=1000,mode=0600
+Secret=forgejo_signing_key_pub,type=mount,target=/run/secrets/forgejo_signing_key.pub,uid=1000,gid=1000,mode=0644
+```
+
+- The gitea process runs as **container uid 1000 (`git`)**, so the mounts set
+  `uid=1000,gid=1000` (podman maps these through the rootless userns — a host bind
+  mount would instead surface as container-root and the `git` user couldn't read a
+  `0600` private key). Private key `0600`, public key `0644`.
+- The **canonical key source** lives at `~/containers/secrets/forgejo_signing_key{,.pub}`
+  (the `secrets/` dir is gitignored wholesale) as the DR copy; the podman secrets are
+  created from it. The **private key is never committed.**
+
+### D3 — Scope: `MERGES=always`
+
+`MERGES=always` signs every server-side merge/squash/rebase commit. This is the
+explicit gap being closed. CRUD web-editor commits (`CRUD_ACTIONS`) and the
+repo-`INITIAL_COMMIT` are *not* signed by this change; the realistic path onto `main`
+is reviewed PRs, which are covered. Those can be added later (`…__CRUD_ACTIONS=always`,
+`…__INITIAL_COMMIT=always`) if web-editor commits to `main` become a thing.
+
+## Consequences
+
+### Positive
+
+- **`main` is fully verifiable end-to-end:** author commits by FIDO2 YubiKeys
+  (ADR-033), forge merge/squash commits by the instance key — and squash-merge can
+  stay the default for clean linear history.
+- **Verifiable locally too:** the instance principal in `allowed_signers` means
+  `git log --show-signature` recognises forge commits on every machine, not only in the
+  Forgejo UI. The public key is served at `/api/v1/signing-key.ssh`.
+- **Convention-aligned:** env-var config + podman secrets, no new mechanism, no mounted
+  `app.ini`.
+
+### Negative / Risks
+
+- **The instance signer is a passphraseless software key.** Anyone who can read the
+  podman secret store (or `secrets/`) on htpc can mint commits that verify as the
+  instance. This is the same trust property GitHub's web-flow signing key has, and is
+  bounded by host hardening + the physical-security model (ADR-033). It is strictly an
+  *instance* identity — it cannot impersonate an *author* (different key, different
+  principal).
+- **Key loss / rotation** invalidates the principal→key mapping: a regenerated key must
+  be re-added to every author host's `allowed_signers`. Mitigated by the DR copy in
+  `secrets/`.
+- **Bootstrap commit is unsigned by Forgejo:** the very PR that introduces this config
+  merges before signing is active, so that one merge commit is not instance-signed
+  (expected, one-time).
+
+## Verification
+
+After creating the key + secrets and restarting Forgejo:
+
+1. `curl -s https://git.patriark.org/api/v1/signing-key.ssh` returns the instance
+   public key (`ssh-ed25519 AAAA…`).
+2. Open a throwaway PR and **squash-merge** it; the resulting `main` commit shows
+   **Verified** in the Forgejo UI (read it via
+   `GET /repos/{o}/{r}/commits?sha=<sha>` → `.commit.verification.verified=true`,
+   reason `patriark.org Forgejo`), and `git log --show-signature` recognises the
+   instance signature once the principal is in `allowed_signers`.
+3. Normal `git push` / `clone` (HTTPS and loopback-SSH, ADR-032) still work.
+
+## Related
+
+- **ADR-033** — Per-Host Commit-Signing Policy (author signing; this ADR is its
+  forge-side complement). *(private)*
+- **ADR-032** — Forgejo Git-over-SSH Loopback.
+- **ADR-030** — Container Supply-Chain Trust Model (signed history is part of
+  provenance).
+- **ADR-006** — YubiKey-First Authentication.
+- `project_forgejo` memory — Forgejo deployment + SSH signing end-to-end.
+
+---
+
+**Decision made by:** User (patriark) + Claude Code analysis
+**Trigger:** Sibling `jern-mgmt` verified that Forgejo server-side merge/squash commits
+land unsigned even when authors sign locally — `main` needed the forge to sign its own
+commits so squash-merge (default) and a fully verifiable history can coexist.

--- a/quadlets/forgejo.container
+++ b/quadlets/forgejo.container
@@ -40,6 +40,31 @@ Environment=FORGEJO__service__DISABLE_REGISTRATION=true
 Environment=FORGEJO__service__REQUIRE_SIGNIN_VIEW=true
 Environment=FORGEJO__session__COOKIE_SECURE=true
 
+# Instance commit signing (ADR-034): the FORGE signs its own server-side merge/
+# squash commits so `main` stays fully verifiable. Authors sign their commits with
+# their FIDO2 YubiKeys (ADR-033); a server can't tap a key, so the instance uses a
+# passphraseless ed25519 SOFTWARE key. This closes the gap where Forgejo-created
+# merge/squash commits (committer <name>@noreply.git.patriark.org) landed UNSIGNED.
+#   - Section [repository.signing]: env escapes the section's dot as _0X2E_.
+#   - SIGNING_KEY points at the PUBLIC key; ssh-keygen derives the private key by
+#     stripping ".pub" (both files mounted below as podman secrets, same dir).
+#   - SIGNING_EMAIL is the signer PRINCIPAL added to allowed_signers on author hosts.
+#   - SIGNING_NAME contains a space -> the whole assignment MUST be double-quoted
+#     (systemd Environment= splits unquoted values on spaces).
+Environment=FORGEJO__repository_0X2E_signing__FORMAT=ssh
+Environment=FORGEJO__repository_0X2E_signing__SIGNING_KEY=/run/secrets/forgejo_signing_key.pub
+Environment="FORGEJO__repository_0X2E_signing__SIGNING_NAME=patriark.org Forgejo"
+Environment=FORGEJO__repository_0X2E_signing__SIGNING_EMAIL=forgejo@git.patriark.org
+Environment=FORGEJO__repository_0X2E_signing__MERGES=always
+
+# Signing keypair as podman secrets, mounted owned by the in-container git user
+# (uid/gid 1000 — gitea runs as uid 1000; podman maps these through the userns).
+# Private key 0600, public 0644. Create the secrets BEFORE (re)starting — see ADR-034:
+#   podman secret create forgejo_signing_key     ~/containers/secrets/forgejo_signing_key
+#   podman secret create forgejo_signing_key_pub ~/containers/secrets/forgejo_signing_key.pub
+Secret=forgejo_signing_key,type=mount,target=/run/secrets/forgejo_signing_key,uid=1000,gid=1000,mode=0600
+Secret=forgejo_signing_key_pub,type=mount,target=/run/secrets/forgejo_signing_key.pub,uid=1000,gid=1000,mode=0644
+
 # Storage (repos/LFS/data on container pool; not a DB, no NOCOW)
 Volume=/mnt/btrfs-pool/subvol7-containers/forgejo:/data:Z
 


### PR DESCRIPTION
## Problem

Forgejo synthesises a **new commit** on every PR merge — and especially on **squash-merge** (our default for clean linear history). Its committer is `<name>@noreply.git.patriark.org` and, with no instance signing configured, that commit is **UNSIGNED**. So `main` accumulates unsigned merge/squash commits even though authors sign their own commits locally with FIDO2 YubiKeys (ADR-033).

Verified on the sibling **jern-mgmt** project (2026-06-06): locally-authored commits show `Good` SSH signatures; every server-side merge/squash commit on the Forgejo instance is unsigned. This is the same gap GitHub closes by re-signing merged `main` with its web-flow key (ADR-033 §D4) — our self-hosted forge had no equivalent.

## Change

Enable Forgejo **instance commit signing** in **SSH format** so the forge signs its own merge/squash commits with a dedicated passphraseless `ed25519` **software** key (a server can't tap a YubiKey). Squash-merge stays the default **and** every commit on `main` becomes verifiable — authors by their YubiKeys, forge merges by the instance key.

- **`quadlets/forgejo.container`** — `[repository.signing]` via env vars (the section's dot is escaped `_0X2E_`; `SIGNING_NAME` is double-quoted for its embedded space) + two podman secret mounts for the keypair, owned by in-container **uid/gid 1000** (the `git` user), private `0600` / public `0644`. `SIGNING_KEY` points at the `.pub`; `ssh-keygen` derives the private key by stripping `.pub`. `MERGES=always`.
- **ADR-034** — forge-side complement to ADR-033 (per-host author signing).
- **CLAUDE.md** — bump latest-ADR pointer 032 → 034.

The **private key is never committed** (handled via podman secrets; `secrets/` is gitignored).

## Verified (empirically, before writing config)

- Running instance: **Forgejo 15.0.2**, **git 2.52.0** (≥2.34), **OpenSSH 10.2p1** (≥8.2p1) — SSH signing supported.
- `ssh-keygen -Y sign -f key.pub` with no agent + passphraseless key → derives the private key and signs; result verifies via `allowed_signers` (principal = `forgejo@git.patriark.org`).
- `environment-to-ini` with `_0X2E_` → produces exactly the intended `[repository.signing]` section.
- Quadlet generates cleanly; `Secret=` lines translate to correct `--secret …,uid=1000,gid=1000,mode=…` args.

## Activation (owner-run, post-merge)

Not active until the instance keypair + podman secrets exist and Forgejo restarts. The keypair is generated by the owner (a server software key — not in CI). Steps + the post-restart verification checklist are in **ADR-034 → Verification**.

## Verification checklist (after key creation + restart)

1. `curl -s https://git.patriark.org/api/v1/signing-key.ssh` returns the instance public key.
2. Throwaway PR, squash-merge → resulting commit shows **Verified** in the UI (`GET /repos/{o}/{r}/commits?sha=<sha>` → `.commit.verification.verified=true`), and `git log --show-signature` recognises it once the principal is in `allowed_signers`.
3. Normal `git push` / `clone` (HTTPS + loopback-SSH) still work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
