### PR TITLE
feat(storage): btrfs dev-stats + SMART health monitoring (ADR-029, part 1/2)

### DIFF
--- a/config/prometheus/alerts/storage-health.yml
+++ b/config/prometheus/alerts/storage-health.yml
@@ -1,0 +1,124 @@
+groups:
+  - name: storage_health
+    interval: 60s
+    rules:
+      # ─────────────────────────────────────────────────────────────────────────
+      # BTRFS per-device error counters (btrfs device stats) — the continuous,
+      # root-free early-warning signal. On a Single-data-profile pool with no live
+      # redundancy these are the first sign a disk is failing, caught the instant the
+      # kernel hits an error during normal I/O (not waiting for the monthly scrub).
+      # Counters are persistent; any nonzero value is abnormal for healthy hardware.
+      # ─────────────────────────────────────────────────────────────────────────
+      - alert: BtrfsDeviceErrors
+        expr: btrfs_device_errors > 0
+        for: 15m
+        labels:
+          severity: critical
+          category: storage
+          component: btrfs-dev-stats
+        annotations:
+          summary: "BTRFS {{ $labels.type }} errors on {{ $labels.device }} ({{ $labels.filesystem }})"
+          description: "btrfs device stats reports {{ $value }} {{ $labels.type }} error(s) on {{ $labels.device }} ({{ $labels.filesystem }}). On the Single-profile pool this is an early disk-failure/bit-rot signal — check SMART, run a scrub to scope damage, verify backups, plan replacement. Counters are persistent; zero with `sudo btrfs dev stats -z <mnt>` after remediation."
+
+      - alert: BtrfsDeviceStatsStale
+        expr: time() - btrfs_device_stats_last_run_timestamp > 3600
+        for: 10m
+        labels:
+          severity: warning
+          category: storage
+          component: btrfs-dev-stats
+        annotations:
+          summary: "BTRFS dev-stats collector stale"
+          description: "btrfs-dev-stats collector last ran {{ $value | humanizeDuration }} ago (expected every 15m). Check `systemctl --user status btrfs-dev-stats.timer`."
+
+      # ─────────────────────────────────────────────────────────────────────────
+      # SMART (drive-firmware view) — complements dev-stats. The two disagreeing is
+      # itself diagnostic.
+      # ─────────────────────────────────────────────────────────────────────────
+      - alert: SmartDeviceHealthFailed
+        expr: smartmon_device_smart_healthy == 0
+        for: 5m
+        labels:
+          severity: critical
+          category: storage
+          component: smartmon
+        annotations:
+          summary: "SMART health FAILED on {{ $labels.device }} ({{ $labels.model }})"
+          description: "smartctl overall-health self-assessment FAILED on {{ $labels.device }} (model {{ $labels.model }}, serial {{ $labels.serial }}). The drive is reporting itself as failing — verify backups and replace it."
+
+      - alert: SmartCurrentPendingSectors
+        expr: smartmon_current_pending_sectors > 0
+        for: 15m
+        labels:
+          severity: critical
+          category: storage
+          component: smartmon
+        annotations:
+          summary: "SMART pending sectors on {{ $labels.device }}"
+          description: "{{ $value }} current-pending (unreadable) sector(s) on {{ $labels.device }} — imminent uncorrectable read errors. Run a scrub to surface affected files; plan replacement."
+
+      - alert: SmartOfflineUncorrectable
+        expr: smartmon_offline_uncorrectable > 0
+        for: 15m
+        labels:
+          severity: critical
+          category: storage
+          component: smartmon
+        annotations:
+          summary: "SMART offline-uncorrectable sectors on {{ $labels.device }}"
+          description: "{{ $value }} offline-uncorrectable sector(s) on {{ $labels.device }} — the drive cannot read these. On Single-profile data, affected files restore from backup. Plan replacement."
+
+      - alert: SmartNvmeCriticalWarning
+        expr: smartmon_nvme_critical_warning > 0
+        for: 5m
+        labels:
+          severity: critical
+          category: storage
+          component: smartmon
+        annotations:
+          summary: "NVMe critical warning on {{ $labels.device }}"
+          description: "NVMe critical_warning bitfield = {{ $value }} (nonzero) on {{ $labels.device }} — spare exhausted / reliability degraded / read-only / temperature alarm. Investigate now (/home + container metadata live here)."
+
+      - alert: SmartReallocatedSectors
+        expr: smartmon_reallocated_sectors > 0
+        for: 30m
+        labels:
+          severity: warning
+          category: storage
+          component: smartmon
+        annotations:
+          summary: "SMART reallocated sectors on {{ $labels.device }}"
+          description: "{{ $value }} reallocated sector(s) on {{ $labels.device }} — the drive is remapping bad sectors. Not yet urgent, but a rising trend means a degrading disk; watch it."
+
+      - alert: SmartDiskTemperatureHigh
+        expr: smartmon_temperature_celsius > 55
+        for: 30m
+        labels:
+          severity: warning
+          category: storage
+          component: smartmon
+        annotations:
+          summary: "Disk {{ $labels.device }} running hot ({{ $value }}°C)"
+          description: "{{ $labels.device }} sustained {{ $value }}°C (>55°C for 30m). Check cabinet airflow/cooling (see the active-cooling fan plan)."
+
+      - alert: SmartNvmeWearHigh
+        expr: smartmon_nvme_percentage_used > 85
+        for: 1h
+        labels:
+          severity: warning
+          category: storage
+          component: smartmon
+        annotations:
+          summary: "NVMe {{ $labels.device }} endurance at {{ $value }}%"
+          description: "NVMe endurance used {{ $value }}% (>85% of rated write life). Plan SSD replacement; /home, container metadata, and Grafana live here."
+
+      - alert: SmartCollectorStale
+        expr: time() - smartmon_collector_last_run_timestamp > 10800
+        for: 10m
+        labels:
+          severity: warning
+          category: storage
+          component: smartmon
+        annotations:
+          summary: "SMART collector stale"
+          description: "smartmon collector last ran {{ $value | humanizeDuration }} ago (expected hourly). Check `systemctl --user status smartmon.timer` and the /etc/sudoers.d/homelab-storage-health grant."

