### PR TITLE
fix(monitoring): stop false "Pi-hole down" pages + exporter self-heal + Pi thermal alerts

### DIFF
--- a/config/prometheus/alerts/dns-resolver-alerts.yml
+++ b/config/prometheus/alerts/dns-resolver-alerts.yml
@@ -93,6 +93,59 @@ groups:
             dig +short doubleclick.net @{{ $labels.instance }}
             ssh patriark@{{ $labels.instance }} 'pihole -g'   # rebuild gravity
 
+  # --- Resolver host thermal (added 2026-06-07) ---------------------------
+  # The Pi resolver sits in a stable-ambient server box at near-zero CPU load,
+  # yet runs chronically at 80–86°C and is firmware-throttling its clock to
+  # 600–900 MHz (max 1800). At idle that points to a heat-removal fault (fan not
+  # spinning / heatsink contact / enclosure airflow), NOT compute. Throttling
+  # slows the Pi-hole v6 API and can cause intermittent LAN-wide DNS latency, so
+  # the resolver's temperature is now a first-class signal. NOTE: with the Pi in
+  # its current state these WILL fire on deploy — that is correct; silence only
+  # while actively servicing the cooling issue.
+  - name: dns_resolver_host
+    interval: 1m
+    rules:
+
+      - alert: PiHoleResolverHot
+        expr: node_thermal_zone_temp{job="node-exporter-pi"} > 80
+        for: 15m
+        labels:
+          severity: warning
+          category: capacity
+          component: dns_resolver
+          service: pihole
+        annotations:
+          summary: "Pi resolver running hot ({{ $value | printf \"%.1f\" }}°C) — thermal throttling"
+          description: |
+            node_thermal_zone_temp on the Pi resolver ({{ $labels.instance }}) has
+            been >80°C for >15m. The Pi 4 soft limit is 80°C, so the CPU is being
+            clock-capped. At idle in a stable-ambient enclosure this indicates a
+            cooling fault, not load. Throttling degrades the Pi-hole API and DNS.
+          runbook: |
+            ssh patriark@192.168.1.69 'vcgencmd get_throttled; vcgencmd measure_temp'
+            # 0x0 = healthy; bit3 set = soft-temp-limit active. Check fan/heatsink:
+            ssh patriark@192.168.1.69 'cat /sys/class/thermal/cooling_device*/cur_state'
+            bash scripts/pihole-forensics.sh   # full thermal + cooling capture
+
+      - alert: PiHoleResolverCriticalTemp
+        expr: node_thermal_zone_temp{job="node-exporter-pi"} > 84
+        for: 15m
+        labels:
+          severity: critical
+          category: capacity
+          component: dns_resolver
+          service: pihole
+        annotations:
+          summary: "Pi resolver near hard thermal limit ({{ $value | printf \"%.1f\" }}°C)"
+          description: |
+            Pi resolver ({{ $labels.instance }}) >84°C for >15m — approaching the
+            85°C hard throttle limit. Sustained operation here risks instability
+            and shortened hardware life for the LAN's DNS resolver. Treat the
+            cooling fault as urgent.
+          runbook: |
+            ssh patriark@192.168.1.69 'vcgencmd measure_temp; vcgencmd get_throttled'
+            # Verify active cooling is present and spinning; check enclosure airflow.
+
   - name: nextcloud_state
     interval: 1m
     rules:

--- a/config/prometheus/alerts/dns-resolver-alerts.yml
+++ b/config/prometheus/alerts/dns-resolver-alerts.yml
@@ -94,14 +94,14 @@ groups:
             ssh patriark@{{ $labels.instance }} 'pihole -g'   # rebuild gravity
 
   # --- Resolver host thermal (added 2026-06-07) ---------------------------
