### PR TITLE
chore(filefrag): retarget baseline to subvol8 post-migration + record after-delta

### DIFF
--- a/docs/98-journals/2026-06-09-adr029-phase-b-db-migration-nocow.md
+++ b/docs/98-journals/2026-06-09-adr029-phase-b-db-migration-nocow.md
@@ -23,9 +23,28 @@
 - **PR #258 merged** (preflight `sudo` fix).
 - **User rebooting now** (`dnf update && reboot`) → then `./scripts/post-reboot-verify.sh`.
 
-## Pending (next session, post-reboot)
+## Finalization (2026-06-09)
 
-1. Commit the 4 quadlet `Volume=` repoint changes (config-as-code — currently uncommitted) + this journal.
-2. Update ADR-029 status → **Phase B done** + tenant table; bump [[project_db_storage_architecture]] memory (it still says "GO pending offline window").
-3. Re-run `sudo bash scripts/filefrag-baseline.sh` for the before/after fragmentation delta.
-4. GH#220: post an "executed 2026-06-09" note (the reminder issue was closed; add the outcome).
+1. ✅ Committed the 4 quadlet `Volume=` repoints + this journal (PR #260).
+2. ✅ ADR-029 status → **Phase B executed** + tenant table/consequences updated; `[[project_db_storage_architecture]]` memory bumped.
+3. ✅ Re-ran `filefrag-baseline.sh` (retargeted from the now-absent subvol7 paths to the subvol8 homes, in this change). Before/after below.
+4. ✅ GH#220: "executed 2026-06-09" outcome posted on the closed reminder issue.
+
+Same session, unrelated but surfaced *by* this migration's reboot: a recurring **boot I/O storm** was root-caused and the monitoring data-plane (prometheus/loki/grafana) reclassified to boot tier C — PR #259 / ADR-035.
+
+### Fragmentation delta — the COW-defeated-by-snapshots antipattern, killed
+
+`filefrag` extents/file, before (subvol7, COW-in-snapshot, 2026-05-22) → after (subvol8, NOCOW, 2026-06-09):
+
+| DB | worst file | before | after |
+|----|-----------|--------|-------|
+| postgresql-immich | PG heap | mean 6.3 / max **1,862** | mean 0.9 / max **1** |
+| nextcloud | `oc_filecache.ibd` | **11,777** | **6** |
+| gathio-db | WiredTiger data | max **2,362** | **2** (the lone max-70 is a transient FTDC `diagnostic.data` file) |
+| prometheus | persistent `chunks_head` | — | **4** |
+
+NOCOW references (unchanged): forgejo-db mean 0.9 / max 18; loki mean 1.0.
+
+**Note on prometheus:** its live `wal/00002638–2640` segments show max ~242 extents — expected for an append-heavy WAL actively being written, and truncated on checkpoint. The *persistent* TSDB (`chunks_head` = 4 extents) is flat, which is the durable measure. NOCOW killed the random-overwrite COW fragmentation; append-growth extents on a live WAL are normal and self-limiting.
+
+Raw baselines (gitignored): `data/backup-logs/filefrag-baseline-2026-05-22-2245.txt` (before), `…-2026-06-09-0735.txt` (after).

--- a/scripts/filefrag-baseline.sh
+++ b/scripts/filefrag-baseline.sh
@@ -2,12 +2,14 @@
 ################################################################################
 # filefrag-baseline.sh — BTRFS fragmentation baseline for DB workloads (ADR-029)
 #
-# Quantifies the "COW defeated by snapshots" antipattern. Run BEFORE and AFTER
-# the Phase B migration to measure the fragmentation delta:
-#   - subvol7 DBs (COW inside a snapshotted subvolume) = the antipattern; expect
-#     high/growing extent counts on hot DB files.
-#   - subvol8 DBs (NOCOW, excluded from snapshots) = the reference; expect low,
-#     stable extent counts.
+# Quantifies the "COW defeated by snapshots" antipattern (ADR-029). The Phase B
+# migration (executed 2026-06-09) moved the 4 hot DBs subvol7 -> subvol8-db (NOCOW),
+# so this now measures all Tier-2 engines in their NOCOW home. Compare the migrated
+# DBs against the pre-migration baseline for the before/after delta:
+#   - PRE (subvol7, COW-in-snapshot, 2026-05-22): nextcloud oc_filecache.ibd = 11,777
+#     extents, gathio max 2,362, immich PG max 1,862
+#     (data/backup-logs/filefrag-baseline-2026-05-22-2245.txt).
+#   - POST (subvol8, NOCOW): expect low, stable counts like the forgejo/loki references.
 #
 # Needs root (DB data dirs are container-subuid-owned, mode 700).
 # Usage:  sudo bash scripts/filefrag-baseline.sh
@@ -17,12 +19,14 @@ set -uo pipefail
 TS="$(date +%Y-%m-%d-%H%M)"
 OUT="/home/patriark/containers/data/backup-logs/filefrag-baseline-${TS}.txt"
 
-# subvol7 = Phase B migration candidates (COW-in-snapshot); subvol8 = reference
+# All Tier-2 engines now live in subvol8-db (NOCOW) after Phase B migration (2026-06-09).
+# First 4 = the migrated DBs (compare vs the 2026-05-22 pre-migration baseline);
+# forgejo-db + loki = the pre-existing NOCOW references.
 DIRS=(
-    "/mnt/btrfs-pool/subvol7-containers/postgresql-immich|subvol7 (candidate)"
-    "/mnt/btrfs-pool/subvol7-containers/nextcloud-db/data|subvol7 (candidate)"
-    "/mnt/btrfs-pool/subvol7-containers/gathio-db|subvol7 (candidate)"
-    "/mnt/btrfs-pool/subvol7-containers/prometheus|subvol7 (candidate)"
+    "/mnt/btrfs-pool/subvol8-db/postgresql-immich|subvol8 (migrated 2026-06-09)"
+    "/mnt/btrfs-pool/subvol8-db/nextcloud-db|subvol8 (migrated 2026-06-09)"
+    "/mnt/btrfs-pool/subvol8-db/gathio-db|subvol8 (migrated 2026-06-09)"
+    "/mnt/btrfs-pool/subvol8-db/prometheus|subvol8 (migrated 2026-06-09)"
     "/mnt/btrfs-pool/subvol8-db/forgejo-db|subvol8 (NOCOW reference)"
     "/mnt/btrfs-pool/subvol8-db/loki|subvol8 (NOCOW reference)"
 )


### PR DESCRIPTION
## What
After the ADR-029 Phase B migration (2026-06-09), `filefrag-baseline.sh` read its 4 candidate DBs as `ABSENT` — they moved `subvol7-containers` → `subvol8-db`. Retargets the paths so the tool measures the migrated DBs in their NOCOW home, and records the before/after fragmentation delta in the migration journal.

## The delta — COW-in-snapshot antipattern eliminated
`filefrag` extents/file, before (subvol7 COW-in-snapshot, 2026-05-22) → after (subvol8 NOCOW, 2026-06-09):

| DB | worst file | before | after |
|----|-----------|--------|-------|
| postgresql-immich | PG heap | max **1,862** | max **1** |
| nextcloud | `oc_filecache.ibd` | **11,777** | **6** |
| gathio-db | WiredTiger data | max **2,362** | **2** |
| prometheus | persistent `chunks_head` | — | **4** |

Live prometheus `wal/*` still shows ~242 extents (append-heavy, truncated on checkpoint); the persistent TSDB is flat. NOCOW references unchanged (forgejo 0.9, loki 1.0).

Closes the last ADR-029 Phase B follow-up. Refs: ADR-029, GH#220.

🤖 Generated with [Claude Code](https://claude.com/claude-code)