--- a/config/sudoers.d/homelab-storage-health
+++ b/config/sudoers.d/homelab-storage-health
@@ -1,0 +1,34 @@
+# Storage-health monitoring (ADR-029) — least-privilege root grant
+#
+# Lets the unattended USER systemd collector (scripts/smartmon-collector.sh, run by
+# smartmon.timer as patriark) read SMART data, which requires root. The grant is
+# read-only and exact: only `smartctl -j -H -A -i` (JSON + health + attributes +
+# identity — none of which can write to or reconfigure the device), and only on the
+# fixed internal disks (4 pool members + the NVMe). No wildcards. This extends the
+# pattern already established by the existing /etc/sudoers.d btrfs grant used by the
+# backup system (which holds far more powerful verbs, incl. `btrfs receive`).
+#
+# Removable LUKS2 backup drives are intentionally NOT here — their letters are not
+# stable; their filesystem-level health is covered (when mounted) by the root-free
+# btrfs-dev-stats collector. by-id SMART for them can be added later.
+#
+# INSTALL (one-time, by the owner):
+#   sudo install -m 0440 -o root -g root \
+#       ~/containers/config/sudoers.d/homelab-storage-health \
+#       /etc/sudoers.d/homelab-storage-health
+#   sudo visudo -c                 # must report: /etc/sudoers.d/homelab-storage-health: parsed OK
+#
+# NOTE: the device list and the smartctl flags below must stay byte-for-byte in sync
+# with DEVICES[] and the invocation in scripts/smartmon-collector.sh, or sudo will
+# refuse the command (NOPASSWD matches the exact argv).
+#
+# (Part 2 / scrub timer will add `btrfs scrub start|status` lines here.)
+
+Cmnd_Alias HOMELAB_SMARTCTL = \
+    /usr/sbin/smartctl -j -H -A -i /dev/sda, \
+    /usr/sbin/smartctl -j -H -A -i /dev/sdb, \
+    /usr/sbin/smartctl -j -H -A -i /dev/sdc, \
+    /usr/sbin/smartctl -j -H -A -i /dev/sdd, \
+    /usr/sbin/smartctl -j -H -A -i /dev/nvme0
+
+patriark ALL=(root) NOPASSWD: HOMELAB_SMARTCTL

