### PR TITLE
feat(storage): scheduled btrfs scrub (ADR-029, part 2/2)

### DIFF
--- a/config/prometheus/alerts/storage-health.yml
+++ b/config/prometheus/alerts/storage-health.yml
@@ -128,3 +128,41 @@ groups:
         annotations:
           summary: "SMART collector stale"
           description: "smartmon collector last ran {{ $value | humanizeDuration }} ago (expected hourly). Check `systemctl --user status smartmon.timer` and the /etc/sudoers.d/homelab-storage-health grant."
+
+      # ─────────────────────────────────────────────────────────────────────────
+      # BTRFS scrub (bit-rot detection + metadata repair). On Single data / RAID1
+      # metadata: corrected = the metadata mirror self-healed (a disk whispering);
+      # uncorrectable = data the scrub could not repair (restore from backup).
+      # ─────────────────────────────────────────────────────────────────────────
+      - alert: BtrfsScrubUncorrectableErrors
+        expr: btrfs_scrub_uncorrectable_errors > 0
+        for: 5m
+        labels:
+          severity: critical
+          category: storage
+          component: btrfs-scrub
+        annotations:
+          summary: "BTRFS scrub found UNCORRECTABLE errors on {{ $labels.filesystem }}"
+          description: "The last scrub of {{ $labels.filesystem }} found {{ $value }} uncorrectable error(s) — data the scrub could not repair (no redundant data copy on Single profile). Identify the affected files and restore them from the Urd backups."
+
+      - alert: BtrfsScrubCorrectedErrors
+        expr: btrfs_scrub_corrected_errors > 0
+        for: 5m
+        labels:
+          severity: warning
+          category: storage
+          component: btrfs-scrub
+        annotations:
+          summary: "BTRFS scrub corrected errors on {{ $labels.filesystem }}"
+          description: "The last scrub of {{ $labels.filesystem }} corrected {{ $value }} error(s) from a redundant copy (e.g. the RAID1 metadata mirror). The data is intact, but a disk is whispering — cross-check SMART and btrfs device stats to find the culprit."
+
+      - alert: BtrfsScrubOverdue
+        expr: time() - btrfs_scrub_last_completion_timestamp{filesystem=~"pool|home"} > 86400 * 45
+        for: 1h
+        labels:
+          severity: warning
+          category: storage
+          component: btrfs-scrub
+        annotations:
+          summary: "BTRFS scrub overdue on {{ $labels.filesystem }}"
+          description: "{{ $labels.filesystem }} has not completed a scrub in {{ $value | humanizeDuration }} (monthly cadence + grace). Bit rot could be accumulating undetected. Check `systemctl --user status btrfs-scrub-internal.timer`."

--- a/config/sudoers.d/homelab-storage-health
+++ b/config/sudoers.d/homelab-storage-health
@@ -1,12 +1,13 @@
 # Storage-health monitoring (ADR-029) — least-privilege root grant
 #
-# Lets the unattended USER systemd collector (scripts/smartmon-collector.sh, run by
-# smartmon.timer as patriark) read SMART data, which requires root. The grant is
-# read-only and exact: only `smartctl -j -H -A -i` (JSON + health + attributes +
-# identity — none of which can write to or reconfigure the device), and only on the
-# fixed internal disks (4 pool members + the NVMe). No wildcards. This extends the
-# pattern already established by the existing /etc/sudoers.d btrfs grant used by the
-# backup system (which holds far more powerful verbs, incl. `btrfs receive`).
+# Lets the unattended USER systemd timers (run as patriark) perform the two root-only
+# storage-health operations: SMART reads (scripts/smartmon-collector.sh) and btrfs scrub
+# (scripts/btrfs-scrub.sh). Both grants are exact and non-destructive: `smartctl -j -H -A
+# -i` is read-only (cannot write/reconfigure the device); `btrfs scrub` reads every block
+# and can repair only from a redundant copy (cannot modify file data). No wildcards; exact
+# devices/mountpoints. This extends the pattern already established by the existing
+# /etc/sudoers.d btrfs grant used by the backup system (which holds far more powerful
+# verbs, incl. `btrfs receive`).
 #
 # Removable LUKS2 backup drives are intentionally NOT here — their letters are not
 # stable; their filesystem-level health is covered (when mounted) by the root-free
@@ -22,8 +23,6 @@
 # with DEVICES[] and the invocation in scripts/smartmon-collector.sh, or sudo will
 # refuse the command (NOPASSWD matches the exact argv).
 #