-  # The Pi resolver sits in a stable-ambient server box at near-zero CPU load,
-  # yet runs chronically at 80–86°C and is firmware-throttling its clock to
-  # 600–900 MHz (max 1800). At idle that points to a heat-removal fault (fan not
-  # spinning / heatsink contact / enclosure airflow), NOT compute. Throttling
-  # slows the Pi-hole v6 API and can cause intermittent LAN-wide DNS latency, so
-  # the resolver's temperature is now a first-class signal. NOTE: with the Pi in
-  # its current state these WILL fire on deploy — that is correct; silence only
-  # while actively servicing the cooling issue.
+  # Origin: the Pi was found chronically at 80–86°C with the CPU idle (0.8%) —
+  # not a workload. Physical inspection traced it to a hot ISP modem stacked
+  # directly beneath the Pi in a passively-cooled, dusty 6U wall cabinet with
+  # minimal airflow. Dispersing the units dropped the Pi to ~63°C immediately.
+  # The cabinet still has no active cooling and the Pi has no heatsink, so the
+  # resolver's temperature stays a first-class signal: these alerts are dormant
+  # at healthy temps and serve as early warning if it climbs again (re-stacking,
+  # summer ambient, a fan failure). Throttling degrades the Pi-hole API and DNS.
   - name: dns_resolver_host
     interval: 1m
     rules:

--- a/config/prometheus/alerts/infrastructure-critical.yml
+++ b/config/prometheus/alerts/infrastructure-critical.yml
@@ -20,8 +20,17 @@ groups:
       # Specific services have dedicated alerts (TraefikDown, PrometheusDown, etc.)
       # This is a safety net to catch anything we might have missed
       # Defense in depth: critical services get specific alerts + this generic one
+      #
+      # EXCLUSION — job="pihole": the pihole-exporter is a metrics SIDECAR, not the
+      # resolver. Its liveness has a dedicated, correctly-scoped signal
+      # (PiHoleExporterDown, warning). A slow/wedged exporter scrape must NOT page
+      # as CRITICAL "Pi-hole is down" — that conflates sidecar liveness with DNS
+      # health and contradicts ADR-031 D5 (functional > liveness; the blackbox
+      # dns_functional probe is the authoritative resolver-down signal). This
+      # exclusion is the fix for the 2026-06-04 false-page incident where a 0.26s→
+      # >10s exporter latency regression tripped the 10s scrape_timeout for 3 days.
       - alert: HostDown
-        expr: up == 0
+        expr: up{job!="pihole"} == 0
         for: 5m
         labels:
           severity: critical

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -198,7 +198,18 @@ scrape_configs:
           role: 'dns_resolver'
 
   # Pi-hole exporter — query/block stats from the Pi-hole v6 API.
+  # Timeout/interval (2026-06-07): the exporter serves /metrics SYNCHRONOUSLY —
+  # each scrape runs a full Pi-hole v6 login→query cycle. Steady-state latency is
+  # ~0.26s, but a wedged/degraded exporter (or a slow transient) can spike to
+  # 6–14s. The global default scrape_timeout=10s tripped up=0 for 3 days on
+  # 2026-06-04 with a false "down" page. 20s timeout gives huge headroom over
+  # normal so transients never flap `up`; a genuinely stalled exporter (>20s) is
+  # still caught by PiHoleExporterDown (warning, for:5m) + the watchdog timer.
+  # 30s interval matches the exporter's own INTERVAL=30s and reduces Pi-hole API
+  # login churn (also eases the GH#246 session leak). timeout must be ≤ interval.
   - job_name: 'pihole'
+    scrape_interval: 30s
+    scrape_timeout: 20s
     static_configs:
       - targets: ['pihole-exporter:9617']
         labels:

--- a/quadlets/pihole-exporter.container
+++ b/quadlets/pihole-exporter.container
@@ -28,10 +28,14 @@ Environment=TZ=Europe/Oslo
 # Create secret:  printf '<app-password>' | podman secret create pihole_api_token -
 Secret=pihole_api_token,type=env,target=PIHOLE_PASSWORD
 
-HealthCmd=wget --no-verbose --tries=1 -O /dev/null http://localhost:9617/metrics || exit 1
-HealthInterval=30s
-HealthTimeout=5s
-HealthRetries=3
+# NO HealthCmd: this image (ekofr/pihole-exporter) is distroless — it has no
+# wget/curl/sh, so the previous `HealthCmd=wget ...` could NEVER run ("executable
+# file wget not found"). The container therefore reported a PERMANENT false
+# "unhealthy", and because the process never exits, Restart=on-failure could not
+# auto-heal a wedged-but-running exporter. This is exactly how the 2026-06-04
+# latency regression went unrecovered for 3 days. Liveness/self-heal is now
+# enforced externally by pihole-exporter-watchdog.timer (host-side probe of
+# /metrics with restart-on-stall), which does not depend on in-container tooling.
 
 User=1000:1000
 NoNewPrivileges=true