--- a/docs/20-operations/guides/storage-health-monitoring.md
+++ b/docs/20-operations/guides/storage-health-monitoring.md
@@ -1,0 +1,84 @@
+# Storage-Health Monitoring (btrfs dev-stats + SMART)
+
+**Status:** Part 1 of 2 (early-warning observability). Part 2 = scheduled `btrfs scrub`.
+**Context:** ADR-029. The pool is **Single data profile — no live redundancy**, so a disk
+failure is a *restore* event and bit rot is not auto-repaired on data. Early warning is
+therefore the primary defense. Capacity alerting already existed; this adds the two
+missing layers: continuous per-device error counters and SMART in the Discord alert path.
+
+## What it monitors
+
+| Layer | Source | Privilege | Cadence | Catches |
+|---|---|---|---|---|
+| **BTRFS dev-stats** | `btrfs device stats` | **none** (root-free) | 15 min | Per-device write/read/flush/**corruption**/generation errors the kernel hits during *normal* I/O — the earliest signal, between scrubs |
+| **SMART** | `smartctl --json` | root (scoped sudo) | hourly | Drive-firmware pre-failure: health self-assessment, pending/reallocated/offline-uncorrectable sectors, temperature, NVMe wear |
+
+The two are complementary (filesystem view vs. firmware view); them disagreeing is itself
+diagnostic. dev-stats covers the pool **and** mounted backup drives; SMART covers the
+fixed internal disks (4 pool members + the NVMe). Removable LUKS2 backups are covered at
+the filesystem level by dev-stats when mounted.
+
+## Components
+
+- `scripts/btrfs-dev-stats-collector.sh` → `btrfs_device_errors{filesystem,device,type}` (+ present/last-run)
+- `scripts/smartmon-collector.sh` → `smartmon_*` (health, sectors, temp, NVMe wear)
+- `systemd/btrfs-dev-stats.{service,timer}` (user, 15 min) · `systemd/smartmon.{service,timer}` (user, hourly)
+- `config/sudoers.d/homelab-storage-health` — least-privilege, read-only `smartctl` on the fixed devices
+- `config/prometheus/alerts/storage-health.yml` — 10 alerts → Alertmanager → Discord by `severity`
+
+Metrics land in `~/containers/data/backup-metrics/*.prom` (node_exporter textfile collector,
+written as user 1000 — same contract as `db-dump.sh`).
+
+## Install
+
+```bash
+# 1. SMART sudo grant (one-time, root). Read-only, exact-args, no wildcards.
+sudo install -m 0440 -o root -g root \
+    ~/containers/config/sudoers.d/homelab-storage-health \
+    /etc/sudoers.d/homelab-storage-health
+sudo visudo -c            # must print: .../homelab-storage-health: parsed OK
+
+# 2. Install + enable the user timers (hand-written units are copied, not symlinked).
+install -m 0644 ~/containers/systemd/btrfs-dev-stats.{service,timer} \
+                ~/containers/systemd/smartmon.{service,timer} \
+                ~/.config/systemd/user/
+systemctl --user daemon-reload
+systemctl --user enable --now btrfs-dev-stats.timer smartmon.timer
+
+# 3. Activate the alerts (prometheus auto-loads alerts/*.yml on reload).
+podman exec prometheus wget -qO- --post-data='' http://localhost:9090/-/reload
+```
+
+## Verify
+
+```bash
+# Collectors produce valid metrics
+systemctl --user start btrfs-dev-stats.service smartmon.service
+cat ~/containers/data/backup-metrics/btrfs-dev-stats.prom    # per-device counters, all 0 on healthy hw
+cat ~/containers/data/backup-metrics/smartmon.prom           # smartmon_devices_collected should be 5 post-sudoers
+
+# Prometheus sees them + the rules loaded
+podman exec prometheus wget -qO- 'http://localhost:9090/api/v1/query?query=btrfs_device_errors' | jq '.data.result | length'
+podman exec prometheus wget -qO- 'http://localhost:9090/api/v1/query?query=smartmon_device_smart_healthy'
+```
+
+If `smartmon_devices_collected` stays `0` after install, the sudoers grant isn't matching —
+confirm the smartctl argv in the script equals the `Cmnd_Alias` byte-for-byte.
+
+## Operating notes
+
+- **dev-stats counters are persistent** — any nonzero is abnormal. After replacing a disk
+  or clearing a transient, zero them: `sudo btrfs dev stats -z /mnt`.
+- **Single data / RAID1 metadata** (pool): a scrub (Part 2) can self-heal *metadata* but
+  not *data*; a `corruption` error here means a file to restore from backup. `/home` is
+  Metadata=single — its NVMe health matters most (covered by the NVMe SMART alerts).
+- Alerts route to Discord by `severity` (critical = act now / data-loss-adjacent; warning =
+  trend to watch). Same path as the backup alerts.
+
+## Part 2 — scheduled scrub (planned)
+
+`btrfs scrub` (bit-rot *detection*, and metadata repair) over the pool + backups, run as a
+heavily-throttled, Urd-coordinated, staggered timer. Deferred to its own PR because it puts
+sustained read load on the live HDD pool (recall the boot I/O storm) and warrants a
+supervised first run. Will add `btrfs scrub start|status` lines to the sudoers grant and
+`btrfs_scrub_*` metrics/alerts (split `uncorrectable`=critical vs `corrected`=warning).

