### PR TITLE
fix(storage): throttle scrub via 'scrub limit --all', not 'scrub start --limit'

### DIFF
--- a/config/sudoers.d/homelab-storage-health
+++ b/config/sudoers.d/homelab-storage-health
@@ -32,13 +32,17 @@ Cmnd_Alias HOMELAB_SMARTCTL = \
 
 # btrfs scrub for scripts/btrfs-scrub.sh (btrfs-scrub-*.timer). scrub reads every block and
 # can repair only from a redundant copy (RAID1 metadata) — it cannot modify file data, and
-# these are the only btrfs verbs granted here. Exact mountpoints + exact flags including the
-# --limit value; keep byte-for-byte in sync with LIMIT and the invocation in btrfs-scrub.sh.
+# these are the only btrfs verbs granted here. The pool throttle is applied via
+# `scrub limit --all` (scrub start --limit unreliably skips devids on multi-device fs);
+# /home + backups scrub unlimited. Exact mountpoints + exact flags incl. the 30m/0 limit
+# values — keep byte-for-byte in sync with POOL_LIMIT and the invocations in btrfs-scrub.sh.
 Cmnd_Alias HOMELAB_SCRUB = \
-    /usr/sbin/btrfs scrub start -B -d -c 3 --limit 80m /mnt, \
-    /usr/sbin/btrfs scrub start -B -d -c 3 --limit 80m /home, \
-    /usr/sbin/btrfs scrub start -B -d -c 3 --limit 80m /run/media/patriark/WD-18TB, \
-    /usr/sbin/btrfs scrub start -B -d -c 3 --limit 80m /run/media/patriark/2TB-backup, \
+    /usr/sbin/btrfs scrub limit --all --limit 30m /mnt, \
+    /usr/sbin/btrfs scrub limit --all --limit 0 /mnt, \
+    /usr/sbin/btrfs scrub start -B -d -c 3 /mnt, \
+    /usr/sbin/btrfs scrub start -B -d -c 3 /home, \
+    /usr/sbin/btrfs scrub start -B -d -c 3 /run/media/patriark/WD-18TB, \
+    /usr/sbin/btrfs scrub start -B -d -c 3 /run/media/patriark/2TB-backup, \
     /usr/sbin/btrfs scrub status -R /mnt, \
     /usr/sbin/btrfs scrub status -R /home, \
     /usr/sbin/btrfs scrub status -R /run/media/patriark/WD-18TB, \

--- a/docs/20-operations/guides/storage-health-monitoring.md
+++ b/docs/20-operations/guides/storage-health-monitoring.md
@@ -88,9 +88,13 @@ on the pool it can also **repair metadata** from the RAID1 mirror, but not data)
 **uncorrectable = critical** (data to restore), **corrected = warning** (a disk whispering),
 plus **overdue** (pool/home, >45 d).
 
