### PR TITLE
fix(monitoring): defer prometheus/loki/grafana boot I/O to tier C (ADR-035)

### DIFF
--- a/docs/20-operations/decisions/2026-06-09-ADR-035-boot-time-io-tiering.md
+++ b/docs/20-operations/decisions/2026-06-09-ADR-035-boot-time-io-tiering.md
@@ -1,0 +1,157 @@
+# ADR-035: Boot-Time I/O Tiering for Service Startup
+
+**Date:** 2026-06-09
+**Status:** Accepted (Tier-C reclassification of prometheus/loki/grafana implemented;
+full validation on next reboot, per the established boot-storm verification practice)
+
+---
+
+## Context
+
+After a reboot on 2026-06-09 the host thrashed for ~7 minutes: load peaked ~18 and the
+GNOME terminal (ptyxis) took minutes to open. The owner's first read was "podman is in a
+death loop." Systematic debugging refuted that:
+
+- **Not a death loop.** One `podman system service` (the API socket), zero restarting or
+  failed container units, all ~30 containers active.
+- **Not memory.** 24 GiB free throughout; swap barely touched. PSI showed memory pressure
+  ~0%.
+- **It was I/O saturation.** `/proc/pressure/io` showed `full avg300 ≈ 40%` — at the peak,
+  *all* tasks were stalled on disk 40% of the time. The frozen terminal was a *symptom* of
+  I/O starvation, not podman looping. The storm self-resolved (load → 0.47).
+
+The boot journal pinned the dominant I/O producers by their wall-clock ≫ CPU-time ratios
+(the signature of a process blocked on disk, not spinning):
+
+| Service | Boot recovery work | CPU vs wall clock |
+|---|---|---|
+| prometheus | TSDB mmap-chunk replay 3.1 s + WAL replay 16.5 s (~20 s reads) | — |
+| loki | WAL checkpoint + segment recovery | **2.1 s CPU over 3 min 5 s wall** |
+| cadvisor | "recovery of all containers" | 0.49 s CPU over 1 min 56 s wall |
+
+### Why the existing mitigation didn't catch this
+
+A prior boot storm (2026-05-27, PR #242 — documented in
+`docs/98-journals/2026-05-27-post-update-boot-storm-and-homepage-decom.md`) introduced a
+per-unit startup-tiering scheme using `StartupCPUWeight` / `StartupIOWeight`, which apply
+**only while the user manager is in `starting` state and revert once `default.target` is
+reached** — so they carry zero steady-state cost. That scheme defined:
+
+- **Tier A (weight 200, "keystones"):** Traefik, the 4 databases, the 3 Redis instances,
+  Authelia. Win the disk during boot.
+- **Tier C (weight 50, "ancillaries"):** the 6 exporters, unpoller, cadvisor, promtail,
+  alert-discord-relay, unifi-syslog. Yield during the fan-out.
+- **Tier B (implicit default 100):** "apps — unchanged."
+
+The scheme was **documented only in a journal, never formalized**, and its classification
+was structural ("keystones vs exporters"), not measured. **Prometheus, Loki, and Grafana —
+the three heaviest I/O producers in the fleet — fell into "Tier B, apps, unchanged" by
+omission.** They were never demoted, so on every reboot their TSDB/WAL recovery competed at
+default weight (100) against the application tier and saturated the shared BTRFS pool
+(`/dev/sdc`, an HDD on the `bfq` scheduler, which honours cgroup `io.weight`). The
+slice-level companion drop-in (`container.slice.d/boot-priority.conf`, yielding the whole
+container slice to `user.slice`) was intact, but it cannot help once these units' recovery
+I/O saturates the disk in absolute terms.
+
+This ADR **formalizes the tier model** and **corrects the misclassification** so the gap is
+a tracked standard rather than journal lore.
+
+## Decision
+
+### D1 — The boot-tier model is a standard, not lore
+
+Every service that starts at boot is assigned to one of three startup tiers via
+`StartupCPUWeight` / `StartupIOWeight` in the quadlet `[Service]` section. These weights
+apply only during `default.target` assembly and revert afterward (no steady-state effect).
+
+| Tier | Weight | Membership rule |
+|---|---|---|
+| **A — keystone** | 200 | Reverse proxy, databases, caches, auth — anything the app tier *functionally blocks on*. Must come up first. |
+| **B — application** | 100 (default, implicit) | User-facing application containers. Left at default. |
+| **C — ancillary / deferrable** | 50 | Observability, exporters, log shippers, and **any service whose boot-time I/O is heavy but whose availability is not on a user's critical path** — it can come up after the app tier settles. Also gets `After=traefik.service` to stage it past the storm peak. |
+
+**Classification is by measured boot I/O and criticality, not by category label.** A
+"monitoring" service is not automatically Tier C, and Tier B is not a default dumping
+ground: if a service does heavy recovery I/O at boot and nothing user-facing waits on it,
+it belongs in Tier C regardless of what kind of service it is.
+
+### D2 — Reclassify prometheus, loki, grafana from implicit Tier B → Tier C
+
+Each gains, in its quadlet:
+
+```ini
+[Unit]
+After=… traefik.service          # stage past the storm peak
+
+[Service]
+StartupCPUWeight=50
+StartupIOWeight=50
+```
+
+Prometheus and Loki store on `/mnt/btrfs-pool/subvol8-db` (HDD/`bfq`, per ADR-029), where
+`StartupIOWeight` is effective. Grafana stores on the SSD (`/home`, `none` scheduler) where
+IOWeight has little effect — it is tiered for consistency and for the CPU-weight and
+ordering benefit. Alertmanager, alert-discord-relay, and the exporters **stay early**
+(un-deferred) so the alerting path is not blinded during the post-reboot window.
+
+### D3 — Companion slice drop-in remains out of git
+
+`~/.config/systemd/user/container.slice.d/boot-priority.conf` (demotes `container.slice`
+relative to `user.slice` so the desktop session stays responsive) is user-systemd config,
+not container infrastructure, and stays out of version control — consistent with the
+2026-05-27 decision. Its presence is a precondition for the desktop-responsiveness benefit.
+
+## Consequences
+
+**Positive**
+- The two heaviest boot I/O producers (Prometheus, Loki) now yield to the DB/app tiers on
+  the shared HDD during boot, flattening the I/O storm and shortening the window in which
+  the desktop session is starved.
+- The tier model is now a tracked standard with an explicit classification rule, so future
+  services are placed deliberately and this class of regression is less likely to recur.
+
+**Negative / accepted trade-offs**
+- The monitoring **data-plane** (metrics scraping, dashboards, log ingestion) comes up
+  slightly later after a reboot. The **alerting path** (Alertmanager + relay) is
+  intentionally *not* deferred, so this is a brief gap in retrospective data, not in paging.
+- `Startup*Weight` only governs the `starting` phase. Where a service is marked `active`
+  (podman sdnotify on container start) **before** its internal recovery finishes, some
+  recovery I/O can spill past `default.target` and escape the weighting. This is a known
+  limitation, not a defect (see Future Work).
+
+**Neutral**
+- Zero steady-state cost: weights revert once boot completes.
+
+## Future Work (if the storm still bites on the next reboot)
+
+Ship this minimal, in-house-pattern fix first and **measure one reboot**. If I/O pressure
+during cold boot is still unacceptable, escalate in this order:
+
+1. Order the heavy monitoring units after the data tier is *ready* (not just started) —
+   e.g. `Notify=healthy` on the databases so `After=` waits for real readiness.
+2. Add an adaptive **I/O-quiesce gate**: a oneshot that polls `/proc/pressure/io` and
+   releases a `homelab-monitoring.target` when `full avg10` is sustainedly low or a hard
+   timeout (~180 s) elapses, fail-open. Considered and deliberately deferred here as
+   over-engineered for a self-resolving, infrequent event.
+
+## References
+
+- `docs/98-journals/2026-05-27-post-update-boot-storm-and-homepage-decom.md` — origin of the
+  tier scheme (PR #242); this ADR formalizes and corrects it.
+- `docs/98-journals/2026-06-09-reboot-io-storm-not-podman-deathloop.md` — this incident's
+  debugging narrative.
+- **ADR-029** — three-tier DB storage; places Prometheus/Loki data on `subvol8-db` (HDD),
+  the device under contention.
+- **ADR-003** — monitoring stack architecture (the services being tiered).
+- **ADR-011** — service dependency mapping (sibling: startup ordering).
+
+## Files Touched
+
+- `quadlets/prometheus.container`, `quadlets/loki.container`, `quadlets/grafana.container` —
+  `After=traefik.service` + `StartupCPUWeight=50` / `StartupIOWeight=50`.
+
+**Verification (post-edit, pre-reboot):** `systemctl --user daemon-reload`; confirmed
+`StartupCPUWeight=50 / StartupIOWeight=50` applied on all three via `systemctl --user show`;
+`systemd-analyze --user verify` reports no ordering cycles. Full validation on next reboot:
+`coredumpctl list --since=boot` empty, no `start operation timed out`, lower peak
+`/proc/pressure/io`, ptyxis responsive within seconds.

--- a/docs/98-journals/2026-06-09-reboot-io-storm-not-podman-deathloop.md
+++ b/docs/98-journals/2026-06-09-reboot-io-storm-not-podman-deathloop.md
@@ -1,0 +1,64 @@
+# Reboot I/O Storm Misread as a Podman Death Loop
+
+**Date:** 2026-06-09
+**Context:** Post-reboot the host thrashed for ~7 minutes; ptyxis took minutes to open. The
+owner's read was "podman is in a death loop starting all the containers." Systematic
+debugging refuted that and traced it to a recurrence of the 2026-05-27 boot storm. Fix +
+formalization landed as ADR-035.
+
+## Symptom vs. cause
+
+The reported symptom — frozen desktop, terminal taking minutes — *looked* like podman
+spinning. Evidence said otherwise:
+
+- **Not a death loop.** 1 `podman system service` (the API socket), 0 restarting/failed
+  container units, all ~30 containers active. A loop would show podman process churn and
+  restarting units; neither was present.
+- **Not memory.** 24 GiB available throughout, swap ~146 MiB, PSI memory ~0%.
+- **I/O saturation was the whole story.** `/proc/pressure/io` `full avg300 ≈ 40%` — every
+  task stalled on disk 40% of the time at peak. Load had already fallen 18 → 0.47 by the
+  time we finished looking; the storm self-resolves.
+
+Dominant producers, proven by wall-clock ≫ CPU-time (blocked on disk, not spinning):
+Prometheus TSDB+WAL replay (~20 s of reads) and Loki WAL recovery (**2.1 s CPU over 3 min
+5 s wall**), with cAdvisor's container scan third. Root cause: ~30 containers cold-starting
+in parallel on the BTRFS pool, and the three heaviest monitoring services were never
+demoted in the 2026-05-27 boot-tier scheme (they sat at implicit Tier B / default weight
+100). See ADR-035 for the fix.
+
+## The red herring (lesson)
+
+The first `ps` snapshot showed `localsearch-extractor` (GNOME file indexer) at **63 % CPU** —
+the single largest consumer. The tempting hypothesis: the desktop indexer was crawling the
+photo/music subvolumes (reached via the `~/Pictures → /mnt/btrfs-pool/...` symlinks) and
+generating the I/O storm. A fix was even chosen on that basis (exclude the data dirs from
+indexing).
+
+**Verifying before acting killed the hypothesis.** `localsearch status` reported **34 files
+indexed, idle** — it does *not* follow the directory symlinks out to the subvolumes; the
+"63 %" was `ps` averaging a just-spawned, short-lived extractor over its brief lifetime. The
+chosen `ignored-directories` setting would have been a **no-op**. It was not applied.
+
+- **`ps %CPU` is a lifetime average, not an instantaneous rate.** A freshly-forked process
+  that did one CPU burst reads deceptively high. Confirm "what is this process doing *now*"
+  before building a theory on it.
+- **Ask the component, don't infer from one surface.** `localsearch status` (34 files)
+  settled in one command what a CPU snapshot only hinted at.
+- **A chosen fix is not a committed fix.** The premise was re-checked between decision and
+  execution; the no-op was caught before it shipped.
+
+## Loose ends (benign, no action)
+
+- Loki logged a WAL-segment corruption warning on recovery — Loki itself says *"No
+  administrator action is needed"* (single ingester; at most seconds of recent logs lost).
+  Classic unclean-shutdown artifact.
+- `podman-user-wait-network-online.service` failed (timed out polling the system
+  `network-online.target` from the user session). Cosmetic rootless-podman shim; all
+  containers started regardless.
+
+## Fix
+
+ADR-035: reclassified prometheus / loki / grafana from implicit Tier B → Tier C
+(`StartupCPUWeight=50`, `StartupIOWeight=50`, `After=traefik.service`), completing and
+formalizing the 2026-05-27 scheme. Alerting path (Alertmanager + relay) intentionally left
+early. Validation deferred to the next reboot.

--- a/quadlets/grafana.container
+++ b/quadlets/grafana.container
@@ -1,6 +1,6 @@
 [Unit]
 Description=Grafana Monitoring Dashboard
-After=network-online.target monitoring-network.service
+After=network-online.target monitoring-network.service traefik.service
 Wants=monitoring-network.service network-online.target
 
 [Container]
@@ -42,6 +42,12 @@ MemoryMax=1G
 MemoryHigh=900M
 Restart=on-failure
 TimeoutStartSec=300
+# Boot tier C: yield during fan-out; After=traefik.service defers past the storm.
+# Added 2026-06-09: completes the tier-C monitoring data-plane. Grafana data is on the
+# SSD (/home), so ordering matters more than IOWeight here, but tiered for consistency
+# with prometheus/loki. See ADR-035.
+StartupCPUWeight=50
+StartupIOWeight=50
 
 [Install]
 WantedBy=default.target

--- a/quadlets/loki.container
+++ b/quadlets/loki.container
@@ -1,6 +1,6 @@
 [Unit]
 Description=Loki Log Aggregation System
-After=network-online.target monitoring-network.service
+After=network-online.target monitoring-network.service traefik.service
 Wants=monitoring-network.service network-online.target
 
 [Container]
@@ -32,6 +32,12 @@ DNS=192.168.1.69
 Slice=container.slice
 Restart=on-failure
 TimeoutStartSec=120
+# Boot tier C: yield during fan-out; After=traefik.service defers past the storm.
+# Added 2026-06-09: WAL recovery ran 2.1s CPU over 3min wall clock (heavily I/O-blocked
+# on subvol8-db/HDD) — among the heaviest fleet boot I/O. Previously implicit tier B
+# (default 100) — reclassified after a recurring boot storm. See ADR-035.
+StartupCPUWeight=50
+StartupIOWeight=50
 
 # Resource Limits
 MemoryMax=512M

--- a/quadlets/prometheus.container
+++ b/quadlets/prometheus.container
@@ -1,6 +1,6 @@
 [Unit]
 Description=Prometheus Metrics Database
-After=network-online.target monitoring-network.service node_exporter.service
+After=network-online.target monitoring-network.service node_exporter.service traefik.service
 Wants=monitoring-network.service network-online.target node_exporter.service
 
 [Container]
@@ -49,6 +49,12 @@ Slice=container.slice
 Restart=on-failure
 TimeoutStartSec=120
 OOMPolicy=kill
+# Boot tier C: yield during fan-out; After=traefik.service defers past the storm.
+# Added 2026-06-09: TSDB mmap+WAL replay (~20s of reads on subvol8-db/HDD) is among
+# the heaviest fleet boot I/O. Previously implicit tier B (default 100) — reclassified
+# after a recurring boot storm. See ADR-035.
+StartupCPUWeight=50
+StartupIOWeight=50
 
 # Resource Limits
 MemoryMax=1G


### PR DESCRIPTION
## Problem
Post-reboot (2026-06-09) the host thrashed ~7 min — load peaked ~18, ptyxis took minutes to open. Diagnosed as **I/O saturation** (`/proc/pressure/io full avg300 ≈ 40%`), **not** a podman death loop and **not** memory (24 GiB free throughout). ~30 containers cold-start in parallel on the BTRFS pool; the heaviest producers are Prometheus TSDB/WAL replay (~20 s of reads) and Loki WAL recovery (2.1 s CPU over **3 min wall** = blocked on disk).

## Root cause
Recurrence of the 2026-05-27 boot storm. That fix introduced a boot-tier weighting scheme (A=200 keystones, C=50 ancillaries) but left **prometheus / loki / grafana — the three heaviest I/O producers — at implicit tier B (default weight 100)**. Confirmed empirically: their `StartupIOWeight` was unset while the light exporters were already at 50.

## Change
Reclassify the three to **tier C**: `StartupCPUWeight=50`, `StartupIOWeight=50`, `After=traefik.service`. The alerting path (alertmanager + relay) is deliberately left early → no alerting blind spot.

## Docs
- **ADR-035** formalizes the A/B/C tier model + a measured classification rule (so this gap can't recur silently)
- Journal records the incident, including a `localsearch` red-herring caught by verifying before acting

## Verification
- `systemctl --user daemon-reload` → all three report `StartupIOWeight=50`
- `systemd-analyze --user verify` → no ordering cycles
- Full validation on next reboot (lower peak `/proc/pressure/io`, ptyxis responsive within seconds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)