--- a/scripts/btrfs-dev-stats-collector.sh
+++ b/scripts/btrfs-dev-stats-collector.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+################################################################################
+# btrfs-dev-stats-collector.sh — per-device BTRFS error counters → node_exporter
+#
+# Part of the storage-health monitoring for the Single-data-profile pool (ADR-029):
+# with no live data redundancy, the earliest, most actionable signal that a disk is
+# going bad is BTRFS's own persistent per-device error counters. They accumulate
+# CONTINUOUSLY during normal operation — the instant the kernel hits an I/O or
+# checksum error on a real read/write — so they catch a failing/rotting device
+# *between* the monthly scrubs, which a scrub-only design cannot.
+#
+#   write/read/flush_io_errs -> the drive is failing I/O (classic pre-death signal)
+#   corruption_errs          -> bit-rot / CSUM failures hit during production reads
+#   generation_errs          -> stale metadata (transid mismatch)
+#
+# Counters are PERSISTENT (only `btrfs dev stats -z` resets them), so we alert on the
+# value, not a rate. After replacing/clearing a disk, zero them.
+#
+# Root-free by design: `btrfs device stats` needs no privileges (verified). Runs as a
+# USER systemd oneshot and writes its .prom as user 1000, so the file lands with the
+# correct container_file_t SELinux context for the rootless node_exporter (same
+# contract as db-dump.sh).
+#
+# Schedule: btrfs-dev-stats.timer @ every 15 min.
+################################################################################
+set -uo pipefail
+export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+
+TEXTFILE_DIR="${HOME}/containers/data/backup-metrics"
+OUT="${TEXTFILE_DIR}/btrfs-dev-stats.prom"
+RUN_TS="$(date +%s)"
+
+# mountpoint -> friendly filesystem label. Pool is canonically mounted at /mnt
+# (subvolid=5); /mnt/btrfs-pool is a subvolume path, not the mountpoint. Backups are
+# removable LUKS2 drives — present only when connected; absent = skip, never fail.
+declare -A FS=(
+    ["/mnt"]="pool"
+    ["/run/media/patriark/WD-18TB"]="WD-18TB"
+    ["/run/media/patriark/2TB-backup"]="2TB-backup"
+)
+
+emit() {
+    local mnt label key val dev typ present
+    echo "# HELP btrfs_device_errors BTRFS persistent per-device error counter (btrfs device stats)."
+    echo "# TYPE btrfs_device_errors gauge"
+    for mnt in "${!FS[@]}"; do
+        mountpoint -q "$mnt" 2>/dev/null || continue
+        label="${FS[$mnt]}"
+        # lines look like: [/dev/sdc].write_io_errs    0
+        btrfs device stats "$mnt" 2>/dev/null | while read -r key val; do
+            dev="${key%%]*}"; dev="${dev#[}"                 # /dev/sdc | /dev/mapper/luks-...
+            typ="${key##*.}"; typ="${typ%_errs}"; typ="${typ%_io}"  # write|read|flush|corruption|generation
+            [[ -n "$dev" && -n "$typ" && -n "$val" ]] || continue
+            echo "btrfs_device_errors{filesystem=\"${label}\",device=\"${dev}\",type=\"${typ}\"} ${val}"
+        done
+    done
+
+    echo "# HELP btrfs_device_stats_present BTRFS filesystem mounted (1) and collected this run."
+    echo "# TYPE btrfs_device_stats_present gauge"
+    for mnt in "${!FS[@]}"; do
+        label="${FS[$mnt]}"
+        if mountpoint -q "$mnt" 2>/dev/null; then present=1; else present=0; fi
+        echo "btrfs_device_stats_present{filesystem=\"${label}\"} ${present}"
+    done
+
+    echo "# HELP btrfs_device_stats_last_run_timestamp Unix time of the last dev-stats collection."
+    echo "# TYPE btrfs_device_stats_last_run_timestamp gauge"
+    echo "btrfs_device_stats_last_run_timestamp ${RUN_TS}"
+}
+
+mkdir -p "$TEXTFILE_DIR"
+tmp="$(mktemp "${TEXTFILE_DIR}/.devstats.XXXXXX")" || exit 1
+trap 'rm -f "$tmp"' EXIT
+emit > "$tmp"
+chmod 644 "$tmp"
+mv -f "$tmp" "$OUT"
+trap - EXIT

