### PR TITLE
feat(supply-chain): batch digest adoption, 9 services (ADR-030 P1 bump path)

### DIFF
--- a/docs/AUTO-IMAGE-PIN-INDEX.md
+++ b/docs/AUTO-IMAGE-PIN-INDEX.md
@@ -1,6 +1,6 @@
 # Container Image Pin Index (Auto-Generated)
 
-**Generated:** 2026-06-10 05:04:35 UTC
+**Generated:** 2026-06-10 21:19:57 UTC
 **Source:** `/home/patriark/containers/quadlets` — ADR-030 (Container Supply-Chain Trust Model)
 
 Pins live in each quadlet's `Image=` line (where Podman reads them); this is
@@ -33,38 +33,38 @@ For local builds the `Digest` column shows the **base image** pin (FROM …@sha2
 | alert-discord-relay | yes | 🔨 base-pinned | `localhost/alert-discord-relay` | 2026-05-23 | `sha256:a3ab0b966bc4…` | no | n/a (Tier 2) |
 | alertmanager | yes | 🔒 pinned | `quay.io/prometheus/alertmanager` | latest | `sha256:51a825c2a40a…` | no | — unsigned |
 | audiobookshelf | yes | 🔒 pinned | `ghcr.io/advplyr/audiobookshelf` | 2.35.0 | `sha256:89276ff2e0b3…` | no | — unsigned |
-| authelia | yes | 🔒 pinned | `docker.io/authelia/authelia` | latest | `sha256:0c824dcab1ae…` | no | — unsigned |
+| authelia | yes | 🔒 pinned | `docker.io/authelia/authelia` | latest | `sha256:1b363e9279e7…` | no | — unsigned |
 | blackbox-exporter | yes | 🔒 pinned | `quay.io/prometheus/blackbox-exporter` | latest | `sha256:e753ff9f3fc4…` | no | — unsigned |
 | cadvisor | no | 🔒 pinned | `gcr.io/cadvisor/cadvisor` | latest | `sha256:3de2bd520312…` | no | — unsigned |
 | crowdsec | yes | 🔒 pinned | `docker.io/crowdsecurity/crowdsec` | latest | `sha256:2f527c9bb8b3…` | no | — unsigned |
 | forgejo-db | no | 🔒 pinned | `docker.io/library/postgres` | 16-alpine | `sha256:16bc17c64a57…` | no | — unsigned |
 | forgejo | yes | 🔒 pinned | `codeberg.org/forgejo/forgejo` | 15 | `sha256:db04c7114b65…` | no | — unsigned |
-| gathio-db | no | 🔒 pinned | `docker.io/library/mongo` | 7 | `sha256:32979a1189df…` | no | — unsigned |
-| gathio | yes | 🔒 pinned | `ghcr.io/lowercasename/gathio` | latest | `sha256:b7e9675d4e22…` | no | — unsigned |
-| grafana | yes | 🔒 pinned | `docker.io/grafana/grafana` | latest | `sha256:2d1f9ae67c17…` | no | — unsigned |
+| gathio-db | no | 🔒 pinned | `docker.io/library/mongo` | 7 | `sha256:c1a84ab5d0c1…` | no | — unsigned |
+| gathio | yes | 🔒 pinned | `ghcr.io/lowercasename/gathio` | latest | `sha256:ff66a8d2cc52…` | no | — unsigned |
+| grafana | yes | 🔒 pinned | `docker.io/grafana/grafana` | latest | `sha256:5dad0df181cb…` | no | — unsigned |
 | home-assistant | yes | 🔒 pinned | `ghcr.io/home-assistant/home-assistant` | stable | `sha256:d4fbec16196d…` | no | ✓ verified |
 | immich-ml | no | 🔒 pinned | `ghcr.io/immich-app/immich-machine-learning` | v2.7.5 | `sha256:a2501141440f…` | no | — unsigned |
 | immich-server | yes | 🔒 pinned | `ghcr.io/immich-app/immich-server` | v2.7.5 | `sha256:c15bff75068e…` | no | — unsigned |
 | jellyfin | yes | 🔒 pinned | `docker.io/jellyfin/jellyfin` | latest | `sha256:1694ff069f0c…` | no | — unsigned |
 | loki | yes | 🔒 pinned | `docker.io/grafana/loki` | latest | `sha256:191d4fdfb726…` | no | — unsigned |
 | navidrome | yes | 🔒 pinned | `docker.io/deluan/navidrome` | latest | `sha256:9fa40b3d8dec…` | no | — unsigned |
-| nextcloud-db | no | 🔒 pinned | `docker.io/library/mariadb` | 11 | `sha256:78a5047d3ba3…` | no | — unsigned |
+| nextcloud-db | no | 🔒 pinned | `docker.io/library/mariadb` | 11 | `sha256:be1ef4fe5f14…` | no | — unsigned |
 | nextcloud-redis | no | 🔒 pinned | `docker.io/library/redis` | 7-alpine | `sha256:6ab0b6e73817…` | no | — unsigned |
 | nextcloud | yes | 🔒 pinned | `docker.io/library/nextcloud` | 33 | `sha256:b67959acacd5…` | no | — unsigned |
 | node_exporter | no | 🔒 pinned | `quay.io/prometheus/node-exporter` | latest | `sha256:0f422f62c15f…` | no | — unsigned |
 | pihole-exporter | yes | 🔒 pinned | `docker.io/ekofr/pihole-exporter` | latest | `sha256:a890cc731a39…` | no | — unsigned |
 | postgres-exporter | no | 🔒 pinned | `quay.io/prometheuscommunity/postgres-exporter` | latest | `sha256:e96064f87622…` | no | — unsigned |
 | postgresql-immich | no | 🔒 pinned | `ghcr.io/immich-app/postgres` | 14-vectorchord0.4.3-pgvectors0.2.0 | `sha256:bcf63357191b…` | no | — unsigned |
-| prometheus | yes | 🔒 pinned | `quay.io/prometheus/prometheus` | latest | `sha256:c0b857aead0d…` | no | — unsigned |
+| prometheus | yes | 🔒 pinned | `quay.io/prometheus/prometheus` | latest | `sha256:69f524141883…` | no | — unsigned |
 | promtail | no | 🔒 pinned | `docker.io/grafana/promtail` | latest | `sha256:6cfa64ec432b…` | no | — unsigned |
 | proton-bridge | yes | 🔨 base-pinned | `localhost/proton-bridge` | 3.23.1 | `sha256:747502f9190e…` | no | n/a (Tier 2) |
 | qbittorrent | yes | 🔒 pinned | `docker.io/linuxserver/qbittorrent` | latest | `sha256:f76c4363cce0…` | no | — unsigned |
-| redis-authelia-exporter | no | 🔒 pinned | `quay.io/oliver006/redis_exporter` | latest | `sha256:e8c209894d4c…` | no | — unsigned |
+| redis-authelia-exporter | no | 🔒 pinned | `quay.io/oliver006/redis_exporter` | latest | `sha256:2e9795be900d…` | no | — unsigned |
 | redis-authelia | no | 🔒 pinned | `docker.io/library/redis` | 7-alpine | `sha256:6ab0b6e73817…` | no | — unsigned |
-| redis-immich-exporter | no | 🔒 pinned | `quay.io/oliver006/redis_exporter` | latest | `sha256:e8c209894d4c…` | no | — unsigned |
-| redis-immich | no | 🔒 pinned | `docker.io/valkey/valkey` | latest | `sha256:8436e10bc65c…` | no | — unsigned |
+| redis-immich-exporter | no | 🔒 pinned | `quay.io/oliver006/redis_exporter` | latest | `sha256:2e9795be900d…` | no | — unsigned |
+| redis-immich | no | 🔒 pinned | `docker.io/valkey/valkey` | latest | `sha256:4963247afc4c…` | no | — unsigned |
 | traefik | yes | 🔒 pinned | `docker.io/library/traefik` | latest | `sha256:6b9cbca6fac4…` | no | — unsigned |
-| unifi-syslog | no | 🔒 pinned | `docker.io/linuxserver/syslog-ng` | latest | `sha256:0d164e438d1f…` | no | — unsigned |
+| unifi-syslog | no | 🔒 pinned | `docker.io/linuxserver/syslog-ng` | latest | `sha256:b77c32d93b9e…` | no | — unsigned |
 | unpoller | yes | 🔒 pinned | `ghcr.io/unpoller/unpoller` | latest | `sha256:bf7bdcc59fcd…` | no | — unsigned |
 | vaultwarden | yes | 🔒 pinned | `docker.io/vaultwarden/server` | latest | `sha256:d626d04934cd…` | no | — unsigned |
 

--- a/quadlets/authelia.container
+++ b/quadlets/authelia.container
@@ -5,9 +5,10 @@ Wants=auth_services-network.service network-online.target reverse_proxy-network.
 Requires=redis-authelia.service
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-23 (index digest, multi-arch)
-# ADR-030 P1/P4: egress-tier, deliberate updates only (already carried no AutoUpdate). Bump = resolve new digest, bake, edit, restart.
-Image=docker.io/authelia/authelia@sha256:0c824dcab1ae97c56bf673c5e77fe8cc6bcd400564555140cc8002a12c6b6463
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-06-10 (index digest, multi-arch)
+# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = adopt new digest (pin-container-image.sh --adopt), bake, restart.
+# ADR-030 P6: no publisher signature (tracked unsigned)
+Image=docker.io/authelia/authelia@sha256:1b363e9279e742397966333f364e0876ae02bf5c876de73e83af6d48c57ff51b
 ContainerName=authelia
 
 # Multi-network: Serves SSO portal + handles auth verification

--- a/quadlets/gathio-db.container
+++ b/quadlets/gathio-db.container
@@ -4,8 +4,9 @@ After=network-online.target gathio-network.service
 Wants=gathio-network.service network-online.target
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: 7, resolved 2026-05-23 (index digest, multi-arch)
-Image=docker.io/library/mongo@sha256:32979a1189dfdc44da3f5ed40d910495f5ad8f6f7f77556646f890a30b2d3f56
+# ADR-030 P2: digest-pinned (integrity). tag: 7, resolved 2026-06-10 (index digest, multi-arch)
+# ADR-030 P6: no publisher signature (tracked unsigned)
+Image=docker.io/library/mongo@sha256:c1a84ab5d0c17deed1e0dba1d24bd7c76e5c7b281145fe536911939b1551754c
 ContainerName=gathio-db
 HostName=gathio-db
 

--- a/quadlets/gathio.container
+++ b/quadlets/gathio.container
@@ -5,8 +5,9 @@ Wants=network-online.target
 Requires=gathio-db.service
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-23 (index digest, multi-arch)
-Image=ghcr.io/lowercasename/gathio@sha256:b7e9675d4e22b62e4ad82c495889cfb605a69ae0a2199140c18ccd2772d8b0b5
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-06-10 (index digest, multi-arch)
+# ADR-030 P6: no publisher signature (tracked unsigned)
+Image=ghcr.io/lowercasename/gathio@sha256:ff66a8d2cc522568c8a8e2772e969e56f90e2089fb33602d27979134dc8bfe8b
 ContainerName=gathio
 HostName=gathio
 

--- a/quadlets/grafana.container
+++ b/quadlets/grafana.container
@@ -4,9 +4,10 @@ After=network-online.target monitoring-network.service traefik.service
 Wants=monitoring-network.service network-online.target
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-23 (index digest, multi-arch)
-# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart.
-Image=docker.io/grafana/grafana@sha256:2d1f9ae67c1778d33e291d4c3c759cd8b650e67491f02533499eb950e075eeb5
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-06-10 (index digest, multi-arch)
+# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = adopt new digest (pin-container-image.sh --adopt), bake, restart.
+# ADR-030 P6: no publisher signature (tracked unsigned)
+Image=docker.io/grafana/grafana@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
 ContainerName=grafana
 HostName=grafana
 # Static IPs assigned to ensure consistent DNS resolution

--- a/quadlets/nextcloud-db.container
+++ b/quadlets/nextcloud-db.container
@@ -5,8 +5,9 @@ Wants=network-online.target
 
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: 11, resolved 2026-05-23 (index digest, multi-arch)
-Image=docker.io/library/mariadb@sha256:78a5047d3ba33975f183f183c2464cc7f1eab13ec8667e57cc9a5821d6da7577
+# ADR-030 P2: digest-pinned (integrity). tag: 11, resolved 2026-06-10 (index digest, multi-arch)
+# ADR-030 P6: no publisher signature (tracked unsigned)
+Image=docker.io/library/mariadb@sha256:be1ef4fe5f14589325c08a41c76334097ce66c86264b75e1d28342c742782a61
 ContainerName=nextcloud-db
 
 # MariaDB configuration (using podman secrets)

--- a/quadlets/prometheus.container
+++ b/quadlets/prometheus.container
@@ -4,8 +4,9 @@ After=network-online.target monitoring-network.service node_exporter.service tra
 Wants=monitoring-network.service network-online.target node_exporter.service
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-23 (index digest, multi-arch)
-Image=quay.io/prometheus/prometheus@sha256:c0b857aead0d5793aa566adb8f49a9983d6f6031652098759d521a330cfa050f
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-06-10 (index digest, multi-arch)
+# ADR-030 P6: no publisher signature (tracked unsigned)
+Image=quay.io/prometheus/prometheus@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac
 ContainerName=prometheus
 HostName=prometheus
 # Static IPs assigned to ensure consistent DNS resolution

--- a/quadlets/redis-authelia-exporter.container
+++ b/quadlets/redis-authelia-exporter.container
@@ -5,9 +5,10 @@ Wants=network-online.target auth_services-network.service monitoring-network.ser
 Requires=redis-authelia.service
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-23 (index digest, multi-arch)
-# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart.
-Image=quay.io/oliver006/redis_exporter@sha256:e8c209894d4c0cc55b1259ddd47e0b769ad1ff864b356736ee885462a3b0e48c
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-06-10 (index digest, multi-arch)
+# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = adopt new digest (pin-container-image.sh --adopt), bake, restart.
+# ADR-030 P6: no publisher signature (tracked unsigned)
+Image=quay.io/oliver006/redis_exporter@sha256:2e9795be900db073e9475fdb9c5124db309b07a3e4e75a1770705cb03be1a1c8
 ContainerName=redis-authelia-exporter
 HostName=redis-authelia-exporter
 

--- a/quadlets/redis-immich-exporter.container
+++ b/quadlets/redis-immich-exporter.container
@@ -5,9 +5,10 @@ Wants=network-online.target photos-network.service monitoring-network.service
 Requires=redis-immich.service
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-23 (index digest, multi-arch)
-# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart.
-Image=quay.io/oliver006/redis_exporter@sha256:e8c209894d4c0cc55b1259ddd47e0b769ad1ff864b356736ee885462a3b0e48c
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-06-10 (index digest, multi-arch)
+# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = adopt new digest (pin-container-image.sh --adopt), bake, restart.
+# ADR-030 P6: no publisher signature (tracked unsigned)
+Image=quay.io/oliver006/redis_exporter@sha256:2e9795be900db073e9475fdb9c5124db309b07a3e4e75a1770705cb03be1a1c8
 ContainerName=redis-immich-exporter
 HostName=redis-immich-exporter
 

--- a/quadlets/redis-immich.container
+++ b/quadlets/redis-immich.container
@@ -4,8 +4,9 @@ After=network-online.target photos-network.service
 Wants=network-online.target photos-network.service
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-23 (index digest, multi-arch)
-Image=docker.io/valkey/valkey@sha256:8436e10bc65c94886a91d4415b6a6dfa9cb5a306fb3b996e5bb67cd2b4854193
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-06-10 (index digest, multi-arch)
+# ADR-030 P6: no publisher signature (tracked unsigned)
+Image=docker.io/valkey/valkey@sha256:4963247afc4cd33c7d3b2d2816b9f7f8eeebab148d29056c2ca4d7cbc966f2d9
 ContainerName=redis-immich
 
 # Network

--- a/quadlets/unifi-syslog.container
+++ b/quadlets/unifi-syslog.container
@@ -4,9 +4,10 @@ After=network-online.target syslog-network.service traefik.service
 Wants=syslog-network.service network-online.target
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-23 (index digest, multi-arch)
-# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart.
-Image=docker.io/linuxserver/syslog-ng@sha256:0d164e438d1f9ee4b610dfd287323bb3cdb0922f04fcaea3106fc9de7eea19d6
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-06-10 (index digest, multi-arch)
+# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = adopt new digest (pin-container-image.sh --adopt), bake, restart.
+# ADR-030 P6: no publisher signature (tracked unsigned)
+Image=docker.io/linuxserver/syslog-ng@sha256:b77c32d93b9e9b84f4fdd9261d7dd1db3b8a6f90391459b1ca51c82af9828bf8
 ContainerName=unifi-syslog
 HostName=unifi-syslog
 Network=systemd-syslog:ip=10.89.7.69


### PR DESCRIPTION
## Summary

First batch adoption since the ADR-030 Tier 1 migration. `check-image-updates.sh` surfaced 19 available updates; the **P3 bake gate** (≥7d for egress-tier, ≥3d for internal-only, based on image creation dates resolved via skopeo) passed 9 of them:

| Wave | Services | Digest age |
|------|----------|-----------|
| 1 — plumbing | redis-authelia-exporter, redis-immich-exporter, unifi-syslog | 3d, 3d, 20d |
| 2 — apps | gathio | 21d |
| 3 — core (one at a time) | grafana, prometheus, authelia | 8d, 13d, 15d |
| 4 — databases | nextcloud-db (mariadb:11), gathio-db (mongo:7), redis-immich (valkey) | 8d, 26d, 22d |

**Deferred — too young to adopt** (re-check after bake): traefik (0d — its `:latest` tag moved again *during this batch*, validating the bake principle), forgejo (0d), home-assistant (1d), unpoller (1d), navidrome (2d), qbittorrent (2d), jellyfin (4d), nextcloud (4d), alertmanager (5d).

All adoptions went through `pin-container-image.sh --adopt` with the P6 signature gate (all 9 repos unsigned-but-tracked; no known-signer failures).

## Verification

- ✓ All 12 touched services (9 adopted + 3 dependent-app restarts: nextcloud, gathio, immich-server) active; healthchecks healthy
- ✓ All Prometheus scrape targets UP (covers the healthcheck-less distroless exporters)
- ✓ External HTTP: sso.patriark.org 200, grafana /api/health 200, events.patriark.org 200, nextcloud status.php 200, photos /api/server/ping 200
- ✓ Forward-auth chain intact (302 → SSO portal) after authelia bump
- ✓ Pre-commit ADR-030 invariants hold; `AUTO-IMAGE-PIN-INDEX.md` regenerated

## Test Plan

- [ ] Observe Grafana dashboards / alert quiet period over next hours
- [ ] Re-run `./scripts/check-image-updates.sh` in ~1 week to adopt the 9 deferred updates once baked
- [ ] BTRFS snapshots + `git revert` of any digest line available as rollback

🤖 Generated with [Claude Code](https://claude.com/claude-code)