### PR TITLE
chore(adr-029): finalize Phase B DB migration to subvol8-db (NOCOW)

### DIFF
--- a/docs/00-foundation/decisions/2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md
+++ b/docs/00-foundation/decisions/2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md
@@ -1,7 +1,7 @@
 # ADR-029: Three-Tier Database Storage + Dump Backup
 
 **Date:** 2026-05-22
-**Status:** Accepted (Phase A implemented); Phase B deferred/gated
+**Status:** Accepted (Phase A implemented 2026-05-22; Phase B executed 2026-06-09)
 **Supersedes:** ADR-024 (dump-based backup), ADR-025 (deferred DB migration), ADR-027 (forward-only NOCOW placement)
 **Plan:** worked out 2026-05-22 (debate → plan → implementation)
 
@@ -63,7 +63,9 @@ Backup coverage is observable: `db-dumps.prom` (node_exporter textfile) → `db_
 - **`zstd -f` is required** (a failed run leaves an empty `.tmp` that would otherwise block the next run).
 - **Vaultwarden: host `sqlite3 .backup` (no sidecar needed).** Initially assumed to need a sidecar (no `sqlite3` in the image). Ground truth corrected it: the SQLite is host-owned (uid 1000, mode 644) and the host has `sqlite3`, so an online `.backup` (backup API — safe alongside the live writer) + `PRAGMA integrity_check` gives an application-consistent copy with no container involvement. Vaultwarden stays Tier 1 (snapshotted); the dump is an extra offsite, restore-tested safety net for the most security-critical store. *Lesson: re-check the assumption before engineering around it.*
 
-## Phase B — Offline migration into subvol8-db (DEFERRED / gated)
+## Phase B — Offline migration into subvol8-db (EXECUTED 2026-06-09)
+
+**Executed 2026-06-09** during the `dnf update` offline window (`update-before-reboot.sh` → `graceful-shutdown.sh`, all containers cleanly stopped). All four engines (`postgresql-immich`, `nextcloud-db/data`, `gathio-db`, `prometheus`) were migrated into `subvol8-db` and **verified healthy on the new path** — NOCOW (`C`-only, never `m`), no shared extents, sizes matched, sampled files all NOCOW. Quadlet `Volume=` repoints are committed as config-as-code (this change). Rollback sources retained at `<path>.pre-migration-2026-06-09` for ~14 clean days, then `scripts/migrate-db-to-subvol8.sh cleanup <svc> --execute`. A preflight blocker (a `sudo`-less `btrfs subvolume show` whose swallowed stderr inverted the result) was fixed first in **PR #258**. Session lessons: `docs/98-journals/2026-06-09-adr029-phase-b-db-migration-nocow.md`. The original gated runbook is retained below as the as-executed procedure.
 
 Move the four engines still in `subvol7` (`postgresql-immich`, `nextcloud-db/data`, `gathio-db`, `prometheus`) into `subvol8-db` (forgejo-db + loki are already there). **Gate:** (a) restore-test track record (the job now exists — let it run a few Sundays); (b) **measurement — DONE 2026-05-22, justifies migration:** subvol7 DBs show heavy COW-in-snapshot fragmentation (nextcloud `oc_filecache.ibd` = 11,777 extents; gathio max 2,362; immich PG mean 6.3 / max 1,862) vs the subvol8 NOCOW reference (forgejo PG mean 0.9 / max 8, loki mean 1.0) — a near-controlled same-engine comparison (immich vs forgejo PostgreSQL). Baseline saved under `data/backup-logs/`, regenerate via `scripts/filefrag-baseline.sh`; (c) the defensive tool `scripts/migrate-db-to-subvol8.sh` is **built** (dry-run default, typed-confirm + `--execute` gates, no-reflink copy with post-copy verification, health-gated source retention, `rollback`/`cleanup`). Remaining gate: a restore-test track record (a) before executing.
 
@@ -87,13 +89,13 @@ The defensive tool `scripts/migrate-db-to-subvol8.sh` is **built** (dry-run defa
 | forgejo-db | PostgreSQL | yes | `pg_dump` (Phase A) |
 | loki | TSDB / logs | yes | **none — Tier 3, regenerable** (nightly dump froze it ~15 min on cold cache; dropped) |
 | ~~unifi-syslog~~ | append-only syslog | — | **moved to Tier 1** (subvol7, snapshot+offsite) — overrides ADR-027's placement; append-only forensic logs belong in the snapshot tier and the COW cost is negligible |
-| *(Phase B)* postgresql-immich, nextcloud-db, gathio-db, prometheus | server engines | yes | dumps (Phase A) + offline migration (Phase B) |
+| postgresql-immich, nextcloud-db, gathio-db, prometheus | server engines | yes | dumps (Phase A) + **migrated to subvol8-db 2026-06-09 (Phase B ✓)** |
 
 New tenants follow the growth rule; update this table rather than writing a new ADR (unless the tier policy itself changes).
 
 ## Consequences
 
-**Positive:** every database (PostgreSQL, MariaDB, MongoDB, Prometheus, plus vaultwarden SQLite) now has an application-consistent, offsite, restore-tested backup; the forgejo-db hole is closed (loki is reclassified Tier 3 — regenerable, accepted no-backup); NOCOW will actually work once Phase B completes; the architecture has a single durable growth rule.
+**Positive:** every database (PostgreSQL, MariaDB, MongoDB, Prometheus, plus vaultwarden SQLite) now has an application-consistent, offsite, restore-tested backup; the forgejo-db hole is closed (loki is reclassified Tier 3 — regenerable, accepted no-backup); NOCOW now works for every Tier-2 engine (Phase B completed 2026-06-09); the architecture has a single durable growth rule.
 
 **Negative / accepted:** Prometheus dumps are full TSDB snapshots (~1.5 GB/night, no dedup) — local retention is shortened to 7 and offsite growth is governed by Urd's subvol7 retention; a future option is dumping Prometheus weekly rather than daily. `--web.enable-admin-api` exposes destructive TSDB endpoints to the unauthenticated monitoring network (accepted; external path is Authelia-fronted; only the snapshot endpoint is used). Live DB files in `subvol8-db` have no filesystem-snapshot rollback — recovery is via dumps, which is the intended model.
 

--- a/docs/98-journals/2026-06-09-adr029-phase-b-db-migration-nocow.md
+++ b/docs/98-journals/2026-06-09-adr029-phase-b-db-migration-nocow.md
@@ -1,0 +1,31 @@
+# ADR-029 Phase B — DB Migration to subvol8-db (NOCOW) — Session Lessons
+
+**Date:** 2026-06-09
+**Scope:** Executed Phase B of ADR-029 — migrated the 4 remaining COW-in-snapshot databases (`gathio-db`, `nextcloud-db`, `prometheus`, `postgresql-immich`) from `subvol7-containers` into `subvol8-db` (NOCOW). All 4 verified healthy on the new path. PR #258 fixed a preflight blocker first.
+**Refs:** ADR-029 · GH#220 (execution reminder) · PR #258 · memory [[project_db_storage_architecture]] · [[project_platform_gotchas]]
+
+---
+
+## Lessons learned
+
+**1. The dry-run preflight earned its entire keep — a swallowed-stderr permission failure was masquerading as a real negative.** `cmd_preflight` ran `btrfs subvolume show "$SUBVOL8"` *without* `sudo` — the only privileged call in the script missing it. As a non-root user it failed with `Operation not permitted`; `>/dev/null 2>&1` discarded the stderr, so preflight reported the *opposite of the truth* (`subvol8-db is NOT a subvolume`) and set `fail=1`. Under `--execute` that `fail=1` is hard-gated (`die "Preflight FAILED"`), and because the call lacked `sudo`, priming sudo wouldn't have helped — it would have **aborted the real migration mid-offline-window**. Two takeaways: (a) actually *run* the dry-run on safety-critical tooling before the window, don't just trust that it's ready; (b) never `2>&1`-swallow stderr on a privileged probe — a permission error and a genuine negative become indistinguishable. Ground-truthed subvolumehood the unprivileged way instead: inode `256` + `findmnt`.
+
+**2. `chattr -m` then `+C` — and why "no `m`" still means "uncompressed."** The script does `chattr -m` (REMOVE the explicit no-compress attribute) then `chattr +C` (set NOCOW). The `-`/`+` is remove/add, so the dirs end with **only `C`, no `m`** (`lsattr -d` → `---------------C------` on all 4). This matters because this homelab previously proved the *explicit* `m` attribute causes harm/inconvenience alongside NOCOW — so the tool deliberately avoids leaving it set. BUT the data is still uncompressed regardless: NOCOW and compression are mutually exclusive on btrfs (`C` and `c` can't coexist). So "no `m`" ≠ "compressed" — don't conflate the two mechanisms. The compression loss is intrinsic to the NOCOW design and accepted (it's the price of killing COW fragmentation); only the separately-harmful `m` flag is avoided. **Invariant for any future NOCOW DB dir: end state should be `C` only, never `m`.**
+
+**3. `--yes` "one gulp" was safe *because* each migrate is atomic and health-gated — and I verified that before trusting it.** Checked all 4 quadlets actually define healthchecks (`mongosh ping`, `healthcheck.sh`, `/-/healthy`, `pg_isready`) before recommending `--yes`; without a real healthcheck, `wait_healthy`'s `podman healthcheck run` would false-fail and auto-rollback every service. With real gates: unhealthy → auto-reverts the quadlet, source untouched; `|| break` halts the loop; source only *renamed* (never deleted) after health passes. Partial migration is acceptable by design. Don't hand someone a `--yes` loop without confirming the inner safety gate is real.
+
+**4. Interactive sudo can't be driven through the agent's shell — the human runs the privileged loop.** The agent's Bash has no TTY and Fedora uses per-tty sudo timestamps, so `sudo -v` can't be primed for it and every privileged step would hang. The migration (sudo rsync/du/find/filefrag/mv) and even preflight were run by the user in their own terminal while the agent verified output line-by-line. Same shape as the ansible-become friction — the working pattern is "user elevates, agent reads the result."
+
+## State at landing
+
+- **Migrated + verified healthy on subvol8-db (NOCOW, `C`-only):** `gathio-db`, `nextcloud-db`, `prometheus`, `postgresql-immich`. No shared extents, sizes matched, sampled files all NOCOW.
+- **Rollback artifacts retained:** sources at `<path>.pre-migration-2026-06-09` (incl. `nextcloud-db/data.pre-migration-…`). Delete after ~14 clean days: `./scripts/migrate-db-to-subvol8.sh cleanup <svc> --execute`.
+- **PR #258 merged** (preflight `sudo` fix).
+- **User rebooting now** (`dnf update && reboot`) → then `./scripts/post-reboot-verify.sh`.
+
+## Pending (next session, post-reboot)
+
+1. Commit the 4 quadlet `Volume=` repoint changes (config-as-code — currently uncommitted) + this journal.
+2. Update ADR-029 status → **Phase B done** + tenant table; bump [[project_db_storage_architecture]] memory (it still says "GO pending offline window").
+3. Re-run `sudo bash scripts/filefrag-baseline.sh` for the before/after fragmentation delta.
+4. GH#220: post an "executed 2026-06-09" note (the reminder issue was closed; add the outcome).

--- a/docs/AUTO-DEPENDENCY-GRAPH.md
+++ b/docs/AUTO-DEPENDENCY-GRAPH.md
@@ -1,6 +1,6 @@
 # Service Dependency Graph (Auto-Generated)
 
-**Generated:** 2026-06-04 15:10:33 UTC
+**Generated:** 2026-06-09 00:01:11 UTC
 **System:** fedora-htpc
 
 ---

--- a/docs/AUTO-DOCUMENTATION-INDEX.md
+++ b/docs/AUTO-DOCUMENTATION-INDEX.md
@@ -1,7 +1,7 @@
 # Documentation Index (Auto-Generated)
 
-**Generated:** 2026-06-04 23:38:27 UTC
-**Total Documents:** 431
+**Generated:** 2026-06-09 00:01:12 UTC
+**Total Documents:** 434
 
 ---
 
@@ -22,7 +22,7 @@
 
 ## Documentation by Category
 
-### 00-foundation/ (28 documents)
+### 00-foundation/ (29 documents)
 
 **Fundamentals and core concepts**
 
@@ -55,6 +55,7 @@
 - ADR-030: [2026-05-23-ADR-030-container-supply-chain-trust-model](00-foundation/decisions/2026-05-23-ADR-030-container-supply-chain-trust-model.md)
 - ADR-031: [2026-05-25-ADR-031-dns-resolver-first-class-and-ha](00-foundation/decisions/2026-05-25-ADR-031-dns-resolver-first-class-and-ha.md)
 - ADR-032: [2026-06-05-ADR-032-forgejo-git-over-ssh-loopback](00-foundation/decisions/2026-06-05-ADR-032-forgejo-git-over-ssh-loopback.md)
+- ADR-034: [2026-06-06-ADR-034-forgejo-instance-commit-signing-ssh](00-foundation/decisions/2026-06-06-ADR-034-forgejo-instance-commit-signing-ssh.md)
 - : [README](00-foundation/decisions/fixtures/README.md)
 - ADR-023: [2026-04-18-ADR-023-btrfs-storage-architecture-databases](00-foundation/decisions/withdrawn/2026-04-18-ADR-023-btrfs-storage-architecture-databases.md)
 
@@ -180,7 +181,7 @@
 
 ---
 
-### 97-plans/ (39 documents)
+### 97-plans/ (40 documents)
 
 **Strategic plans and forward-looking projects**
 - 📋 [2025-01-08-unpoller-with-advanced-networks-monitoring-plan.md](97-plans/2025-01-08-unpoller-with-advanced-networks-monitoring-plan.md)
@@ -204,6 +205,7 @@
 - 📋 [2026-05-25-monitoring-metric-diet.md](97-plans/2026-05-25-monitoring-metric-diet.md)
 - 📋 [2026-05-25-pihole-resolver-first-class-and-ha.md](97-plans/2026-05-25-pihole-resolver-first-class-and-ha.md)
 - 📋 [2026-05-25-slo-alert-coverage.md](97-plans/2026-05-25-slo-alert-coverage.md)
+- 📋 [2026-06-07-cabinet-cooling-fan-controller-SKETCH.md](97-plans/2026-06-07-cabinet-cooling-fan-controller-SKETCH.md)
 - 📋 [ADR-REORGANIZATION-PLAN.md](97-plans/ADR-REORGANIZATION-PLAN.md)
 - 📋 [MIGRATION-PLAN-FINAL.md](97-plans/MIGRATION-PLAN-FINAL.md)
 - ✅ [PLAN-1-AUTO-UPDATE-SAFETY-NET.md](97-plans/PLAN-1-AUTO-UPDATE-SAFETY-NET.md)
@@ -225,7 +227,7 @@
 
 ---
 
-### 98-journals/ (212 documents)
+### 98-journals/ (213 documents)
 
 **Chronological project history (append-only log)**
 
@@ -244,17 +246,19 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 ## Recently Updated (Last 7 Days)
 
 - 2026-06-04: [2026-03-28-ADR-021-urd-backup-tool.md](00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md)
-- 2026-06-05: [2026-06-05-ADR-032-forgejo-git-over-ssh-loopback.md](00-foundation/decisions/2026-06-05-ADR-032-forgejo-git-over-ssh-loopback.md)
+- 2026-06-09: [2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md](00-foundation/decisions/2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md)
+- 2026-06-06: [2026-06-05-ADR-032-forgejo-git-over-ssh-loopback.md](00-foundation/decisions/2026-06-05-ADR-032-forgejo-git-over-ssh-loopback.md)
+- 2026-06-06: [2026-06-06-ADR-034-forgejo-instance-commit-signing-ssh.md](00-foundation/decisions/2026-06-06-ADR-034-forgejo-instance-commit-signing-ssh.md)
+- 2026-06-07: [2026-06-07-cabinet-cooling-fan-controller-SKETCH.md](97-plans/2026-06-07-cabinet-cooling-fan-controller-SKETCH.md)
 - 2026-06-04: [2026-06-04-branch-hygiene-adr021-cross-repo-and-churn-alert.md](98-journals/2026-06-04-branch-hygiene-adr021-cross-repo-and-churn-alert.md)
-- 2026-06-01: [2026-06-01-skill-usage-report.md](99-reports/2026-06-01-skill-usage-report.md)
-- 2026-06-01: [remediation-monthly-202605.md](99-reports/remediation-monthly-202605.md)
-- 2026-06-01: [security-audit-2026-06-01.md](99-reports/security-audit-2026-06-01.md)
-- 2026-06-05: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
-- 2026-06-05: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
-- 2026-06-05: [AUTO-EGRESS-BASELINE-INDEX.md](AUTO-EGRESS-BASELINE-INDEX.md)
-- 2026-06-05: [AUTO-IMAGE-PIN-INDEX.md](AUTO-IMAGE-PIN-INDEX.md)
-- 2026-06-05: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
-- 2026-06-05: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
+- 2026-06-09: [2026-06-09-adr029-phase-b-db-migration-nocow.md](98-journals/2026-06-09-adr029-phase-b-db-migration-nocow.md)
+- 2026-06-09: [remediation-monthly-202605.md](99-reports/remediation-monthly-202605.md)
+- 2026-06-09: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
+- 2026-06-09: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
+- 2026-06-09: [AUTO-EGRESS-BASELINE-INDEX.md](AUTO-EGRESS-BASELINE-INDEX.md)
+- 2026-06-09: [AUTO-IMAGE-PIN-INDEX.md](AUTO-IMAGE-PIN-INDEX.md)
+- 2026-06-09: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
+- 2026-06-09: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
 
 ---
 

--- a/docs/AUTO-EGRESS-BASELINE-INDEX.md
+++ b/docs/AUTO-EGRESS-BASELINE-INDEX.md
@@ -1,6 +1,6 @@
 # Egress Observatory — Baseline Index (Auto-Generated)
 
-**Generated:** 2026-06-04 15:10:35 UTC
+**Generated:** 2026-06-09 00:01:13 UTC
 **Implements:** ADR-030 P7 (Tier 4) — egress detection. **Mode:** shadow (observe-only)
 
 Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers (attributable, rootless, scratch-safe, DNS-method-agnostic). Detection, not prevention. See `config/supply-chain/known-egress.md` for method and residual/evasion scope.
@@ -9,35 +9,35 @@ Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers
 
 | Component | Last run | Detail |
 |---|---|---|
-| Collector (`egress-collector.service`) | 19s ago | 22 services sampled |
-| Classifier (`egress-detect.timer`) | 10m ago | mode=shadow (observe-only); last window 7 dest(s) |
+| Collector (`egress-collector.service`) | 23s ago | 22 services sampled |
+| Classifier (`egress-detect.timer`) | 8m ago | mode=shadow (observe-only); last window 9 dest(s) |
 
 ## Per-service egress
 
 | Service | Mode | Public dests | Unexpected | Peers (swarm) |
 |---|---|---|---|---|
-| alert-discord-relay | classify | 4 | 4 (unarmed) | — |
+| alert-discord-relay | classify | 5 | 5 (unarmed) | — |
 | alertmanager | classify | 2 | 2 (unarmed) | — |
 | audiobookshelf | classify | — | — | — |
 | authelia | classify | — | — | — |
 | blackbox-exporter | classify | — | — | — |
-| crowdsec | classify | 21 | 21 (unarmed) | — |
+| crowdsec | classify | 30 | 30 (unarmed) | — |
 | forgejo | classify | — | — | — |
-| gathio | classify | 1 | 1 (unarmed) | — |
+| gathio | classify | 2 | 2 (unarmed) | — |
 | grafana | classify | 3 | 3 (unarmed) | — |
-| home-assistant | classify | 29 | 29 (unarmed) | — |
+| home-assistant | classify | 41 | 41 (unarmed) | — |
 | immich-server | classify | 2 | 2 (unarmed) | — |
-| jellyfin | classify | 14 | 14 (unarmed) | — |
+| jellyfin | classify | 15 | 15 (unarmed) | — |
 | loki | classify | 1 | 1 (unarmed) | — |
-| navidrome | classify | 7 | 7 (unarmed) | — |
+| navidrome | classify | 8 | 8 (unarmed) | — |
 | nextcloud | classify | 4 | 4 (unarmed) | — |
 | pihole-exporter | classify | — | — | — |
 | prometheus | classify | — | — | — |
 | proton-bridge | classify | 2 | 2 (unarmed) | — |
-| qbittorrent | peer-swarm (count-only) | — | — | 360 |
-| traefik | classify | 7 | 7 (unarmed) | — |
+| qbittorrent | peer-swarm (count-only) | — | — | 127 |
+| traefik | classify | 8 | 8 (unarmed) | — |
 | unpoller | classify | — | — | — |
-| vaultwarden | classify | 55 | 55 (unarmed) | — |
+| vaultwarden | classify | 79 | 79 (unarmed) | — |
 
 ## Zero-egress candidates — blast-radius reduction (REPORT ONLY)
 
@@ -51,223 +51,273 @@ Egress-tier services with **no observed public destination** over the window. Ea
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `162.159.128.233` | 443 | ⚠️ unexpected | 8d ago | 3d ago | 8 |
-| `162.159.135.232` | 443 | ⚠️ unexpected | 10d ago | 10d ago | 6 |
-| `162.159.136.232` | 443 | ⚠️ unexpected | 3d ago | 2d ago | 4 |
-| `162.159.138.232` | 443 | ⚠️ unexpected | 10d ago | 2d ago | 8 |
+| `162.159.128.233` | 443 | ⚠️ unexpected | 12d ago | 62m ago | 32 |
+| `162.159.135.232` | 443 | ⚠️ unexpected | 15d ago | 62m ago | 41 |
+| `162.159.136.232` | 443 | ⚠️ unexpected | 7d ago | 62m ago | 37 |
+| `162.159.137.232` | 443 | ⚠️ unexpected | 4d ago | 62m ago | 40 |
+| `162.159.138.232` | 443 | ⚠️ unexpected | 14d ago | 72m ago | 44 |
 
 ### alertmanager
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `162.159.135.232` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 2 |
-| `162.159.138.232` | 80 | ⚠️ unexpected | 9d ago | 9d ago | 2 |
+| `162.159.135.232` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 2 |
+| `162.159.138.232` | 80 | ⚠️ unexpected | 14d ago | 14d ago | 2 |
 
 ### crowdsec
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `108.128.137.208` | 443 | ⚠️ unexpected | 6d ago | 71m ago | 371 |
-| `108.128.190.179` | 443 | ⚠️ unexpected | 7d ago | 40m ago | 416 |
-| `108.128.222.234` | 443 | ⚠️ unexpected | 10d ago | 3d ago | 472 |
-| `108.132.165.136` | 443 | ⚠️ unexpected | 2d ago | 2h ago | 108 |
-| `18.200.183.204` | 443 | ⚠️ unexpected | 11d ago | 4d ago | 362 |
-| `34.240.98.252` | 443 | ⚠️ unexpected | 8h ago | 50m ago | 24 |
-| `34.242.194.148` | 443 | ⚠️ unexpected | 4d ago | 30m ago | 313 |
-| `34.249.149.68` | 443 | ⚠️ unexpected | 31h ago | 12h ago | 55 |
-| `34.250.77.39` | 443 | ⚠️ unexpected | 10d ago | 22h ago | 582 |
-| `34.255.59.56` | 443 | ⚠️ unexpected | 10d ago | 34h ago | 512 |
-| `52.17.58.50` | 443 | ⚠️ unexpected | 10d ago | 8d ago | 181 |
-| `52.18.68.74` | 443 | ⚠️ unexpected | 8d ago | 27h ago | 458 |
-| `52.210.229.63` | 443 | ⚠️ unexpected | 2d ago | 61m ago | 144 |
-| `52.30.5.78` | 443 | ⚠️ unexpected | 10d ago | 7d ago | 157 |
-| `54.246.207.199` | 443 | ⚠️ unexpected | 27h ago | 10m ago | 109 |
-| `54.76.192.134` | 443 | ⚠️ unexpected | 3d ago | 3h ago | 239 |
-| `54.77.8.107` | 443 | ⚠️ unexpected | 10d ago | 2d ago | 533 |
-| `63.34.141.128` | 443 | ⚠️ unexpected | 10d ago | 6d ago | 196 |
-| `63.35.22.155` | 443 | ⚠️ unexpected | 11d ago | 10d ago | 15 |
-| `79.125.15.38` | 443 | ⚠️ unexpected | 10d ago | 6d ago | 232 |
-| `99.80.129.27` | 443 | ⚠️ unexpected | 6d ago | 2d ago | 263 |
+| `108.128.137.208` | 443 | ⚠️ unexpected | 10d ago | 2d ago | 486 |
+| `108.128.190.179` | 443 | ⚠️ unexpected | 12d ago | 3d ago | 515 |
+| `108.128.222.234` | 443 | ⚠️ unexpected | 15d ago | 7d ago | 472 |
+| `108.132.135.16` | 443 | ⚠️ unexpected | 17h ago | 3h ago | 63 |
+| `108.132.165.136` | 443 | ⚠️ unexpected | 6d ago | 37h ago | 237 |
+| `18.200.183.204` | 443 | ⚠️ unexpected | 15d ago | 9d ago | 362 |
+| `34.240.98.252` | 443 | ⚠️ unexpected | 4d ago | 19h ago | 252 |
+| `34.242.194.148` | 443 | ⚠️ unexpected | 9d ago | 2d ago | 406 |
+| `34.249.149.68` | 443 | ⚠️ unexpected | 5d ago | 8h ago | 277 |
+| `34.250.39.237` | 443 | ⚠️ unexpected | 2d ago | 3h ago | 124 |
+| `34.250.77.39` | 443 | ⚠️ unexpected | 15d ago | 5d ago | 582 |
+| `34.254.73.132` | 443 | ⚠️ unexpected | 2d ago | 40m ago | 168 |
+| `34.255.59.56` | 443 | ⚠️ unexpected | 15d ago | 5d ago | 512 |
+| `52.17.58.50` | 443 | ⚠️ unexpected | 14d ago | 12d ago | 181 |
+| `52.18.68.74` | 443 | ⚠️ unexpected | 12d ago | 5d ago | 458 |
+| `52.19.64.236` | 443 | ⚠️ unexpected | 35h ago | 8m ago | 60 |
+| `52.210.229.63` | 443 | ⚠️ unexpected | 6d ago | 19h ago | 370 |
+| `52.213.228.152` | 443 | ⚠️ unexpected | 15h ago | 3h ago | 40 |
+| `52.30.5.78` | 443 | ⚠️ unexpected | 15d ago | 12d ago | 157 |
+| `52.48.23.149` | 443 | ⚠️ unexpected | 3d ago | 4h ago | 232 |
+| `52.48.238.219` | 443 | ⚠️ unexpected | 3h ago | 8m ago | 15 |
+| `54.195.186.68` | 443 | ⚠️ unexpected | 4d ago | 11h ago | 249 |
+| `54.246.207.199` | 443 | ⚠️ unexpected | 5d ago | 4d ago | 113 |
+| `54.76.192.134` | 443 | ⚠️ unexpected | 7d ago | 2d ago | 337 |
+| `54.77.8.107` | 443 | ⚠️ unexpected | 15d ago | 7d ago | 533 |
+| `63.34.141.128` | 443 | ⚠️ unexpected | 15d ago | 11d ago | 196 |
+| `63.35.170.229` | 443 | ⚠️ unexpected | 2d ago | 2h ago | 144 |
+| `63.35.22.155` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 15 |
+| `79.125.15.38` | 443 | ⚠️ unexpected | 15d ago | 10d ago | 232 |
+| `99.80.129.27` | 443 | ⚠️ unexpected | 11d ago | 6d ago | 263 |
 
 ### gathio
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.16.4.34` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 9 |
+| `104.16.4.34` | 443 | ⚠️ unexpected | 12d ago | 12d ago | 9 |
+| `104.16.7.34` | 443 | ⚠️ unexpected | 72m ago | 72m ago | 4 |
 
 ### grafana
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `192.0.73.2` | 443 | ⚠️ unexpected | 9d ago | 7d ago | 4 |
-| `34.120.177.193` | 443 | ⚠️ unexpected | 11d ago | 10m ago | 7859 |
-| `34.96.126.106` | 443 | ⚠️ unexpected | 10d ago | 5h ago | 53 |
+| `192.0.73.2` | 443 | ⚠️ unexpected | 14d ago | 2d ago | 8 |
+| `34.120.177.193` | 443 | ⚠️ unexpected | 15d ago | 8m ago | 10953 |
+| `34.96.126.106` | 443 | ⚠️ unexpected | 14d ago | 13h ago | 72 |
 
 ### home-assistant
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.26.4.238` | 443 | ⚠️ unexpected | 10d ago | 16h ago | 14 |
-| `104.26.5.238` | 443 | ⚠️ unexpected | 11d ago | 4h ago | 23 |
-| `151.101.1.195` | 443 | ⚠️ unexpected | 10d ago | 18h ago | 15 |
-| `151.101.65.195` | 443 | ⚠️ unexpected | 8d ago | 42h ago | 8 |
-| `157.249.81.141` | 443 | ⚠️ unexpected | 10d ago | 82m ago | 136 |
-| `172.67.68.90` | 443 | ⚠️ unexpected | 10d ago | 114m ago | 23 |
-| `18.158.22.138` | 8883 | ⚠️ unexpected | 8d ago | 7d ago | 1702 |
-| `18.158.224.141` | 8883 | ⚠️ unexpected | 37h ago | 10m ago | 4389 |
-| `18.159.79.242` | 8883 | ⚠️ unexpected | 3d ago | 2d ago | 2777 |
-| `18.184.210.208` | 8883 | ⚠️ unexpected | 11d ago | 10d ago | 1297 |
-| `18.194.113.141` | 8883 | ⚠️ unexpected | 6d ago | 6d ago | 356 |
-| `18.196.104.106` | 8883 | ⚠️ unexpected | 4d ago | 3d ago | 2729 |
-| `18.198.195.194` | 8883 | ⚠️ unexpected | 10d ago | 8d ago | 5585 |
-| `3.120.216.195` | 443 | ⚠️ unexpected | 7d ago | 10m ago | 677 |
-| `3.120.53.2` | 8883 | ⚠️ unexpected | 7d ago | 6d ago | 3923 |
-| `3.121.10.31` | 8883 | ⚠️ unexpected | 6d ago | 6d ago | 759 |
-| `3.121.111.53` | 443 | ⚠️ unexpected | 2d ago | 20m ago | 249 |
-| `3.121.169.115` | 8883 | ⚠️ unexpected | 6d ago | 4d ago | 4472 |
-| `3.122.171.67` | 443 | ⚠️ unexpected | 6d ago | 10m ago | 586 |
-| `3.122.70.209` | 8883 | ⚠️ unexpected | 2d ago | 37h ago | 2815 |
-| `3.124.29.182` | 443 | ⚠️ unexpected | 11d ago | 2d ago | 810 |
-| `3.125.66.145` | 443 | ⚠️ unexpected | 11d ago | 6d ago | 491 |
-| `3.67.142.130` | 443 | ⚠️ unexpected | 11d ago | 28h ago | 907 |
-| `35.156.5.143` | 443 | ⚠️ unexpected | 27h ago | 10m ago | 94 |
-| `35.158.64.12` | 443 | ⚠️ unexpected | 25h ago | 20m ago | 79 |
-| `52.29.210.73` | 443 | ⚠️ unexpected | 11d ago | 25h ago | 926 |
-| `52.57.174.242` | 443 | ⚠️ unexpected | 11d ago | 7d ago | 429 |
-| `52.58.153.107` | 443 | ⚠️ unexpected | 2d ago | 30m ago | 247 |
-| `63.181.74.73` | 443 | ⚠️ unexpected | 11d ago | 2d ago | 789 |
+| `104.26.4.238` | 443 | ⚠️ unexpected | 15d ago | 16h ago | 22 |
+| `104.26.5.238` | 443 | ⚠️ unexpected | 15d ago | 10h ago | 32 |
+| `151.101.1.195` | 443 | ⚠️ unexpected | 15d ago | 3h ago | 20 |
+| `151.101.65.195` | 443 | ⚠️ unexpected | 13d ago | 3d ago | 13 |
+| `157.249.81.141` | 443 | ⚠️ unexpected | 15d ago | 3h ago | 193 |
+| `172.67.68.90` | 443 | ⚠️ unexpected | 14d ago | 4h ago | 32 |
+| `18.156.89.194` | 443 | ⚠️ unexpected | 2d ago | 8m ago | 334 |
+| `18.158.217.49` | 8883 | ⚠️ unexpected | 45h ago | 22h ago | 2668 |
+| `18.158.22.138` | 8883 | ⚠️ unexpected | 12d ago | 12d ago | 1702 |
+| `18.158.224.141` | 8883 | ⚠️ unexpected | 5d ago | 3d ago | 5641 |
+| `18.159.77.159` | 8883 | ⚠️ unexpected | 3d ago | 3d ago | 755 |
+| `18.159.79.242` | 8883 | ⚠️ unexpected | 7d ago | 6d ago | 2777 |
+| `18.184.210.208` | 8883 | ⚠️ unexpected | 15d ago | 14d ago | 1297 |
+| `18.184.241.150` | 8883 | ⚠️ unexpected | 46h ago | 45h ago | 58 |
+| `18.194.113.141` | 8883 | ⚠️ unexpected | 10d ago | 10d ago | 356 |
+| `18.194.166.209` | 8883 | ⚠️ unexpected | 72m ago | 8m ago | 133 |
+| `18.196.104.106` | 8883 | ⚠️ unexpected | 8d ago | 7d ago | 2729 |
+| `18.198.195.194` | 8883 | ⚠️ unexpected | 14d ago | 12d ago | 5585 |
+| `3.120.211.84` | 8883 | ⚠️ unexpected | 3d ago | 46h ago | 4832 |
+| `3.120.216.195` | 443 | ⚠️ unexpected | 12d ago | 2d ago | 800 |
+| `3.120.53.2` | 8883 | ⚠️ unexpected | 12d ago | 10d ago | 3923 |
+| `3.121.10.31` | 8883 | ⚠️ unexpected | 10d ago | 10d ago | 759 |
+| `3.121.101.237` | 8883 | ⚠️ unexpected | 22h ago | 118m ago | 2420 |
+| `3.121.111.53` | 443 | ⚠️ unexpected | 7d ago | 23h ago | 599 |
+| `3.121.169.115` | 8883 | ⚠️ unexpected | 10d ago | 8d ago | 4472 |
+| `3.122.171.67` | 443 | ⚠️ unexpected | 10d ago | 2d ago | 708 |
+| `3.122.70.209` | 8883 | ⚠️ unexpected | 6d ago | 5d ago | 2815 |
+| `3.124.29.182` | 443 | ⚠️ unexpected | 15d ago | 7d ago | 810 |
+| `3.125.16.42` | 443 | ⚠️ unexpected | 2d ago | 10h ago | 239 |
+| `3.125.66.145` | 443 | ⚠️ unexpected | 15d ago | 10d ago | 491 |
+| `3.67.142.130` | 443 | ⚠️ unexpected | 15d ago | 5d ago | 907 |
+| `35.156.5.143` | 443 | ⚠️ unexpected | 5d ago | 2d ago | 254 |
+| `35.158.64.12` | 443 | ⚠️ unexpected | 5d ago | 8m ago | 546 |
+| `52.28.32.0` | 443 | ⚠️ unexpected | 28h ago | 30m ago | 118 |
+| `52.29.1.243` | 443 | ⚠️ unexpected | 9h ago | 8m ago | 55 |
+| `52.29.210.73` | 443 | ⚠️ unexpected | 15d ago | 5d ago | 926 |
+| `52.57.174.242` | 443 | ⚠️ unexpected | 15d ago | 12d ago | 429 |
+| `52.58.153.107` | 443 | ⚠️ unexpected | 7d ago | 28h ago | 542 |
+| `52.58.33.43` | 443 | ⚠️ unexpected | 23h ago | 8m ago | 122 |
+| `63.181.21.188` | 443 | ⚠️ unexpected | 2d ago | 19m ago | 313 |
+| `63.181.74.73` | 443 | ⚠️ unexpected | 15d ago | 7d ago | 789 |
 
 ### immich-server
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.21.71.92` | 443 | ⚠️ unexpected | 10d ago | 50m ago | 302 |
-| `172.67.170.79` | 443 | ⚠️ unexpected | 11d ago | 4h ago | 259 |
+| `104.21.71.92` | 443 | ⚠️ unexpected | 15d ago | 2h ago | 406 |
+| `172.67.170.79` | 443 | ⚠️ unexpected | 15d ago | 30m ago | 378 |
 
 ### jellyfin
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.17.207.5` | 443 | ⚠️ unexpected | 11d ago | 11d ago | 5 |
-| `104.17.208.5` | 443 | ⚠️ unexpected | 10d ago | 2d ago | 14 |
-| `139.59.139.28` | 443 | ⚠️ unexpected | 8d ago | 2d ago | 9 |
-| `146.190.237.6` | 443 | ⚠️ unexpected | 5d ago | 22h ago | 14 |
-| `151.101.1.229` | 443 | ⚠️ unexpected | 5d ago | 3d ago | 6 |
-| `151.101.129.229` | 443 | ⚠️ unexpected | 4d ago | 22h ago | 7 |
-| `151.101.193.229` | 443 | ⚠️ unexpected | 9d ago | 8d ago | 4 |
-| `157.245.38.19` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 5 |
-| `161.35.245.42` | 443 | ⚠️ unexpected | 4d ago | 2d ago | 5 |
-| `165.227.169.147` | 443 | ⚠️ unexpected | 11d ago | 46h ago | 18 |
-| `165.227.244.161` | 443 | ⚠️ unexpected | 10d ago | 46h ago | 14 |
-| `178.105.98.131` | 443 | ⚠️ unexpected | 11d ago | 22h ago | 10 |
-| `206.189.97.173` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 5 |
-| `68.183.204.194` | 443 | ⚠️ unexpected | 11d ago | 3d ago | 7 |
+| `104.17.207.5` | 443 | ⚠️ unexpected | 15d ago | 7h ago | 9 |
+| `104.17.208.5` | 443 | ⚠️ unexpected | 14d ago | 2d ago | 18 |
+| `139.59.139.28` | 443 | ⚠️ unexpected | 12d ago | 7d ago | 9 |
+| `146.190.237.6` | 443 | ⚠️ unexpected | 10d ago | 3d ago | 18 |
+| `151.101.1.229` | 443 | ⚠️ unexpected | 10d ago | 31h ago | 10 |
+| `151.101.129.229` | 443 | ⚠️ unexpected | 9d ago | 5d ago | 7 |
+| `151.101.193.229` | 443 | ⚠️ unexpected | 13d ago | 4d ago | 6 |
+| `151.101.65.229` | 443 | ⚠️ unexpected | 72m ago | 72m ago | 1 |
+| `157.245.38.19` | 443 | ⚠️ unexpected | 11d ago | 11d ago | 5 |
+| `161.35.245.42` | 443 | ⚠️ unexpected | 9d ago | 4d ago | 7 |
+| `165.227.169.147` | 443 | ⚠️ unexpected | 15d ago | 72m ago | 32 |
+| `165.227.244.161` | 443 | ⚠️ unexpected | 14d ago | 72m ago | 19 |
+| `178.105.98.131` | 443 | ⚠️ unexpected | 15d ago | 31h ago | 14 |
+| `206.189.97.173` | 443 | ⚠️ unexpected | 8d ago | 7h ago | 9 |
+| `68.183.204.194` | 443 | ⚠️ unexpected | 15d ago | 72m ago | 9 |
 
 ### loki
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `34.96.126.106` | 443 | ⚠️ unexpected | 11d ago | 40m ago | 330 |
+| `34.96.126.106` | 443 | ⚠️ unexpected | 15d ago | 5h ago | 451 |
 
 ### navidrome
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `130.211.19.189` | 443 | ⚠️ unexpected | 10d ago | 6d ago | 13 |
-| `151.101.237.188` | 443 | ⚠️ unexpected | 10d ago | 6d ago | 7 |
-| `151.101.238.53` | 443 | ⚠️ unexpected | 10d ago | 6d ago | 6 |
-| `151.101.238.79` | 443 | ⚠️ unexpected | 10d ago | 6d ago | 6 |
-| `2.22.225.107` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `2.22.225.83` | 443 | ⚠️ unexpected | 10d ago | 10d ago | 4 |
-| `209.141.42.198` | 443 | ⚠️ unexpected | 10d ago | 22h ago | 35 |
+| `104.21.43.229` | 443 | ⚠️ unexpected | 72m ago | 72m ago | 1 |
+| `130.211.19.189` | 443 | ⚠️ unexpected | 14d ago | 11d ago | 13 |
+| `151.101.237.188` | 443 | ⚠️ unexpected | 14d ago | 11d ago | 7 |
+| `151.101.238.53` | 443 | ⚠️ unexpected | 14d ago | 11d ago | 6 |
+| `151.101.238.79` | 443 | ⚠️ unexpected | 14d ago | 11d ago | 6 |
+| `2.22.225.107` | 443 | ⚠️ unexpected | 11d ago | 11d ago | 3 |
+| `2.22.225.83` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 4 |
+| `209.141.42.198` | 443 | ⚠️ unexpected | 15d ago | 40m ago | 52 |
 
 ### nextcloud
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `65.108.197.113` | 443 | ⚠️ unexpected | 8d ago | 2d ago | 8 |
-| `65.109.114.179` | 443 | ⚠️ unexpected | 10d ago | 7h ago | 8 |
-| `65.21.231.50` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 2 |
-| `95.217.53.153` | 443 | ⚠️ unexpected | 9d ago | 31h ago | 12 |
+| `65.108.197.113` | 443 | ⚠️ unexpected | 12d ago | 6d ago | 8 |
+| `65.109.114.179` | 443 | ⚠️ unexpected | 14d ago | 15h ago | 14 |
+| `65.21.231.50` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 2 |
+| `95.217.53.153` | 443 | ⚠️ unexpected | 13d ago | 28h ago | 14 |
 
 ### proton-bridge
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `185.70.42.41` | 443 | ⚠️ unexpected | 11d ago | 10m ago | 8875 |
-| `185.70.42.45` | 443 | ⚠️ unexpected | 10d ago | 61m ago | 281 |
+| `185.70.42.41` | 443 | ⚠️ unexpected | 15d ago | 8m ago | 12366 |
+| `185.70.42.45` | 443 | ⚠️ unexpected | 15d ago | 108m ago | 405 |
 
 ### traefik
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.19.192.29` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 5 |
-| `104.19.193.29` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 6 |
-| `104.26.3.101` | 443 | ⚠️ unexpected | 9d ago | 7d ago | 15 |
-| `13.39.208.199` | 443 | ⚠️ unexpected | 11d ago | 23h ago | 35 |
-| `140.82.121.5` | 443 | ⚠️ unexpected | 9d ago | 23h ago | 7 |
-| `140.82.121.6` | 443 | ⚠️ unexpected | 11d ago | 46h ago | 6 |
-| `172.65.32.248` | 443 | ⚠️ unexpected | 9d ago | 6d ago | 25 |
+| `104.19.192.29` | 443 | ⚠️ unexpected | 11d ago | 11d ago | 5 |
+| `104.19.193.29` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 6 |
+| `104.26.3.101` | 443 | ⚠️ unexpected | 14d ago | 12d ago | 15 |
+| `13.39.208.199` | 443 | ⚠️ unexpected | 15d ago | 62m ago | 56 |
+| `140.82.121.5` | 443 | ⚠️ unexpected | 14d ago | 7h ago | 12 |
+| `140.82.121.6` | 443 | ⚠️ unexpected | 15d ago | 72m ago | 10 |
+| `172.65.32.248` | 443 | ⚠️ unexpected | 14d ago | 11d ago | 25 |
+| `172.67.75.8` | 443 | ⚠️ unexpected | 108m ago | 108m ago | 5 |
 
 ### vaultwarden
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.16.123.96` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 3 |
-| `104.16.132.229` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 3 |
-| `104.16.99.29` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 3 |
-| `104.17.17.78` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 2 |
-| `104.17.17.78` | 80 | ⚠️ unexpected | 4d ago | 4d ago | 2 |
-| `104.18.14.13` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 3 |
-| `104.18.161.117` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 3 |
-| `104.18.179.120` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 3 |
-| `104.18.193.106` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 2 |
-| `104.18.27.69` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 3 |
-| `104.18.35.237` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 3 |
-| `104.20.7.63` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 3 |
-| `104.26.1.18` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 2 |
-| `151.101.129.91` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 1 |
-| `151.101.237.91` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 1 |
-| `151.101.239.52` | 443 | ⚠️ unexpected | 3d ago | 45h ago | 2 |
-| `151.101.67.52` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 1 |
-| `162.125.248.18` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 1 |
-| `162.125.71.18` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 1 |
-| `162.159.137.232` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 3 |
-| `172.67.74.138` | 443 | ⚠️ unexpected | 44h ago | 44h ago | 3 |
-| `18.195.2.2` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 3 |
-| `185.31.213.113` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 3 |
-| `193.212.190.216` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 1 |
-| `194.132.66.34` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 2 |
-| `217.114.94.2` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 3 |
-| `3.167.1.165` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 3 |
-| `3.167.2.39` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 2 |
-| `3.167.2.44` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 3 |
-| `3.167.2.45` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 3 |
-| `3.167.2.93` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 2 |
-| `3.167.2.97` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 3 |
-| `3.33.186.135` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 3 |
-| `34.110.155.89` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 3 |
-| `35.186.224.24` | 443 | ⚠️ unexpected | 47h ago | 47h ago | 2 |
-| `52.195.100.115` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 2 |
-| `52.198.57.38` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 1 |
-| `52.222.187.52` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 3 |
-| `52.84.50.103` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 2 |
-| `52.84.50.125` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 3 |
-| `52.84.50.126` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 3 |
-| `52.84.50.128` | 443 | ⚠️ unexpected | 47h ago | 47h ago | 2 |
-| `52.84.50.128` | 80 | ⚠️ unexpected | 47h ago | 47h ago | 2 |
-| `52.84.50.14` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 2 |
-| `52.84.50.16` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 3 |
-| `52.84.50.22` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 3 |
-| `52.84.50.4` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 2 |
-| `52.84.50.61` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 3 |
-| `62.249.184.112` | 443 | ⚠️ unexpected | 44h ago | 44h ago | 1 |
-| `66.33.60.34` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 3 |
-| `76.76.21.21` | 443 | ⚠️ unexpected | 9d ago | 4d ago | 5 |
-| `76.76.21.22` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 2 |
-| `95.101.10.146` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 1 |
-| `95.101.10.154` | 443 | ⚠️ unexpected | 45h ago | 45h ago | 1 |
-| `98.82.155.134` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 3 |
+| `104.16.123.96` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `104.16.132.229` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `104.16.99.29` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `104.17.17.78` | 443 | ⚠️ unexpected | 8d ago | 2d ago | 5 |
+| `104.17.17.78` | 80 | ⚠️ unexpected | 8d ago | 2d ago | 5 |
+| `104.18.14.13` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `104.18.161.117` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `104.18.179.120` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 3 |
+| `104.18.193.106` | 443 | ⚠️ unexpected | 8d ago | 2d ago | 5 |
+| `104.18.27.69` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `104.18.35.237` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `104.19.171.101` | 80 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
+| `104.19.171.101` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
+| `104.19.172.101` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
+| `104.19.172.101` | 80 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
+| `104.20.7.63` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 3 |
+| `104.26.1.18` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 2 |
+| `13.107.6.156` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
+| `135.181.128.221` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 2 |
+| `138.199.37.230` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
+| `150.171.109.200` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 2 |
+| `151.101.129.91` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 1 |
+| `151.101.237.91` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 1 |
+| `151.101.239.52` | 443 | ⚠️ unexpected | 8d ago | 6d ago | 2 |
+| `151.101.67.52` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 1 |
+| `162.125.248.18` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 1 |
+| `162.125.71.18` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 1 |
+| `162.159.137.232` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `172.66.137.109` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 2 |
+| `172.67.74.138` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `18.195.2.2` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 3 |
+| `18.224.126.143` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
+| `185.109.198.109` | 80 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
+| `185.31.213.113` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 3 |
+| `193.212.190.216` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 1 |
+| `194.132.66.34` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 2 |
+| `194.242.11.186` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 2 |
+| `198.252.206.1` | 80 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
+| `198.252.206.1` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
+| `20.190.147.4` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
+| `20.190.177.20` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
+| `217.114.94.2` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `3.167.1.165` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 3 |
+| `3.167.2.39` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 2 |
+| `3.167.2.44` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `3.167.2.45` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `3.167.2.93` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 2 |
+| `3.167.2.97` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `3.33.186.135` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `34.110.155.89` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `34.95.108.49` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 2 |
+| `35.186.224.24` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 2 |
+| `35.231.208.158` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 2 |
+| `52.195.100.115` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 2 |
+| `52.196.64.126` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 3 |
+| `52.198.57.38` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 1 |
+| `52.222.187.52` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 3 |
+| `52.84.50.103` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 2 |
+| `52.84.50.115` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 3 |
+| `52.84.50.125` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `52.84.50.126` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `52.84.50.128` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 2 |
+| `52.84.50.128` | 80 | ⚠️ unexpected | 6d ago | 6d ago | 2 |
+| `52.84.50.14` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 2 |
+| `52.84.50.16` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `52.84.50.2` | 443 | ⚠️ unexpected | 33h ago | 33h ago | 2 |
+| `52.84.50.22` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `52.84.50.4` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 2 |
+| `52.84.50.61` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `54.240.174.10` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 2 |
+| `54.240.174.91` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 2 |
+| `62.249.184.112` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 1 |
+| `66.33.60.34` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 3 |
+| `76.76.21.21` | 443 | ⚠️ unexpected | 14d ago | 8d ago | 5 |
+| `76.76.21.22` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 2 |
+| `95.101.10.146` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 1 |
+| `95.101.10.154` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 1 |
+| `95.101.10.97` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 1 |
+| `98.82.155.134` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 3 |
 
 ---
 

--- a/docs/AUTO-IMAGE-PIN-INDEX.md
+++ b/docs/AUTO-IMAGE-PIN-INDEX.md
@@ -1,6 +1,6 @@
 # Container Image Pin Index (Auto-Generated)
 
-**Generated:** 2026-06-04 15:10:35 UTC
+**Generated:** 2026-06-09 00:01:13 UTC
 **Source:** `/home/patriark/containers/quadlets` — ADR-030 (Container Supply-Chain Trust Model)
 
 Pins live in each quadlet's `Image=` line (where Podman reads them); this is

--- a/docs/AUTO-NETWORK-TOPOLOGY.md
+++ b/docs/AUTO-NETWORK-TOPOLOGY.md
@@ -1,6 +1,6 @@
 # Network Topology (Auto-Generated)
 
-**Generated:** 2026-06-04 15:10:28 UTC
+**Generated:** 2026-06-09 00:01:07 UTC
 **System:** fedora-htpc | **Networks:** 11 | **Containers:** 37
 
 ---

--- a/docs/AUTO-SERVICE-CATALOG.md
+++ b/docs/AUTO-SERVICE-CATALOG.md
@@ -1,7 +1,7 @@
 # Service Catalog (Auto-Generated)
 
-**Generated:** 2026-06-04 15:10:27 UTC
-**System:** fedora-htpc | **Services:** 37/37 running | **Health:** 32/33 healthy (4 without healthcheck)
+**Generated:** 2026-06-09 00:01:06 UTC
+**System:** fedora-htpc | **Services:** 37/37 running | **Health:** 32/32 healthy (5 without healthcheck)
 
 ---
 
@@ -9,83 +9,83 @@
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| audiobookshelf | advplyr/audiobookshelf@sha256:89276ff2e0b3d2f | ✅ healthy | 7d | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
-| blackbox-exporter | quay.io/prometheus/blackbox-exporter@sha256:e | ✅ healthy | 7d | — | — |
-| forgejo | codeberg.org/forgejo/forgejo@sha256:db04c7114 | ✅ healthy | 7d | [git.patriark.org](https://git.patriark.org) | — |
-| forgejo-db | postgres@sha256:16bc17c64a573ef34162af9298258 | ✅ healthy | 7d | — | — |
-| navidrome | deluan/navidrome@sha256:9fa40b3d8dec43ceb2213 | ✅ healthy | 7d | [musikk.patriark.org](https://musikk.patriark.org) | — |
-| pihole-exporter | ekofr/pihole-exporter@sha256:a890cc731a39da71 | ⚠️ unhealthy | 7d | — | — |
-| postgres-exporter | quay.io/prometheuscommunity/postgres-exporter | ✅ healthy | 7d | — | — |
-| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | 7d | — | — |
-| qbittorrent | linuxserver/qbittorrent@sha256:f76c4363cce083 | ✅ healthy | 7d | [torrent.patriark.org](https://torrent.patriark.org) | — |
-| redis-authelia-exporter | quay.io/oliver006/redis_exporter@sha256:e8c20 | — no check | 7d | — | — |
-| redis-immich-exporter | quay.io/oliver006/redis_exporter@sha256:e8c20 | — no check | 7d | — | — |
-| unifi-syslog | linuxserver/syslog-ng@sha256:0d164e438d1f9ee4 | ✅ healthy | 7d | — | — |
+| audiobookshelf | advplyr/audiobookshelf@sha256:89276ff2e0b3d2f | ✅ healthy | ~anh | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
+| blackbox-exporter | quay.io/prometheus/blackbox-exporter@sha256:e | ✅ healthy | ~anh | — | — |
+| forgejo | codeberg.org/forgejo/forgejo@sha256:db04c7114 | ✅ healthy | ~anh | [git.patriark.org](https://git.patriark.org) | — |
+| forgejo-db | postgres@sha256:16bc17c64a573ef34162af9298258 | ✅ healthy | ~anh | — | — |
+| navidrome | deluan/navidrome@sha256:9fa40b3d8dec43ceb2213 | ✅ healthy | ~anh | [musikk.patriark.org](https://musikk.patriark.org) | — |
+| pihole-exporter | ekofr/pihole-exporter@sha256:a890cc731a39da71 | — no check | ~anh | — | — |
+| postgres-exporter | quay.io/prometheuscommunity/postgres-exporter | ✅ healthy | ~anh | — | — |
+| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | ~anh | — | — |
+| qbittorrent | linuxserver/qbittorrent@sha256:f76c4363cce083 | ✅ healthy | ~anh | [torrent.patriark.org](https://torrent.patriark.org) | — |
+| redis-authelia-exporter | quay.io/oliver006/redis_exporter@sha256:e8c20 | — no check | ~anh | — | — |
+| redis-immich-exporter | quay.io/oliver006/redis_exporter@sha256:e8c20 | — no check | ~anh | — | — |
+| unifi-syslog | linuxserver/syslog-ng@sha256:0d164e438d1f9ee4 | ✅ healthy | ~anh | — | — |
 
 ## Core Infrastructure (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| authelia | authelia/authelia@sha256:0c824dcab1ae97c56bf6 | ✅ healthy | 7d | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
-| crowdsec | crowdsecurity/crowdsec@sha256:2f527c9bb8b3671 | ✅ healthy | 7d | — | [guide](10-services/guides/crowdsec.md) |
-| redis-authelia | redis@sha256:6ab0b6e7381779332f97b8ca76193e45 | ✅ healthy | 7d | — | — |
-| traefik | traefik@sha256:6b9cbca6fac42ab0075f5437d8dc16 | ✅ healthy | 7d | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
+| authelia | authelia/authelia@sha256:0c824dcab1ae97c56bf6 | ✅ healthy | ~anh | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
+| crowdsec | crowdsecurity/crowdsec@sha256:2f527c9bb8b3671 | ✅ healthy | ~anh | — | [guide](10-services/guides/crowdsec.md) |
+| redis-authelia | redis@sha256:6ab0b6e7381779332f97b8ca76193e45 | ✅ healthy | ~anh | — | — |
+| traefik | traefik@sha256:6b9cbca6fac42ab0075f5437d8dc16 | ✅ healthy | ~anh | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
 
 ## Nextcloud (3)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| nextcloud-db | mariadb@sha256:78a5047d3ba33975f183f183c2464c | ✅ healthy | 7d | — | [guide](10-services/guides/nextcloud.md) |
-| nextcloud | nextcloud@sha256:b67959acacd54ed2d110e111c8b2 | ✅ healthy | 7d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
-| nextcloud-redis | redis@sha256:6ab0b6e7381779332f97b8ca76193e45 | ✅ healthy | 7d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-db | mariadb@sha256:78a5047d3ba33975f183f183c2464c | ✅ healthy | ~anh | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud | nextcloud@sha256:b67959acacd54ed2d110e111c8b2 | ✅ healthy | ~anh | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-redis | redis@sha256:6ab0b6e7381779332f97b8ca76193e45 | ✅ healthy | ~anh | — | [guide](10-services/guides/nextcloud.md) |
 
 ## Immich (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| immich-ml | immich-app/immich-machine-learning@sha256:a25 | ✅ healthy | 7d | — | [guide](10-services/guides/immich.md) |
-| immich-server | immich-app/immich-server@sha256:c15bff75068ef | ✅ healthy | 7d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
-| postgresql-immich | immich-app/postgres@sha256:bcf63357191b76a916 | ✅ healthy | 7d | — | — |
-| redis-immich | valkey/valkey@sha256:8436e10bc65c94886a91d441 | ✅ healthy | 7d | — | — |
+| immich-ml | immich-app/immich-machine-learning@sha256:a25 | ✅ healthy | ~anh | — | [guide](10-services/guides/immich.md) |
+| immich-server | immich-app/immich-server@sha256:c15bff75068ef | ✅ healthy | ~anh | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
+| postgresql-immich | immich-app/postgres@sha256:bcf63357191b76a916 | ✅ healthy | ~anh | — | — |
+| redis-immich | valkey/valkey@sha256:8436e10bc65c94886a91d441 | ✅ healthy | ~anh | — | — |
 
 ## Jellyfin (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| jellyfin | jellyfin/jellyfin@sha256:1694ff069f0c9dafb283 | ✅ healthy | 7d | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
+| jellyfin | jellyfin/jellyfin@sha256:1694ff069f0c9dafb283 | ✅ healthy | ~anh | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
 
 ## Vaultwarden (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| vaultwarden | vaultwarden/server@sha256:d626d04934cd1192ad8 | ✅ healthy | 7d | [vault.patriark.org](https://vault.patriark.org) | — |
+| vaultwarden | vaultwarden/server@sha256:d626d04934cd1192ad8 | ✅ healthy | ~anh | [vault.patriark.org](https://vault.patriark.org) | — |
 
 ## Home Automation (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| home-assistant | home-assistant/home-assistant@sha256:d4fbec16 | ✅ healthy | 7d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
+| home-assistant | home-assistant/home-assistant@sha256:d4fbec16 | ✅ healthy | ~anh | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
 
 ## Gathio (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| gathio-db | mongo@sha256:32979a1189dfdc44da3f5ed40d910495 | ✅ healthy | 7d | — | — |
-| gathio | lowercasename/gathio@sha256:b7e9675d4e22b62e4 | ✅ healthy | 7d | [events.patriark.org](https://events.patriark.org) | — |
+| gathio-db | mongo@sha256:32979a1189dfdc44da3f5ed40d910495 | ✅ healthy | ~anh | — | — |
+| gathio | lowercasename/gathio@sha256:b7e9675d4e22b62e4 | ✅ healthy | ~anh | [events.patriark.org](https://events.patriark.org) | — |
 
 ## Monitoring (9)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| alert-discord-relay | localhost/alert-discord-relay:2026-05-23 | ✅ healthy | 7d | — | [guide](10-services/guides/alert-discord-relay.md) |
-| alertmanager | quay.io/prometheus/alertmanager@sha256:51a825 | ✅ healthy | 7d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| cadvisor | gcr.io/cadvisor/cadvisor@sha256:3de2bd5203120 | ✅ healthy | 7d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| grafana | grafana/grafana@sha256:2d1f9ae67c1778d33e291d | ✅ healthy | 7d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| loki | grafana/loki@sha256:191d4fdfb7264f16989f0a57f | — no check | 7d | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| node_exporter | quay.io/prometheus/node-exporter@sha256:0f422 | ✅ healthy | 7d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| prometheus | quay.io/prometheus/prometheus@sha256:c0b857ae | ✅ healthy | 7d | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| promtail | grafana/promtail@sha256:6cfa64ec432b24a912d64 | ✅ healthy | 7d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| unpoller | unpoller/unpoller@sha256:bf7bdcc59fcdaa469968 | — no check | 7d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| alert-discord-relay | localhost/alert-discord-relay:2026-05-23 | ✅ healthy | ~anh | — | [guide](10-services/guides/alert-discord-relay.md) |
+| alertmanager | quay.io/prometheus/alertmanager@sha256:51a825 | ✅ healthy | ~anh | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| cadvisor | gcr.io/cadvisor/cadvisor@sha256:3de2bd5203120 | ✅ healthy | ~anh | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| grafana | grafana/grafana@sha256:2d1f9ae67c1778d33e291d | ✅ healthy | ~anh | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| loki | grafana/loki@sha256:191d4fdfb7264f16989f0a57f | — no check | ~anh | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| node_exporter | quay.io/prometheus/node-exporter@sha256:0f422 | ✅ healthy | ~anh | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| prometheus | quay.io/prometheus/prometheus@sha256:c0b857ae | ✅ healthy | ~anh | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| promtail | grafana/promtail@sha256:6cfa64ec432b24a912d64 | ✅ healthy | ~anh | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| unpoller | unpoller/unpoller@sha256:bf7bdcc59fcdaa469968 | — no check | ~anh | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
 
 ---
 
@@ -93,7 +93,7 @@
 
 - **Total Running:** 37
 - **Total Defined:** 37
-- **System Load:** 0,62, 0,70, 0,87
+- **System Load:** 3,93, 2,44, 1,69
 
 ---
 

--- a/quadlets/gathio-db.container
+++ b/quadlets/gathio-db.container
@@ -14,7 +14,7 @@ Secret=gathio_mongodb_password,type=env,target=MONGO_INITDB_ROOT_PASSWORD
 Environment=MONGO_INITDB_ROOT_USERNAME=gathio
 
 # Storage (will set NOCOW attribute)
-Volume=/mnt/btrfs-pool/subvol7-containers/gathio-db:/data/db:Z
+Volume=/mnt/btrfs-pool/subvol8-db/gathio-db:/data/db:Z
 
 # Network (dedicated Gathio network)
 Network=systemd-gathio

--- a/quadlets/nextcloud-db.container
+++ b/quadlets/nextcloud-db.container
@@ -18,7 +18,7 @@ Environment=MYSQL_INNODB_FLUSH_METHOD=O_DIRECT
 Environment=MYSQL_INNODB_FILE_PER_TABLE=1
 
 # Storage (BTRFS with NOCOW)
-Volume=/mnt/btrfs-pool/subvol7-containers/nextcloud-db/data:/var/lib/mysql:Z
+Volume=/mnt/btrfs-pool/subvol8-db/nextcloud-db:/var/lib/mysql:Z
 
 # Networks
 Network=systemd-nextcloud

--- a/quadlets/postgresql-immich.container
+++ b/quadlets/postgresql-immich.container
@@ -18,7 +18,7 @@ Secret=postgres-password,type=env,target=POSTGRES_PASSWORD
 Environment=POSTGRES_INITDB_ARGS=--data-checksums
 
 # Storage (BTRFS pool with NOCOW)
-Volume=/mnt/btrfs-pool/subvol7-containers/postgresql-immich:/var/lib/postgresql/data:Z
+Volume=/mnt/btrfs-pool/subvol8-db/postgresql-immich:/var/lib/postgresql/data:Z
 
 PodmanArgs=--shm-size=128m
 

--- a/quadlets/prometheus.container
+++ b/quadlets/prometheus.container
@@ -16,7 +16,7 @@ Network=systemd-monitoring:ip=10.89.4.79
 Volume=%h/containers/config/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro,Z
 Volume=%h/containers/config/prometheus/alerts:/etc/prometheus/alerts:ro,Z
 Volume=%h/containers/config/prometheus/rules:/etc/prometheus/rules:ro,Z
-Volume=/mnt/btrfs-pool/subvol7-containers/prometheus:/prometheus:Z
+Volume=/mnt/btrfs-pool/subvol8-db/prometheus:/prometheus:Z
 
 # Podman secrets for authentication
 Secret=ha-prometheus-token,type=mount,target=/run/secrets/ha-prometheus-token


### PR DESCRIPTION
## What
Finalizes the config-as-code tail of ADR-029 **Phase B**, executed 2026-06-09 during the `dnf update` offline window. The 4 remaining COW-in-snapshot databases — `gathio-db`, `nextcloud-db`, `postgresql-immich`, `prometheus` — were migrated from `subvol7-containers` into `subvol8-db` (NOCOW, `C`-only), all verified healthy on the new path. `forgejo-db` + `loki` were already there.

## Changes
- **4 quadlet `Volume=` repoints** to `subvol8-db`
- **ADR-029** status → *Phase B executed 2026-06-09*; tenant table + consequences updated
- **Session-lessons journal** (`docs/98-journals/2026-06-09-adr029-phase-b-db-migration-nocow.md`)
- **AUTO docs regenerated** — replaces a broken `0/0` regen captured mid-boot-storm (2026-06-08 22:35Z) with the real `37/37` catalog

## Not included / follow-ups
- `*.pre-migration-2026-06-09` rollback sources retained ~14 days (not committed), then `migrate-db-to-subvol8.sh cleanup <svc> --execute`
- `sudo bash scripts/filefrag-baseline.sh` for the before/after fragmentation delta (needs interactive sudo — owner task)

Preflight blocker fixed first in #258. Refs: ADR-029, GH#220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)