-# (Part 2 / scrub timer will add `btrfs scrub start|status` lines here.)
-
 Cmnd_Alias HOMELAB_SMARTCTL = \
     /usr/sbin/smartctl -j -H -A -i /dev/sda, \
     /usr/sbin/smartctl -j -H -A -i /dev/sdb, \
@@ -31,4 +30,18 @@ Cmnd_Alias HOMELAB_SMARTCTL = \
     /usr/sbin/smartctl -j -H -A -i /dev/sdd, \
     /usr/sbin/smartctl -j -H -A -i /dev/nvme0
 
-patriark ALL=(root) NOPASSWD: HOMELAB_SMARTCTL
+# btrfs scrub for scripts/btrfs-scrub.sh (btrfs-scrub-*.timer). scrub reads every block and
+# can repair only from a redundant copy (RAID1 metadata) — it cannot modify file data, and
+# these are the only btrfs verbs granted here. Exact mountpoints + exact flags including the
+# --limit value; keep byte-for-byte in sync with LIMIT and the invocation in btrfs-scrub.sh.
+Cmnd_Alias HOMELAB_SCRUB = \
+    /usr/sbin/btrfs scrub start -B -d -c 3 --limit 80m /mnt, \
+    /usr/sbin/btrfs scrub start -B -d -c 3 --limit 80m /home, \
+    /usr/sbin/btrfs scrub start -B -d -c 3 --limit 80m /run/media/patriark/WD-18TB, \
+    /usr/sbin/btrfs scrub start -B -d -c 3 --limit 80m /run/media/patriark/2TB-backup, \
+    /usr/sbin/btrfs scrub status -R /mnt, \
+    /usr/sbin/btrfs scrub status -R /home, \
+    /usr/sbin/btrfs scrub status -R /run/media/patriark/WD-18TB, \
+    /usr/sbin/btrfs scrub status -R /run/media/patriark/2TB-backup
+
+patriark ALL=(root) NOPASSWD: HOMELAB_SMARTCTL, HOMELAB_SCRUB

--- a/docs/20-operations/guides/storage-health-monitoring.md
+++ b/docs/20-operations/guides/storage-health-monitoring.md
@@ -1,6 +1,7 @@
 # Storage-Health Monitoring (btrfs dev-stats + SMART)
 
-**Status:** Part 1 of 2 (early-warning observability). Part 2 = scheduled `btrfs scrub`.
+**Status:** Both parts implemented. Part 1 (dev-stats + SMART) is deployed and live; Part 2
+(scrub) is installed, with its timers enabled by the owner after a supervised first run.
 **Context:** ADR-029. The pool is **Single data profile — no live redundancy**, so a disk
 failure is a *restore* event and bit rot is not auto-repaired on data. Early warning is
 therefore the primary defense. Capacity alerting already existed; this adds the two
@@ -12,6 +13,7 @@ missing layers: continuous per-device error counters and SMART in the Discord al
 |---|---|---|---|---|
 | **BTRFS dev-stats** | `btrfs device stats` | **none** (root-free) | 15 min | Per-device write/read/flush/**corruption**/generation errors the kernel hits during *normal* I/O — the earliest signal, between scrubs |
 | **SMART** | `smartctl --json` | root (scoped sudo) | hourly | Drive-firmware pre-failure: health self-assessment, pending/reallocated/offline-uncorrectable sectors, temperature, NVMe wear |
+| **BTRFS scrub** | `btrfs scrub` | root (scoped sudo) | monthly | Reads every block + verifies checksums — bit-rot *detection* (and metadata repair from the RAID1 mirror) |
 
 The two are complementary (filesystem view vs. firmware view); them disagreeing is itself
 diagnostic. dev-stats covers the pool **and** mounted backup drives; SMART covers the
@@ -22,9 +24,11 @@ the filesystem level by dev-stats when mounted.
 
 - `scripts/btrfs-dev-stats-collector.sh` → `btrfs_device_errors{filesystem,device,type}` (+ present/last-run)
 - `scripts/smartmon-collector.sh` → `smartmon_*` (health, sectors, temp, NVMe wear)
