### PR TITLE
fix(security-audit): de-flake SA-AUTH-02 Authelia health check

### DIFF
--- a/docs/AUTO-DEPENDENCY-GRAPH.md
+++ b/docs/AUTO-DEPENDENCY-GRAPH.md
@@ -1,6 +1,6 @@
 # Service Dependency Graph (Auto-Generated)
 
-**Generated:** 2026-06-09 00:01:11 UTC
+**Generated:** 2026-06-10 05:04:34 UTC
 **System:** fedora-htpc
 
 ---
@@ -194,12 +194,12 @@ Derived from `After=` directives in quadlet files. systemd handles this automati
 | forgejo-db | (no ordering constraints) |
 | gathio | gathio-db |
 | gathio-db | (no ordering constraints) |
-| grafana | (no ordering constraints) |
+| grafana | traefik |
 | home-assistant | (no ordering constraints) |
 | immich-ml | (no ordering constraints) |
 | immich-server | postgresql-immich,redis-immich |
 | jellyfin | (no ordering constraints) |
-| loki | (no ordering constraints) |
+| loki | traefik |
 | navidrome | traefik |
 | nextcloud | nextcloud-db,nextcloud-redis |
 | nextcloud-db | (no ordering constraints) |
@@ -208,7 +208,7 @@ Derived from `After=` directives in quadlet files. systemd handles this automati
 | pihole-exporter | traefik |
 | postgres-exporter | postgresql-immich |
 | postgresql-immich | (no ordering constraints) |
-| prometheus | node_exporter |
+| prometheus | node_exporter,traefik |
 | promtail | loki,traefik |
 | proton-bridge | (no ordering constraints) |
 | qbittorrent | (no ordering constraints) |

--- a/docs/AUTO-DOCUMENTATION-INDEX.md
+++ b/docs/AUTO-DOCUMENTATION-INDEX.md
@@ -1,7 +1,7 @@
 # Documentation Index (Auto-Generated)
 
-**Generated:** 2026-06-09 00:01:12 UTC
-**Total Documents:** 434
+**Generated:** 2026-06-10 05:04:34 UTC
+**Total Documents:** 438
 
 ---
 
@@ -98,7 +98,7 @@
 
 ---
 
-### 20-operations/ (26 documents)
+### 20-operations/ (28 documents)
 
 **Operational procedures, runbooks, and architecture**
 
@@ -118,6 +118,7 @@
 - [permission-optimization-nextcloud.md](20-operations/guides/permission-optimization-nextcloud.md)
 - [remediation-chains.md](20-operations/guides/remediation-chains.md)
 - [resource-limits-configuration.md](20-operations/guides/resource-limits-configuration.md)
+- [storage-health-monitoring.md](20-operations/guides/storage-health-monitoring.md)
 - [storage-layout.md](20-operations/guides/storage-layout.md)
 - [tier3-initial-backup.md](20-operations/guides/tier3-initial-backup.md)
 - [unpoller-metrics-guide.md](20-operations/guides/unpoller-metrics-guide.md)
@@ -227,7 +228,7 @@
 
 ---
 
-### 98-journals/ (213 documents)
+### 98-journals/ (215 documents)
 
 **Chronological project history (append-only log)**
 
@@ -249,16 +250,20 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 - 2026-06-09: [2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md](00-foundation/decisions/2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md)
 - 2026-06-06: [2026-06-05-ADR-032-forgejo-git-over-ssh-loopback.md](00-foundation/decisions/2026-06-05-ADR-032-forgejo-git-over-ssh-loopback.md)
 - 2026-06-06: [2026-06-06-ADR-034-forgejo-instance-commit-signing-ssh.md](00-foundation/decisions/2026-06-06-ADR-034-forgejo-instance-commit-signing-ssh.md)
+- 2026-06-09: [2026-06-09-ADR-035-boot-time-io-tiering.md](20-operations/decisions/2026-06-09-ADR-035-boot-time-io-tiering.md)
+- 2026-06-09: [storage-health-monitoring.md](20-operations/guides/storage-health-monitoring.md)
 - 2026-06-07: [2026-06-07-cabinet-cooling-fan-controller-SKETCH.md](97-plans/2026-06-07-cabinet-cooling-fan-controller-SKETCH.md)
 - 2026-06-04: [2026-06-04-branch-hygiene-adr021-cross-repo-and-churn-alert.md](98-journals/2026-06-04-branch-hygiene-adr021-cross-repo-and-churn-alert.md)
 - 2026-06-09: [2026-06-09-adr029-phase-b-db-migration-nocow.md](98-journals/2026-06-09-adr029-phase-b-db-migration-nocow.md)
+- 2026-06-09: [2026-06-09-reboot-io-storm-not-podman-deathloop.md](98-journals/2026-06-09-reboot-io-storm-not-podman-deathloop.md)
+- 2026-06-09: [2026-06-09-storage-health-monitoring.md](98-journals/2026-06-09-storage-health-monitoring.md)
 - 2026-06-09: [remediation-monthly-202605.md](99-reports/remediation-monthly-202605.md)
-- 2026-06-09: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
-- 2026-06-09: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
-- 2026-06-09: [AUTO-EGRESS-BASELINE-INDEX.md](AUTO-EGRESS-BASELINE-INDEX.md)
-- 2026-06-09: [AUTO-IMAGE-PIN-INDEX.md](AUTO-IMAGE-PIN-INDEX.md)
-- 2026-06-09: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
-- 2026-06-09: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
+- 2026-06-10: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
+- 2026-06-10: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
+- 2026-06-10: [AUTO-EGRESS-BASELINE-INDEX.md](AUTO-EGRESS-BASELINE-INDEX.md)
+- 2026-06-10: [AUTO-IMAGE-PIN-INDEX.md](AUTO-IMAGE-PIN-INDEX.md)
+- 2026-06-10: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
+- 2026-06-10: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
 
 ---
 

--- a/docs/AUTO-EGRESS-BASELINE-INDEX.md
+++ b/docs/AUTO-EGRESS-BASELINE-INDEX.md
@@ -1,6 +1,6 @@
 # Egress Observatory — Baseline Index (Auto-Generated)
 
-**Generated:** 2026-06-09 00:01:13 UTC
+**Generated:** 2026-06-10 05:04:35 UTC
 **Implements:** ADR-030 P7 (Tier 4) — egress detection. **Mode:** shadow (observe-only)
 
 Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers (attributable, rootless, scratch-safe, DNS-method-agnostic). Detection, not prevention. See `config/supply-chain/known-egress.md` for method and residual/evasion scope.
@@ -9,8 +9,8 @@ Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers
 
 | Component | Last run | Detail |
 |---|---|---|
-| Collector (`egress-collector.service`) | 23s ago | 22 services sampled |
-| Classifier (`egress-detect.timer`) | 8m ago | mode=shadow (observe-only); last window 9 dest(s) |
+| Collector (`egress-collector.service`) | 2s ago | 22 services sampled |
+| Classifier (`egress-detect.timer`) | 106s ago | mode=shadow (observe-only); last window 4 dest(s) |
 
 ## Per-service egress
 
@@ -21,11 +21,11 @@ Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers
 | audiobookshelf | classify | — | — | — |
 | authelia | classify | — | — | — |
 | blackbox-exporter | classify | — | — | — |