--- a/scripts/pihole-exporter-watchdog.sh
+++ b/scripts/pihole-exporter-watchdog.sh
@@ -1,0 +1,127 @@
+#!/bin/bash
+################################################################################
+# pihole-exporter-watchdog.sh — self-heal a wedged pihole-exporter
+#
+# Context (2026-06-04 false-page incident):
+#   ekofr/pihole-exporter serves /metrics SYNCHRONOUSLY (full Pi-hole v6
+#   login→query cycle per scrape). On 2026-06-04 its latency stepped 0.26s →
+#   >10s and stayed there for 3 days, tripping Prometheus' scrape_timeout
+#   (up=0) and a false CRITICAL "Pi-hole down" page. The process never crashed
+#   (RestartCount=0) and the image is distroless (no in-container HealthCmd
+#   possible), so nothing auto-recovered it. A manual restart fixed it instantly.
+#
+#   This watchdog supplies the missing self-heal WITHOUT depending on
+#   in-container tooling: it reads the verdict Prometheus already computes every
+#   scrape (up + scrape_duration), and restarts pihole-exporter.service when the
+#   exporter is wedged or degrading toward the timeout.
+#
+# Triggers a restart when EITHER:
+#   - DOWN:      up{job="pihole"} has been 0 for the whole last 5m, OR
+#   - DEGRADING: mean scrape_duration over 5m > 15s (creeping toward the 20s
+#                timeout — heals proactively, before `up` flips and pages).
+#
+# Cooldown: never restarts more than once per COOLDOWN_SECS. If it's still bad
+# after a restart, that means the fault is NOT the exporter (e.g. Pi-hole API
+# genuinely down) — we back off and let PiHoleExporterDown (warning) page instead
+# of crash-looping the sidecar.
+#
+# Emits a textfile metric (node_exporter collector dir) so restarts are visible
+# and a future alert can catch a flapping watchdog (= deeper problem).
+#
+# Safe: only ever restarts a metrics SIDECAR — zero DNS impact.
+################################################################################
+
+set -euo pipefail
+
+PROM_CONTAINER="${PROM_CONTAINER:-prometheus}"
+EXPORTER_UNIT="${EXPORTER_UNIT:-pihole-exporter.service}"
+DEGRADE_SECS="${DEGRADE_SECS:-15}"        # mean scrape_duration over 5m above this = degrading
+COOLDOWN_SECS="${COOLDOWN_SECS:-1200}"    # min seconds between restarts (20m)
+METRICS_DIR="${HOME}/containers/data/backup-metrics"
+METRICS_FILE="${METRICS_DIR}/pihole-exporter-watchdog.prom"
+
+# systemd-cron environment (consistent with sibling scripts)
+export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+export DBUS_SESSION_BUS_ADDRESS="unix:path=${XDG_RUNTIME_DIR}/bus"
+
+log() { printf '[%s] %s\n' "$(date '+%Y-%m-%d %H:%M:%S')" "$*"; }
+
+now=$(date +%s)
+
+# --- read the verdict Prometheus already computes -----------------------------
+# Returns the scalar value of an instant query, or "" if unavailable/empty.
+promq() {
+    local enc="$1" out
+    out=$(podman exec "$PROM_CONTAINER" wget -qO- "http://localhost:9090/api/v1/query?query=${enc}" 2>/dev/null) || return 0
+    printf '%s' "$out" | python3 -c '
+import json, sys
+try:
+    r = json.load(sys.stdin)["data"]["result"]
+    print(r[0]["value"][1] if r else "")
+except Exception:
+    print("")
+' 2>/dev/null || printf ''
+}
+
+# up==0 for the ENTIRE last 5m (max_over_time==0 ⇒ never came up). 1=down, 0=ok, ""=unknown.
+down=$(promq 'max_over_time(up%7Bjob%3D%22pihole%22%7D%5B5m%5D)')
+# mean scrape latency over 5m.
+dur=$(promq 'avg_over_time(scrape_duration_seconds%7Bjob%3D%22pihole%22%7D%5B5m%5D)')
+
+if [[ -z "$down" && -z "$dur" ]]; then
+    log "Prometheus unreachable or no pihole samples yet — nothing to evaluate (exit 0)"
+    # still refresh heartbeat below
+fi
+
+is_down=0;     [[ "$down" == "0" ]] && is_down=1   # max_over_time==0 means continuously down
+is_degraded=0; [[ -n "$dur" ]] && awk "BEGIN{exit !($dur > $DEGRADE_SECS)}" && is_degraded=1
+
+# --- read prior watchdog state ------------------------------------------------
+prev_total=0; last_restart=0
+if [[ -f "$METRICS_FILE" ]]; then
+    prev_total=$(awk '/^pihole_exporter_watchdog_restart_total /{print int($2)}' "$METRICS_FILE" 2>/dev/null || echo 0)
+    last_restart=$(awk '/^pihole_exporter_watchdog_last_restart_timestamp_seconds /{print int($2)}' "$METRICS_FILE" 2>/dev/null || echo 0)
+fi
+prev_total=${prev_total:-0}; last_restart=${last_restart:-0}
+
+restarted=0
+reason=""
+[[ $is_down -eq 1 ]] && reason="up=0 for >5m"
+[[ $is_degraded -eq 1 ]] && reason="${reason:+$reason; }mean scrape_duration ${dur}s > ${DEGRADE_SECS}s"
+
+if [[ $is_down -eq 1 || $is_degraded -eq 1 ]]; then
+    since_last=$(( now - last_restart ))
+    if (( since_last >= COOLDOWN_SECS )); then
+        log "UNHEALTHY ($reason) → restarting ${EXPORTER_UNIT}"
+        if systemctl --user restart "$EXPORTER_UNIT"; then
+            restarted=1; last_restart=$now; prev_total=$(( prev_total + 1 ))
+            log "restart issued (restart_total=$prev_total)"
+        else
+            log "ERROR: systemctl --user restart ${EXPORTER_UNIT} failed"
+        fi
+    else
+        log "UNHEALTHY ($reason) but in cooldown (${since_last}s < ${COOLDOWN_SECS}s) — backing off; PiHoleExporterDown will page if persistent"
+    fi
+else
+    log "healthy (down='${down:-NA}' mean_scrape_duration='${dur:-NA}s')"
+fi
+
+# --- emit textfile metric (atomic, in-dir tmp → inherits container_file_t) -----
+mkdir -p "$METRICS_DIR"
+out=$(cat <<EOF
+# HELP pihole_exporter_watchdog_last_run_timestamp_seconds Unix timestamp of the last watchdog run.
+# TYPE pihole_exporter_watchdog_last_run_timestamp_seconds gauge
+pihole_exporter_watchdog_last_run_timestamp_seconds $now
+# HELP pihole_exporter_watchdog_restart_total Cumulative pihole-exporter restarts issued by the watchdog.
+# TYPE pihole_exporter_watchdog_restart_total counter
+pihole_exporter_watchdog_restart_total $prev_total
+# HELP pihole_exporter_watchdog_last_restart_timestamp_seconds Unix timestamp of the last restart issued.
+# TYPE pihole_exporter_watchdog_last_restart_timestamp_seconds gauge
+pihole_exporter_watchdog_last_restart_timestamp_seconds $last_restart
+# HELP pihole_exporter_watchdog_restarted Whether this run issued a restart (1) or not (0).
+# TYPE pihole_exporter_watchdog_restarted gauge
+pihole_exporter_watchdog_restarted $restarted
+EOF
+)
+printf '%s\n' "$out" > "${METRICS_FILE}.tmp"
+mv "${METRICS_FILE}.tmp" "$METRICS_FILE"