--- a/scripts/smartmon-collector.sh
+++ b/scripts/smartmon-collector.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+################################################################################
+# smartmon-collector.sh — SMART health/attributes → node_exporter textfile
+#
+# Storage-health monitoring (ADR-029). On a Single-data-profile pool with no live
+# redundancy, SMART pre-failure attributes are the drive-firmware view of "this disk
+# is about to die" — the complement to btrfs-dev-stats (the filesystem view). This
+# puts them in the Prometheus -> Alertmanager -> Discord path you actually watch,
+# instead of relying on smartd's local mail.
+#
+# Scope: the stable, fixed-bay internal disks (4 pool members + the NVMe SSD). These
+# are the redundancy-less data + system devices. Removable LUKS2 backup drives are
+# covered (when mounted) by btrfs-dev-stats-collector.sh; their by-id SMART can be
+# added later. Device letters here are stable (fixed SATA bays + the sole NVMe).
+#
+# Privilege: smartctl needs root, granted via a tightly-scoped, no-wildcard
+# /etc/sudoers.d/homelab-storage-health (read-only -H -A -i on these exact devices).
+# The .prom is written as user 1000 (correct container_file_t context for the rootless
+# node_exporter). Parses smartctl --json — NEVER the exit code (smartctl returns 0 with
+# the real status inside the JSON). Degrades gracefully: if sudo/devices are absent it
+# still writes a valid file (just the run timestamp), so the unit never fails.
+#
+# Schedule: smartmon.timer @ hourly (SMART attributes change slowly).
+################################################################################
+set -uo pipefail
+export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+
+TEXTFILE_DIR="${HOME}/containers/data/backup-metrics"
+OUT="${TEXTFILE_DIR}/smartmon.prom"
+RUN_TS="$(date +%s)"
+SMARTCTL="/usr/sbin/smartctl"
+DEVICES=(/dev/sda /dev/sdb /dev/sdc /dev/sdd /dev/nvme0)
+
+# --- collect JSON per present device (read-only smartctl via NOPASSWD sudo) ---------
+declare -A J
+ORDER=()
+for dev in "${DEVICES[@]}"; do
+    [[ -e "$dev" ]] || continue
+    out="$(sudo -n "$SMARTCTL" -j -H -A -i "$dev" 2>/dev/null)" || true
+    [[ -n "$out" ]] || continue
+    # must be parseable JSON with a device block, else skip
+    jq -e '.device' >/dev/null 2>&1 <<<"$out" || continue
+    J["$dev"]="$out"; ORDER+=("$dev")
+done
+
+san() { local s="${1//\\/}"; printf '%s' "${s//\"/}"; }   # strip backslashes + quotes for label safety
+
+emit() {
+    local dev j model serial proto v
+
+    echo "# HELP smartmon_device_smart_healthy SMART overall-health self-assessment (1=PASSED, 0=FAILED)."
+    echo "# TYPE smartmon_device_smart_healthy gauge"
+    for dev in "${ORDER[@]}"; do
+        j="${J[$dev]}"
+        model="$(san "$(jq -r '.model_name // .scsi_model_name // "unknown"' <<<"$j")")"
+        serial="$(san "$(jq -r '.serial_number // "unknown"' <<<"$j")")"
+        proto="$(san "$(jq -r '.device.protocol // "unknown"' <<<"$j")")"
+        v="$(jq -r 'if .smart_status.passed==true then 1 elif .smart_status.passed==false then 0 else empty end' <<<"$j")"
+        [[ -n "$v" ]] && echo "smartmon_device_smart_healthy{device=\"${dev}\",model=\"${model}\",serial=\"${serial}\",protocol=\"${proto}\"} ${v}"
+    done
+
+    echo "# HELP smartmon_temperature_celsius Current drive temperature (Celsius)."
+    echo "# TYPE smartmon_temperature_celsius gauge"
+    for dev in "${ORDER[@]}"; do
+        v="$(jq -r '.temperature.current // empty' <<<"${J[$dev]}")"
+        [[ -n "$v" ]] && echo "smartmon_temperature_celsius{device=\"${dev}\"} ${v}"
+    done
+
+    echo "# HELP smartmon_power_on_hours Drive power-on time (hours)."
+    echo "# TYPE smartmon_power_on_hours gauge"
+    for dev in "${ORDER[@]}"; do
+        v="$(jq -r '.power_on_time.hours // empty' <<<"${J[$dev]}")"
+        [[ -n "$v" ]] && echo "smartmon_power_on_hours{device=\"${dev}\"} ${v}"
+    done
+
+    # --- ATA pre-failure attributes (the early-warning trio) ---
+    echo "# HELP smartmon_reallocated_sectors ATA attr 5 (Reallocated_Sector_Ct) raw value."
+    echo "# TYPE smartmon_reallocated_sectors gauge"
+    for dev in "${ORDER[@]}"; do
+        v="$(jq -r '.ata_smart_attributes.table[]? | select(.id==5) | .raw.value' <<<"${J[$dev]}" 2>/dev/null | head -1)"
+        [[ -n "$v" ]] && echo "smartmon_reallocated_sectors{device=\"${dev}\"} ${v}"
+    done
+    echo "# HELP smartmon_current_pending_sectors ATA attr 197 (Current_Pending_Sector) raw value."
+    echo "# TYPE smartmon_current_pending_sectors gauge"
+    for dev in "${ORDER[@]}"; do
+        v="$(jq -r '.ata_smart_attributes.table[]? | select(.id==197) | .raw.value' <<<"${J[$dev]}" 2>/dev/null | head -1)"
+        [[ -n "$v" ]] && echo "smartmon_current_pending_sectors{device=\"${dev}\"} ${v}"
+    done
+    echo "# HELP smartmon_offline_uncorrectable ATA attr 198 (Offline_Uncorrectable) raw value."
+    echo "# TYPE smartmon_offline_uncorrectable gauge"
+    for dev in "${ORDER[@]}"; do
+        v="$(jq -r '.ata_smart_attributes.table[]? | select(.id==198) | .raw.value' <<<"${J[$dev]}" 2>/dev/null | head -1)"
+        [[ -n "$v" ]] && echo "smartmon_offline_uncorrectable{device=\"${dev}\"} ${v}"
+    done
+
+    # --- NVMe health log (SSD wear + media errors) ---
+    echo "# HELP smartmon_nvme_media_errors NVMe media_errors count."
+    echo "# TYPE smartmon_nvme_media_errors gauge"
+    for dev in "${ORDER[@]}"; do
+        v="$(jq -r '.nvme_smart_health_information_log.media_errors // empty' <<<"${J[$dev]}")"
+        [[ -n "$v" ]] && echo "smartmon_nvme_media_errors{device=\"${dev}\"} ${v}"
+    done
+    echo "# HELP smartmon_nvme_percentage_used NVMe endurance used (percent; 100 = rated life)."
+    echo "# TYPE smartmon_nvme_percentage_used gauge"
+    for dev in "${ORDER[@]}"; do
+        v="$(jq -r '.nvme_smart_health_information_log.percentage_used // empty' <<<"${J[$dev]}")"
+        [[ -n "$v" ]] && echo "smartmon_nvme_percentage_used{device=\"${dev}\"} ${v}"
+    done
+    echo "# HELP smartmon_nvme_available_spare NVMe available spare (percent)."
+    echo "# TYPE smartmon_nvme_available_spare gauge"
+    for dev in "${ORDER[@]}"; do
+        v="$(jq -r '.nvme_smart_health_information_log.available_spare // empty' <<<"${J[$dev]}")"
+        [[ -n "$v" ]] && echo "smartmon_nvme_available_spare{device=\"${dev}\"} ${v}"
+    done
+    echo "# HELP smartmon_nvme_critical_warning NVMe critical_warning bitfield (0 = healthy)."
+    echo "# TYPE smartmon_nvme_critical_warning gauge"
+    for dev in "${ORDER[@]}"; do
+        v="$(jq -r '.nvme_smart_health_information_log.critical_warning // empty' <<<"${J[$dev]}")"
+        [[ -n "$v" ]] && echo "smartmon_nvme_critical_warning{device=\"${dev}\"} ${v}"
+    done
+
+    echo "# HELP smartmon_devices_collected Number of devices SMART data was read from this run."
+    echo "# TYPE smartmon_devices_collected gauge"
+    echo "smartmon_devices_collected ${#ORDER[@]}"
+    echo "# HELP smartmon_collector_last_run_timestamp Unix time of the last SMART collection."
+    echo "# TYPE smartmon_collector_last_run_timestamp gauge"
+    echo "smartmon_collector_last_run_timestamp ${RUN_TS}"
+}
+
+mkdir -p "$TEXTFILE_DIR"
+tmp="$(mktemp "${TEXTFILE_DIR}/.smartmon.XXXXXX")" || exit 1
+trap 'rm -f "$tmp"' EXIT
+emit > "$tmp"
+chmod 644 "$tmp"
+mv -f "$tmp" "$OUT"
+trap - EXIT