-| crowdsec | classify | 30 | 30 (unarmed) | — |
+| crowdsec | classify | 33 | 33 (unarmed) | — |
 | forgejo | classify | — | — | — |
 | gathio | classify | 2 | 2 (unarmed) | — |
 | grafana | classify | 3 | 3 (unarmed) | — |
-| home-assistant | classify | 41 | 41 (unarmed) | — |
+| home-assistant | classify | 42 | 42 (unarmed) | — |
 | immich-server | classify | 2 | 2 (unarmed) | — |
 | jellyfin | classify | 15 | 15 (unarmed) | — |
 | loki | classify | 1 | 1 (unarmed) | — |
@@ -34,10 +34,10 @@ Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers
 | pihole-exporter | classify | — | — | — |
 | prometheus | classify | — | — | — |
 | proton-bridge | classify | 2 | 2 (unarmed) | — |
-| qbittorrent | peer-swarm (count-only) | — | — | 127 |
+| qbittorrent | peer-swarm (count-only) | — | — | 131 |
 | traefik | classify | 8 | 8 (unarmed) | — |
 | unpoller | classify | — | — | — |
-| vaultwarden | classify | 79 | 79 (unarmed) | — |
+| vaultwarden | classify | 80 | 80 (unarmed) | — |
 
 ## Zero-egress candidates — blast-radius reduction (REPORT ONLY)
 