--- a/scripts/pihole-forensics.sh
+++ b/scripts/pihole-forensics.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# pihole-forensics.sh — read-only diagnostic capture for the Pi-hole v6 resolver.
+#
+# Context: pihole-exporter (on fedora-htpc) degraded to >10s scrape latency at
+# 2026-06-04 ~20:28 UTC (= 22:28 CEST), tripping a false "Pi-hole down" page for
+# 3 days. A restart of the *exporter* fixed it (latency 0.25s), so FTL itself was
+# not the bottleneck. This script captures what happened ON THE PI around that
+# window to identify the TRIGGER (FTL restart? gravity run? session throttle?
+# under-voltage?) and to confirm the resolver is healthy.
+#
+# SAFE: read-only. No restarts, no config changes, no deletes. Per-command timeout
+# so it can never hang. Secrets (password, session IDs) are never written.
+#
+# Usage on the Pi (raspberrypi @ 192.168.1.69):
+#   # optional: lets the script time a REAL authenticated login cycle
+#   export PIHOLE_PW='your-admin-or-app-password'
+#   sudo -E bash pihole-forensics.sh
+#   # then copy the printed output file back.
+#
+# Without sudo it still runs; privileged log reads will just be marked SKIPPED.
+
+set -u
+API="http://127.0.0.1:80"            # FTL embedded webserver / API base
+INCIDENT_DATE="2026-06-04"           # local date of the regression onset (CEST)
+OUT="${HOME:-/tmp}/pihole-forensics-$(hostname)-$(date +%Y%m%d-%H%M%S).txt"
+
+# ---- helpers ---------------------------------------------------------------
+exec > >(tee -a "$OUT") 2>&1
+sec()  { printf '\n========== %s ==========\n' "$*"; }
+run()  { printf '$ %s\n' "$*"; timeout 25 bash -c "$*" 2>&1 || echo "[exit $? — failed/timeout/skipped]"; echo; }
+have() { command -v "$1" >/dev/null 2>&1; }
+redact() { sed -E 's/("sid"|"validity"|"csrf")[^,}]*/\1":"<redacted>"/g; s/password=[^ &]*/password=<redacted>/g'; }
+# run() executes via `bash -c`, a child shell — export redact so it's importable
+# there (the original bug: "redact: command not found" inside run()).
+export -f redact
+
+sec "META"
+echo "output_file : $OUT"
+echo "generated   : $(date -u '+%Y-%m-%dT%H:%M:%SZ') (UTC) / $(date '+%Y-%m-%d %H:%M:%S %Z') (local)"
+echo "host        : $(hostname)  kernel=$(uname -r)"
+echo "incident    : ${INCIDENT_DATE} ~20:28 UTC (22:28 CEST) — exporter latency 0.26s -> >10s"
+echo "auth probe  : $([ -n "${PIHOLE_PW:-}" ] && echo 'PIHOLE_PW set — real login cycle will be timed' || echo 'PIHOLE_PW unset — only unauth timing')"
+
+sec "SYSTEM STATE (now)"
+run "uptime"
+run "free -h"
+run "df -h / /var /var/log 2>/dev/null | sort -u"
+run "cat /proc/loadavg"
+
+sec "RASPBERRY PI HEALTH (throttling / under-voltage — a classic cause of erratic slowness)"
+if have vcgencmd; then
+  run "vcgencmd get_throttled"   # 0x0 = healthy; any bit set = power/thermal event
+  run "vcgencmd measure_temp"
+else echo "vcgencmd not present (not a Pi, or firmware tools missing)"; fi
+run "sudo dmesg -T 2>/dev/null | grep -iE 'under-voltage|throttl|oom|hung task' | tail -30 || echo '[needs sudo / none found]'"
+
+sec "THERMAL / COOLING DEEP-DIVE (idle CPU + chronic 80-86C ⇒ heat-removal fault, not load)"
+if have vcgencmd; then
+  run "vcgencmd measure_clock arm"        # throttled clock sits well below max (1.5-1.8GHz)
+  run "vcgencmd measure_volts core"
+  run "vcgencmd get_config int | grep -iE 'fan|temp|arm_freq|over_volt' || echo '[no relevant config ints]'"
+fi
+echo "--- thermal zones (type + temp, millideg) + trip points ---"
+run "for z in /sys/class/thermal/thermal_zone*; do printf '%s type=' \"\$z\"; cat \"\$z/type\" 2>/dev/null; printf '  temp='; cat \"\$z/temp\" 2>/dev/null; done"
+echo "--- cooling devices: a fan appears here; cur_state 0 while HOT = fan NOT spinning ---"
+run "for c in /sys/class/thermal/cooling_device*; do printf '%s type=' \"\$c\"; cat \"\$c/type\" 2>/dev/null; printf '  cur='; cat \"\$c/cur_state\" 2>/dev/null; printf ' max='; cat \"\$c/max_state\" 2>/dev/null; echo; done 2>/dev/null || echo '[no cooling_device entries — no managed fan]'"
+echo "--- fan / cooling directives in firmware config.txt (missing dtoverlay = fan never told to spin) ---"
+run "grep -inE 'fan|dtoverlay|temp|cooling' /boot/firmware/config.txt /boot/config.txt 2>/dev/null || echo '[no fan/cooling directives found]'"
+echo "--- top CPU consumers (confirm NOTHING is generating the heat) ---"
+run "ps -eo pcpu,pmem,comm --sort=-pcpu | head -8"
+echo "--- USB devices (a faulty/hot peripheral can heat the board) ---"
+run "lsusb 2>/dev/null || echo '[lsusb n/a]'"
+
+sec "PI-HOLE / FTL VERSION & STATUS"
+run "pihole -v 2>&1 | head"
+run "pihole-FTL --version 2>&1 | head"
+run "pihole status 2>&1 | head"
+
+sec "FTL SERVICE LIFECYCLE (did FTL restart at the incident time?)"
+run "systemctl show pihole-FTL -p ActiveEnterTimestamp,ExecMainStartTimestamp,NRestarts,ActiveState,SubState"
+run "systemctl status pihole-FTL --no-pager -n 5 2>&1 | head -20"
+
+sec "FTL/SYSTEM JOURNAL AROUND INCIDENT (${INCIDENT_DATE} 20:00–23:30 local)"
+run "sudo journalctl -u pihole-FTL --since '${INCIDENT_DATE} 20:00:00' --until '${INCIDENT_DATE} 23:30:00' --no-pager 2>&1 | tail -120 || echo '[needs sudo]'"
+run "sudo journalctl --since '${INCIDENT_DATE} 20:20:00' --until '${INCIDENT_DATE} 22:40:00' --no-pager 2>&1 | grep -iE 'pihole|FTL|lighttpd|webserver|reboot|shutdown|systemd' | tail -80 || echo '[needs sudo]'"
+
+sec "FTL.log AROUND INCIDENT (lifecycle + auth/session events)"
+for f in /var/log/pihole/FTL.log /var/log/pihole/FTL.log.1; do
+  [ -f "$f" ] || continue
+  echo "--- $f : lines on ${INCIDENT_DATE} 20:00–23:59 local ---"
+  run "grep -E '${INCIDENT_DATE} 2[0-3]:' '$f' | redact | tail -150"
+done
+echo "--- recent FTL lifecycle/auth/error lines (whole log) ---"
+run "grep -hiE 'Starting|Shutting down|listening|api|auth|session|seat|rate.?limit|ERROR|WARNING' /var/log/pihole/FTL.log 2>/dev/null | redact | tail -80"
+
+sec "API CONFIG — session limits & rate limiting (the throttle suspects)"
+for key in webserver.api.max_sessions webserver.api.app_sudo webserver.api.prettyJSON \
+           webserver.api.maxHistory dns.rateLimit.count dns.rateLimit.interval \
+           webserver.session.timeout misc.privacylevel; do
+  run "pihole-FTL --config $key 2>&1 | head -3"
+done
+
+sec "WHAT'S LISTENING ON :80 / FIREWALL (port 80 reachable from .70?)"
+run "sudo ss -tlnp 2>/dev/null | grep -E ':80 |:443 |:53 ' || ss -tln | grep -E ':80|:443|:53'"
+run "sudo ufw status 2>&1 | head -20 || echo '[ufw not used / needs sudo]'"
+
+sec "PACKAGE / GRAVITY ACTIVITY ON INCIDENT DATE (did an update restart FTL?)"
+run "grep -A2 -iE '${INCIDENT_DATE}|$(date -d "${INCIDENT_DATE}" '+%Y-%m-%d' 2>/dev/null)' /var/log/apt/history.log 2>/dev/null | tail -40 || echo '[no apt history match]'"
+run "zgrep -A2 -iE '${INCIDENT_DATE}' /var/log/apt/history.log.1.gz 2>/dev/null | tail -40 || true"
+run "ls -l --time-style=full-iso /etc/pihole/gravity.db 2>/dev/null"
+run "tail -15 /var/log/pihole/pihole_updateGravity.log 2>/dev/null || echo '[no gravity log]'"
+
+sec "LIVE API TIMING (reproduce what the exporter does)"
+echo "--- unauthenticated GETs (baseline; should be ~0.001s, HTTP 401) ---"
+for ep in /api/auth /api/stats/summary /api/info/ftl; do
+  run "curl -s -o /dev/null -w '$ep -> HTTP %{http_code} time_total=%{time_total}s\n' --max-time 20 '$API$ep'"
+done
+echo "--- failed POST /api/auth (dummy pw): measures brute-force/throttle delay ---"
+run "curl -s -o /dev/null -w 'POST /api/auth(bad) -> HTTP %{http_code} time_total=%{time_total}s\n' --max-time 20 -H 'Content-Type: application/json' -d '{\"password\":\"forensic-probe\"}' '$API/api/auth'"
+
+if [ -n "${PIHOLE_PW:-}" ]; then
+  echo "--- REAL authenticated cycle: login -> sessions -> summary -> logout (timed) ---"
+  SID=$(curl -s --max-time 20 -H 'Content-Type: application/json' \
+        -d "{\"password\":\"${PIHOLE_PW}\"}" "$API/api/auth" \
+        | grep -oE '"sid"[[:space:]]*:[[:space:]]*"[^"]+"' | sed -E 's/.*"sid"[^"]*"([^"]+)"/\1/' )
+  if [ -n "${SID:-}" ]; then
+    echo "login: OK (sid captured, redacted)"
+    run "curl -s -o /dev/null -w 'GET /api/auth/sessions -> HTTP %{http_code} time_total=%{time_total}s\n' --max-time 20 -H 'sid: $SID' '$API/api/auth/sessions'"
+    echo "--- active sessions (counts only; SIDs redacted) ---"
+    run "curl -s --max-time 20 -H 'sid: $SID' '$API/api/auth/sessions' | redact | head -40"
+    run "curl -s -o /dev/null -w 'GET /api/stats/summary -> HTTP %{http_code} time_total=%{time_total}s\n' --max-time 20 -H 'sid: $SID' '$API/api/stats/summary'"
+    # be a good citizen: delete the session we created
+    curl -s -o /dev/null --max-time 10 -X DELETE -H "sid: $SID" "$API/api/auth" && echo "logout: OK (session cleaned up)"
+  else
+    echo "login FAILED with provided PIHOLE_PW (wrong password, or API rejected). Skipped authed timing."
+  fi
+else
+  echo "(PIHOLE_PW unset — skipped authenticated timing. Re-run with it set for the highest-value measurement.)"
+fi
+
+sec "DONE"
+echo "Output written to: $OUT"
+echo "Send this file back. Key things I'll look for:"
+echo "  1. COOLING: cooling_device cur_state (0 while hot = fan not spinning), and"
+echo "     whether config.txt has a fan dtoverlay at all. Leading hypothesis: heat-"
+echo "     removal fault (idle CPU at 0.8% but 80-86C ⇒ not a workload problem)."
+echo "  2. vcgencmd get_throttled bits + measure_clock arm (throttled below max)."
+echo "  3. ps top CPU consumers (confirm nothing is generating the heat)."
+echo "  4. FTL lifecycle / FTL.log around ${INCIDENT_DATE} 22:28 CEST (exporter-wedge trigger)."