--- a/systemd/btrfs-dev-stats.service
+++ b/systemd/btrfs-dev-stats.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=BTRFS per-device error counters -> node_exporter textfile (storage-health, ADR-029)
+Documentation=file:///home/patriark/containers/docs/20-operations/guides/storage-health-monitoring.md
+
+[Service]
+Type=oneshot
+ExecStart=%h/containers/scripts/btrfs-dev-stats-collector.sh
+TimeoutStartSec=2m
+
+# Root-free, trivial I/O — but stay polite anyway
+Nice=19
+IOSchedulingClass=idle
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/systemd/btrfs-dev-stats.timer
+++ b/systemd/btrfs-dev-stats.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Collect BTRFS per-device error counters every 15 minutes
+
+[Timer]
+OnBootSec=3min
+OnUnitActiveSec=15min
+
+[Install]
+WantedBy=timers.target

--- a/systemd/smartmon.service
+++ b/systemd/smartmon.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=SMART disk health -> node_exporter textfile (storage-health, ADR-029)
+Documentation=file:///home/patriark/containers/docs/20-operations/guides/storage-health-monitoring.md
+
+[Service]
+Type=oneshot
+ExecStart=%h/containers/scripts/smartmon-collector.sh
+TimeoutStartSec=2m
+
+# smartctl reads are light; stay polite
+Nice=19
+IOSchedulingClass=idle
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/systemd/smartmon.timer
+++ b/systemd/smartmon.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Collect SMART disk health hourly
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=1h
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Why
The BTRFS pool is **Single data profile — no live redundancy**. A disk failure is a *restore* event and bit rot is not auto-repaired on data, so **early warning is the primary defense**. Capacity alerting already existed; this adds the two missing layers, into the existing Prometheus → Alertmanager → Discord path.