@@ -51,273 +51,278 @@ Egress-tier services with **no observed public destination** over the window. Ea
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `162.159.128.233` | 443 | ⚠️ unexpected | 12d ago | 62m ago | 32 |
-| `162.159.135.232` | 443 | ⚠️ unexpected | 15d ago | 62m ago | 41 |
-| `162.159.136.232` | 443 | ⚠️ unexpected | 7d ago | 62m ago | 37 |
-| `162.159.137.232` | 443 | ⚠️ unexpected | 4d ago | 62m ago | 40 |
-| `162.159.138.232` | 443 | ⚠️ unexpected | 14d ago | 72m ago | 44 |
+| `162.159.128.233` | 443 | ⚠️ unexpected | 13d ago | 30h ago | 32 |
+| `162.159.135.232` | 443 | ⚠️ unexpected | 16d ago | 30h ago | 41 |
+| `162.159.136.232` | 443 | ⚠️ unexpected | 9d ago | 30h ago | 37 |
+| `162.159.137.232` | 443 | ⚠️ unexpected | 5d ago | 30h ago | 40 |
+| `162.159.138.232` | 443 | ⚠️ unexpected | 15d ago | 30h ago | 44 |
 
 ### alertmanager
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `162.159.135.232` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 2 |
-| `162.159.138.232` | 80 | ⚠️ unexpected | 14d ago | 14d ago | 2 |
+| `162.159.135.232` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 2 |
+| `162.159.138.232` | 80 | ⚠️ unexpected | 15d ago | 15d ago | 2 |
 
 ### crowdsec
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `108.128.137.208` | 443 | ⚠️ unexpected | 10d ago | 2d ago | 486 |
-| `108.128.190.179` | 443 | ⚠️ unexpected | 12d ago | 3d ago | 515 |
-| `108.128.222.234` | 443 | ⚠️ unexpected | 15d ago | 7d ago | 472 |
-| `108.132.135.16` | 443 | ⚠️ unexpected | 17h ago | 3h ago | 63 |
-| `108.132.165.136` | 443 | ⚠️ unexpected | 6d ago | 37h ago | 237 |
-| `18.200.183.204` | 443 | ⚠️ unexpected | 15d ago | 9d ago | 362 |
-| `34.240.98.252` | 443 | ⚠️ unexpected | 4d ago | 19h ago | 252 |
-| `34.242.194.148` | 443 | ⚠️ unexpected | 9d ago | 2d ago | 406 |
-| `34.249.149.68` | 443 | ⚠️ unexpected | 5d ago | 8h ago | 277 |
-| `34.250.39.237` | 443 | ⚠️ unexpected | 2d ago | 3h ago | 124 |
-| `34.250.77.39` | 443 | ⚠️ unexpected | 15d ago | 5d ago | 582 |
-| `34.254.73.132` | 443 | ⚠️ unexpected | 2d ago | 40m ago | 168 |
-| `34.255.59.56` | 443 | ⚠️ unexpected | 15d ago | 5d ago | 512 |
-| `52.17.58.50` | 443 | ⚠️ unexpected | 14d ago | 12d ago | 181 |
-| `52.18.68.74` | 443 | ⚠️ unexpected | 12d ago | 5d ago | 458 |
-| `52.19.64.236` | 443 | ⚠️ unexpected | 35h ago | 8m ago | 60 |
-| `52.210.229.63` | 443 | ⚠️ unexpected | 6d ago | 19h ago | 370 |
-| `52.213.228.152` | 443 | ⚠️ unexpected | 15h ago | 3h ago | 40 |
-| `52.30.5.78` | 443 | ⚠️ unexpected | 15d ago | 12d ago | 157 |
-| `52.48.23.149` | 443 | ⚠️ unexpected | 3d ago | 4h ago | 232 |
-| `52.48.238.219` | 443 | ⚠️ unexpected | 3h ago | 8m ago | 15 |
-| `54.195.186.68` | 443 | ⚠️ unexpected | 4d ago | 11h ago | 249 |
-| `54.246.207.199` | 443 | ⚠️ unexpected | 5d ago | 4d ago | 113 |
-| `54.76.192.134` | 443 | ⚠️ unexpected | 7d ago | 2d ago | 337 |
-| `54.77.8.107` | 443 | ⚠️ unexpected | 15d ago | 7d ago | 533 |
-| `63.34.141.128` | 443 | ⚠️ unexpected | 15d ago | 11d ago | 196 |
-| `63.35.170.229` | 443 | ⚠️ unexpected | 2d ago | 2h ago | 144 |
-| `63.35.22.155` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 15 |
-| `79.125.15.38` | 443 | ⚠️ unexpected | 15d ago | 10d ago | 232 |
-| `99.80.129.27` | 443 | ⚠️ unexpected | 11d ago | 6d ago | 263 |
+| `108.128.137.208` | 443 | ⚠️ unexpected | 11d ago | 3d ago | 486 |
+| `108.128.190.179` | 443 | ⚠️ unexpected | 13d ago | 4d ago | 515 |
+| `108.128.222.234` | 443 | ⚠️ unexpected | 16d ago | 9d ago | 472 |
+| `108.132.135.16` | 443 | ⚠️ unexpected | 46h ago | 28h ago | 68 |
+| `108.132.165.136` | 443 | ⚠️ unexpected | 7d ago | 2d ago | 237 |
+| `18.200.183.204` | 443 | ⚠️ unexpected | 16d ago | 10d ago | 362 |
+| `34.240.98.252` | 443 | ⚠️ unexpected | 5d ago | 2d ago | 252 |
+| `34.242.194.148` | 443 | ⚠️ unexpected | 10d ago | 4d ago | 406 |
+| `34.249.149.68` | 443 | ⚠️ unexpected | 6d ago | 37h ago | 277 |
+| `34.250.39.237` | 443 | ⚠️ unexpected | 3d ago | 3h ago | 183 |
+| `34.250.77.39` | 443 | ⚠️ unexpected | 16d ago | 6d ago | 582 |
+| `34.254.73.132` | 443 | ⚠️ unexpected | 3d ago | 44m ago | 269 |
+| `34.255.143.231` | 443 | ⚠️ unexpected | 26h ago | 107m ago | 53 |
+| `34.255.59.56` | 443 | ⚠️ unexpected | 16d ago | 7d ago | 512 |
+| `52.17.58.50` | 443 | ⚠️ unexpected | 16d ago | 13d ago | 181 |
+| `52.18.68.74` | 443 | ⚠️ unexpected | 13d ago | 6d ago | 458 |
+| `52.19.64.236` | 443 | ⚠️ unexpected | 2d ago | 2h ago | 118 |
+| `52.210.229.63` | 443 | ⚠️ unexpected | 8d ago | 2d ago | 370 |
+| `52.213.228.152` | 443 | ⚠️ unexpected | 44h ago | 12m ago | 106 |
+| `52.30.5.78` | 443 | ⚠️ unexpected | 16d ago | 13d ago | 157 |
+| `52.48.23.149` | 443 | ⚠️ unexpected | 4d ago | 33h ago | 232 |
+| `52.48.238.219` | 443 | ⚠️ unexpected | 32h ago | 44m ago | 69 |
+| `54.195.186.68` | 443 | ⚠️ unexpected | 5d ago | 40h ago | 249 |
+| `54.246.207.199` | 443 | ⚠️ unexpected | 6d ago | 5d ago | 113 |
+| `54.76.169.38` | 443 | ⚠️ unexpected | 22h ago | 3h ago | 44 |
+| `54.76.192.134` | 443 | ⚠️ unexpected | 8d ago | 3d ago | 337 |
+| `54.77.8.107` | 443 | ⚠️ unexpected | 16d ago | 8d ago | 533 |
+| `63.34.141.128` | 443 | ⚠️ unexpected | 16d ago | 12d ago | 196 |
+| `63.35.170.229` | 443 | ⚠️ unexpected | 3d ago | 5h ago | 198 |
+| `63.35.22.155` | 443 | ⚠️ unexpected | 16d ago | 16d ago | 15 |
+| `79.125.15.38` | 443 | ⚠️ unexpected | 16d ago | 12d ago | 232 |
+| `99.80.129.27` | 443 | ⚠️ unexpected | 12d ago | 7d ago | 263 |
+| `99.81.12.92` | 443 | ⚠️ unexpected | 26h ago | 2h ago | 67 |
 
 ### gathio
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.16.4.34` | 443 | ⚠️ unexpected | 12d ago | 12d ago | 9 |
-| `104.16.7.34` | 443 | ⚠️ unexpected | 72m ago | 72m ago | 4 |
+| `104.16.4.34` | 443 | ⚠️ unexpected | 13d ago | 13d ago | 9 |
+| `104.16.7.34` | 443 | ⚠️ unexpected | 30h ago | 30h ago | 4 |
 
 ### grafana
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `192.0.73.2` | 443 | ⚠️ unexpected | 14d ago | 2d ago | 8 |
-| `34.120.177.193` | 443 | ⚠️ unexpected | 15d ago | 8m ago | 10953 |
-| `34.96.126.106` | 443 | ⚠️ unexpected | 14d ago | 13h ago | 72 |
+| `192.0.73.2` | 443 | ⚠️ unexpected | 15d ago | 3d ago | 8 |
+| `34.120.177.193` | 443 | ⚠️ unexpected | 16d ago | 106s ago | 11817 |
+| `34.96.126.106` | 443 | ⚠️ unexpected | 15d ago | 18h ago | 77 |
 
 ### home-assistant
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.26.4.238` | 443 | ⚠️ unexpected | 15d ago | 16h ago | 22 |
-| `104.26.5.238` | 443 | ⚠️ unexpected | 15d ago | 10h ago | 32 |
-| `151.101.1.195` | 443 | ⚠️ unexpected | 15d ago | 3h ago | 20 |
-| `151.101.65.195` | 443 | ⚠️ unexpected | 13d ago | 3d ago | 13 |
-| `157.249.81.141` | 443 | ⚠️ unexpected | 15d ago | 3h ago | 193 |
-| `172.67.68.90` | 443 | ⚠️ unexpected | 14d ago | 4h ago | 32 |
-| `18.156.89.194` | 443 | ⚠️ unexpected | 2d ago | 8m ago | 334 |
-| `18.158.217.49` | 8883 | ⚠️ unexpected | 45h ago | 22h ago | 2668 |
-| `18.158.22.138` | 8883 | ⚠️ unexpected | 12d ago | 12d ago | 1702 |
-| `18.158.224.141` | 8883 | ⚠️ unexpected | 5d ago | 3d ago | 5641 |
-| `18.159.77.159` | 8883 | ⚠️ unexpected | 3d ago | 3d ago | 755 |
-| `18.159.79.242` | 8883 | ⚠️ unexpected | 7d ago | 6d ago | 2777 |
-| `18.184.210.208` | 8883 | ⚠️ unexpected | 15d ago | 14d ago | 1297 |
-| `18.184.241.150` | 8883 | ⚠️ unexpected | 46h ago | 45h ago | 58 |
-| `18.194.113.141` | 8883 | ⚠️ unexpected | 10d ago | 10d ago | 356 |
-| `18.194.166.209` | 8883 | ⚠️ unexpected | 72m ago | 8m ago | 133 |
-| `18.196.104.106` | 8883 | ⚠️ unexpected | 8d ago | 7d ago | 2729 |
-| `18.198.195.194` | 8883 | ⚠️ unexpected | 14d ago | 12d ago | 5585 |
-| `3.120.211.84` | 8883 | ⚠️ unexpected | 3d ago | 46h ago | 4832 |
-| `3.120.216.195` | 443 | ⚠️ unexpected | 12d ago | 2d ago | 800 |
-| `3.120.53.2` | 8883 | ⚠️ unexpected | 12d ago | 10d ago | 3923 |
-| `3.121.10.31` | 8883 | ⚠️ unexpected | 10d ago | 10d ago | 759 |
-| `3.121.101.237` | 8883 | ⚠️ unexpected | 22h ago | 118m ago | 2420 |
-| `3.121.111.53` | 443 | ⚠️ unexpected | 7d ago | 23h ago | 599 |
-| `3.121.169.115` | 8883 | ⚠️ unexpected | 10d ago | 8d ago | 4472 |
-| `3.122.171.67` | 443 | ⚠️ unexpected | 10d ago | 2d ago | 708 |
-| `3.122.70.209` | 8883 | ⚠️ unexpected | 6d ago | 5d ago | 2815 |
-| `3.124.29.182` | 443 | ⚠️ unexpected | 15d ago | 7d ago | 810 |
-| `3.125.16.42` | 443 | ⚠️ unexpected | 2d ago | 10h ago | 239 |
-| `3.125.66.145` | 443 | ⚠️ unexpected | 15d ago | 10d ago | 491 |
-| `3.67.142.130` | 443 | ⚠️ unexpected | 15d ago | 5d ago | 907 |
-| `35.156.5.143` | 443 | ⚠️ unexpected | 5d ago | 2d ago | 254 |
-| `35.158.64.12` | 443 | ⚠️ unexpected | 5d ago | 8m ago | 546 |
-| `52.28.32.0` | 443 | ⚠️ unexpected | 28h ago | 30m ago | 118 |
-| `52.29.1.243` | 443 | ⚠️ unexpected | 9h ago | 8m ago | 55 |
-| `52.29.210.73` | 443 | ⚠️ unexpected | 15d ago | 5d ago | 926 |
-| `52.57.174.242` | 443 | ⚠️ unexpected | 15d ago | 12d ago | 429 |
-| `52.58.153.107` | 443 | ⚠️ unexpected | 7d ago | 28h ago | 542 |
-| `52.58.33.43` | 443 | ⚠️ unexpected | 23h ago | 8m ago | 122 |
-| `63.181.21.188` | 443 | ⚠️ unexpected | 2d ago | 19m ago | 313 |
-| `63.181.74.73` | 443 | ⚠️ unexpected | 15d ago | 7d ago | 789 |
+| `104.26.4.238` | 443 | ⚠️ unexpected | 16d ago | 45h ago | 22 |
+| `104.26.5.238` | 443 | ⚠️ unexpected | 16d ago | 12h ago | 36 |
+| `151.101.1.195` | 443 | ⚠️ unexpected | 16d ago | 32h ago | 20 |
+| `151.101.65.195` | 443 | ⚠️ unexpected | 14d ago | 8h ago | 14 |
+| `157.249.81.141` | 443 | ⚠️ unexpected | 16d ago | 13h ago | 201 |
+| `172.67.68.90` | 443 | ⚠️ unexpected | 15d ago | 33h ago | 32 |
+| `18.156.89.194` | 443 | ⚠️ unexpected | 4d ago | 33m ago | 419 |
+| `18.158.11.29` | 8883 | ⚠️ unexpected | 3h ago | 106s ago | 442 |
+| `18.158.217.49` | 8883 | ⚠️ unexpected | 3d ago | 2d ago | 2668 |
+| `18.158.22.138` | 8883 | ⚠️ unexpected | 14d ago | 13d ago | 1702 |
+| `18.158.224.141` | 8883 | ⚠️ unexpected | 7d ago | 5d ago | 5641 |
+| `18.159.77.159` | 8883 | ⚠️ unexpected | 5d ago | 4d ago | 755 |
+| `18.159.79.242` | 8883 | ⚠️ unexpected | 9d ago | 8d ago | 2777 |
+| `18.184.210.208` | 8883 | ⚠️ unexpected | 16d ago | 16d ago | 1297 |
+| `18.184.241.150` | 8883 | ⚠️ unexpected | 3d ago | 3d ago | 58 |
+| `18.194.113.141` | 8883 | ⚠️ unexpected | 11d ago | 11d ago | 356 |
+| `18.194.166.209` | 8883 | ⚠️ unexpected | 30h ago | 3h ago | 3094 |
+| `18.196.104.106` | 8883 | ⚠️ unexpected | 10d ago | 9d ago | 2729 |
+| `18.198.195.194` | 8883 | ⚠️ unexpected | 16d ago | 14d ago | 5585 |
+| `3.120.211.84` | 8883 | ⚠️ unexpected | 4d ago | 3d ago | 4832 |
+| `3.120.216.195` | 443 | ⚠️ unexpected | 13d ago | 4d ago | 800 |
+| `3.120.53.2` | 8883 | ⚠️ unexpected | 13d ago | 12d ago | 3923 |
+| `3.121.10.31` | 8883 | ⚠️ unexpected | 12d ago | 11d ago | 759 |
+| `3.121.101.237` | 8883 | ⚠️ unexpected | 2d ago | 31h ago | 2420 |
+| `3.121.111.53` | 443 | ⚠️ unexpected | 8d ago | 2d ago | 599 |
+| `3.121.169.115` | 8883 | ⚠️ unexpected | 11d ago | 10d ago | 4472 |
+| `3.122.171.67` | 443 | ⚠️ unexpected | 12d ago | 3d ago | 708 |
+| `3.122.70.209` | 8883 | ⚠️ unexpected | 8d ago | 7d ago | 2815 |
+| `3.124.29.182` | 443 | ⚠️ unexpected | 16d ago | 8d ago | 810 |
+| `3.125.16.42` | 443 | ⚠️ unexpected | 3d ago | 39h ago | 239 |
+| `3.125.66.145` | 443 | ⚠️ unexpected | 16d ago | 12d ago | 491 |
+| `3.67.142.130` | 443 | ⚠️ unexpected | 16d ago | 6d ago | 907 |
+| `35.156.5.143` | 443 | ⚠️ unexpected | 6d ago | 3d ago | 254 |
+| `35.158.64.12` | 443 | ⚠️ unexpected | 6d ago | 12m ago | 656 |
+| `52.28.32.0` | 443 | ⚠️ unexpected | 2d ago | 12m ago | 225 |
+| `52.29.1.243` | 443 | ⚠️ unexpected | 38h ago | 106s ago | 160 |
+| `52.29.210.73` | 443 | ⚠️ unexpected | 16d ago | 6d ago | 926 |
+| `52.57.174.242` | 443 | ⚠️ unexpected | 16d ago | 13d ago | 429 |
+| `52.58.153.107` | 443 | ⚠️ unexpected | 8d ago | 2d ago | 542 |
+| `52.58.33.43` | 443 | ⚠️ unexpected | 2d ago | 12m ago | 218 |
+| `63.181.21.188` | 443 | ⚠️ unexpected | 3d ago | 33m ago | 425 |
+| `63.181.74.73` | 443 | ⚠️ unexpected | 16d ago | 8d ago | 789 |
 
 ### immich-server
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.21.71.92` | 443 | ⚠️ unexpected | 15d ago | 2h ago | 406 |
-| `172.67.170.79` | 443 | ⚠️ unexpected | 15d ago | 30m ago | 378 |
+| `104.21.71.92` | 443 | ⚠️ unexpected | 16d ago | 97m ago | 436 |
+| `172.67.170.79` | 443 | ⚠️ unexpected | 16d ago | 33m ago | 415 |
 
 ### jellyfin
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.17.207.5` | 443 | ⚠️ unexpected | 15d ago | 7h ago | 9 |
-| `104.17.208.5` | 443 | ⚠️ unexpected | 14d ago | 2d ago | 18 |
-| `139.59.139.28` | 443 | ⚠️ unexpected | 12d ago | 7d ago | 9 |
-| `146.190.237.6` | 443 | ⚠️ unexpected | 10d ago | 3d ago | 18 |
-| `151.101.1.229` | 443 | ⚠️ unexpected | 10d ago | 31h ago | 10 |
-| `151.101.129.229` | 443 | ⚠️ unexpected | 9d ago | 5d ago | 7 |
-| `151.101.193.229` | 443 | ⚠️ unexpected | 13d ago | 4d ago | 6 |
-| `151.101.65.229` | 443 | ⚠️ unexpected | 72m ago | 72m ago | 1 |
-| `157.245.38.19` | 443 | ⚠️ unexpected | 11d ago | 11d ago | 5 |
-| `161.35.245.42` | 443 | ⚠️ unexpected | 9d ago | 4d ago | 7 |
-| `165.227.169.147` | 443 | ⚠️ unexpected | 15d ago | 72m ago | 32 |
-| `165.227.244.161` | 443 | ⚠️ unexpected | 14d ago | 72m ago | 19 |
-| `178.105.98.131` | 443 | ⚠️ unexpected | 15d ago | 31h ago | 14 |
-| `206.189.97.173` | 443 | ⚠️ unexpected | 8d ago | 7h ago | 9 |
-| `68.183.204.194` | 443 | ⚠️ unexpected | 15d ago | 72m ago | 9 |
+| `104.17.207.5` | 443 | ⚠️ unexpected | 16d ago | 36h ago | 9 |
+| `104.17.208.5` | 443 | ⚠️ unexpected | 15d ago | 3d ago | 18 |
+| `139.59.139.28` | 443 | ⚠️ unexpected | 13d ago | 8d ago | 9 |
+| `146.190.237.6` | 443 | ⚠️ unexpected | 11d ago | 4d ago | 18 |
+| `151.101.1.229` | 443 | ⚠️ unexpected | 11d ago | 2d ago | 10 |
+| `151.101.129.229` | 443 | ⚠️ unexpected | 10d ago | 6h ago | 10 |
+| `151.101.193.229` | 443 | ⚠️ unexpected | 14d ago | 5d ago | 6 |
+| `151.101.65.229` | 443 | ⚠️ unexpected | 30h ago | 30h ago | 1 |
+| `157.245.38.19` | 443 | ⚠️ unexpected | 12d ago | 12d ago | 5 |
+| `161.35.245.42` | 443 | ⚠️ unexpected | 10d ago | 5d ago | 7 |
+| `165.227.169.147` | 443 | ⚠️ unexpected | 16d ago | 30h ago | 32 |
+| `165.227.244.161` | 443 | ⚠️ unexpected | 15d ago | 30h ago | 19 |
+| `178.105.98.131` | 443 | ⚠️ unexpected | 16d ago | 6h ago | 17 |
+| `206.189.97.173` | 443 | ⚠️ unexpected | 9d ago | 6h ago | 14 |
+| `68.183.204.194` | 443 | ⚠️ unexpected | 16d ago | 6h ago | 10 |
 
 ### loki
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `34.96.126.106` | 443 | ⚠️ unexpected | 15d ago | 5h ago | 451 |
+| `34.96.126.106` | 443 | ⚠️ unexpected | 16d ago | 2h ago | 486 |
 
 ### navidrome
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.21.43.229` | 443 | ⚠️ unexpected | 72m ago | 72m ago | 1 |
-| `130.211.19.189` | 443 | ⚠️ unexpected | 14d ago | 11d ago | 13 |
-| `151.101.237.188` | 443 | ⚠️ unexpected | 14d ago | 11d ago | 7 |
-| `151.101.238.53` | 443 | ⚠️ unexpected | 14d ago | 11d ago | 6 |
-| `151.101.238.79` | 443 | ⚠️ unexpected | 14d ago | 11d ago | 6 |
-| `2.22.225.107` | 443 | ⚠️ unexpected | 11d ago | 11d ago | 3 |
-| `2.22.225.83` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 4 |
-| `209.141.42.198` | 443 | ⚠️ unexpected | 15d ago | 40m ago | 52 |
+| `104.21.43.229` | 443 | ⚠️ unexpected | 30h ago | 30h ago | 1 |
+| `130.211.19.189` | 443 | ⚠️ unexpected | 15d ago | 12d ago | 13 |
+| `151.101.237.188` | 443 | ⚠️ unexpected | 15d ago | 12d ago | 7 |
+| `151.101.238.53` | 443 | ⚠️ unexpected | 15d ago | 12d ago | 6 |
+| `151.101.238.79` | 443 | ⚠️ unexpected | 15d ago | 12d ago | 6 |
+| `2.22.225.107` | 443 | ⚠️ unexpected | 12d ago | 12d ago | 3 |
+| `2.22.225.83` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 4 |
+| `209.141.42.198` | 443 | ⚠️ unexpected | 16d ago | 5h ago | 55 |
 
 ### nextcloud
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `65.108.197.113` | 443 | ⚠️ unexpected | 12d ago | 6d ago | 8 |
-| `65.109.114.179` | 443 | ⚠️ unexpected | 14d ago | 15h ago | 14 |
-| `65.21.231.50` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 2 |
-| `95.217.53.153` | 443 | ⚠️ unexpected | 13d ago | 28h ago | 14 |
+| `65.108.197.113` | 443 | ⚠️ unexpected | 13d ago | 7d ago | 8 |
+| `65.109.114.179` | 443 | ⚠️ unexpected | 15d ago | 44h ago | 14 |
+| `65.21.231.50` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 2 |
+| `95.217.53.153` | 443 | ⚠️ unexpected | 14d ago | 20h ago | 16 |
 
 ### proton-bridge
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `185.70.42.41` | 443 | ⚠️ unexpected | 15d ago | 8m ago | 12366 |
-| `185.70.42.45` | 443 | ⚠️ unexpected | 15d ago | 108m ago | 405 |
+| `185.70.42.41` | 443 | ⚠️ unexpected | 16d ago | 106s ago | 13357 |
+| `185.70.42.45` | 443 | ⚠️ unexpected | 16d ago | 22m ago | 447 |
 
 ### traefik
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.19.192.29` | 443 | ⚠️ unexpected | 11d ago | 11d ago | 5 |
-| `104.19.193.29` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 6 |
-| `104.26.3.101` | 443 | ⚠️ unexpected | 14d ago | 12d ago | 15 |
-| `13.39.208.199` | 443 | ⚠️ unexpected | 15d ago | 62m ago | 56 |
-| `140.82.121.5` | 443 | ⚠️ unexpected | 14d ago | 7h ago | 12 |
-| `140.82.121.6` | 443 | ⚠️ unexpected | 15d ago | 72m ago | 10 |
-| `172.65.32.248` | 443 | ⚠️ unexpected | 14d ago | 11d ago | 25 |
-| `172.67.75.8` | 443 | ⚠️ unexpected | 108m ago | 108m ago | 5 |
+| `104.19.192.29` | 443 | ⚠️ unexpected | 12d ago | 12d ago | 5 |
+| `104.19.193.29` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 6 |
+| `104.26.3.101` | 443 | ⚠️ unexpected | 15d ago | 13d ago | 15 |
+| `13.39.208.199` | 443 | ⚠️ unexpected | 16d ago | 6h ago | 59 |
+| `140.82.121.5` | 443 | ⚠️ unexpected | 15d ago | 36h ago | 12 |
+| `140.82.121.6` | 443 | ⚠️ unexpected | 16d ago | 6h ago | 11 |
+| `172.65.32.248` | 443 | ⚠️ unexpected | 15d ago | 12d ago | 25 |
+| `172.67.75.8` | 443 | ⚠️ unexpected | 30h ago | 30h ago | 5 |
 
 ### vaultwarden
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.16.123.96` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `104.16.132.229` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `104.16.99.29` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `104.17.17.78` | 443 | ⚠️ unexpected | 8d ago | 2d ago | 5 |
-| `104.17.17.78` | 80 | ⚠️ unexpected | 8d ago | 2d ago | 5 |
-| `104.18.14.13` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `104.18.161.117` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `104.18.179.120` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 3 |
-| `104.18.193.106` | 443 | ⚠️ unexpected | 8d ago | 2d ago | 5 |
-| `104.18.27.69` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `104.18.35.237` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `104.19.171.101` | 80 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
-| `104.19.171.101` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
-| `104.19.172.101` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
-| `104.19.172.101` | 80 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
-| `104.20.7.63` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 3 |
-| `104.26.1.18` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 2 |
-| `13.107.6.156` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
-| `135.181.128.221` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 2 |
-| `138.199.37.230` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
-| `150.171.109.200` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 2 |
-| `151.101.129.91` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 1 |
-| `151.101.237.91` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 1 |
-| `151.101.239.52` | 443 | ⚠️ unexpected | 8d ago | 6d ago | 2 |
-| `151.101.67.52` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 1 |
-| `162.125.248.18` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 1 |
-| `162.125.71.18` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 1 |
-| `162.159.137.232` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `172.66.137.109` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 2 |
-| `172.67.74.138` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `18.195.2.2` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 3 |
-| `18.224.126.143` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
-| `185.109.198.109` | 80 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
-| `185.31.213.113` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 3 |
-| `193.212.190.216` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 1 |
-| `194.132.66.34` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 2 |
-| `194.242.11.186` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 2 |
-| `198.252.206.1` | 80 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
-| `198.252.206.1` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
-| `20.190.147.4` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
-| `20.190.177.20` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 3 |
-| `217.114.94.2` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `3.167.1.165` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 3 |
-| `3.167.2.39` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 2 |
-| `3.167.2.44` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `3.167.2.45` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `3.167.2.93` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 2 |
-| `3.167.2.97` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `3.33.186.135` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `34.110.155.89` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `34.95.108.49` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 2 |
-| `35.186.224.24` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 2 |
-| `35.231.208.158` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 2 |
-| `52.195.100.115` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 2 |
-| `52.196.64.126` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 3 |
-| `52.198.57.38` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 1 |
-| `52.222.187.52` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 3 |
-| `52.84.50.103` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 2 |
-| `52.84.50.115` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 3 |
-| `52.84.50.125` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `52.84.50.126` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `52.84.50.128` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 2 |
-| `52.84.50.128` | 80 | ⚠️ unexpected | 6d ago | 6d ago | 2 |
-| `52.84.50.14` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 2 |
-| `52.84.50.16` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `52.84.50.2` | 443 | ⚠️ unexpected | 33h ago | 33h ago | 2 |
-| `52.84.50.22` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `52.84.50.4` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 2 |
-| `52.84.50.61` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
-| `54.240.174.10` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 2 |
-| `54.240.174.91` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 2 |
-| `62.249.184.112` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 1 |
-| `66.33.60.34` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 3 |
-| `76.76.21.21` | 443 | ⚠️ unexpected | 14d ago | 8d ago | 5 |
-| `76.76.21.22` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 2 |
-| `95.101.10.146` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 1 |
-| `95.101.10.154` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 1 |
-| `95.101.10.97` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 1 |
-| `98.82.155.134` | 443 | ⚠️ unexpected | 14d ago | 14d ago | 3 |
+| `104.16.123.96` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
+| `104.16.132.229` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
+| `104.16.99.29` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
+| `104.17.17.78` | 443 | ⚠️ unexpected | 9d ago | 3d ago | 5 |
+| `104.17.17.78` | 80 | ⚠️ unexpected | 9d ago | 3d ago | 5 |
+| `104.18.14.13` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
+| `104.18.161.117` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
+| `104.18.179.120` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 3 |
+| `104.18.193.106` | 443 | ⚠️ unexpected | 9d ago | 3d ago | 5 |
+| `104.18.27.69` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
+| `104.18.35.237` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
+| `104.19.171.101` | 80 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
+| `104.19.171.101` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
+| `104.19.172.101` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
+| `104.19.172.101` | 80 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
+| `104.20.7.63` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 3 |
+| `104.26.1.18` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 2 |
+| `13.107.6.156` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
+| `135.181.128.221` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 2 |
+| `138.199.37.230` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
+| `150.171.109.200` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 2 |
+| `151.101.129.91` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 1 |
+| `151.101.237.91` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 1 |
+| `151.101.239.52` | 443 | ⚠️ unexpected | 9d ago | 7d ago | 2 |
+| `151.101.67.52` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 1 |
+| `162.125.248.18` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 1 |
+| `162.125.71.18` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 1 |
+| `162.159.137.232` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
+| `172.66.137.109` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 2 |
+| `172.67.74.138` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
+| `18.195.2.2` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 3 |
+| `18.224.126.143` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
+| `185.109.198.109` | 80 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
+| `185.31.213.113` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 3 |
+| `193.212.190.216` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 1 |
+| `194.132.66.34` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 2 |
+| `194.242.11.186` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 2 |
+| `198.252.206.1` | 80 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
+| `198.252.206.1` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
+| `20.190.147.4` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
+| `20.190.177.20` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
+| `217.114.94.2` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
+| `3.167.1.165` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 3 |
+| `3.167.2.39` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 2 |
+| `3.167.2.44` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
+| `3.167.2.45` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
+| `3.167.2.93` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 2 |
+| `3.167.2.97` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
+| `3.33.186.135` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
+| `34.110.155.89` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
+| `34.95.108.49` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 2 |
+| `35.186.224.24` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 2 |
+| `35.231.208.158` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 2 |
+| `52.195.100.115` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 2 |
+| `52.196.64.126` | 443 | ⚠️ unexpected | 5d ago | 5d ago | 3 |
+| `52.198.57.38` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 1 |
+| `52.222.187.52` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 3 |
+| `52.84.50.103` | 443 | ⚠️ unexpected | 15d ago | 8h ago | 4 |
+| `52.84.50.115` | 443 | ⚠️ unexpected | 5d ago | 5d ago | 3 |
+| `52.84.50.125` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
+| `52.84.50.126` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
+| `52.84.50.128` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 2 |
+| `52.84.50.128` | 80 | ⚠️ unexpected | 7d ago | 7d ago | 2 |
+| `52.84.50.14` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 2 |
+| `52.84.50.16` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
+| `52.84.50.2` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 2 |
+| `52.84.50.22` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
+| `52.84.50.4` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 2 |
+| `52.84.50.61` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
+| `54.178.185.42` | 443 | ⚠️ unexpected | 8h ago | 8h ago | 2 |
+| `54.240.174.10` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 2 |
+| `54.240.174.91` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 2 |
+| `62.249.184.112` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 1 |
+| `66.33.60.34` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 3 |
+| `76.76.21.21` | 443 | ⚠️ unexpected | 15d ago | 9d ago | 5 |
+| `76.76.21.22` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 2 |
+| `95.101.10.146` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 1 |
+| `95.101.10.154` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 1 |
+| `95.101.10.97` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 1 |
+| `98.82.155.134` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 3 |
 
 ---
 

--- a/docs/AUTO-IMAGE-PIN-INDEX.md
+++ b/docs/AUTO-IMAGE-PIN-INDEX.md
@@ -1,6 +1,6 @@
 # Container Image Pin Index (Auto-Generated)
 
-**Generated:** 2026-06-09 00:01:13 UTC
+**Generated:** 2026-06-10 05:04:35 UTC
 **Source:** `/home/patriark/containers/quadlets` — ADR-030 (Container Supply-Chain Trust Model)
 
 Pins live in each quadlet's `Image=` line (where Podman reads them); this is

--- a/docs/AUTO-NETWORK-TOPOLOGY.md
+++ b/docs/AUTO-NETWORK-TOPOLOGY.md
@@ -1,6 +1,6 @@
 # Network Topology (Auto-Generated)
 
-**Generated:** 2026-06-09 00:01:07 UTC
+**Generated:** 2026-06-10 05:04:29 UTC
 **System:** fedora-htpc | **Networks:** 11 | **Containers:** 37
 
 ---

--- a/docs/AUTO-SERVICE-CATALOG.md
+++ b/docs/AUTO-SERVICE-CATALOG.md
@@ -1,6 +1,6 @@
 # Service Catalog (Auto-Generated)
 
-**Generated:** 2026-06-09 00:01:06 UTC
+**Generated:** 2026-06-10 05:04:28 UTC
 **System:** fedora-htpc | **Services:** 37/37 running | **Health:** 32/32 healthy (5 without healthcheck)
 
 ---
@@ -9,83 +9,83 @@
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| audiobookshelf | advplyr/audiobookshelf@sha256:89276ff2e0b3d2f | ✅ healthy | ~anh | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
-| blackbox-exporter | quay.io/prometheus/blackbox-exporter@sha256:e | ✅ healthy | ~anh | — | — |
-| forgejo | codeberg.org/forgejo/forgejo@sha256:db04c7114 | ✅ healthy | ~anh | [git.patriark.org](https://git.patriark.org) | — |
-| forgejo-db | postgres@sha256:16bc17c64a573ef34162af9298258 | ✅ healthy | ~anh | — | — |
-| navidrome | deluan/navidrome@sha256:9fa40b3d8dec43ceb2213 | ✅ healthy | ~anh | [musikk.patriark.org](https://musikk.patriark.org) | — |
-| pihole-exporter | ekofr/pihole-exporter@sha256:a890cc731a39da71 | — no check | ~anh | — | — |
-| postgres-exporter | quay.io/prometheuscommunity/postgres-exporter | ✅ healthy | ~anh | — | — |
-| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | ~anh | — | — |
-| qbittorrent | linuxserver/qbittorrent@sha256:f76c4363cce083 | ✅ healthy | ~anh | [torrent.patriark.org](https://torrent.patriark.org) | — |
-| redis-authelia-exporter | quay.io/oliver006/redis_exporter@sha256:e8c20 | — no check | ~anh | — | — |
-| redis-immich-exporter | quay.io/oliver006/redis_exporter@sha256:e8c20 | — no check | ~anh | — | — |
-| unifi-syslog | linuxserver/syslog-ng@sha256:0d164e438d1f9ee4 | ✅ healthy | ~anh | — | — |
+| audiobookshelf | advplyr/audiobookshelf@sha256:89276ff2e0b3d2f | ✅ healthy | 30h | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
+| blackbox-exporter | quay.io/prometheus/blackbox-exporter@sha256:e | ✅ healthy | 30h | — | — |
+| forgejo | codeberg.org/forgejo/forgejo@sha256:db04c7114 | ✅ healthy | 30h | [git.patriark.org](https://git.patriark.org) | — |
+| forgejo-db | postgres@sha256:16bc17c64a573ef34162af9298258 | ✅ healthy | 30h | — | — |
+| navidrome | deluan/navidrome@sha256:9fa40b3d8dec43ceb2213 | ✅ healthy | 30h | [musikk.patriark.org](https://musikk.patriark.org) | — |
+| pihole-exporter | ekofr/pihole-exporter@sha256:a890cc731a39da71 | — no check | 30h | — | — |
+| postgres-exporter | quay.io/prometheuscommunity/postgres-exporter | ✅ healthy | 30h | — | — |
+| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | 30h | — | — |
+| qbittorrent | linuxserver/qbittorrent@sha256:f76c4363cce083 | ✅ healthy | 30h | [torrent.patriark.org](https://torrent.patriark.org) | — |
+| redis-authelia-exporter | quay.io/oliver006/redis_exporter@sha256:e8c20 | — no check | 30h | — | — |
+| redis-immich-exporter | quay.io/oliver006/redis_exporter@sha256:e8c20 | — no check | 30h | — | — |
+| unifi-syslog | linuxserver/syslog-ng@sha256:0d164e438d1f9ee4 | ✅ healthy | 30h | — | — |
 
 ## Core Infrastructure (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| authelia | authelia/authelia@sha256:0c824dcab1ae97c56bf6 | ✅ healthy | ~anh | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
-| crowdsec | crowdsecurity/crowdsec@sha256:2f527c9bb8b3671 | ✅ healthy | ~anh | — | [guide](10-services/guides/crowdsec.md) |
-| redis-authelia | redis@sha256:6ab0b6e7381779332f97b8ca76193e45 | ✅ healthy | ~anh | — | — |
-| traefik | traefik@sha256:6b9cbca6fac42ab0075f5437d8dc16 | ✅ healthy | ~anh | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
+| authelia | authelia/authelia@sha256:0c824dcab1ae97c56bf6 | ✅ healthy | 30h | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
+| crowdsec | crowdsecurity/crowdsec@sha256:2f527c9bb8b3671 | ✅ healthy | 30h | — | [guide](10-services/guides/crowdsec.md) |
+| redis-authelia | redis@sha256:6ab0b6e7381779332f97b8ca76193e45 | ✅ healthy | 30h | — | — |
+| traefik | traefik@sha256:6b9cbca6fac42ab0075f5437d8dc16 | ✅ healthy | 30h | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
 
 ## Nextcloud (3)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| nextcloud-db | mariadb@sha256:78a5047d3ba33975f183f183c2464c | ✅ healthy | ~anh | — | [guide](10-services/guides/nextcloud.md) |
-| nextcloud | nextcloud@sha256:b67959acacd54ed2d110e111c8b2 | ✅ healthy | ~anh | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
-| nextcloud-redis | redis@sha256:6ab0b6e7381779332f97b8ca76193e45 | ✅ healthy | ~anh | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-db | mariadb@sha256:78a5047d3ba33975f183f183c2464c | ✅ healthy | 30h | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud | nextcloud@sha256:b67959acacd54ed2d110e111c8b2 | ✅ healthy | 30h | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-redis | redis@sha256:6ab0b6e7381779332f97b8ca76193e45 | ✅ healthy | 30h | — | [guide](10-services/guides/nextcloud.md) |
 
 ## Immich (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| immich-ml | immich-app/immich-machine-learning@sha256:a25 | ✅ healthy | ~anh | — | [guide](10-services/guides/immich.md) |
-| immich-server | immich-app/immich-server@sha256:c15bff75068ef | ✅ healthy | ~anh | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
-| postgresql-immich | immich-app/postgres@sha256:bcf63357191b76a916 | ✅ healthy | ~anh | — | — |
-| redis-immich | valkey/valkey@sha256:8436e10bc65c94886a91d441 | ✅ healthy | ~anh | — | — |
+| immich-ml | immich-app/immich-machine-learning@sha256:a25 | ✅ healthy | 30h | — | [guide](10-services/guides/immich.md) |
+| immich-server | immich-app/immich-server@sha256:c15bff75068ef | ✅ healthy | 30h | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
+| postgresql-immich | immich-app/postgres@sha256:bcf63357191b76a916 | ✅ healthy | 30h | — | — |
+| redis-immich | valkey/valkey@sha256:8436e10bc65c94886a91d441 | ✅ healthy | 30h | — | — |
 
 ## Jellyfin (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| jellyfin | jellyfin/jellyfin@sha256:1694ff069f0c9dafb283 | ✅ healthy | ~anh | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
+| jellyfin | jellyfin/jellyfin@sha256:1694ff069f0c9dafb283 | ✅ healthy | 30h | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
 
 ## Vaultwarden (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| vaultwarden | vaultwarden/server@sha256:d626d04934cd1192ad8 | ✅ healthy | ~anh | [vault.patriark.org](https://vault.patriark.org) | — |
+| vaultwarden | vaultwarden/server@sha256:d626d04934cd1192ad8 | ✅ healthy | 30h | [vault.patriark.org](https://vault.patriark.org) | — |
 
 ## Home Automation (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| home-assistant | home-assistant/home-assistant@sha256:d4fbec16 | ✅ healthy | ~anh | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
+| home-assistant | home-assistant/home-assistant@sha256:d4fbec16 | ✅ healthy | 30h | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
 
 ## Gathio (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| gathio-db | mongo@sha256:32979a1189dfdc44da3f5ed40d910495 | ✅ healthy | ~anh | — | — |
-| gathio | lowercasename/gathio@sha256:b7e9675d4e22b62e4 | ✅ healthy | ~anh | [events.patriark.org](https://events.patriark.org) | — |
+| gathio-db | mongo@sha256:32979a1189dfdc44da3f5ed40d910495 | ✅ healthy | 30h | — | — |
+| gathio | lowercasename/gathio@sha256:b7e9675d4e22b62e4 | ✅ healthy | 30h | [events.patriark.org](https://events.patriark.org) | — |
 
 ## Monitoring (9)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| alert-discord-relay | localhost/alert-discord-relay:2026-05-23 | ✅ healthy | ~anh | — | [guide](10-services/guides/alert-discord-relay.md) |
-| alertmanager | quay.io/prometheus/alertmanager@sha256:51a825 | ✅ healthy | ~anh | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| cadvisor | gcr.io/cadvisor/cadvisor@sha256:3de2bd5203120 | ✅ healthy | ~anh | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| grafana | grafana/grafana@sha256:2d1f9ae67c1778d33e291d | ✅ healthy | ~anh | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| loki | grafana/loki@sha256:191d4fdfb7264f16989f0a57f | — no check | ~anh | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| node_exporter | quay.io/prometheus/node-exporter@sha256:0f422 | ✅ healthy | ~anh | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| prometheus | quay.io/prometheus/prometheus@sha256:c0b857ae | ✅ healthy | ~anh | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| promtail | grafana/promtail@sha256:6cfa64ec432b24a912d64 | ✅ healthy | ~anh | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| unpoller | unpoller/unpoller@sha256:bf7bdcc59fcdaa469968 | — no check | ~anh | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| alert-discord-relay | localhost/alert-discord-relay:2026-05-23 | ✅ healthy | 30h | — | [guide](10-services/guides/alert-discord-relay.md) |
+| alertmanager | quay.io/prometheus/alertmanager@sha256:51a825 | ✅ healthy | 30h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| cadvisor | gcr.io/cadvisor/cadvisor@sha256:3de2bd5203120 | ✅ healthy | 30h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| grafana | grafana/grafana@sha256:2d1f9ae67c1778d33e291d | ✅ healthy | 30h | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| loki | grafana/loki@sha256:191d4fdfb7264f16989f0a57f | — no check | 30h | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| node_exporter | quay.io/prometheus/node-exporter@sha256:0f422 | ✅ healthy | 30h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| prometheus | quay.io/prometheus/prometheus@sha256:c0b857ae | ✅ healthy | 30h | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| promtail | grafana/promtail@sha256:6cfa64ec432b24a912d64 | ✅ healthy | 30h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| unpoller | unpoller/unpoller@sha256:bf7bdcc59fcdaa469968 | — no check | 30h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
 
 ---
 
@@ -93,7 +93,7 @@
 
 - **Total Running:** 37
 - **Total Defined:** 37
-- **System Load:** 3,93, 2,44, 1,69
+- **System Load:** 1,28, 1,62, 1,66
 
 ---
 

--- a/scripts/security-audit.sh
+++ b/scripts/security-audit.sh
@@ -279,11 +279,17 @@ run_auth_checks() {
     fi
 
     # SA-AUTH-02 (L1): Authelia health endpoint responds
+    # Reads the container's own healthcheck (probes /api/health every 10s) via
+    # inspect instead of podman exec — exec startup alone takes ~4s and races
+    # the timeout under audit load, causing false L1 failures.
     if should_run 1 auth; then
-        if timeout 5 podman exec authelia wget -q -O- http://localhost:9091/api/health 2>/dev/null | grep -q "OK" 2>/dev/null; then
+        authelia_health=$(timeout 10 podman inspect authelia --format '{{.State.Health.Status}}' 2>/dev/null)
+        if [[ "$authelia_health" == "healthy" ]]; then
             record_check "SA-AUTH-02" 1 auth "PASS" "Authelia health endpoint OK"
+        elif [[ "$authelia_health" == "starting" ]] && timeout 15 podman exec authelia wget -q -O- http://localhost:9091/api/health 2>/dev/null | grep -q "OK" 2>/dev/null; then
+            record_check "SA-AUTH-02" 1 auth "PASS" "Authelia health endpoint OK (healthcheck still starting)"
         else
-            record_check "SA-AUTH-02" 1 auth "FAIL" "Authelia health endpoint not responding"
+            record_check "SA-AUTH-02" 1 auth "FAIL" "Authelia health endpoint not responding (health status: ${authelia_health:-unknown})"
         fi
     fi
 


### PR DESCRIPTION
## Summary

- **De-flakes SA-AUTH-02** (L1 Authelia health): the check probed `/api/health` via `timeout 5 podman exec authelia wget …`, but `podman exec` startup alone takes ~4s — under level-3 audit load it raced the 5s timeout and misreported a FAIL on a healthy SSO stack (score 100 → 78 on the 2026-06-10 18:03 run; Authelia was up 41h with a clean journal).
- New implementation reads the container's own healthcheck state via `podman inspect --format '{{.State.Health.Status}}'` (~0.03s, local metadata, no in-container process). The quadlet healthcheck already probes the exact same endpoint every 10s, so the signal is unchanged.
- If the healthcheck is in `starting` state (e.g. right after restart), falls back to the direct exec probe with a 15s timeout instead of failing outright.
- FAIL message now includes the observed health status for faster triage.
- Also includes the routine refresh of 6 auto-generated `docs/AUTO-*.md` files.

## Context

Found during today's `/security-auditor` run: the only L1 failure in 15 consecutive daily audits was this false positive. Companion remediation (no code change): `secrets/forgejo_signing_key.pub` tightened to 600, clearing SA-SEC-03.

## Verification

- ✓ `bash -n scripts/security-audit.sh` clean
- ✓ `--category auth` → SA-AUTH-02 PASS ("Authelia health endpoint OK")
- ✓ Full level-3 audit → **93/100, 0 failures** (remaining warns are known: ADR-030 image aging, doc churn)
- ✓ Pre-commit ADR-030 supply-chain invariants hold

## Test Plan

- [ ] Next scheduled biweekly audit run (06:45 timer) reports SA-AUTH-02 PASS
- [ ] Optional: restart authelia and run `--category auth` during the `starting` window to exercise the fallback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)