-**Throttling** (this pool serves every service — see the 2026-06 boot I/O storm):
-`btrfs scrub start -B -d -c 3 --limit 80m` = foreground + per-device + idle ioprio + a hard
-80 MiB/s/device cap (restored after), and the units add `Nice=19` + `IOSchedulingClass=idle`.
+**Throttling** (this pool serves every service — see the 2026-06 boot I/O storm): the pool is
+capped at **30 MiB/s/device via `btrfs scrub limit --all`** *before* `scrub start` — **not**
+`scrub start --limit`, which silently skips some devids on a multi-device fs (it left devid 1
+unlimited and blew the cap to ~407 MiB/s; caught on the 2026-06-09 supervised run). The cap is
+reset to unlimited after. 30 MiB/s/device held `io full` PSI ~6% on the live pool (~24h for a
+full ~11 TiB pass). **/home (SSD) and the idle, separate-spindle backup drives scrub
+unlimited.** Units add `Nice=19` + `IOSchedulingClass=idle`.
 
 **Schedule (staggered, clear of Urd's 04:00):**
 - `btrfs-scrub-internal.timer` — pool `/mnt` + `/home`, **1st Sunday 14:00**
@@ -113,19 +117,24 @@ install -m 0644 ~/containers/systemd/btrfs-scrub-internal.{service,timer} \
                 ~/containers/systemd/btrfs-scrub-backups.{service,timer} ~/.config/systemd/user/
 systemctl --user daemon-reload
 
-# Supervised first run — watch that services stay responsive under the throttled scrub:
+# Supervised first run — watch that io *full* PSI stays low (not "some": a throttled scrub
+# inflates "some" by waiting on its own rate budget — only "full" means services are starved):
 systemctl --user start btrfs-scrub-internal.service &
-# in another pane: watch -n5 'cat /proc/pressure/io; echo; sudo btrfs scrub status /mnt'
-# Jellyfin/Immich/etc. should stay responsive. If I/O pressure spikes, lower --limit in
-# scripts/btrfs-scrub.sh AND the sudoers line (keep them byte-for-byte identical), re-install.
+# in another pane: watch -n5 'grep full /proc/pressure/io; sudo -n btrfs scrub status -R /mnt | grep bytes_scrubbed'
+# Jellyfin/Immich/etc. should stay responsive. To retune: change POOL_LIMIT in
+# scripts/btrfs-scrub.sh AND the matching `scrub limit` values in the sudoers line
+# (byte-for-byte), re-install. You can also adjust a running scrub live:
+#   sudo btrfs scrub limit --all --limit 20m /mnt
 
 # Once comfortable, enable the monthly timers:
 systemctl --user enable --now btrfs-scrub-internal.timer btrfs-scrub-backups.timer
 ```
 
-The pool scrub of ~11 TiB at 80 MiB/s/device runs **several hours** — expected. Watch the
-first completion's `btrfs_scrub_corrected_errors` (sdc has 8 reallocated sectors and is the
-likeliest source of a corrected/metadata blip).
+The pool scrub of ~11 TiB at 30 MiB/s/device (120 MiB/s total) runs **~24h** — expected and
+fine; it's a low-priority background integrity pass, not time-critical (finishes well within
+the monthly cadence). Watch the first completion's `btrfs_scrub_corrected_errors` (sdc has 8
+reallocated sectors and is the likeliest source of a corrected/metadata blip).
 
-> **Note:** `--limit` is fixed at `80m` in both the script and the sudoers line because sudo
-> matches the exact argv. To change the cap, edit *both* in lockstep.
+> **Note:** the pool cap (`30m`) and reset (`0`) are fixed in both the script (`POOL_LIMIT`)
+> and the sudoers `scrub limit` lines because sudo matches the exact argv. To change the cap,
+> edit *both* in lockstep. `/home` and the backups carry no cap.

--- a/scripts/btrfs-scrub.sh
+++ b/scripts/btrfs-scrub.sh
@@ -8,14 +8,18 @@
 # metadata mirror doing its job (a disk whispering). The point on Single data is
 # DETECTION: learn a file rotted while a good copy still exists in Urd.
 #
-# Throttling (this pool serves all services — see the 2026-06 boot I/O storm):
-#   btrfs scrub start -B -d -c 3 --limit 80m
-#     -B  foreground (the unit stays active for the scrub's duration -> coherent metrics)
-#     -d  per-device stats
-#     -c 3  idle ioprio class (bfq honours it)
-#     --limit 80m  hard 80 MiB/s/device cap, restored afterwards
-#   + unit-level Nice=19 / IOSchedulingClass=idle (belt-and-suspenders).
-# The --limit value here MUST match /etc/sudoers.d/homelab-storage-health byte-for-byte.
+# Throttling (the pool serves all services — see the 2026-06 boot I/O storm). The POOL is
+# capped via `btrfs scrub limit --all` BEFORE start, NOT `scrub start --limit`: the latter
+# silently skips some devids on a multi-device fs (verified 2026-06-09 — it left devid 1
+# unlimited, blowing the cap to ~407 MiB/s). /home (SSD) and the idle, separate-spindle
+# backup drives scrub unlimited (no service impact; per-device caps would also make the
+# single-device backups absurdly slow).
+#   btrfs scrub limit --all --limit 30m /mnt   # cap EVERY pool device (reliable)
+#   btrfs scrub start  -B -d -c 3 /mnt          # -B foreground, -d per-device, -c 3 idle ioprio
+#   btrfs scrub limit --all --limit 0  /mnt     # reset to unlimited afterwards (hygiene)
+#   + unit-level Nice=19 / IOSchedulingClass=idle.
+# 30 MiB/s/device held `io full` PSI ~6% on the live pool (supervised run 2026-06-09);
+# ~24h for a full ~11 TiB pass. These exact commands/values MUST match the sudoers grant.
 #
 # Usage:  btrfs-scrub.sh <mountpoint> [<mountpoint> ...]
 #   Each arg is scrubbed if it is a mounted btrfs (removable backups are skipped cleanly
@@ -26,7 +30,7 @@ set -uo pipefail
 export XDG_RUNTIME_DIR="/run/user/$(id -u)"
 
 BTRFS="/usr/sbin/btrfs"
-LIMIT="80m"                              # keep in sync with sudoers
+POOL_LIMIT="30m"                         # MiB/s per pool device; keep in sync with sudoers
 TEXTFILE_DIR="${HOME}/containers/data/backup-metrics"
 STATE_DIR="${TEXTFILE_DIR}/.scrub-state"
 OUT="${TEXTFILE_DIR}/btrfs-scrub.prom"
@@ -43,18 +47,33 @@ label_for() {  # mountpoint -> friendly filesystem label
     esac
 }
 
+limit_for() {  # MiB/s per device, or "" for unlimited. Only the pool is throttled.
+    case "$1" in
+        /mnt) echo "$POOL_LIMIT" ;;
+        *)    echo "" ;;
+    esac
+}
+
 scrub_one() {
-    local mnt="$1" label start end dur status corrected uncorrectable rc
+    local mnt="$1" label start end dur status corrected uncorrectable rc limit
     label="$(label_for "$mnt")"
     if ! mountpoint -q "$mnt" 2>/dev/null; then
         log "[$label] $mnt not mounted — skipping (removable/absent)"
         return 0
     fi
-    log "[$label] scrub starting on $mnt (idle ioprio, --limit ${LIMIT})"
+    limit="$(limit_for "$mnt")"
+    if [[ -n "$limit" ]]; then
+        log "[$label] capping every device at ${limit} via 'scrub limit --all' (pool serves services)"
+        sudo -n "$BTRFS" scrub limit --all --limit "$limit" "$mnt" >/dev/null 2>&1 \
+            || log "[$label] WARN: could not set scrub limit — scrub may run unthrottled"
+    fi
+    log "[$label] scrub starting on $mnt (idle ioprio${limit:+, ${limit}/device})"
     start="$(date +%s)"
-    sudo -n "$BTRFS" scrub start -B -d -c 3 --limit "$LIMIT" "$mnt" >/dev/null 2>&1
+    sudo -n "$BTRFS" scrub start -B -d -c 3 "$mnt" >/dev/null 2>&1
     rc=$?
     end="$(date +%s)"; dur=$((end - start))
+    # Reset the device cap so a future MANUAL full-speed scrub isn't silently throttled.
+    [[ -n "$limit" ]] && sudo -n "$BTRFS" scrub limit --all --limit 0 "$mnt" >/dev/null 2>&1 || true
     # btrfs scrub -B returns 0 (clean) or 3 (completed, found uncorrectable errors) when it
     # actually RAN; anything else means it failed to start/complete (sudo denied, drive gone,
     # already running). Do NOT record a completion in that case, or last_completion_timestamp


### PR DESCRIPTION
**Found on the supervised first run** (working exactly as intended — a real throttling bug caught on a watched pass, not as a sluggish homelab some Sunday).

## The bug
`btrfs scrub start --limit 80m` **silently skips some devids** on a multi-device fs — it left pool **devid 1 unlimited**, so the real rate was `3×80 + 1×unlimited ≈ 407 MiB/s` and `io full` PSI hit ~17-20%. The `--limit` flag on `scrub start` is unreliable here.

## The fix
`btrfs scrub limit --all` caps **every** device reliably (verified live: rate fell to exactly 60 MiB/s at 15m, 120 at 30m). So:
- `scrub limit --all --limit 30m /mnt` **before** `scrub start -B -d -c 3 /mnt` (no `--limit`), then reset to `0` (unlimited) after.
- **30 MiB/s/device** held `io full` PSI **~6-9%** on the live pool — ~24h for a full ~11 TiB pass (low-priority background, finishes well within the monthly cadence).
- **Pool only** is capped. `/home` (SSD) and the idle, separate-spindle backups scrub **unlimited** — no service impact, and it fixes single-device backups being absurdly slow under a per-device cap.

## Also
- Sudoers updated: drop `scrub start --limit`, add exact `scrub limit --all --limit 30m|0 /mnt` lines.
- Doc: corrected throttle explanation + the `some` vs `full` PSI gotcha (a throttled scrub inflates `some` by waiting on its budget; only `full` means starvation).

`bash -n` clean, `visudo -cf` parsed OK. The live first-pass scrub (started manually, throttled to 30m) is unaffected and validating the metrics pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)