### PR TITLE
feat(supply-chain): ADR-036 — bake policy codified + batch adoption tooling

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,10 +89,11 @@ Pattern-based deployment available via `homelab-deployment` skill (see `.claude/
 
 Governed by **ADR-030 (Container Supply-Chain Trust Model):** **fully implemented (Tier 1 + Tier 2)** — every registry image is digest-pinned (`tag@sha256:…`, tag = discovery handle, digest = execution contract), all `AutoUpdate=registry` lines are stripped, and the 2 local builds pin their `FROM` bases by digest. Nothing updates automatically; superseded ADR-015's `:latest`/auto-update trust model. A pre-commit hook enforces the invariants (egress tier pinned + de-automated, local bases pinned, no signature failures); `docs/AUTO-IMAGE-PIN-INDEX.md` is the daily audit view.
 
-**Deliberate update loop:**
-1. **Discover:** `scripts/check-image-updates.sh` — skopeo digest-diff against registry tags, notify-only, never pulls
-2. **Adopt (after cooling-off):** `scripts/pin-container-image.sh <svc> --adopt <digest> --apply` — P6 signature gate verifies known signers fail-closed (`config/supply-chain/signers.yaml`)
-3. **Restart:** `systemctl --user daemon-reload && systemctl --user restart <svc>.service`
+**Deliberate update loop (ADR-036):**
+1. **Discover:** `scripts/check-image-updates.sh` — skopeo digest-diff, notify-only; annotates each candidate BAKED/TOO-YOUNG against the P3 bake policy (`config/supply-chain/bake-policy.yml`: egress 7d, internal 3d) and writes machine-readable JSON
+2. **Adopt:** `scripts/adopt-baked.sh [--dry-run]` — wave-ordered batch (plumbing → apps → core → DBs + dependent restarts), per-service health + HTTP verification, halt-on-failure; P6 signature gate applies via `pin-container-image.sh`
+3. **Exception lane:** a release fixing a known-exploited CVE in an egress-tier service may skip the bake via `--allow-young <svc>` — commit message must name the CVE
+4. **Single-service path:** `scripts/pin-container-image.sh <svc> --adopt <digest> --apply` + daemon-reload + restart
 
 **Class-specific rules:**
 - **Databases:** PostgreSQL, MariaDB, MongoDB pinned to major-version tags; major upgrades are explicit migration projects (ADR-029 dump backbone), never casual bumps
@@ -103,7 +104,7 @@ Rollback: `git revert` of the digest line + restart; BTRFS snapshots as second p
 
 ### Architecture Decision Records
 
-**Architectural decisions recorded as ADRs — latest is ADR-034** (see `docs/*/decisions/` for full details; number new ADRs sequentially from the latest)
+**Architectural decisions recorded as ADRs — latest is ADR-036** (see `docs/*/decisions/` for full details; number new ADRs sequentially from the latest)
 
 **Design-Guiding ADRs (affect future decisions):**
 - **ADR-001:** Rootless Containers — UID 1000, `:Z` SELinux labels on all mounts
@@ -119,6 +120,7 @@ Rollback: `git revert` of the digest line + restart; BTRFS snapshots as second p
 - **ADR-021:** Urd Backup Tool — Rust-based BTRFS Time Machine replaces shell script (supersedes ADR-020 implementation)
 - **ADR-030:** Container Supply-Chain Trust Model — digest pinning, deliberate (de-automated) updates, cooling-off interval, graduated signature verification (supersedes ADR-015 trust model)
 - **ADR-031:** DNS Resolver First-Class & HA — redundancy-before-monitoring, active/passive keepalived VIP, alert-path resolver must be independent of the monitored resolver, resolver managed-as-code + SSO admin (status: Accepted, implementation phased)
+- **ADR-036:** Bake Policy & Exception Lane (amends ADR-030) — P3 cooling-off codified (egress 7d / internal 3d in `bake-policy.yml`), wave-ordered batch adoption via `adopt-baked.sh`, security-release CVE override with `--allow-young`
 
 Check if an ADR exists before proposing changes. Reference the ADR and explain what changed if suggesting alternatives. New decisions get new ADRs (don't edit existing ones).
 

--- a/config/supply-chain/bake-policy.yml
+++ b/config/supply-chain/bake-policy.yml
@@ -1,0 +1,12 @@
+# ADR-036 — P3 bake intervals (cooling-off before deliberate adoption).
+# Consumed by scripts/check-image-updates.sh (verdict annotation) and
+# scripts/adopt-baked.sh (adoption gate).
+#
+# Tier is derived per service from its quadlet: a container on the
+# reverse_proxy network (Network=systemd-reverse_proxy…) is egress-tier.
+#
+# Exception lane (ADR-036): a release fixing a known-exploited CVE in an
+# egress-tier service MAY be adopted before the bake interval elapses —
+# adopt-baked.sh --allow-young <svc>, and note the skip in the commit message.
+egress_days: 7
+internal_days: 3

--- a/docs/00-foundation/decisions/2026-06-10-ADR-036-bake-policy-and-exception-lane.md
+++ b/docs/00-foundation/decisions/2026-06-10-ADR-036-bake-policy-and-exception-lane.md
@@ -1,0 +1,131 @@
+# ADR-036: Bake Policy Codification and Security-Release Exception Lane
+
+**Date:** 2026-06-10
+**Status:** Accepted (implemented: bake-policy.yml, check-image-updates.sh verdicts,
+adopt-baked.sh, service-url.sh)
+**Amends:** ADR-030 (Container Supply-Chain Trust Model) — concretizes P3, adds the
+exception lane. ADR-030's principles are unchanged.
+
+---
+
+## Context
+
+ADR-030 P3 established the cooling-off interval as a *principle*: "a new digest is
+adopted only after a bake interval," with the egress tier getting "the longest bake."
+No number was ever written down, and no tooling enforced or even surfaced the
+interval.
+
+The first batch adoption under the executed Tier 1 migration (2026-06-10, PR #270)
+exposed what that costs in practice:
+
+- **The bake gate was manual.** `check-image-updates.sh` reported *availability* but
+  not *age* — applying P3 meant 19 hand-run `skopeo inspect` calls to fetch creation
+  dates and an ad-hoc threshold decision (≥7d egress / ≥3d internal) made on the
+  spot rather than by policy.
+- **The adopt loop was manual.** Nine adoptions took ~45 supervised minutes of
+  pin → daemon-reload → restart → wait → verify, with verification hostnames
+  guessed (twice wrongly) despite the truth sitting in `routers.yml` (ADR-016).
+- **The bake principle was validated twice in one session.** `traefik:latest` moved
+  *between the discovery sweep and the age check* (~30 min apart), and `mongo:7`
+  moved again within the hour after adoption. Same-day digests are demonstrably
+  churny; the interval is doing real work.
+- **The doctrine tension was unresolved.** The bake interval deliberately trades
+  CVE-patch latency for the ecosystem's poisoned-release detection latency. That
+  trade is correct as a *default* here (defense-in-depth absorbs patch latency; a
+  poisoned image starts inside the trust boundary), but ADR-030 provided no
+  legitimate fast path for the case where the calculus inverts: a release fixing an
+  actively-exploited CVE in an internet-facing service. A policy with no exception
+  lane gets bypassed ad hoc — or worse, obeyed when it shouldn't be.
+
+## Decision
+
+### 1. Bake thresholds are policy, not prose
+
+`config/supply-chain/bake-policy.yml` defines the P3 intervals:
+
+| Tier | Definition | Bake |
+|------|-----------|------|
+| egress | quadlet on `reverse_proxy` network (`Network=systemd-reverse_proxy…`) | **7 days** |
+| internal | everything else | **3 days** |
+
+Age is measured from the image's `Created` timestamp (via skopeo) to now. A
+rebuilt-but-unchanged upstream image resets the clock — accepted, because the error
+is in the conservative direction.
+
+### 2. Discovery annotates the gate
+
+`check-image-updates.sh` resolves each available digest's age and emits a
+`BAKED` / `TOO-YOUNG (wait Nd)` / `AGE-UNKNOWN` verdict per candidate, plus a
+machine-readable JSON companion (`docs/99-reports/image-updates-YYYYMMDD.json`)
+with full digests, ages, tiers, verdicts, and signature states. The JSON is the
+input contract for batch adoption — no more hand-run skopeo sweeps or truncated
+digests copied from text reports.
+
+### 3. Batch adoption is wave-ordered and halt-on-failure
+
+`scripts/adopt-baked.sh` adopts every `BAKED` candidate in dependency-ordered
+waves — plumbing (exporters/syslog) → apps → core (gateway/auth/monitoring, one at
+a time) → data (databases/caches, each followed by restarts of its dependent apps,
+derived from quadlet `After=`/`Requires=` lines). Each service is verified
+(systemd active + container healthcheck + HTTP through its Traefik route) before
+the next is touched; the first failure halts the batch with rollback instructions.
+Each adoption still flows through `pin-container-image.sh`, so the ADR-030 P6
+signature gate applies unchanged. `--dry-run` prints the plan.
+
+### 4. Exception lane: security releases may skip the bake
+
+A release that fixes a **known-exploited or critical CVE in an egress-tier
+service** MAY be adopted before its bake interval elapses:
+
+```
+scripts/adopt-baked.sh --allow-young <svc>     # or pin-container-image.sh directly
+```
+
+Conditions: the override is per-service and per-invocation (never standing), and
+the commit message MUST name the CVE or security advisory that justified the skip.
+This makes the fast path legitimate, auditable, and rare — the policy bends where
+the threat model says it should, instead of being silently bypassed.
+
+Trigger source: release-feed watching for the egress-tier crown jewels (Traefik,
+Authelia, Nextcloud, Vaultwarden, Immich, Forgejo) is the owner's responsibility;
+automation for this is future work, not a blocker.
+
+### 5. Verification hostnames come from routing truth
+
+`scripts/service-url.sh` derives a container's external URL from
+`config/traefik/dynamic/routers.yml` (backend URL → service → plain `Host()`
+rule). Corollary of ADR-016: routing config is the single source of truth, so
+verification must read it, not guess.
+
+## Consequences
+
+**Positive**
+- The monthly update ritual collapses to: `check-image-updates.sh` → review →
+  `adopt-baked.sh` → commit. The bake gate is computed, not hand-applied.
+- The P3 interval is now enforceable, tunable in one file, and visible in every
+  report — including *when* each deferred candidate becomes adoptable.
+- The exception lane resolves the "pin everything" vs "patch fast" doctrine
+  tension explicitly: bake by default, skip deliberately with a named CVE.
+- Halt-on-failure batches mean a bad image stops the train instead of riding it.
+
+**Negative / accepted**
+- Maximum patch latency for routine updates equals the bake interval. Accepted:
+  single user, layered auth in front of everything, instant BTRFS + git rollback.
+- Image `Created` date is an approximation of release age; registry rebuilds
+  shorten apparent age never lengthen it — errors defer, never rush.
+- Two more scripts to maintain; both are thin orchestration over existing
+  primitives (`pin-container-image.sh`, `skopeo`, `systemctl`).
+
+**Neutral**
+- Thresholds (7d/3d) are first guesses; tune in `bake-policy.yml` as experience
+  accumulates. Raising the egress bake raises supply-chain safety and patch
+  latency together — the file is the dial.
+
+## References
+
+- ADR-030 — Container Supply-Chain Trust Model (P1 deliberate adoption, P3 bake
+  principle, P4 blast-radius tiers, P6 signature gate)
+- ADR-016 — Configuration Design Principles (routing truth in dynamic config)
+- PR #270 — first batch adoption; the session that motivated this ADR
+- `scripts/check-image-updates.sh`, `scripts/adopt-baked.sh`,
+  `scripts/service-url.sh`, `config/supply-chain/bake-policy.yml`

--- a/scripts/adopt-baked.sh
+++ b/scripts/adopt-baked.sh
@@ -1,0 +1,194 @@
+#!/bin/bash
+# adopt-baked.sh — ADR-036 batch adoption of BAKED image updates.
+#
+# Consumes the JSON companion written by check-image-updates.sh and adopts
+# every candidate whose digest has passed the P3 bake interval, in
+# dependency-ordered waves:
+#
+#   wave 1  plumbing   exporters, syslog, log shippers (cheap canaries)
+#   wave 2  apps       user-facing services
+#   wave 3  core       gateway / auth / monitoring — one at a time
+#   wave 4  data       databases & caches, each followed by a restart of its
+#                      dependent apps (derived from quadlet After=/Requires=)
+#
+# Per service: pin-container-image.sh --adopt (ADR-030 P6 signature gate)
+# → restart → wait for systemd active + container healthcheck → HTTP verify
+# via the Traefik route (service-url.sh) when one exists. Halts on the first
+# failure with rollback instructions — a halted batch is a feature, not a bug.
+#
+# Usage: adopt-baked.sh [--dry-run] [--report <json>] [--only svc,svc]
+#                       [--allow-young svc,svc]
+#   --dry-run       print the wave plan, change nothing
+#   --report        candidate JSON (default: newest image-updates-*.json)
+#   --only          restrict to these services
+#   --allow-young   ADR-036 exception lane: adopt a TOO-YOUNG candidate
+#                   (security-release override; note the reason in the commit)
+set -euo pipefail
+
+CONTAINERS_DIR="$HOME/containers"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+QUADLET_DIR="${QUADLET_DIR:-$CONTAINERS_DIR/quadlets}"
+HEALTH_TIMEOUT="${HEALTH_TIMEOUT:-120}"
+
+DRY_RUN=false; REPORT=""; ONLY=""; ALLOW_YOUNG=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run) DRY_RUN=true ;;
+        --report) REPORT="$2"; shift ;;
+        --only) ONLY="$2"; shift ;;
+        --allow-young) ALLOW_YOUNG="$2"; shift ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+if [ -z "$REPORT" ]; then
+    REPORT="$(ls -t "$CONTAINERS_DIR"/docs/99-reports/image-updates-*.json 2>/dev/null | head -1)"
+fi
+[ -f "${REPORT:-}" ] || { echo "❌ No candidate JSON found — run scripts/check-image-updates.sh first." >&2; exit 2; }
+
+age_hours=$(( ($(date +%s) - $(stat -c %Y "$REPORT")) / 3600 ))
+echo "📋 Candidates: $REPORT (${age_hours}h old)"
+if [ "$age_hours" -gt 24 ]; then
+    echo "⚠️  Report is >24h old — digests may have moved. Re-run check-image-updates.sh." >&2
+    $DRY_RUN || exit 2
+fi
+
+# Select adoptable candidates and order them into waves. TSV out:
+# wave svc digest age tier verdict
+plan="$(python3 - "$REPORT" "$ONLY" "$ALLOW_YOUNG" <<'EOF'
+import json, re, sys
+report, only, allow_young = sys.argv[1], sys.argv[2], sys.argv[3]
+only = {s for s in only.split(',') if s}
+allow_young = {s for s in allow_young.split(',') if s}
+data = json.load(open(report))
+
+def wave(svc):
+    if re.search(r'exporter|syslog|promtail|cadvisor|unpoller|relay|blackbox', svc):
+        return 1
+    if re.search(r'-db$|^postgresql|^redis-|valkey|mongo', svc):
+        return 4
+    if svc in ('traefik', 'authelia', 'crowdsec', 'prometheus', 'grafana',
+               'loki', 'alertmanager'):
+        return 3
+    return 2
+
+rows = []
+for c in data['candidates']:
+    svc, verdict = c['service'], c['verdict']
+    if only and svc not in only:
+        continue
+    if c.get('signature') == 'FAILED':
+        print(f"SKIP\t{svc}\t-\t-\t-\tSIGNATURE-FAILED", file=sys.stderr)
+        continue
+    if verdict == 'BAKED' or (verdict == 'TOO-YOUNG' and svc in allow_young):
+        note = 'BAKED' if verdict == 'BAKED' else 'YOUNG-OVERRIDE'
+        rows.append((wave(svc), svc, c['available'], c['age_days'], c['tier'], note))
+    elif verdict in ('TOO-YOUNG', 'FLOATING', 'AGE-UNKNOWN'):
+        print(f"SKIP\t{svc}\t-\t{c.get('age_days','-')}\t{c.get('tier','-')}\t{verdict}", file=sys.stderr)
+
+for r in sorted(rows):
+    print('\t'.join(str(x) for x in r))
+EOF
+)" || true
+
+if [ -z "$plan" ]; then
+    echo "✅ Nothing to adopt — no BAKED candidates in the report."
+    exit 0
+fi
+
+WAVE_NAMES=([1]="plumbing" [2]="apps" [3]="core" [4]="data")
+echo ""
+echo "── Adoption plan ──"
+while IFS=$'\t' read -r wv svc digest age tier note; do
+    printf "  wave %s (%-8s) %-25s age %sd [%s] %s\n" "$wv" "${WAVE_NAMES[$wv]}" "$svc" "$age" "$tier" "$note"
+done <<< "$plan"
+echo ""
+
+if $DRY_RUN; then
+    echo "(dry-run — nothing changed)"
+    exit 0
+fi
+
+# Dependent apps of a data-tier service: quadlets that declare After=/Requires=
+# on it. Restarting the DB drops their connections; restart them deliberately.
+dependents_of() {
+    grep -lE "^(After|Requires|Wants)=.*\b$1\.service" "$QUADLET_DIR"/*.container 2>/dev/null \
+        | xargs -rn1 basename | sed 's/\.container$//' | grep -vx "$1" || true
+}
+
+verify_service() {
+    local svc="$1" deadline=$((SECONDS + HEALTH_TIMEOUT)) state="" health=""
+    while [ $SECONDS -lt $deadline ]; do
+        state="$(systemctl --user is-active "$svc.service" 2>/dev/null || true)"
+        health="$(podman inspect "$svc" --format '{{if .State.Health}}{{.State.Health.Status}}{{else}}no-healthcheck{{end}}' 2>/dev/null || echo missing)"
+        if [ "$state" = "active" ] && { [ "$health" = "healthy" ] || [ "$health" = "no-healthcheck" ]; }; then
+            break
+        fi
+        [ "$state" = "failed" ] && break
+        sleep 3
+    done
+    if [ "$state" != "active" ]; then
+        echo "    ❌ $svc: systemd state '$state' (health: $health)"; return 1
+    fi
+
+    local url code=""
+    if url="$("$SCRIPT_DIR/service-url.sh" "$svc" 2>/dev/null)"; then
+        code="$(curl -s -o /dev/null -m 15 -w '%{http_code}' "$url" || echo 000)"
+        # 2xx/3xx/401/403 all mean "responding behind the middleware chain"
+        if [[ "$code" =~ ^[23] ]] || [ "$code" = "401" ] || [ "$code" = "403" ]; then
+            echo "    ✓ $svc: active / $health / $url → $code"
+        else
+            echo "    ❌ $svc: active but $url → $code"; return 1
+        fi
+    elif [ "$health" = "healthy" ] || [ "$health" = "no-healthcheck" ]; then
+        echo "    ✓ $svc: active / $health (no Traefik route)"
+    else
+        echo "    ❌ $svc: active but healthcheck stuck in '$health'"; return 1
+    fi
+}
+
+halt() {
+    local svc="$1"
+    cat >&2 <<EOM
+
+❌ HALTED at $svc — remaining candidates NOT adopted.
+Rollback this service:
+  git -C "$CONTAINERS_DIR" checkout -- quadlets/$svc.container
+  systemctl --user daemon-reload && systemctl --user restart $svc.service
+Already-adopted services from this run keep their new digests (each verified
+healthy); commit or revert them per quadlet via git.
+EOM
+    exit 1
+}
+
+adopted=()
+current_wave=""
+while IFS=$'\t' read -r wv svc digest age tier note; do
+    if [ "$wv" != "$current_wave" ]; then
+        current_wave="$wv"
+        echo "═══ Wave $wv: ${WAVE_NAMES[$wv]} ═══"
+    fi
+    echo "  ▶ $svc → ${digest:0:19}… (age ${age}d, $tier, $note)"
+    "$SCRIPT_DIR/pin-container-image.sh" "$svc" --adopt "$digest" --apply || halt "$svc"
+    systemctl --user daemon-reload
+    systemctl --user restart "$svc.service" || halt "$svc"
+    verify_service "$svc" || halt "$svc"
+    adopted+=("$svc")
+
+    if [ "$wv" = "4" ]; then
+        for dep in $(dependents_of "$svc"); do
+            systemctl --user is-active --quiet "$dep.service" 2>/dev/null || continue
+            echo "    ↻ dependent: $dep"
+            systemctl --user restart "$dep.service" || halt "$dep"
+            verify_service "$dep" || halt "$dep"
+        done
+    fi
+done <<< "$plan"
+
+echo ""
+echo "✅ Adopted ${#adopted[@]} service(s): ${adopted[*]}"
+echo ""
+echo "Next steps:"
+echo "  ./scripts/generate-image-pin-index.sh        # refresh AUTO-IMAGE-PIN-INDEX.md"
+echo "  git add quadlets/ docs/AUTO-IMAGE-PIN-INDEX.md && commit via PR"

--- a/scripts/check-image-updates.sh
+++ b/scripts/check-image-updates.sh
@@ -8,8 +8,17 @@
 # be deliberately bumped. It NEVER pulls or changes anything — visibility only,
 # preserving "trust is accepted deliberately" (P1).
 #
-# To adopt an available update: bake (P3), then (the digest is verified at this step,
-# ADR-030 P6):
+# ADR-036: each available update is annotated with the digest's age and a
+# BAKED / TOO-YOUNG verdict against the P3 bake policy
+# (config/supply-chain/bake-policy.yml; egress tier = quadlet on the
+# reverse_proxy network). A machine-readable JSON companion (full digests,
+# ages, tiers, verdicts) is written next to the text report — it is the
+# input contract for scripts/adopt-baked.sh.
+#
+# To adopt baked updates in dependency-ordered waves:
+#   scripts/adopt-baked.sh [--dry-run]
+# To adopt a single update by hand (digest is signature-verified at this
+# step, ADR-030 P6):
 #   scripts/pin-container-image.sh <svc> --adopt <new-digest> --apply
 #   systemctl --user daemon-reload && systemctl --user restart <svc>.service
 #
@@ -19,8 +28,22 @@ set -uo pipefail
 QUADLET_DIR="${QUADLET_DIR:-$HOME/containers/quadlets}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 SIGNERS_FILE="${SIGNERS_FILE:-$HOME/containers/config/supply-chain/signers.yaml}"
+BAKE_POLICY="${BAKE_POLICY:-$HOME/containers/config/supply-chain/bake-policy.yml}"
 REPORT_FILE="$HOME/containers/docs/99-reports/image-updates-$(date +%Y%m%d).txt"
+JSON_FILE="${REPORT_FILE%.txt}.json"
 mkdir -p "$(dirname "$REPORT_FILE")"
+
+# ADR-036 P3 bake thresholds (days). Policy file overrides the defaults.
+BAKE_EGRESS=7
+BAKE_INTERNAL=3
+if [ -f "$BAKE_POLICY" ]; then
+    v="$(python3 -c "import yaml; print((yaml.safe_load(open('$BAKE_POLICY')) or {}).get('egress_days',''))" 2>/dev/null)"
+    [ -n "$v" ] && BAKE_EGRESS="$v"
+    v="$(python3 -c "import yaml; print((yaml.safe_load(open('$BAKE_POLICY')) or {}).get('internal_days',''))" 2>/dev/null)"
+    [ -n "$v" ] && BAKE_INTERNAL="$v"
+fi
+
+is_egress() { grep -qE '^Network=systemd-reverse_proxy' "$1"; }
 
 # ADR-030 P6 (Tier 3): pre-load repos that have a known signer so we can verify the
 # AVAILABLE digest and front-load the trust signal BEFORE a deliberate adopt (advisory).
@@ -30,59 +53,100 @@ if [ -f "$SIGNERS_FILE" ]; then
         python3 -c "import yaml; d=yaml.safe_load(open('$SIGNERS_FILE')) or {}; [print(s.get('repo','')) for s in (d.get('signers') or [])]" 2>/dev/null)
 fi
 
-updates=(); failed=(); local_builds=(); uptodate=0
+NOW_EPOCH=$(date +%s)
+updates=(); failed=(); local_builds=(); uptodate=0; baked_count=0; young_count=0
+json_rows=()  # TSV: service repo tag pinned available created age_days tier bake_days verdict signature
 
 for f in "$QUADLET_DIR"/*.container; do
     name="$(basename "$f" .container)"
     img="$(grep -m1 -E '^Image=' "$f" | sed 's/^Image=//' | tr -d '[:space:]')"
     [ -n "$img" ] || continue
 
+    tier="internal"; bake_days="$BAKE_INTERNAL"
+    if is_egress "$f"; then tier="egress"; bake_days="$BAKE_EGRESS"; fi
+
     if [[ "$img" == localhost/* ]]; then
         local_builds+=("$name (${img})"); continue
     fi
     if [[ "$img" != *@sha256:* ]]; then
-        updates+=("$name: ⚠️ FLOATING (not digest-pinned): $img"); continue
+        updates+=("$name: ⚠️ FLOATING (not digest-pinned): $img")
+        json_rows+=("$name"$'\t'"$img"$'\t'"-"$'\t'"-"$'\t'"-"$'\t'"-"$'\t'"-"$'\t'"$tier"$'\t'"$bake_days"$'\t'"FLOATING"$'\t'"-")
+        continue
     fi
 
     repo="${img%@*}"; pinned="${img##*@}"
     tag="$(grep -m1 -oE 'tag: [^,]+' "$f" | sed 's/tag: //')"; [ -n "$tag" ] || tag="latest"
 
-    current="$(timeout 30 skopeo inspect "docker://${repo}:${tag}" --format '{{.Digest}}' 2>/dev/null)"
-    if [ -z "$current" ]; then
+    probe="$(timeout 30 skopeo inspect "docker://${repo}:${tag}" --format '{{.Digest}}|{{.Created}}' 2>/dev/null)"
+    if [ -z "$probe" ]; then
         sleep 2  # registries (esp. GHCR/Docker Hub) throttle bursts — retry once
-        current="$(timeout 30 skopeo inspect "docker://${repo}:${tag}" --format '{{.Digest}}' 2>/dev/null)"
+        probe="$(timeout 30 skopeo inspect "docker://${repo}:${tag}" --format '{{.Digest}}|{{.Created}}' 2>/dev/null)"
     fi
-    if [ -z "$current" ]; then
+    if [ -z "$probe" ]; then
         failed+=("$name (${repo}:${tag})"); continue
     fi
     sleep 0.2  # be gentle on registries between checks
 
+    current="${probe%%|*}"
+    created_raw="${probe#*|}"
+    # skopeo emits e.g. "2026-06-05 16:06:15.177357755 +0000 UTC" — strip
+    # fractional seconds and the trailing zone name for GNU date.
+    created_clean="$(echo "$created_raw" | sed 's/\.[0-9]*//; s/ UTC$//; s/ m=.*$//')"
+    created_epoch="$(date -d "$created_clean" +%s 2>/dev/null)"
+    age_days="?"
+    [ -n "$created_epoch" ] && age_days=$(( (NOW_EPOCH - created_epoch) / 86400 ))
+
     # ADR-030 P6 advisory: if this repo has a known signer, verify the AVAILABLE digest
-    signote=""
+    signote=""; sigstate="unsigned"
     if [ -n "${SIGNER_REPOS[$repo]:-}" ]; then
         "$SCRIPT_DIR/verify-image-signature.sh" "${repo}@${current}" --quiet >/dev/null 2>&1
         case $? in
-            0) signote="  [✓ signature verified]" ;;
-            1) signote="  [✗ SIGNATURE FAILED — do not adopt]" ;;
-            *) signote="  [⚠ signature check error]" ;;
+            0) signote="  [✓ signature verified]"; sigstate="verified" ;;
+            1) signote="  [✗ SIGNATURE FAILED — do not adopt]"; sigstate="FAILED" ;;
+            *) signote="  [⚠ signature check error]"; sigstate="check-error" ;;
         esac
     fi
 
     if [ "$current" != "$pinned" ]; then
-        updates+=("$name | ${repo}:${tag} | pinned ${pinned:0:19}… → available ${current:0:19}…${signote}")
+        # ADR-036 bake verdict: digest age vs per-tier threshold
+        if [ "$age_days" = "?" ]; then
+            verdict="AGE-UNKNOWN"
+            bakenote="age unknown [${tier}, bake ${bake_days}d] → verify manually"
+        elif [ "$age_days" -ge "$bake_days" ]; then
+            verdict="BAKED"; baked_count=$((baked_count+1))
+            bakenote="age ${age_days}d [${tier}, bake ${bake_days}d] → BAKED ✓"
+        else
+            verdict="TOO-YOUNG"; young_count=$((young_count+1))
+            bakenote="age ${age_days}d [${tier}, bake ${bake_days}d] → TOO YOUNG (wait $((bake_days - age_days))d)"
+        fi
+        updates+=("$name | ${repo}:${tag} | pinned ${pinned:0:19}… → available ${current:0:19}… | ${bakenote}${signote}")
+        json_rows+=("$name"$'\t'"$repo"$'\t'"$tag"$'\t'"$pinned"$'\t'"$current"$'\t'"$created_clean"$'\t'"$age_days"$'\t'"$tier"$'\t'"$bake_days"$'\t'"$verdict"$'\t'"$sigstate")
     else
         uptodate=$((uptodate+1))
         [ -n "$signote" ] && updates+=("$name | ${repo}:${tag} | up-to-date${signote}")
     fi
 done
 
+# Machine-readable companion — the input contract for adopt-baked.sh.
+printf '%s\n' "${json_rows[@]:-}" | python3 -c "
+import sys, json
+cols = ['service','repo','tag','pinned','available','created','age_days','tier','bake_days','verdict','signature']
+rows = [dict(zip(cols, l.rstrip('\n').split('\t'))) for l in sys.stdin if l.strip()]
+for r in rows:
+    for k in ('age_days','bake_days'):
+        try: r[k] = int(r[k])
+        except (ValueError, TypeError): pass
+json.dump({'generated': '$(date -Iseconds)', 'bake_policy': {'egress_days': $BAKE_EGRESS, 'internal_days': $BAKE_INTERNAL}, 'candidates': rows}, open('$JSON_FILE','w'), indent=1)
+"
+
 {
     echo "Container Image Update Check (ADR-030 notify-only / skopeo digest-diff)"
     echo "Generated: $(date)"
+    echo "Bake policy (ADR-036): egress ${BAKE_EGRESS}d, internal ${BAKE_INTERNAL}d"
     echo "========================================"
     echo ""
     echo "Up to date (pinned == current tag digest): ${uptodate}"
-    echo "Updates available: ${#updates[@]}"
+    echo "Updates available: ${#updates[@]} (baked: ${baked_count}, too young: ${young_count})"
     echo "Local builds (rebuild to update, Tier 2): ${#local_builds[@]}"
     echo "Check failed (registry unreachable / rate-limited): ${#failed[@]}"
     echo ""
@@ -102,14 +166,18 @@ done
         echo ""
     fi
     echo "========================================"
-    echo "To adopt an update deliberately (after a bake interval, P3; digest is"
-    echo "signature-verified at adopt time per ADR-030 P6):"
+    echo "Machine-readable: $JSON_FILE"
+    echo ""
+    echo "To adopt all BAKED updates in dependency-ordered waves (ADR-036):"
+    echo "  scripts/adopt-baked.sh --dry-run   # review the plan"
+    echo "  scripts/adopt-baked.sh             # execute with per-service verification"
+    echo "To adopt a single update by hand (signature-verified at adopt, ADR-030 P6):"
     echo "  scripts/pin-container-image.sh <svc> --adopt <available-digest> --apply"
     echo "  systemctl --user daemon-reload && systemctl --user restart <svc>.service"
 } > "$REPORT_FILE"
 
 echo "🔍 Image update check complete → $REPORT_FILE"
-echo "   up-to-date=$uptodate  available=${#updates[@]}  local=${#local_builds[@]}  failed=${#failed[@]}"
+echo "   up-to-date=$uptodate  available=${#updates[@]} (baked=$baked_count young=$young_count)  local=${#local_builds[@]}  failed=${#failed[@]}"
 if [ ${#updates[@]} -gt 0 ]; then
     echo ""
     printf '   • %s\n' "${updates[@]}"

--- a/scripts/service-url.sh
+++ b/scripts/service-url.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+# service-url.sh — derive a service's external URL from Traefik dynamic config.
+#
+# Routing truth lives in config/traefik/dynamic/routers.yml (ADR-016), so the
+# external hostname for a container is mechanical: find the Traefik service
+# whose backend URL targets the container, then the router with a plain
+# Host(`…`) rule for that service. No more guessed hostnames in verify steps.
+#
+# Usage: service-url.sh <container-name>
+#   stdout: https://<host>/   (exit 0)
+#   exit 1: container has no Traefik route (internal-only service)
+set -euo pipefail
+
+ROUTERS_YML="${ROUTERS_YML:-$HOME/containers/config/traefik/dynamic/routers.yml}"
+CONTAINER="${1:?usage: service-url.sh <container-name>}"
+
+python3 - "$CONTAINER" "$ROUTERS_YML" <<'EOF'
+import re, sys
+import yaml
+from urllib.parse import urlparse
+
+container, routers_yml = sys.argv[1], sys.argv[2]
+d = yaml.safe_load(open(routers_yml)) or {}
+http = d.get('http', {})
+routers, services = http.get('routers', {}) or {}, http.get('services', {}) or {}
+
+# Traefik's own dashboard has no backend service entry
+if container == 'traefik':
+    matched = {'api@internal'}
+else:
+    matched = {
+        sname for sname, s in services.items()
+        for srv in (s.get('loadBalancer', {}) or {}).get('servers', []) or []
+        if urlparse(srv.get('url', '')).hostname == container
+    }
+if not matched:
+    sys.exit(1)
+
+# Prefer the catch-all router (rule is exactly Host(`…`)) over path-scoped ones
+plain, scoped = [], []
+for r in routers.values():
+    if r.get('service') not in matched:
+        continue
+    m = re.fullmatch(r"Host\(`([^`]+)`\)", r.get('rule', '').strip())
+    if m:
+        plain.append(m.group(1))
+    else:
+        m = re.search(r"Host\(`([^`]+)`\)", r.get('rule', ''))
+        if m:
+            scoped.append(m.group(1))
+hosts = plain or scoped
+if not hosts:
+    sys.exit(1)
+print(f"https://{hosts[0]}/")
+EOF


### PR DESCRIPTION
## Summary

Implements the three automation gaps identified after the first batch adoption (#270), and writes **ADR-036** (amending ADR-030) to codify what was previously prose.

### Piece 1 — Bake gate in discovery
`check-image-updates.sh` now resolves each available digest's **age** and emits a `BAKED ✓` / `TOO YOUNG (wait Nd)` verdict against `config/supply-chain/bake-policy.yml` (**egress 7d / internal 3d**; tier derived from the quadlet's networks). It also writes a machine-readable JSON companion with full digests — eliminating the manual 19-call skopeo sweep and truncated-digest copying from #270.

### Piece 2 — `adopt-baked.sh`
Wave-ordered batch adoption: plumbing → apps → core (one at a time) → data, with dependent-app restarts derived from quadlet `After=`/`Requires=` (matches #270's manual restarts exactly, plus the exporters that were missed). Per-service verification: systemd active + container healthcheck + HTTP through the Traefik route. **Halts on first failure** with rollback instructions. `--dry-run` for plan review; `--allow-young <svc>` is the ADR-036 exception lane (security-release override, CVE must be named in the commit). P6 signature gate unchanged.

### Piece 3 — `service-url.sh`
Derives a container's external URL from `routers.yml` (backend URL → service → plain `Host()` rule). ADR-016 corollary: verification reads routing truth instead of guessing — resolves the two wrong-hostname guesses from #270 (`events.`, `sso.`).

### ADR-036
Codifies the thresholds, the exception lane (bake by default, skip deliberately with a named CVE), and resolves the "pin everything" vs "patch fast" doctrine tension explicitly. CLAUDE.md updated (update loop + ADR index, latest 034→036 — the 034 pointer was already stale).

## Verification

- ✓ `bash -n` clean on all three scripts
- ✓ Live discovery run: all 10 current candidates annotated TOO-YOUNG with correct wait times; caught `mongo:7` moving again within an hour of #270 (the gate demonstrably earning its keep)
- ✓ JSON companion validates (full digests, ages, tiers, verdicts, signature states)
- ✓ `adopt-baked.sh --dry-run` renders correct wave plans with and without `--allow-young`; "nothing to adopt" path exits clean
- ✓ `service-url.sh` resolves all routed services; exits 1 for internal-only (redis-immich)
- ✓ Dependent derivation: nextcloud-db→nextcloud, gathio-db→gathio, redis-immich→immich-server+exporter, postgresql-immich→immich-server+postgres-exporter

## Test Plan

- [ ] Next monthly ritual: `check-image-updates.sh` → review → `adopt-baked.sh --dry-run` → `adopt-baked.sh` (most of the 10 deferred candidates will have baked by ~2026-06-17)
- [ ] First real `adopt-baked.sh` run observed end-to-end before trusting it unattended

🤖 Generated with [Claude Code](https://claude.com/claude-code)