--- a/systemd/pihole-exporter-watchdog.service
+++ b/systemd/pihole-exporter-watchdog.service
@@ -1,0 +1,24 @@
+[Unit]
+# Self-heal a wedged pihole-exporter (2026-06-04 false-page incident). The image
+# is distroless so no in-container HealthCmd is possible; this reads the verdict
+# Prometheus already computes (up + scrape_duration) and restarts the exporter
+# when it is down >5m or degrading toward the scrape_timeout. Restarting a metrics
+# sidecar has zero DNS impact.
+Description=Pi-hole exporter watchdog (restart-on-stall self-heal)
+Documentation=file:/home/patriark/containers/scripts/pihole-exporter-watchdog.sh
+After=network-online.target prometheus.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/containers/scripts/pihole-exporter-watchdog.sh
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=60s
+
+# PrivateTmp intentionally NOT set — rootless podman's pause-process needs
+# access to the user's real /tmp namespace (see project_platform_gotchas).
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=default.target

--- a/systemd/pihole-exporter-watchdog.timer
+++ b/systemd/pihole-exporter-watchdog.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=Pi-hole exporter watchdog timer (every 5m)
+Documentation=file:/home/patriark/containers/scripts/pihole-exporter-watchdog.sh
+Requires=pihole-exporter-watchdog.service
+
+[Timer]
+# Every 5 min. Detection budget for a wedged exporter is therefore ~5–10 min
+# (vs. the 3-day outage this prevents). The script's own 20-min cooldown stops
+# crash-loops when the fault is upstream (real Pi-hole API outage) rather than
+# the exporter itself.
+OnBootSec=6min
+OnUnitActiveSec=5min
+RandomizedDelaySec=30s
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Three days of recurring **CRITICAL "Pi-hole down"** Discord pages — while DNS was healthy the whole time. Root-caused via `/systematic-debugging` to the **metrics exporter**, not the resolver. This PR removes the false page, makes the exporter self-heal, and adds visibility for a **separate hardware problem** the investigation surfaced (the Pi is overheating).

