### PR TITLE
fix(migrate-db): sudo on btrfs subvolume show in ADR-029 preflight

### DIFF
--- a/scripts/migrate-db-to-subvol8.sh
+++ b/scripts/migrate-db-to-subvol8.sh
@@ -95,7 +95,7 @@ cmd_preflight() {
     info "  quadlet: $q"
 
     [[ -d "$SUBVOL8" ]] || { warn "  subvol8-db missing"; fail=1; }
-    btrfs subvolume show "$SUBVOL8" >/dev/null 2>&1 && ok "  subvol8-db is a subvolume" || { warn "  subvol8-db is NOT a subvolume"; fail=1; }
+    sudo btrfs subvolume show "$SUBVOL8" >/dev/null 2>&1 && ok "  subvol8-db is a subvolume" || { warn "  subvol8-db is NOT a subvolume"; fail=1; }
     sudo test -d "$src" && ok "  source dir exists" || { warn "  source dir missing"; fail=1; }
     if sudo test -e "$dst"; then warn "  target already exists ($dst) — migrate would refuse"; fail=1; else ok "  target does not exist yet"; fi
     [[ -f "$q" ]] && grep -q "^Volume=${src}:" "$q" && ok "  quadlet Volume= line found" || { warn "  quadlet Volume=${src}: line NOT found"; fail=1; }


### PR DESCRIPTION
## Summary

A dry-run preflight of the Phase B migration tool (ADR-029, GH#220) surfaced a latent blocker that would have aborted the real migration inside the offline window. This is the one-line fix.

## The bug

`scripts/migrate-db-to-subvol8.sh:98` called `btrfs subvolume show "$SUBVOL8"` **without `sudo`** — the only privileged call in the script missing it. `btrfs subvolume show` needs root, so for the normal user it failed with `ERROR: Could not search B-tree: Operation not permitted`. stderr was swallowed by `>/dev/null 2>&1`, so preflight falsely reported `subvol8-db is NOT a subvolume` and set `fail=1`.

## Impact

Under `--execute`, preflight is hard-gated (`fail=1` → `die "Preflight FAILED"`). Because the call lacked `sudo`, priming sudo did **not** help — so this would have aborted the real Phase B DB migration mid-offline-window. Caught by a dry-run preflight before scheduling the window.

## Fix

Add `sudo`, matching every other privileged call in the script (`sudo test`, `sudo du`, `sudo lsattr`, `sudo filefrag`).

## Verification

- `bash -n` clean.
- Re-ran preflight on all 4 candidates (gathio-db, nextcloud-db, prometheus, postgresql-immich) → each now reports `[OK] subvol8-db is a subvolume`; only the expected `service is RUNNING` warning remains (correct outside an offline window).
- Independently confirmed `subvol8-db` is a real subvolume (inode 256), `patriark:patriark 755`, writable — so the mutation path's unprivileged `mkdir`/`chattr` are also sound.

## Status

GH#220 (Phase B execution) remains **GO** — all three gates met and the migration tool is now actually executable. Remaining work is operational: open the offline window, then `migrate <svc> --execute` smallest-first with `verify` after each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)