-- `systemd/btrfs-dev-stats.{service,timer}` (user, 15 min) · `systemd/smartmon.{service,timer}` (user, hourly)
-- `config/sudoers.d/homelab-storage-health` — least-privilege, read-only `smartctl` on the fixed devices
-- `config/prometheus/alerts/storage-health.yml` — 10 alerts → Alertmanager → Discord by `severity`
+- `scripts/btrfs-scrub.sh` → `btrfs_scrub_*` (per-fs state files rendered into one `.prom`)
+- `systemd/btrfs-dev-stats.{service,timer}` (15 min) · `systemd/smartmon.{service,timer}` (hourly)
+- `systemd/btrfs-scrub-internal.{service,timer}` (pool+/home, 1st Sun) · `systemd/btrfs-scrub-backups.{service,timer}` (backups, 3rd Sun, Urd-guarded)
+- `config/sudoers.d/homelab-storage-health` — least-privilege: read-only `smartctl` + `btrfs scrub` on exact devices/mountpoints
+- `config/prometheus/alerts/storage-health.yml` — 13 alerts → Alertmanager → Discord by `severity`
 
 Metrics land in `~/containers/data/backup-metrics/*.prom` (node_exporter textfile collector,
 written as user 1000 — same contract as `db-dump.sh`).
@@ -75,10 +79,53 @@ confirm the smartctl argv in the script equals the `Cmnd_Alias` byte-for-byte.
 - Alerts route to Discord by `severity` (critical = act now / data-loss-adjacent; warning =
   trend to watch). Same path as the backup alerts.
 
-## Part 2 — scheduled scrub (planned)
+## Part 2 — scheduled scrub
 
-`btrfs scrub` (bit-rot *detection*, and metadata repair) over the pool + backups, run as a
-heavily-throttled, Urd-coordinated, staggered timer. Deferred to its own PR because it puts
-sustained read load on the live HDD pool (recall the boot I/O storm) and warrants a
-supervised first run. Will add `btrfs scrub start|status` lines to the sudoers grant and
-`btrfs_scrub_*` metrics/alerts (split `uncorrectable`=critical vs `corrected`=warning).
+`scripts/btrfs-scrub.sh` reads every block and verifies checksums (bit-rot **detection**;
+on the pool it can also **repair metadata** from the RAID1 mirror, but not data). Metrics:
+`btrfs_scrub_{uncorrectable,corrected}_errors`, `…_last_completion_timestamp`,
+`…_duration_seconds`, `…_exit_code` per `filesystem`. Alerts split the profile reality:
+**uncorrectable = critical** (data to restore), **corrected = warning** (a disk whispering),
+plus **overdue** (pool/home, >45 d).
+
+**Throttling** (this pool serves every service — see the 2026-06 boot I/O storm):
+`btrfs scrub start -B -d -c 3 --limit 80m` = foreground + per-device + idle ioprio + a hard
+80 MiB/s/device cap (restored after), and the units add `Nice=19` + `IOSchedulingClass=idle`.
+
+**Schedule (staggered, clear of Urd's 04:00):**
+- `btrfs-scrub-internal.timer` — pool `/mnt` + `/home`, **1st Sunday 14:00**
+- `btrfs-scrub-backups.timer` — WD-18TB + 2TB-backup, **3rd Sunday 14:00**, with an
+  `ExecCondition` that skips if `urd-backup.service` is active, and a per-drive mount guard
+  (no-op when a removable backup is unplugged).
+
+### Install (after a supervised first run)
+
+The sudoers grant already includes scrub if you re-installed `homelab-storage-health` after
+this change (it now holds `HOMELAB_SCRUB`). Re-install if needed, then **scrub once by hand
+while watching I/O** before trusting the timer:
+
+```bash
+sudo install -m 0440 -o root -g root \
+    ~/containers/config/sudoers.d/homelab-storage-health /etc/sudoers.d/homelab-storage-health
+sudo visudo -c
+
+install -m 0644 ~/containers/systemd/btrfs-scrub-internal.{service,timer} \
+                ~/containers/systemd/btrfs-scrub-backups.{service,timer} ~/.config/systemd/user/
+systemctl --user daemon-reload
+
+# Supervised first run — watch that services stay responsive under the throttled scrub:
+systemctl --user start btrfs-scrub-internal.service &
+# in another pane: watch -n5 'cat /proc/pressure/io; echo; sudo btrfs scrub status /mnt'
+# Jellyfin/Immich/etc. should stay responsive. If I/O pressure spikes, lower --limit in
+# scripts/btrfs-scrub.sh AND the sudoers line (keep them byte-for-byte identical), re-install.
+
+# Once comfortable, enable the monthly timers:
+systemctl --user enable --now btrfs-scrub-internal.timer btrfs-scrub-backups.timer
+```
+
+The pool scrub of ~11 TiB at 80 MiB/s/device runs **several hours** — expected. Watch the
+first completion's `btrfs_scrub_corrected_errors` (sdc has 8 reallocated sectors and is the
+likeliest source of a corrected/metadata blip).
+
+> **Note:** `--limit` is fixed at `80m` in both the script and the sudoers line because sudo
+> matches the exact argv. To change the cap, edit *both* in lockstep.