## Root cause

The `pihole-exporter` sidecar serves `/metrics` **synchronously** (a full Pi-hole v6 login→query cycle per scrape). On 2026-06-04 ~20:28 UTC its latency step-changed **0.26s → >10s** and stayed there, tripping Prometheus' default **10s `scrape_timeout`** (`up{job="pihole"}=0`). The generic **`HostDown`** rule (`up==0`, critical) then paged every ~1h as *"Service pihole on raspberrypi is down"*.

Meanwhile DNS was fine throughout: blackbox `dns_functional`/`dns_blocked` green, `pihole_status=1`, 55k queries/day. The exporter never crashed (`RestartCount=0`) and its image is **distroless** — so the `HealthCmd=wget` could never run, the container was permanently false-"unhealthy", and `Restart=on-failure` could never auto-recover it. A manual restart fixed it instantly (latency → 0.25s).

## Changes

| Area | Change |
|---|---|
| `infrastructure-critical.yml` | `HostDown` excludes `job="pihole"` — a sidecar timeout no longer pages as critical "DNS down" (ADR-031 D5: functional > liveness). `PiHoleExporterDown` (warning) remains. |
| `prometheus.yml` | pihole job: `scrape_interval: 30s` + `scrape_timeout: 20s` (~75× headroom; also reduces API login churn / GH#246 leak). |
| `pihole-exporter.container` | Drop the broken `HealthCmd=wget` (distroless). |
| `pihole-exporter-watchdog.{sh,service,timer}` | **New** host-side self-heal: reads `up` + `scrape_duration` from Prometheus, restarts the exporter when down >5m or degrading toward the timeout. 20m cooldown avoids crash-loops on upstream faults. Emits watchdog metrics. |
| `dns-resolver-alerts.yml` | **New** `PiHoleResolverHot` (warn >80°C/15m) + `PiHoleResolverCriticalTemp` (crit >84°C/15m) on `node_thermal_zone_temp`. |
| `pihole-forensics.sh` | Fix `redact()` (not visible in `run()`'s `bash -c` child → `export -f`); add thermal/cooling deep-dive section. |

## ⚠️ Separate finding: the Pi is overheating

Idle CPU (**0.8%**) yet chronically **80–86°C**, firmware-throttling the clock to 600–900 MHz (max 1800). In a stable-ambient server box that indicates a **heat-removal fault (fan/heatsink/airflow), not load**. The new thermal alerts **will fire on deploy** in this state — that's intended. Investigation of the cooling fault is ongoing (use the new `pihole-forensics.sh` cooling section on the Pi).

## Validation

- `promtool check rules` + `promtool check config` — pass
- `bash -n` both scripts — clean
- Watchdog dry-run: evaluated **healthy**, did not restart, emitted metrics correctly

## Deploy steps (post-merge, on fedora-htpc)

```bash
cd ~/containers && git pull
# 1. quadlet: drop broken healthcheck
systemctl --user daemon-reload && systemctl --user restart pihole-exporter.service
# 2. enable the watchdog
systemctl --user daemon-reload   # picks up systemd/ via your usual link, if applicable
systemctl --user enable --now pihole-exporter-watchdog.timer
# 3. reload Prometheus (alert + scrape changes)
curl -X POST http://<prometheus>:9090/-/reload   # or: systemctl --user restart prometheus.service
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)