## What (Part 1 of 2 — early-warning observability)
| Layer | Source | Privilege | Cadence | Catches |
|---|---|---|---|---|
| **BTRFS dev-stats** | `btrfs device stats` | **none** | 15 min | per-device write/read/flush/**corruption**/generation errors hit during *normal* I/O — the earliest signal, *between* scrubs |
| **SMART** | `smartctl --json` | scoped sudo | hourly | health self-assessment, pending/reallocated/offline-uncorrectable sectors, temp, NVMe wear |

dev-stats covers the pool **and** mounted backups; SMART covers the fixed internal disks (4 pool + NVMe).

## Files
- `scripts/btrfs-dev-stats-collector.sh` (root-free) + `scripts/smartmon-collector.sh`
- `systemd/btrfs-dev-stats.{service,timer}` (15m) · `systemd/smartmon.{service,timer}` (hourly) — user units
- `config/sudoers.d/homelab-storage-health` — least-privilege, read-only `smartctl`, **no wildcards**, exact devices (extends the existing btrfs sudoers grant)
- `config/prometheus/alerts/storage-health.yml` — 10 alerts (promtool-validated)
- `docs/20-operations/guides/storage-health-monitoring.md` — install (incl. the one root step) + verify

## Verification
- Both collectors run live; `btrfs device stats` confirmed root-free across pool + both backups.
- `promtool check metrics` clean on both `.prom`; `promtool check rules` → 10 rules OK.
- `.prom` outputs are gitignored (runtime artifacts).

## Design notes (from infrastructure-architect review)
- User-timers + scoped sudoers (not root system-units): the textfile dir already receives `system_u` writes, so SELinux wasn't the driver — **consistency** with the ~20 existing user units is.
- SMART parses JSON, never the exit code (smartctl returns 0 with status inside).
- Pool mountpoint is `/mnt`; profiles are Data=single / Metadata=RAID1.

## Deferred to Part 2
Scheduled `btrfs scrub` — heavy sustained read I/O on the live HDD pool (recall the boot I/O storm), Urd-coordinated, staggered, supervised first run. Earns its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)