--- a/scripts/btrfs-scrub.sh
+++ b/scripts/btrfs-scrub.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+################################################################################
+# btrfs-scrub.sh — scheduled BTRFS scrub with metrics (storage-health, ADR-029, part 2)
+#
+# Scrub reads every block and verifies checksums. On the Single-data / RAID1-metadata
+# pool it can self-heal METADATA (from the mirror) but NOT data (no data mirror) — so a
+# `uncorrectable` error is data to restore from backup, while a `corrected` error is the
+# metadata mirror doing its job (a disk whispering). The point on Single data is
+# DETECTION: learn a file rotted while a good copy still exists in Urd.
+#
+# Throttling (this pool serves all services — see the 2026-06 boot I/O storm):
+#   btrfs scrub start -B -d -c 3 --limit 80m
+#     -B  foreground (the unit stays active for the scrub's duration -> coherent metrics)
+#     -d  per-device stats
+#     -c 3  idle ioprio class (bfq honours it)
+#     --limit 80m  hard 80 MiB/s/device cap, restored afterwards
+#   + unit-level Nice=19 / IOSchedulingClass=idle (belt-and-suspenders).
+# The --limit value here MUST match /etc/sudoers.d/homelab-storage-health byte-for-byte.
+#
+# Usage:  btrfs-scrub.sh <mountpoint> [<mountpoint> ...]
+#   Each arg is scrubbed if it is a mounted btrfs (removable backups are skipped cleanly
+#   when absent). Per-fs results are kept as state files and rendered into a single
+#   btrfs-scrub.prom (one HELP/TYPE per metric; all filesystems in one file).
+################################################################################
+set -uo pipefail
+export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+
+BTRFS="/usr/sbin/btrfs"
+LIMIT="80m"                              # keep in sync with sudoers
+TEXTFILE_DIR="${HOME}/containers/data/backup-metrics"
+STATE_DIR="${TEXTFILE_DIR}/.scrub-state"
+OUT="${TEXTFILE_DIR}/btrfs-scrub.prom"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] $*" >&2; }
+
+label_for() {  # mountpoint -> friendly filesystem label
+    case "$1" in
+        /mnt)                              echo "pool" ;;
+        /home)                             echo "home" ;;
+        /run/media/patriark/WD-18TB)       echo "WD-18TB" ;;
+        /run/media/patriark/2TB-backup)    echo "2TB-backup" ;;
+        *)                                 echo "$(basename "$1")" ;;
+    esac
+}
+
+scrub_one() {
+    local mnt="$1" label start end dur status corrected uncorrectable rc
+    label="$(label_for "$mnt")"
+    if ! mountpoint -q "$mnt" 2>/dev/null; then
+        log "[$label] $mnt not mounted — skipping (removable/absent)"
+        return 0
+    fi
+    log "[$label] scrub starting on $mnt (idle ioprio, --limit ${LIMIT})"
+    start="$(date +%s)"
+    sudo -n "$BTRFS" scrub start -B -d -c 3 --limit "$LIMIT" "$mnt" >/dev/null 2>&1
+    rc=$?
+    end="$(date +%s)"; dur=$((end - start))
+    # btrfs scrub -B returns 0 (clean) or 3 (completed, found uncorrectable errors) when it
+    # actually RAN; anything else means it failed to start/complete (sudo denied, drive gone,
+    # already running). Do NOT record a completion in that case, or last_completion_timestamp
+    # would advance and mask BtrfsScrubOverdue — the prior real scrub's state is kept instead.
+    if [[ $rc -ne 0 && $rc -ne 3 ]]; then
+        log "[$label] scrub did NOT run (rc=${rc}) — keeping previous state, not recording completion"
+        return 0
+    fi
+    # Parse the RAW status counters — NEVER the exit code as the source of truth.
+    # corrected/uncorrectable are the decision buckets.
+    status="$(sudo -n "$BTRFS" scrub status -R "$mnt" 2>/dev/null)"
+    corrected="$(grep -oiP 'corrected_errors:\s*\K[0-9]+' <<<"$status" | head -1)"
+    uncorrectable="$(grep -oiP 'uncorrectable_errors:\s*\K[0-9]+' <<<"$status" | head -1)"
+    corrected="${corrected:-0}"; uncorrectable="${uncorrectable:-0}"
+    log "[$label] scrub done in ${dur}s rc=${rc} corrected=${corrected} uncorrectable=${uncorrectable}"
+    mkdir -p "$STATE_DIR"
+    cat > "${STATE_DIR}/${label}" <<EOF
+filesystem=${label}
+completion_ts=${end}
+duration=${dur}
+corrected=${corrected}
+uncorrectable=${uncorrectable}
+exit_code=${rc}
+run_ts=${end}
+EOF
+}
+
+getf() { grep -oP "(?<=^${2}=).*" "$1" 2>/dev/null; }
+
+render() {  # render all per-fs state files into one valid .prom (HELP/TYPE once per metric)
+    local s
+    echo "# HELP btrfs_scrub_uncorrectable_errors BTRFS scrub uncorrectable errors (data loss on Single profile — restore from backup)."
+    echo "# TYPE btrfs_scrub_uncorrectable_errors gauge"
+    for s in "$STATE_DIR"/*; do [ -e "$s" ] || continue; echo "btrfs_scrub_uncorrectable_errors{filesystem=\"$(getf "$s" filesystem)\"} $(getf "$s" uncorrectable)"; done
+    echo "# HELP btrfs_scrub_corrected_errors BTRFS scrub corrected errors (self-healed from a good copy, e.g. RAID1 metadata mirror — a disk whispering)."
+    echo "# TYPE btrfs_scrub_corrected_errors gauge"
+    for s in "$STATE_DIR"/*; do [ -e "$s" ] || continue; echo "btrfs_scrub_corrected_errors{filesystem=\"$(getf "$s" filesystem)\"} $(getf "$s" corrected)"; done
+    echo "# HELP btrfs_scrub_last_completion_timestamp Unix time the last scrub of this filesystem finished."
+    echo "# TYPE btrfs_scrub_last_completion_timestamp gauge"
+    for s in "$STATE_DIR"/*; do [ -e "$s" ] || continue; echo "btrfs_scrub_last_completion_timestamp{filesystem=\"$(getf "$s" filesystem)\"} $(getf "$s" completion_ts)"; done
+    echo "# HELP btrfs_scrub_duration_seconds Duration of the last scrub of this filesystem."
+    echo "# TYPE btrfs_scrub_duration_seconds gauge"
+    for s in "$STATE_DIR"/*; do [ -e "$s" ] || continue; echo "btrfs_scrub_duration_seconds{filesystem=\"$(getf "$s" filesystem)\"} $(getf "$s" duration)"; done
+    echo "# HELP btrfs_scrub_exit_code Exit code of the last scrub (0=clean, 3=errors found, other=run failure)."
+    echo "# TYPE btrfs_scrub_exit_code gauge"
+    for s in "$STATE_DIR"/*; do [ -e "$s" ] || continue; echo "btrfs_scrub_exit_code{filesystem=\"$(getf "$s" filesystem)\"} $(getf "$s" exit_code)"; done
+}
+
+[[ $# -ge 1 ]] || { log "usage: $(basename "$0") <mountpoint> [<mountpoint> ...]"; exit 2; }
+for mnt in "$@"; do scrub_one "$mnt"; done
+
+mkdir -p "$TEXTFILE_DIR"
+tmp="$(mktemp "${TEXTFILE_DIR}/.scrub.XXXXXX")" || exit 1
+trap 'rm -f "$tmp"' EXIT
+render > "$tmp"
+chmod 644 "$tmp"
+mv -f "$tmp" "$OUT"
+trap - EXIT
+log "rendered $OUT"

--- a/systemd/btrfs-scrub-backups.service
+++ b/systemd/btrfs-scrub-backups.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=BTRFS scrub — external backup drives when mounted (storage-health, ADR-029)
+Documentation=file:///home/patriark/containers/docs/20-operations/guides/storage-health-monitoring.md
+
+[Service]
+Type=oneshot
+# Skip cleanly (don't fail) if Urd is sending — two jobs on the WD-18TB send target would
+# both crawl. Urd runs 04:00; this timer fires 14:00, so this is the belt-and-suspenders
+# guard for the edge case where a send is still running.
+ExecCondition=/bin/bash -c '! systemctl --user is-active --quiet urd-backup.service'
+ExecStart=%h/containers/scripts/btrfs-scrub.sh /run/media/patriark/WD-18TB /run/media/patriark/2TB-backup
+TimeoutStartSec=24h
+
+Nice=19
+IOSchedulingClass=idle
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/systemd/btrfs-scrub-backups.timer
+++ b/systemd/btrfs-scrub-backups.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Monthly BTRFS scrub of external backup drives (3rd Sunday)
+
+[Timer]
+# 3rd Sunday, 14:00 — a different week from the internal scrub, clear of Urd's 04:00.
+# The script skips any drive that isn't mounted (removable), so this is a no-op when the
+# backups are disconnected.
+OnCalendar=Sun *-*-15..21 14:00:00
+Persistent=true
+RandomizedDelaySec=600
+
+[Install]
+WantedBy=timers.target

--- a/systemd/btrfs-scrub-internal.service
+++ b/systemd/btrfs-scrub-internal.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=BTRFS scrub — internal filesystems: pool (/mnt) + /home (storage-health, ADR-029)
+Documentation=file:///home/patriark/containers/docs/20-operations/guides/storage-health-monitoring.md
+
+[Service]
+Type=oneshot
+ExecStart=%h/containers/scripts/btrfs-scrub.sh /mnt /home
+# A full Single-profile pool scrub on 3.6T spindles, throttled to 80 MiB/s/device, can
+# run many hours. -B foreground keeps the unit active for the duration.
+TimeoutStartSec=24h
+
+# Throttle hard — this pool serves every service (recall the 2026-06 boot I/O storm).
+# The btrfs --limit 80m cap is in the script; these are belt-and-suspenders.
+Nice=19
+IOSchedulingClass=idle
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/systemd/btrfs-scrub-internal.timer
+++ b/systemd/btrfs-scrub-internal.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Monthly BTRFS scrub of internal filesystems (pool + /home), 1st Sunday
+
+[Timer]
+# 1st Sunday of the month, 14:00 — well clear of Urd's 04:00 send window.
+OnCalendar=Sun *-*-01..07 14:00:00
+Persistent=true
+RandomizedDelaySec=600
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
Completes storage-health monitoring. Part 1 (#262) added the early-warning observability (dev-stats + SMART); this adds bit-rot **detection** + metadata repair via scheduled `btrfs scrub` — the last gap for a Single-data-profile pool where a corrupt data block is otherwise discovered only on read (the worst time).

## What
- **`scripts/btrfs-scrub.sh`** — `btrfs scrub start -B -d -c 3 --limit 80m` (foreground, per-device, idle ioprio, **hard 80 MiB/s/device cap, restored after**) + `Nice=19`/`IOSchedulingClass=idle` units. Throttled hard because this pool serves every service (cf. the 2026-06 boot I/O storm). Parses `scrub status -R` (corrected vs uncorrectable), **never the exit code**; records a completion **only when the scrub actually ran** (rc 0/3) so a failed run can't mask the overdue alert. Per-fs state files → one valid `.prom`.
- **Staggered timers, clear of Urd's 04:00:** `btrfs-scrub-internal` (pool + /home) 1st Sun 14:00; `btrfs-scrub-backups` (WD-18TB + 2TB) 3rd Sun 14:00, with an `ExecCondition` skip-if-`urd-backup`-active guard + per-drive mount guard (no-op when a removable backup is unplugged).
- **sudoers:** exact, no-wildcard `btrfs scrub start/status` on the 4 mountpoints (scrub cannot modify file data).
- **3 alerts:** `BtrfsScrubUncorrectableErrors` (critical — data to restore), `BtrfsScrubCorrectedErrors` (warning — disk whispering), `BtrfsScrubOverdue` (warning, pool/home >45d). Split reflects Data=single / Metadata=RAID1.

## Verification
- `bash -n` clean; dry run without the grant → "did NOT run", empty valid `.prom`, **no fake completion state**.
- `promtool check rules` → 13 rules; `promtool check metrics` clean; `visudo -cf` → parsed OK.

## Not auto-enabled — supervised first run
The timers are **not** enabled by this PR. The guide documents a hand-run first scrub (watching `/proc/pressure/io` for service impact) before enabling, given the sustained read load on the live HDD pool. Owner installs the sudoers + units and enables when comfortable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)