### PR TITLE
feat(supply-chain): ADR-036 layers 1+2 — update nudge alerts + monthly-update.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Pattern-based deployment available via `homelab-deployment` skill (see `.claude/
 
 Governed by **ADR-030 (Container Supply-Chain Trust Model):** **fully implemented (Tier 1 + Tier 2)** — every registry image is digest-pinned (`tag@sha256:…`, tag = discovery handle, digest = execution contract), all `AutoUpdate=registry` lines are stripped, and the 2 local builds pin their `FROM` bases by digest. Nothing updates automatically; superseded ADR-015's `:latest`/auto-update trust model. A pre-commit hook enforces the invariants (egress tier pinned + de-automated, local bases pinned, no signature failures); `docs/AUTO-IMAGE-PIN-INDEX.md` is the daily audit view.
 
-**Deliberate update loop (ADR-036):**
+**Deliberate update loop (ADR-036)** — single entry point: `scripts/monthly-update.sh` (chains all steps below interactively; Discord nudges via `ImageUpdatesBaked*` alerts when ≥5 updates are baked):
 1. **Discover:** `scripts/check-image-updates.sh` — skopeo digest-diff, notify-only; annotates each candidate BAKED/TOO-YOUNG against the P3 bake policy (`config/supply-chain/bake-policy.yml`: egress 7d, internal 3d) and writes machine-readable JSON
 2. **Adopt:** `scripts/adopt-baked.sh [--dry-run]` — wave-ordered batch (plumbing → apps → core → DBs + dependent restarts), per-service health + HTTP verification, halt-on-failure; P6 signature gate applies via `pin-container-image.sh`
 3. **Exception lane:** a release fixing a known-exploited CVE in an egress-tier service may skip the bake via `--allow-young <svc>` — commit message must name the CVE

--- a/config/prometheus/alerts/image-update-alerts.yml
+++ b/config/prometheus/alerts/image-update-alerts.yml
@@ -1,0 +1,40 @@
+# ADR-036 layer 1 — the system tells the human when the monthly update ritual
+# is worth running; adoption itself stays behind a human keystroke (ADR-030 P1).
+# Metric source: scripts/check-image-updates.sh (weekly timer, Sun 10:00) →
+# data/backup-metrics/image-updates.prom → node_exporter textfile collector.
+# Alertmanager routes ImageUpdatesBaked.* with repeat_interval 168h (weekly
+# reminder, not 4-hourly noise).
+groups:
+  - name: image_updates
+    rules:
+      - alert: ImageUpdatesBakedReady
+        expr: image_updates_baked_count >= 5
+        for: 24h
+        labels:
+          severity: info
+        annotations:
+          summary: "{{ $value }} container updates baked and ready to adopt"
+          description: "{{ $value }} image updates have passed their ADR-036 bake interval. Run: scripts/monthly-update.sh (or adopt-baked.sh --dry-run to review the plan)."
+
+      # Even a small number of baked updates shouldn't sit forever — nudge
+      # monthly if anything adoptable has been waiting.
+      - alert: ImageUpdatesBakedStale
+        expr: image_updates_baked_count >= 1
+        for: 720h
+        labels:
+          severity: info
+        annotations:
+          summary: "Baked image updates waiting >30d"
+          description: "{{ $value }} baked update(s) have been adoptable for over 30 days. Run: scripts/monthly-update.sh"
+
+      # The nudge path is only trustworthy if the feed itself runs — alert if
+      # the weekly sweep hasn't completed in >8 days (timer broken or script
+      # failing; this metric family has a history of dying silently).
+      - alert: ImageUpdateFeedStale
+        expr: time() - image_updates_last_run_timestamp_seconds > 8 * 86400
+        for: 1h
+        labels:
+          severity: warning
+        annotations:
+          summary: "Image update feed has not run in >8 days"
+          description: "check-image-updates.timer (Sun 10:00) appears broken — the ADR-036 update nudge is blind. Check: systemctl --user status check-image-updates.{timer,service}"

--- a/docs/AUTO-DEPENDENCY-GRAPH.md
+++ b/docs/AUTO-DEPENDENCY-GRAPH.md
@@ -1,6 +1,6 @@
 # Service Dependency Graph (Auto-Generated)
 
-**Generated:** 2026-06-10 05:04:34 UTC
+**Generated:** 2026-06-11 05:00:34 UTC
 **System:** fedora-htpc
 
 ---

--- a/docs/AUTO-DOCUMENTATION-INDEX.md
+++ b/docs/AUTO-DOCUMENTATION-INDEX.md
@@ -1,7 +1,7 @@
 # Documentation Index (Auto-Generated)
 
-**Generated:** 2026-06-10 05:04:34 UTC
-**Total Documents:** 438
+**Generated:** 2026-06-11 05:00:35 UTC
+**Total Documents:** 439
 
 ---
 
@@ -22,7 +22,7 @@
 
 ## Documentation by Category
 
-### 00-foundation/ (29 documents)
+### 00-foundation/ (30 documents)
 
 **Fundamentals and core concepts**
 
@@ -56,6 +56,7 @@
 - ADR-031: [2026-05-25-ADR-031-dns-resolver-first-class-and-ha](00-foundation/decisions/2026-05-25-ADR-031-dns-resolver-first-class-and-ha.md)
 - ADR-032: [2026-06-05-ADR-032-forgejo-git-over-ssh-loopback](00-foundation/decisions/2026-06-05-ADR-032-forgejo-git-over-ssh-loopback.md)
 - ADR-034: [2026-06-06-ADR-034-forgejo-instance-commit-signing-ssh](00-foundation/decisions/2026-06-06-ADR-034-forgejo-instance-commit-signing-ssh.md)
+- ADR-036: [2026-06-10-ADR-036-bake-policy-and-exception-lane](00-foundation/decisions/2026-06-10-ADR-036-bake-policy-and-exception-lane.md)
 - : [README](00-foundation/decisions/fixtures/README.md)
 - ADR-023: [2026-04-18-ADR-023-btrfs-storage-architecture-databases](00-foundation/decisions/withdrawn/2026-04-18-ADR-023-btrfs-storage-architecture-databases.md)
 
@@ -250,6 +251,7 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 - 2026-06-09: [2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md](00-foundation/decisions/2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md)
 - 2026-06-06: [2026-06-05-ADR-032-forgejo-git-over-ssh-loopback.md](00-foundation/decisions/2026-06-05-ADR-032-forgejo-git-over-ssh-loopback.md)
 - 2026-06-06: [2026-06-06-ADR-034-forgejo-instance-commit-signing-ssh.md](00-foundation/decisions/2026-06-06-ADR-034-forgejo-instance-commit-signing-ssh.md)
+- 2026-06-11: [2026-06-10-ADR-036-bake-policy-and-exception-lane.md](00-foundation/decisions/2026-06-10-ADR-036-bake-policy-and-exception-lane.md)
 - 2026-06-09: [2026-06-09-ADR-035-boot-time-io-tiering.md](20-operations/decisions/2026-06-09-ADR-035-boot-time-io-tiering.md)
 - 2026-06-09: [storage-health-monitoring.md](20-operations/guides/storage-health-monitoring.md)
 - 2026-06-07: [2026-06-07-cabinet-cooling-fan-controller-SKETCH.md](97-plans/2026-06-07-cabinet-cooling-fan-controller-SKETCH.md)
@@ -258,12 +260,12 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 - 2026-06-09: [2026-06-09-reboot-io-storm-not-podman-deathloop.md](98-journals/2026-06-09-reboot-io-storm-not-podman-deathloop.md)
 - 2026-06-09: [2026-06-09-storage-health-monitoring.md](98-journals/2026-06-09-storage-health-monitoring.md)
 - 2026-06-09: [remediation-monthly-202605.md](99-reports/remediation-monthly-202605.md)
-- 2026-06-10: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
-- 2026-06-10: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
-- 2026-06-10: [AUTO-EGRESS-BASELINE-INDEX.md](AUTO-EGRESS-BASELINE-INDEX.md)
-- 2026-06-10: [AUTO-IMAGE-PIN-INDEX.md](AUTO-IMAGE-PIN-INDEX.md)
-- 2026-06-10: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
-- 2026-06-10: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
+- 2026-06-11: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
+- 2026-06-11: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
+- 2026-06-11: [AUTO-EGRESS-BASELINE-INDEX.md](AUTO-EGRESS-BASELINE-INDEX.md)
+- 2026-06-11: [AUTO-IMAGE-PIN-INDEX.md](AUTO-IMAGE-PIN-INDEX.md)
+- 2026-06-11: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
+- 2026-06-11: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
 
 ---
 

--- a/docs/AUTO-EGRESS-BASELINE-INDEX.md
+++ b/docs/AUTO-EGRESS-BASELINE-INDEX.md
@@ -1,6 +1,6 @@
 # Egress Observatory — Baseline Index (Auto-Generated)
 
-**Generated:** 2026-06-10 05:04:35 UTC
+**Generated:** 2026-06-11 05:00:36 UTC
 **Implements:** ADR-030 P7 (Tier 4) — egress detection. **Mode:** shadow (observe-only)
 
 Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers (attributable, rootless, scratch-safe, DNS-method-agnostic). Detection, not prevention. See `config/supply-chain/known-egress.md` for method and residual/evasion scope.
@@ -9,8 +9,8 @@ Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers
 
 | Component | Last run | Detail |
 |---|---|---|
-| Collector (`egress-collector.service`) | 2s ago | 22 services sampled |
-| Classifier (`egress-detect.timer`) | 106s ago | mode=shadow (observe-only); last window 4 dest(s) |
+| Collector (`egress-collector.service`) | 28s ago | 22 services sampled |
+| Classifier (`egress-detect.timer`) | 70s ago | mode=shadow (observe-only); last window 7 dest(s) |
 
 ## Per-service egress
 
@@ -21,12 +21,12 @@ Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers
 | audiobookshelf | classify | — | — | — |
 | authelia | classify | — | — | — |
 | blackbox-exporter | classify | — | — | — |
-| crowdsec | classify | 33 | 33 (unarmed) | — |
+| crowdsec | classify | 37 | 37 (unarmed) | — |
 | forgejo | classify | — | — | — |
 | gathio | classify | 2 | 2 (unarmed) | — |
 | grafana | classify | 3 | 3 (unarmed) | — |
-| home-assistant | classify | 42 | 42 (unarmed) | — |
-| immich-server | classify | 2 | 2 (unarmed) | — |
+| home-assistant | classify | 43 | 43 (unarmed) | — |
+| immich-server | classify | 3 | 3 (unarmed) | — |
 | jellyfin | classify | 15 | 15 (unarmed) | — |
 | loki | classify | 1 | 1 (unarmed) | — |
 | navidrome | classify | 8 | 8 (unarmed) | — |
@@ -34,7 +34,7 @@ Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers
 | pihole-exporter | classify | — | — | — |
 | prometheus | classify | — | — | — |
 | proton-bridge | classify | 2 | 2 (unarmed) | — |
-| qbittorrent | peer-swarm (count-only) | — | — | 131 |
+| qbittorrent | peer-swarm (count-only) | — | — | 140 |
 | traefik | classify | 8 | 8 (unarmed) | — |
 | unpoller | classify | — | — | — |
 | vaultwarden | classify | 80 | 80 (unarmed) | — |
@@ -51,278 +51,284 @@ Egress-tier services with **no observed public destination** over the window. Ea
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `162.159.128.233` | 443 | ⚠️ unexpected | 13d ago | 30h ago | 32 |
-| `162.159.135.232` | 443 | ⚠️ unexpected | 16d ago | 30h ago | 41 |
-| `162.159.136.232` | 443 | ⚠️ unexpected | 9d ago | 30h ago | 37 |
-| `162.159.137.232` | 443 | ⚠️ unexpected | 5d ago | 30h ago | 40 |
-| `162.159.138.232` | 443 | ⚠️ unexpected | 15d ago | 30h ago | 44 |
+| `162.159.128.233` | 443 | ⚠️ unexpected | 14d ago | 2d ago | 32 |
+| `162.159.135.232` | 443 | ⚠️ unexpected | 17d ago | 2d ago | 41 |
+| `162.159.136.232` | 443 | ⚠️ unexpected | 10d ago | 2d ago | 37 |
+| `162.159.137.232` | 443 | ⚠️ unexpected | 6d ago | 2d ago | 40 |
+| `162.159.138.232` | 443 | ⚠️ unexpected | 16d ago | 2d ago | 44 |
 
 ### alertmanager
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `162.159.135.232` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 2 |
-| `162.159.138.232` | 80 | ⚠️ unexpected | 15d ago | 15d ago | 2 |
+| `162.159.135.232` | 443 | ⚠️ unexpected | 16d ago | 16d ago | 2 |
+| `162.159.138.232` | 80 | ⚠️ unexpected | 16d ago | 16d ago | 2 |
 
 ### crowdsec
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `108.128.137.208` | 443 | ⚠️ unexpected | 11d ago | 3d ago | 486 |
-| `108.128.190.179` | 443 | ⚠️ unexpected | 13d ago | 4d ago | 515 |
-| `108.128.222.234` | 443 | ⚠️ unexpected | 16d ago | 9d ago | 472 |
-| `108.132.135.16` | 443 | ⚠️ unexpected | 46h ago | 28h ago | 68 |
-| `108.132.165.136` | 443 | ⚠️ unexpected | 7d ago | 2d ago | 237 |
-| `18.200.183.204` | 443 | ⚠️ unexpected | 16d ago | 10d ago | 362 |
-| `34.240.98.252` | 443 | ⚠️ unexpected | 5d ago | 2d ago | 252 |
-| `34.242.194.148` | 443 | ⚠️ unexpected | 10d ago | 4d ago | 406 |
-| `34.249.149.68` | 443 | ⚠️ unexpected | 6d ago | 37h ago | 277 |
-| `34.250.39.237` | 443 | ⚠️ unexpected | 3d ago | 3h ago | 183 |
-| `34.250.77.39` | 443 | ⚠️ unexpected | 16d ago | 6d ago | 582 |
-| `34.254.73.132` | 443 | ⚠️ unexpected | 3d ago | 44m ago | 269 |
-| `34.255.143.231` | 443 | ⚠️ unexpected | 26h ago | 107m ago | 53 |
-| `34.255.59.56` | 443 | ⚠️ unexpected | 16d ago | 7d ago | 512 |
-| `52.17.58.50` | 443 | ⚠️ unexpected | 16d ago | 13d ago | 181 |
-| `52.18.68.74` | 443 | ⚠️ unexpected | 13d ago | 6d ago | 458 |
-| `52.19.64.236` | 443 | ⚠️ unexpected | 2d ago | 2h ago | 118 |
-| `52.210.229.63` | 443 | ⚠️ unexpected | 8d ago | 2d ago | 370 |
-| `52.213.228.152` | 443 | ⚠️ unexpected | 44h ago | 12m ago | 106 |
-| `52.30.5.78` | 443 | ⚠️ unexpected | 16d ago | 13d ago | 157 |
-| `52.48.23.149` | 443 | ⚠️ unexpected | 4d ago | 33h ago | 232 |
-| `52.48.238.219` | 443 | ⚠️ unexpected | 32h ago | 44m ago | 69 |
-| `54.195.186.68` | 443 | ⚠️ unexpected | 5d ago | 40h ago | 249 |
-| `54.246.207.199` | 443 | ⚠️ unexpected | 6d ago | 5d ago | 113 |
-| `54.76.169.38` | 443 | ⚠️ unexpected | 22h ago | 3h ago | 44 |
-| `54.76.192.134` | 443 | ⚠️ unexpected | 8d ago | 3d ago | 337 |
-| `54.77.8.107` | 443 | ⚠️ unexpected | 16d ago | 8d ago | 533 |
-| `63.34.141.128` | 443 | ⚠️ unexpected | 16d ago | 12d ago | 196 |
-| `63.35.170.229` | 443 | ⚠️ unexpected | 3d ago | 5h ago | 198 |
-| `63.35.22.155` | 443 | ⚠️ unexpected | 16d ago | 16d ago | 15 |
-| `79.125.15.38` | 443 | ⚠️ unexpected | 16d ago | 12d ago | 232 |
-| `99.80.129.27` | 443 | ⚠️ unexpected | 12d ago | 7d ago | 263 |
-| `99.81.12.92` | 443 | ⚠️ unexpected | 26h ago | 2h ago | 67 |
+| `108.128.137.208` | 443 | ⚠️ unexpected | 12d ago | 4d ago | 486 |
+| `108.128.190.179` | 443 | ⚠️ unexpected | 14d ago | 5d ago | 515 |
+| `108.128.222.234` | 443 | ⚠️ unexpected | 17d ago | 10d ago | 472 |
+| `108.132.135.16` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 68 |
+| `108.132.165.136` | 443 | ⚠️ unexpected | 8d ago | 3d ago | 237 |
+| `18.200.183.204` | 443 | ⚠️ unexpected | 17d ago | 11d ago | 362 |
+| `34.240.98.252` | 443 | ⚠️ unexpected | 6d ago | 3d ago | 252 |
+| `34.242.194.148` | 443 | ⚠️ unexpected | 11d ago | 5d ago | 406 |
+| `34.249.149.68` | 443 | ⚠️ unexpected | 7d ago | 2d ago | 277 |
+| `34.250.39.237` | 443 | ⚠️ unexpected | 4d ago | 8h ago | 226 |
+| `34.250.77.39` | 443 | ⚠️ unexpected | 17d ago | 7d ago | 582 |
+| `34.251.83.134` | 443 | ⚠️ unexpected | 11h ago | 22m ago | 42 |
+| `34.254.73.132` | 443 | ⚠️ unexpected | 4d ago | 11m ago | 357 |
+| `34.255.143.231` | 443 | ⚠️ unexpected | 2d ago | 15h ago | 73 |
+| `34.255.59.56` | 443 | ⚠️ unexpected | 17d ago | 8d ago | 512 |
+| `52.17.58.50` | 443 | ⚠️ unexpected | 17d ago | 14d ago | 181 |
+| `52.18.68.74` | 443 | ⚠️ unexpected | 14d ago | 7d ago | 458 |
+| `52.19.64.236` | 443 | ⚠️ unexpected | 3d ago | 3h ago | 171 |
+| `52.210.229.63` | 443 | ⚠️ unexpected | 9d ago | 3d ago | 370 |
+| `52.213.228.152` | 443 | ⚠️ unexpected | 2d ago | 44m ago | 155 |
+| `52.213.66.10` | 443 | ⚠️ unexpected | 9h ago | 75m ago | 24 |
+| `52.30.5.78` | 443 | ⚠️ unexpected | 17d ago | 14d ago | 157 |
+| `52.48.23.149` | 443 | ⚠️ unexpected | 5d ago | 2d ago | 232 |
+| `52.48.238.219` | 443 | ⚠️ unexpected | 2d ago | 44m ago | 116 |
+| `52.50.224.74` | 443 | ⚠️ unexpected | 11h ago | 3h ago | 29 |
+| `54.195.186.68` | 443 | ⚠️ unexpected | 6d ago | 2d ago | 249 |
+| `54.246.207.199` | 443 | ⚠️ unexpected | 7d ago | 6d ago | 113 |
+| `54.76.169.38` | 443 | ⚠️ unexpected | 46h ago | 21h ago | 64 |
+| `54.76.192.134` | 443 | ⚠️ unexpected | 9d ago | 4d ago | 337 |
+| `54.77.24.165` | 443 | ⚠️ unexpected | 12h ago | 9h ago | 23 |
+| `54.77.8.107` | 443 | ⚠️ unexpected | 17d ago | 9d ago | 533 |
+| `63.34.141.128` | 443 | ⚠️ unexpected | 17d ago | 13d ago | 196 |
+| `63.35.170.229` | 443 | ⚠️ unexpected | 4d ago | 15h ago | 228 |
+| `63.35.22.155` | 443 | ⚠️ unexpected | 17d ago | 17d ago | 15 |
+| `79.125.15.38` | 443 | ⚠️ unexpected | 17d ago | 13d ago | 232 |
+| `99.80.129.27` | 443 | ⚠️ unexpected | 13d ago | 8d ago | 263 |
+| `99.81.12.92` | 443 | ⚠️ unexpected | 2d ago | 26h ago | 67 |
 
 ### gathio
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.16.4.34` | 443 | ⚠️ unexpected | 13d ago | 13d ago | 9 |
-| `104.16.7.34` | 443 | ⚠️ unexpected | 30h ago | 30h ago | 4 |
+| `104.16.4.34` | 443 | ⚠️ unexpected | 14d ago | 7h ago | 34 |
+| `104.16.7.34` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 4 |
 
 ### grafana
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `192.0.73.2` | 443 | ⚠️ unexpected | 15d ago | 3d ago | 8 |
-| `34.120.177.193` | 443 | ⚠️ unexpected | 16d ago | 106s ago | 11817 |
-| `34.96.126.106` | 443 | ⚠️ unexpected | 15d ago | 18h ago | 77 |
+| `192.0.73.2` | 443 | ⚠️ unexpected | 16d ago | 4d ago | 8 |
+| `34.120.177.193` | 443 | ⚠️ unexpected | 17d ago | 70s ago | 12532 |
+| `34.96.126.106` | 443 | ⚠️ unexpected | 16d ago | 18h ago | 82 |
 
 ### home-assistant
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.26.4.238` | 443 | ⚠️ unexpected | 16d ago | 45h ago | 22 |
-| `104.26.5.238` | 443 | ⚠️ unexpected | 16d ago | 12h ago | 36 |
-| `151.101.1.195` | 443 | ⚠️ unexpected | 16d ago | 32h ago | 20 |
-| `151.101.65.195` | 443 | ⚠️ unexpected | 14d ago | 8h ago | 14 |
-| `157.249.81.141` | 443 | ⚠️ unexpected | 16d ago | 13h ago | 201 |
-| `172.67.68.90` | 443 | ⚠️ unexpected | 15d ago | 33h ago | 32 |
-| `18.156.89.194` | 443 | ⚠️ unexpected | 4d ago | 33m ago | 419 |
-| `18.158.11.29` | 8883 | ⚠️ unexpected | 3h ago | 106s ago | 442 |
-| `18.158.217.49` | 8883 | ⚠️ unexpected | 3d ago | 2d ago | 2668 |
-| `18.158.22.138` | 8883 | ⚠️ unexpected | 14d ago | 13d ago | 1702 |
-| `18.158.224.141` | 8883 | ⚠️ unexpected | 7d ago | 5d ago | 5641 |
-| `18.159.77.159` | 8883 | ⚠️ unexpected | 5d ago | 4d ago | 755 |
-| `18.159.79.242` | 8883 | ⚠️ unexpected | 9d ago | 8d ago | 2777 |
-| `18.184.210.208` | 8883 | ⚠️ unexpected | 16d ago | 16d ago | 1297 |
-| `18.184.241.150` | 8883 | ⚠️ unexpected | 3d ago | 3d ago | 58 |
-| `18.194.113.141` | 8883 | ⚠️ unexpected | 11d ago | 11d ago | 356 |
-| `18.194.166.209` | 8883 | ⚠️ unexpected | 30h ago | 3h ago | 3094 |
-| `18.196.104.106` | 8883 | ⚠️ unexpected | 10d ago | 9d ago | 2729 |
-| `18.198.195.194` | 8883 | ⚠️ unexpected | 16d ago | 14d ago | 5585 |
-| `3.120.211.84` | 8883 | ⚠️ unexpected | 4d ago | 3d ago | 4832 |
-| `3.120.216.195` | 443 | ⚠️ unexpected | 13d ago | 4d ago | 800 |
-| `3.120.53.2` | 8883 | ⚠️ unexpected | 13d ago | 12d ago | 3923 |
-| `3.121.10.31` | 8883 | ⚠️ unexpected | 12d ago | 11d ago | 759 |
-| `3.121.101.237` | 8883 | ⚠️ unexpected | 2d ago | 31h ago | 2420 |
-| `3.121.111.53` | 443 | ⚠️ unexpected | 8d ago | 2d ago | 599 |
-| `3.121.169.115` | 8883 | ⚠️ unexpected | 11d ago | 10d ago | 4472 |
-| `3.122.171.67` | 443 | ⚠️ unexpected | 12d ago | 3d ago | 708 |
-| `3.122.70.209` | 8883 | ⚠️ unexpected | 8d ago | 7d ago | 2815 |
-| `3.124.29.182` | 443 | ⚠️ unexpected | 16d ago | 8d ago | 810 |
-| `3.125.16.42` | 443 | ⚠️ unexpected | 3d ago | 39h ago | 239 |
-| `3.125.66.145` | 443 | ⚠️ unexpected | 16d ago | 12d ago | 491 |
-| `3.67.142.130` | 443 | ⚠️ unexpected | 16d ago | 6d ago | 907 |
-| `35.156.5.143` | 443 | ⚠️ unexpected | 6d ago | 3d ago | 254 |
-| `35.158.64.12` | 443 | ⚠️ unexpected | 6d ago | 12m ago | 656 |
-| `52.28.32.0` | 443 | ⚠️ unexpected | 2d ago | 12m ago | 225 |
-| `52.29.1.243` | 443 | ⚠️ unexpected | 38h ago | 106s ago | 160 |
-| `52.29.210.73` | 443 | ⚠️ unexpected | 16d ago | 6d ago | 926 |
-| `52.57.174.242` | 443 | ⚠️ unexpected | 16d ago | 13d ago | 429 |
-| `52.58.153.107` | 443 | ⚠️ unexpected | 8d ago | 2d ago | 542 |
-| `52.58.33.43` | 443 | ⚠️ unexpected | 2d ago | 12m ago | 218 |
-| `63.181.21.188` | 443 | ⚠️ unexpected | 3d ago | 33m ago | 425 |
-| `63.181.74.73` | 443 | ⚠️ unexpected | 16d ago | 8d ago | 789 |
+| `104.26.4.238` | 443 | ⚠️ unexpected | 17d ago | 11m ago | 25 |
+| `104.26.5.238` | 443 | ⚠️ unexpected | 17d ago | 9h ago | 38 |
+| `151.101.1.195` | 443 | ⚠️ unexpected | 17d ago | 8h ago | 22 |
+| `151.101.65.195` | 443 | ⚠️ unexpected | 15d ago | 32h ago | 14 |
+| `157.249.81.141` | 443 | ⚠️ unexpected | 17d ago | 70s ago | 202 |
+| `172.67.68.90` | 443 | ⚠️ unexpected | 16d ago | 2d ago | 32 |
+| `18.156.89.194` | 443 | ⚠️ unexpected | 5d ago | 22m ago | 504 |
+| `18.158.11.29` | 8883 | ⚠️ unexpected | 27h ago | 70s ago | 3228 |
+| `18.158.217.49` | 8883 | ⚠️ unexpected | 4d ago | 3d ago | 2668 |
+| `18.158.22.138` | 8883 | ⚠️ unexpected | 15d ago | 14d ago | 1702 |
+| `18.158.224.141` | 8883 | ⚠️ unexpected | 8d ago | 6d ago | 5641 |
+| `18.159.77.159` | 8883 | ⚠️ unexpected | 6d ago | 5d ago | 755 |
+| `18.159.79.242` | 8883 | ⚠️ unexpected | 10d ago | 9d ago | 2777 |
+| `18.184.210.208` | 8883 | ⚠️ unexpected | 17d ago | 17d ago | 1297 |
+| `18.184.241.150` | 8883 | ⚠️ unexpected | 4d ago | 4d ago | 58 |
+| `18.194.113.141` | 8883 | ⚠️ unexpected | 12d ago | 12d ago | 356 |
+| `18.194.166.209` | 8883 | ⚠️ unexpected | 2d ago | 27h ago | 3094 |
+| `18.196.104.106` | 8883 | ⚠️ unexpected | 11d ago | 10d ago | 2729 |
+| `18.198.195.194` | 8883 | ⚠️ unexpected | 17d ago | 15d ago | 5585 |
+| `3.120.211.84` | 8883 | ⚠️ unexpected | 5d ago | 4d ago | 4832 |
+| `3.120.216.195` | 443 | ⚠️ unexpected | 14d ago | 5d ago | 800 |
+| `3.120.53.2` | 8883 | ⚠️ unexpected | 14d ago | 13d ago | 3923 |
+| `3.121.10.31` | 8883 | ⚠️ unexpected | 13d ago | 12d ago | 759 |
+| `3.121.101.237` | 8883 | ⚠️ unexpected | 3d ago | 2d ago | 2420 |
+| `3.121.111.53` | 443 | ⚠️ unexpected | 9d ago | 3d ago | 599 |
+| `3.121.169.115` | 8883 | ⚠️ unexpected | 12d ago | 11d ago | 4472 |
+| `3.122.171.67` | 443 | ⚠️ unexpected | 13d ago | 4d ago | 708 |
+| `3.122.70.209` | 8883 | ⚠️ unexpected | 9d ago | 8d ago | 2815 |
+| `3.124.29.182` | 443 | ⚠️ unexpected | 17d ago | 9d ago | 810 |
+| `3.125.16.42` | 443 | ⚠️ unexpected | 4d ago | 2d ago | 239 |
+| `3.125.66.145` | 443 | ⚠️ unexpected | 17d ago | 13d ago | 491 |
+| `3.67.142.130` | 443 | ⚠️ unexpected | 17d ago | 7d ago | 907 |
+| `35.156.5.143` | 443 | ⚠️ unexpected | 7d ago | 4d ago | 254 |
+| `35.158.64.12` | 443 | ⚠️ unexpected | 7d ago | 14h ago | 693 |
+| `52.28.32.0` | 443 | ⚠️ unexpected | 3d ago | 70s ago | 308 |
+| `52.29.1.243` | 443 | ⚠️ unexpected | 2d ago | 70s ago | 264 |
+| `52.29.210.73` | 443 | ⚠️ unexpected | 17d ago | 7d ago | 926 |
+| `52.57.174.242` | 443 | ⚠️ unexpected | 17d ago | 14d ago | 429 |
+| `52.58.153.107` | 443 | ⚠️ unexpected | 9d ago | 3d ago | 542 |
+| `52.58.33.43` | 443 | ⚠️ unexpected | 3d ago | 11m ago | 293 |
+| `63.181.21.188` | 443 | ⚠️ unexpected | 4d ago | 54m ago | 515 |
+| `63.181.74.73` | 443 | ⚠️ unexpected | 17d ago | 9d ago | 789 |
+| `63.182.123.150` | 443 | ⚠️ unexpected | 14h ago | 70s ago | 45 |
 
 ### immich-server
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.21.71.92` | 443 | ⚠️ unexpected | 16d ago | 97m ago | 436 |
-| `172.67.170.79` | 443 | ⚠️ unexpected | 16d ago | 33m ago | 415 |
+| `104.21.71.92` | 443 | ⚠️ unexpected | 17d ago | 2h ago | 463 |
+| `172.67.170.79` | 443 | ⚠️ unexpected | 17d ago | 11m ago | 438 |
+| `188.114.97.4` | 443 | ⚠️ unexpected | 5h ago | 5h ago | 2 |
 
 ### jellyfin
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.17.207.5` | 443 | ⚠️ unexpected | 16d ago | 36h ago | 9 |
-| `104.17.208.5` | 443 | ⚠️ unexpected | 15d ago | 3d ago | 18 |
-| `139.59.139.28` | 443 | ⚠️ unexpected | 13d ago | 8d ago | 9 |
-| `146.190.237.6` | 443 | ⚠️ unexpected | 11d ago | 4d ago | 18 |
-| `151.101.1.229` | 443 | ⚠️ unexpected | 11d ago | 2d ago | 10 |
-| `151.101.129.229` | 443 | ⚠️ unexpected | 10d ago | 6h ago | 10 |
-| `151.101.193.229` | 443 | ⚠️ unexpected | 14d ago | 5d ago | 6 |
-| `151.101.65.229` | 443 | ⚠️ unexpected | 30h ago | 30h ago | 1 |
-| `157.245.38.19` | 443 | ⚠️ unexpected | 12d ago | 12d ago | 5 |
-| `161.35.245.42` | 443 | ⚠️ unexpected | 10d ago | 5d ago | 7 |
-| `165.227.169.147` | 443 | ⚠️ unexpected | 16d ago | 30h ago | 32 |
-| `165.227.244.161` | 443 | ⚠️ unexpected | 15d ago | 30h ago | 19 |
-| `178.105.98.131` | 443 | ⚠️ unexpected | 16d ago | 6h ago | 17 |
-| `206.189.97.173` | 443 | ⚠️ unexpected | 9d ago | 6h ago | 14 |
-| `68.183.204.194` | 443 | ⚠️ unexpected | 16d ago | 6h ago | 10 |
+| `104.17.207.5` | 443 | ⚠️ unexpected | 17d ago | 2d ago | 9 |
+| `104.17.208.5` | 443 | ⚠️ unexpected | 16d ago | 6h ago | 23 |
+| `139.59.139.28` | 443 | ⚠️ unexpected | 14d ago | 9d ago | 9 |
+| `146.190.237.6` | 443 | ⚠️ unexpected | 12d ago | 5d ago | 18 |
+| `151.101.1.229` | 443 | ⚠️ unexpected | 12d ago | 3d ago | 10 |
+| `151.101.129.229` | 443 | ⚠️ unexpected | 11d ago | 30h ago | 10 |
+| `151.101.193.229` | 443 | ⚠️ unexpected | 15d ago | 6d ago | 6 |
+| `151.101.65.229` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 1 |
+| `157.245.38.19` | 443 | ⚠️ unexpected | 13d ago | 13d ago | 5 |
+| `161.35.245.42` | 443 | ⚠️ unexpected | 11d ago | 6h ago | 10 |
+| `165.227.169.147` | 443 | ⚠️ unexpected | 17d ago | 2d ago | 32 |
+| `165.227.244.161` | 443 | ⚠️ unexpected | 16d ago | 2d ago | 19 |
+| `178.105.98.131` | 443 | ⚠️ unexpected | 17d ago | 30h ago | 17 |
+| `206.189.97.173` | 443 | ⚠️ unexpected | 10d ago | 6h ago | 19 |
+| `68.183.204.194` | 443 | ⚠️ unexpected | 17d ago | 6h ago | 11 |
 
 ### loki
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `34.96.126.106` | 443 | ⚠️ unexpected | 16d ago | 2h ago | 486 |
+| `34.96.126.106` | 443 | ⚠️ unexpected | 17d ago | 2h ago | 516 |
 
 ### navidrome
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.21.43.229` | 443 | ⚠️ unexpected | 30h ago | 30h ago | 1 |
-| `130.211.19.189` | 443 | ⚠️ unexpected | 15d ago | 12d ago | 13 |
-| `151.101.237.188` | 443 | ⚠️ unexpected | 15d ago | 12d ago | 7 |
-| `151.101.238.53` | 443 | ⚠️ unexpected | 15d ago | 12d ago | 6 |
-| `151.101.238.79` | 443 | ⚠️ unexpected | 15d ago | 12d ago | 6 |
-| `2.22.225.107` | 443 | ⚠️ unexpected | 12d ago | 12d ago | 3 |
-| `2.22.225.83` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 4 |
-| `209.141.42.198` | 443 | ⚠️ unexpected | 16d ago | 5h ago | 55 |
+| `104.21.43.229` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 1 |
+| `130.211.19.189` | 443 | ⚠️ unexpected | 16d ago | 13d ago | 13 |
+| `151.101.237.188` | 443 | ⚠️ unexpected | 16d ago | 13d ago | 7 |
+| `151.101.238.53` | 443 | ⚠️ unexpected | 16d ago | 13d ago | 6 |
+| `151.101.238.79` | 443 | ⚠️ unexpected | 16d ago | 13d ago | 6 |
+| `2.22.225.107` | 443 | ⚠️ unexpected | 13d ago | 13d ago | 3 |
+| `2.22.225.83` | 443 | ⚠️ unexpected | 16d ago | 16d ago | 4 |
+| `209.141.42.198` | 443 | ⚠️ unexpected | 17d ago | 5h ago | 57 |
 
 ### nextcloud
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `65.108.197.113` | 443 | ⚠️ unexpected | 13d ago | 7d ago | 8 |
-| `65.109.114.179` | 443 | ⚠️ unexpected | 15d ago | 44h ago | 14 |
-| `65.21.231.50` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 2 |
-| `95.217.53.153` | 443 | ⚠️ unexpected | 14d ago | 20h ago | 16 |
+| `65.108.197.113` | 443 | ⚠️ unexpected | 14d ago | 20h ago | 10 |
+| `65.109.114.179` | 443 | ⚠️ unexpected | 16d ago | 2d ago | 14 |
+| `65.21.231.50` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 2 |
+| `95.217.53.153` | 443 | ⚠️ unexpected | 15d ago | 20h ago | 18 |
 
 ### proton-bridge
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `185.70.42.41` | 443 | ⚠️ unexpected | 16d ago | 106s ago | 13357 |
-| `185.70.42.45` | 443 | ⚠️ unexpected | 16d ago | 22m ago | 447 |
+| `185.70.42.41` | 443 | ⚠️ unexpected | 17d ago | 70s ago | 14163 |
+| `185.70.42.45` | 443 | ⚠️ unexpected | 17d ago | 11m ago | 469 |
 
 ### traefik
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.19.192.29` | 443 | ⚠️ unexpected | 12d ago | 12d ago | 5 |
-| `104.19.193.29` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 6 |
-| `104.26.3.101` | 443 | ⚠️ unexpected | 15d ago | 13d ago | 15 |
-| `13.39.208.199` | 443 | ⚠️ unexpected | 16d ago | 6h ago | 59 |
-| `140.82.121.5` | 443 | ⚠️ unexpected | 15d ago | 36h ago | 12 |
-| `140.82.121.6` | 443 | ⚠️ unexpected | 16d ago | 6h ago | 11 |
-| `172.65.32.248` | 443 | ⚠️ unexpected | 15d ago | 12d ago | 25 |
-| `172.67.75.8` | 443 | ⚠️ unexpected | 30h ago | 30h ago | 5 |
+| `104.19.192.29` | 443 | ⚠️ unexpected | 13d ago | 13d ago | 5 |
+| `104.19.193.29` | 443 | ⚠️ unexpected | 16d ago | 16d ago | 6 |
+| `104.26.3.101` | 443 | ⚠️ unexpected | 16d ago | 14d ago | 15 |
+| `13.39.208.199` | 443 | ⚠️ unexpected | 17d ago | 6h ago | 62 |
+| `140.82.121.5` | 443 | ⚠️ unexpected | 16d ago | 6h ago | 13 |
+| `140.82.121.6` | 443 | ⚠️ unexpected | 17d ago | 30h ago | 11 |
+| `172.65.32.248` | 443 | ⚠️ unexpected | 16d ago | 13d ago | 25 |
+| `172.67.75.8` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 5 |
 
 ### vaultwarden
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.16.123.96` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
-| `104.16.132.229` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
-| `104.16.99.29` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
-| `104.17.17.78` | 443 | ⚠️ unexpected | 9d ago | 3d ago | 5 |
-| `104.17.17.78` | 80 | ⚠️ unexpected | 9d ago | 3d ago | 5 |
-| `104.18.14.13` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
-| `104.18.161.117` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
-| `104.18.179.120` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 3 |
-| `104.18.193.106` | 443 | ⚠️ unexpected | 9d ago | 3d ago | 5 |
-| `104.18.27.69` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
-| `104.18.35.237` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
-| `104.19.171.101` | 80 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
-| `104.19.171.101` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
-| `104.19.172.101` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
-| `104.19.172.101` | 80 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
-| `104.20.7.63` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 3 |
-| `104.26.1.18` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 2 |
-| `13.107.6.156` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
-| `135.181.128.221` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 2 |
-| `138.199.37.230` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
-| `150.171.109.200` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 2 |
-| `151.101.129.91` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 1 |
-| `151.101.237.91` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 1 |
-| `151.101.239.52` | 443 | ⚠️ unexpected | 9d ago | 7d ago | 2 |
-| `151.101.67.52` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 1 |
-| `162.125.248.18` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 1 |
-| `162.125.71.18` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 1 |
-| `162.159.137.232` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
-| `172.66.137.109` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 2 |
-| `172.67.74.138` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
-| `18.195.2.2` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 3 |
-| `18.224.126.143` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
-| `185.109.198.109` | 80 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
-| `185.31.213.113` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 3 |
-| `193.212.190.216` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 1 |
-| `194.132.66.34` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 2 |
-| `194.242.11.186` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 2 |
-| `198.252.206.1` | 80 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
-| `198.252.206.1` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
-| `20.190.147.4` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
-| `20.190.177.20` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 3 |
-| `217.114.94.2` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
-| `3.167.1.165` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 3 |
-| `3.167.2.39` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 2 |
-| `3.167.2.44` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
-| `3.167.2.45` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
-| `3.167.2.93` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 2 |
-| `3.167.2.97` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
-| `3.33.186.135` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
-| `34.110.155.89` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
-| `34.95.108.49` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 2 |
-| `35.186.224.24` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 2 |
-| `35.231.208.158` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 2 |
-| `52.195.100.115` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 2 |
-| `52.196.64.126` | 443 | ⚠️ unexpected | 5d ago | 5d ago | 3 |
-| `52.198.57.38` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 1 |
-| `52.222.187.52` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 3 |
-| `52.84.50.103` | 443 | ⚠️ unexpected | 15d ago | 8h ago | 4 |
-| `52.84.50.115` | 443 | ⚠️ unexpected | 5d ago | 5d ago | 3 |
-| `52.84.50.125` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
-| `52.84.50.126` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
-| `52.84.50.128` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 2 |
-| `52.84.50.128` | 80 | ⚠️ unexpected | 7d ago | 7d ago | 2 |
-| `52.84.50.14` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 2 |
-| `52.84.50.16` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
-| `52.84.50.2` | 443 | ⚠️ unexpected | 2d ago | 2d ago | 2 |
-| `52.84.50.22` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
-| `52.84.50.4` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 2 |
-| `52.84.50.61` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 3 |
-| `54.178.185.42` | 443 | ⚠️ unexpected | 8h ago | 8h ago | 2 |
-| `54.240.174.10` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 2 |
-| `54.240.174.91` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 2 |
-| `62.249.184.112` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 1 |
-| `66.33.60.34` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 3 |
-| `76.76.21.21` | 443 | ⚠️ unexpected | 15d ago | 9d ago | 5 |
-| `76.76.21.22` | 443 | ⚠️ unexpected | 9d ago | 9d ago | 2 |
-| `95.101.10.146` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 1 |
-| `95.101.10.154` | 443 | ⚠️ unexpected | 7d ago | 7d ago | 1 |
-| `95.101.10.97` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 1 |
-| `98.82.155.134` | 443 | ⚠️ unexpected | 15d ago | 15d ago | 3 |
+| `104.16.123.96` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 3 |
+| `104.16.132.229` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 3 |
+| `104.16.99.29` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 3 |
+| `104.17.17.78` | 443 | ⚠️ unexpected | 10d ago | 4d ago | 5 |
+| `104.17.17.78` | 80 | ⚠️ unexpected | 10d ago | 4d ago | 5 |
+| `104.18.14.13` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 3 |
+| `104.18.161.117` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 3 |
+| `104.18.179.120` | 443 | ⚠️ unexpected | 16d ago | 16d ago | 3 |
+| `104.18.193.106` | 443 | ⚠️ unexpected | 10d ago | 4d ago | 5 |
+| `104.18.27.69` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 3 |
+| `104.18.35.237` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 3 |
+| `104.19.171.101` | 80 | ⚠️ unexpected | 4d ago | 4d ago | 3 |
+| `104.19.171.101` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 3 |
+| `104.19.172.101` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 3 |
+| `104.19.172.101` | 80 | ⚠️ unexpected | 4d ago | 4d ago | 3 |
+| `104.20.7.63` | 443 | ⚠️ unexpected | 16d ago | 16d ago | 3 |
+| `104.26.1.18` | 443 | ⚠️ unexpected | 10d ago | 10d ago | 2 |
+| `13.107.6.156` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 3 |
+| `135.181.128.221` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 2 |
+| `138.199.37.230` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 3 |
+| `150.171.109.200` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 2 |
+| `151.101.129.91` | 443 | ⚠️ unexpected | 16d ago | 16d ago | 1 |
+| `151.101.237.91` | 443 | ⚠️ unexpected | 16d ago | 16d ago | 1 |
+| `151.101.239.52` | 443 | ⚠️ unexpected | 10d ago | 8d ago | 2 |
+| `151.101.67.52` | 443 | ⚠️ unexpected | 10d ago | 10d ago | 1 |
+| `162.125.248.18` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 1 |
+| `162.125.71.18` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 1 |
+| `162.159.137.232` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 3 |
+| `172.66.137.109` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 2 |
+| `172.67.74.138` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 3 |
+| `18.195.2.2` | 443 | ⚠️ unexpected | 16d ago | 16d ago | 3 |
+| `18.224.126.143` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 3 |
+| `185.109.198.109` | 80 | ⚠️ unexpected | 4d ago | 4d ago | 3 |
+| `185.31.213.113` | 443 | ⚠️ unexpected | 16d ago | 16d ago | 3 |
+| `193.212.190.216` | 443 | ⚠️ unexpected | 16d ago | 16d ago | 1 |
+| `194.132.66.34` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 2 |
+| `194.242.11.186` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 2 |
+| `198.252.206.1` | 80 | ⚠️ unexpected | 4d ago | 4d ago | 3 |
+| `198.252.206.1` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 3 |
+| `20.190.147.4` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 3 |
+| `20.190.177.20` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 3 |
+| `217.114.94.2` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 3 |
+| `3.167.1.165` | 443 | ⚠️ unexpected | 16d ago | 16d ago | 3 |
+| `3.167.2.39` | 443 | ⚠️ unexpected | 16d ago | 16d ago | 2 |
+| `3.167.2.44` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 3 |
+| `3.167.2.45` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 3 |
+| `3.167.2.93` | 443 | ⚠️ unexpected | 16d ago | 16d ago | 2 |
+| `3.167.2.97` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 3 |
+| `3.33.186.135` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 3 |
+| `34.110.155.89` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 3 |
+| `34.95.108.49` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 2 |
+| `35.186.224.24` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 2 |
+| `35.231.208.158` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 2 |
+| `52.195.100.115` | 443 | ⚠️ unexpected | 10d ago | 10d ago | 2 |
+| `52.196.64.126` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `52.198.57.38` | 443 | ⚠️ unexpected | 16d ago | 16d ago | 1 |
+| `52.222.187.52` | 443 | ⚠️ unexpected | 16d ago | 16d ago | 3 |
+| `52.84.50.103` | 443 | ⚠️ unexpected | 16d ago | 32h ago | 4 |
+| `52.84.50.115` | 443 | ⚠️ unexpected | 6d ago | 6d ago | 3 |
+| `52.84.50.125` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 3 |
+| `52.84.50.126` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 3 |
+| `52.84.50.128` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 2 |
+| `52.84.50.128` | 80 | ⚠️ unexpected | 8d ago | 8d ago | 2 |
+| `52.84.50.14` | 443 | ⚠️ unexpected | 10d ago | 10d ago | 2 |
+| `52.84.50.16` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 3 |
+| `52.84.50.2` | 443 | ⚠️ unexpected | 3d ago | 3d ago | 2 |
+| `52.84.50.22` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 3 |
+| `52.84.50.4` | 443 | ⚠️ unexpected | 16d ago | 16d ago | 2 |
+| `52.84.50.61` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 3 |
+| `54.178.185.42` | 443 | ⚠️ unexpected | 32h ago | 32h ago | 2 |
+| `54.240.174.10` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 2 |
+| `54.240.174.91` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 2 |
+| `62.249.184.112` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 1 |
+| `66.33.60.34` | 443 | ⚠️ unexpected | 16d ago | 16d ago | 3 |
+| `76.76.21.21` | 443 | ⚠️ unexpected | 16d ago | 10d ago | 5 |
+| `76.76.21.22` | 443 | ⚠️ unexpected | 10d ago | 10d ago | 2 |
+| `95.101.10.146` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 1 |
+| `95.101.10.154` | 443 | ⚠️ unexpected | 8d ago | 8d ago | 1 |
+| `95.101.10.97` | 443 | ⚠️ unexpected | 4d ago | 4d ago | 1 |
+| `98.82.155.134` | 443 | ⚠️ unexpected | 16d ago | 16d ago | 3 |
 
 ---
 

--- a/docs/AUTO-IMAGE-PIN-INDEX.md
+++ b/docs/AUTO-IMAGE-PIN-INDEX.md
@@ -1,6 +1,6 @@
 # Container Image Pin Index (Auto-Generated)
 
-**Generated:** 2026-06-10 21:19:57 UTC
+**Generated:** 2026-06-11 05:00:36 UTC
 **Source:** `/home/patriark/containers/quadlets` — ADR-030 (Container Supply-Chain Trust Model)
 
 Pins live in each quadlet's `Image=` line (where Podman reads them); this is

--- a/docs/AUTO-NETWORK-TOPOLOGY.md
+++ b/docs/AUTO-NETWORK-TOPOLOGY.md
@@ -1,6 +1,6 @@
 # Network Topology (Auto-Generated)
 
-**Generated:** 2026-06-10 05:04:29 UTC
+**Generated:** 2026-06-11 05:00:27 UTC
 **System:** fedora-htpc | **Networks:** 11 | **Containers:** 37
 
 ---

--- a/docs/AUTO-SERVICE-CATALOG.md
+++ b/docs/AUTO-SERVICE-CATALOG.md
@@ -1,6 +1,6 @@
 # Service Catalog (Auto-Generated)
 
-**Generated:** 2026-06-10 05:04:28 UTC
+**Generated:** 2026-06-11 05:00:26 UTC
 **System:** fedora-htpc | **Services:** 37/37 running | **Health:** 32/32 healthy (5 without healthcheck)
 
 ---
@@ -9,83 +9,83 @@
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| audiobookshelf | advplyr/audiobookshelf@sha256:89276ff2e0b3d2f | ✅ healthy | 30h | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
-| blackbox-exporter | quay.io/prometheus/blackbox-exporter@sha256:e | ✅ healthy | 30h | — | — |
-| forgejo | codeberg.org/forgejo/forgejo@sha256:db04c7114 | ✅ healthy | 30h | [git.patriark.org](https://git.patriark.org) | — |
-| forgejo-db | postgres@sha256:16bc17c64a573ef34162af9298258 | ✅ healthy | 30h | — | — |
-| navidrome | deluan/navidrome@sha256:9fa40b3d8dec43ceb2213 | ✅ healthy | 30h | [musikk.patriark.org](https://musikk.patriark.org) | — |
-| pihole-exporter | ekofr/pihole-exporter@sha256:a890cc731a39da71 | — no check | 30h | — | — |
-| postgres-exporter | quay.io/prometheuscommunity/postgres-exporter | ✅ healthy | 30h | — | — |
-| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | 30h | — | — |
-| qbittorrent | linuxserver/qbittorrent@sha256:f76c4363cce083 | ✅ healthy | 30h | [torrent.patriark.org](https://torrent.patriark.org) | — |
-| redis-authelia-exporter | quay.io/oliver006/redis_exporter@sha256:e8c20 | — no check | 30h | — | — |
-| redis-immich-exporter | quay.io/oliver006/redis_exporter@sha256:e8c20 | — no check | 30h | — | — |
-| unifi-syslog | linuxserver/syslog-ng@sha256:0d164e438d1f9ee4 | ✅ healthy | 30h | — | — |
+| audiobookshelf | advplyr/audiobookshelf@sha256:89276ff2e0b3d2f | ✅ healthy | 2d | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
+| blackbox-exporter | quay.io/prometheus/blackbox-exporter@sha256:e | ✅ healthy | 2d | — | — |
+| forgejo | codeberg.org/forgejo/forgejo@sha256:db04c7114 | ✅ healthy | 2d | [git.patriark.org](https://git.patriark.org) | — |
+| forgejo-db | postgres@sha256:16bc17c64a573ef34162af9298258 | ✅ healthy | 2d | — | — |
+| navidrome | deluan/navidrome@sha256:9fa40b3d8dec43ceb2213 | ✅ healthy | 2d | [musikk.patriark.org](https://musikk.patriark.org) | — |
+| pihole-exporter | ekofr/pihole-exporter@sha256:a890cc731a39da71 | — no check | 2d | — | — |
+| postgres-exporter | quay.io/prometheuscommunity/postgres-exporter | ✅ healthy | 2d | — | — |
+| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | 2d | — | — |
+| qbittorrent | linuxserver/qbittorrent@sha256:f76c4363cce083 | ✅ healthy | 2d | [torrent.patriark.org](https://torrent.patriark.org) | — |
+| redis-authelia-exporter | quay.io/oliver006/redis_exporter@sha256:2e979 | — no check | 8h | — | — |
+| redis-immich-exporter | quay.io/oliver006/redis_exporter@sha256:2e979 | — no check | 8h | — | — |
+| unifi-syslog | linuxserver/syslog-ng@sha256:b77c32d93b9e9b84 | ✅ healthy | 8h | — | — |
 
 ## Core Infrastructure (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| authelia | authelia/authelia@sha256:0c824dcab1ae97c56bf6 | ✅ healthy | 30h | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
-| crowdsec | crowdsecurity/crowdsec@sha256:2f527c9bb8b3671 | ✅ healthy | 30h | — | [guide](10-services/guides/crowdsec.md) |
-| redis-authelia | redis@sha256:6ab0b6e7381779332f97b8ca76193e45 | ✅ healthy | 30h | — | — |
-| traefik | traefik@sha256:6b9cbca6fac42ab0075f5437d8dc16 | ✅ healthy | 30h | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
+| authelia | authelia/authelia@sha256:1b363e9279e742397966 | ✅ healthy | 8h | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
+| crowdsec | crowdsecurity/crowdsec@sha256:2f527c9bb8b3671 | ✅ healthy | 2d | — | [guide](10-services/guides/crowdsec.md) |
+| redis-authelia | redis@sha256:6ab0b6e7381779332f97b8ca76193e45 | ✅ healthy | 2d | — | — |
+| traefik | traefik@sha256:6b9cbca6fac42ab0075f5437d8dc16 | ✅ healthy | 2d | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
 
 ## Nextcloud (3)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| nextcloud-db | mariadb@sha256:78a5047d3ba33975f183f183c2464c | ✅ healthy | 30h | — | [guide](10-services/guides/nextcloud.md) |
-| nextcloud | nextcloud@sha256:b67959acacd54ed2d110e111c8b2 | ✅ healthy | 30h | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
-| nextcloud-redis | redis@sha256:6ab0b6e7381779332f97b8ca76193e45 | ✅ healthy | 30h | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-db | mariadb@sha256:be1ef4fe5f14589325c08a41c76334 | ✅ healthy | 8h | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud | nextcloud@sha256:b67959acacd54ed2d110e111c8b2 | ✅ healthy | 8h | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-redis | redis@sha256:6ab0b6e7381779332f97b8ca76193e45 | ✅ healthy | 2d | — | [guide](10-services/guides/nextcloud.md) |
 
 ## Immich (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| immich-ml | immich-app/immich-machine-learning@sha256:a25 | ✅ healthy | 30h | — | [guide](10-services/guides/immich.md) |
-| immich-server | immich-app/immich-server@sha256:c15bff75068ef | ✅ healthy | 30h | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
-| postgresql-immich | immich-app/postgres@sha256:bcf63357191b76a916 | ✅ healthy | 30h | — | — |
-| redis-immich | valkey/valkey@sha256:8436e10bc65c94886a91d441 | ✅ healthy | 30h | — | — |
+| immich-ml | immich-app/immich-machine-learning@sha256:a25 | ✅ healthy | 2d | — | [guide](10-services/guides/immich.md) |
+| immich-server | immich-app/immich-server@sha256:c15bff75068ef | ✅ healthy | 8h | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
+| postgresql-immich | immich-app/postgres@sha256:bcf63357191b76a916 | ✅ healthy | 2d | — | — |
+| redis-immich | valkey/valkey@sha256:4963247afc4cd33c7d3b2d28 | ✅ healthy | 8h | — | — |
 
 ## Jellyfin (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| jellyfin | jellyfin/jellyfin@sha256:1694ff069f0c9dafb283 | ✅ healthy | 30h | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
+| jellyfin | jellyfin/jellyfin@sha256:1694ff069f0c9dafb283 | ✅ healthy | 2d | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
 
 ## Vaultwarden (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| vaultwarden | vaultwarden/server@sha256:d626d04934cd1192ad8 | ✅ healthy | 30h | [vault.patriark.org](https://vault.patriark.org) | — |
+| vaultwarden | vaultwarden/server@sha256:d626d04934cd1192ad8 | ✅ healthy | 2d | [vault.patriark.org](https://vault.patriark.org) | — |
 
 ## Home Automation (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| home-assistant | home-assistant/home-assistant@sha256:d4fbec16 | ✅ healthy | 30h | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
+| home-assistant | home-assistant/home-assistant@sha256:d4fbec16 | ✅ healthy | 2d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
 
 ## Gathio (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| gathio-db | mongo@sha256:32979a1189dfdc44da3f5ed40d910495 | ✅ healthy | 30h | — | — |
-| gathio | lowercasename/gathio@sha256:b7e9675d4e22b62e4 | ✅ healthy | 30h | [events.patriark.org](https://events.patriark.org) | — |
+| gathio-db | mongo@sha256:c1a84ab5d0c17deed1e0dba1d24bd7c7 | ✅ healthy | 8h | — | — |
+| gathio | lowercasename/gathio@sha256:ff66a8d2cc522568c | ✅ healthy | 8h | [events.patriark.org](https://events.patriark.org) | — |
 
 ## Monitoring (9)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| alert-discord-relay | localhost/alert-discord-relay:2026-05-23 | ✅ healthy | 30h | — | [guide](10-services/guides/alert-discord-relay.md) |
-| alertmanager | quay.io/prometheus/alertmanager@sha256:51a825 | ✅ healthy | 30h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| cadvisor | gcr.io/cadvisor/cadvisor@sha256:3de2bd5203120 | ✅ healthy | 30h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| grafana | grafana/grafana@sha256:2d1f9ae67c1778d33e291d | ✅ healthy | 30h | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| loki | grafana/loki@sha256:191d4fdfb7264f16989f0a57f | — no check | 30h | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| node_exporter | quay.io/prometheus/node-exporter@sha256:0f422 | ✅ healthy | 30h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| prometheus | quay.io/prometheus/prometheus@sha256:c0b857ae | ✅ healthy | 30h | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| promtail | grafana/promtail@sha256:6cfa64ec432b24a912d64 | ✅ healthy | 30h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| unpoller | unpoller/unpoller@sha256:bf7bdcc59fcdaa469968 | — no check | 30h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| alert-discord-relay | localhost/alert-discord-relay:2026-05-23 | ✅ healthy | 2d | — | [guide](10-services/guides/alert-discord-relay.md) |
+| alertmanager | quay.io/prometheus/alertmanager@sha256:51a825 | ✅ healthy | 2d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| cadvisor | gcr.io/cadvisor/cadvisor@sha256:3de2bd5203120 | ✅ healthy | 2d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| grafana | grafana/grafana@sha256:5dad0df181cb644a14e136 | ✅ healthy | 8h | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| loki | grafana/loki@sha256:191d4fdfb7264f16989f0a57f | — no check | 2d | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| node_exporter | quay.io/prometheus/node-exporter@sha256:0f422 | ✅ healthy | 2d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| prometheus | quay.io/prometheus/prometheus@sha256:69f52414 | ✅ healthy | 8h | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| promtail | grafana/promtail@sha256:6cfa64ec432b24a912d64 | ✅ healthy | 8h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| unpoller | unpoller/unpoller@sha256:bf7bdcc59fcdaa469968 | — no check | 2d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
 
 ---
 
@@ -93,7 +93,7 @@
 
 - **Total Running:** 37
 - **Total Defined:** 37
-- **System Load:** 1,28, 1,62, 1,66
+- **System Load:** 1,87, 1,59, 1,39
 
 ---
 

--- a/scripts/check-image-updates.sh
+++ b/scripts/check-image-updates.sh
@@ -127,6 +127,30 @@ for f in "$QUADLET_DIR"/*.container; do
     fi
 done
 
+# Textfile metrics → node_exporter → Prometheus → ImageUpdatesBaked* alerts
+# (ADR-036 layer 1: the system nudges the human; nothing adopts automatically).
+# Temp MUST be in-dir (a /tmp temp keeps user_tmp_t, unreadable to node_exporter)
+# and 0644 (node_exporter runs unprivileged).
+METRIC_DIR="${METRIC_DIR:-$HOME/containers/data/backup-metrics}"
+if mkdir -p "$METRIC_DIR" 2>/dev/null && tmp_metric="$(mktemp -p "$METRIC_DIR" 2>/dev/null)"; then
+    {
+        echo "# HELP image_updates_baked_count Available image updates past their ADR-036 bake interval (adoptable now)."
+        echo "# TYPE image_updates_baked_count gauge"
+        echo "image_updates_baked_count ${baked_count}"
+        echo "# HELP image_updates_young_count Available image updates still inside their bake interval."
+        echo "# TYPE image_updates_young_count gauge"
+        echo "image_updates_young_count ${young_count}"
+        echo "# HELP image_updates_check_failed_count Images whose registry check failed this sweep."
+        echo "# TYPE image_updates_check_failed_count gauge"
+        echo "image_updates_check_failed_count ${#failed[@]}"
+        echo "# HELP image_updates_last_run_timestamp_seconds Unix time of the last completed update sweep."
+        echo "# TYPE image_updates_last_run_timestamp_seconds gauge"
+        echo "image_updates_last_run_timestamp_seconds $(date +%s)"
+    } > "$tmp_metric"
+    chmod 0644 "$tmp_metric"
+    mv "$tmp_metric" "$METRIC_DIR/image-updates.prom"
+fi
+
 # Machine-readable companion — the input contract for adopt-baked.sh.
 printf '%s\n' "${json_rows[@]:-}" | python3 -c "
 import sys, json

--- a/scripts/monthly-update.sh
+++ b/scripts/monthly-update.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+# monthly-update.sh — the one script name to remember (ADR-036 layer 2).
+#
+# Chains the whole monthly update ritual interactively. The human's job:
+# read the plan, say yes (the ADR-030 P1 deliberate-trust moment), reboot
+# when told. Every step underneath is the existing gated path — this adds
+# orchestration, not new trust decisions.
+#
+#   1. check-image-updates.sh        fresh sweep (verdicts, JSON, metrics)
+#   2. adopt-baked.sh --dry-run      show the wave plan
+#   3. [confirm]                     adopt with per-service verification
+#   4. pin index + git commit + PR   (optional squash-merge from here)
+#   5. [confirm] update-before-reboot.sh   snapshot → graceful shutdown → pull
+#   6. print the manual tail: dnf update → reboot → post-reboot-verify.sh
+#
+# Usage: monthly-update.sh [--allow-young svc,svc] [--skip-os]
+#   --allow-young  ADR-036 exception lane, passed through to adopt-baked.sh
+#                  (security-release override — name the CVE when prompted)
+#   --skip-os      stop after the container phase (no pre-reboot workflow)
+set -euo pipefail
+
+CONTAINERS_DIR="$HOME/containers"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+ALLOW_YOUNG=""; SKIP_OS=false
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --allow-young) ALLOW_YOUNG="$2"; shift ;;
+        --skip-os) SKIP_OS=true ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+    shift
+done
+
+# Interactive by design — the confirm prompts ARE the P1 gate.
+if [ ! -t 0 ]; then
+    echo "❌ monthly-update.sh is interactive (ADR-030 P1: adoption needs a human)." >&2
+    echo "   For unattended visibility use the check-image-updates.timer feed." >&2
+    exit 2
+fi
+
+confirm() {  # confirm "question" → 0 yes / 1 no
+    local reply
+    read -r -p "$1 [y/N] " reply
+    [[ "$reply" =~ ^[Yy]$ ]]
+}
+
+echo "════════════════════════════════════════════════════════════════"
+echo "  MONTHLY UPDATE — $(date +%Y-%m-%d)"
+echo "════════════════════════════════════════════════════════════════"
+echo ""
+echo "── Step 1/5: Discovery sweep (registry digest-diff + bake verdicts) ──"
+"$SCRIPT_DIR/check-image-updates.sh"
+echo ""
+
+echo "── Step 2/5: Adoption plan ──"
+ADOPT_ARGS=()
+[ -n "$ALLOW_YOUNG" ] && ADOPT_ARGS+=(--allow-young "$ALLOW_YOUNG")
+plan_output="$("$SCRIPT_DIR/adopt-baked.sh" --dry-run "${ADOPT_ARGS[@]}" 2>&1)"
+echo "$plan_output"
+echo ""
+
+adopted_any=false
+if grep -q "Adoption plan" <<< "$plan_output"; then
+    if [ -n "$ALLOW_YOUNG" ]; then
+        echo "⚠️  --allow-young is the ADR-036 security-release exception lane:"
+        echo "    the commit message must name the CVE/advisory that justifies it."
+    fi
+    if confirm "Adopt the plan above now (per-service verification, halts on failure)?"; then
+        echo ""
+        echo "── Step 3/5: Adopting ──"
+        "$SCRIPT_DIR/adopt-baked.sh" "${ADOPT_ARGS[@]}"
+        adopted_any=true
+    else
+        echo "   Skipped adoption."
+    fi
+else
+    echo "   Nothing baked — container phase is a no-op this month."
+fi
+echo ""
+
+if $adopted_any; then
+    echo "── Step 4/5: Pin index + commit ──"
+    "$SCRIPT_DIR/generate-image-pin-index.sh" >/dev/null 2>&1 || true
+    cd "$CONTAINERS_DIR"
+    if [ -n "$(git status --porcelain -- quadlets/)" ]; then
+        if confirm "Commit adopted pins and open a PR?"; then
+            # SSH-login sessions lack the agent socket → signing hangs without this
+            export SSH_AUTH_SOCK="${SSH_AUTH_SOCK:-/run/user/1000/gcr/ssh}"
+            branch="chore/image-adoption-$(date +%Y%m%d)"
+            services="$(git status --porcelain -- quadlets/ | awk '{print $2}' | xargs -rn1 basename | sed 's/\.container$//' | paste -sd', ')"
+            git checkout -b "$branch"
+            git add quadlets/ docs/AUTO-IMAGE-PIN-INDEX.md
+            git commit -m "chore(supply-chain): monthly digest adoption — ${services}
+
+Adopted via monthly-update.sh → adopt-baked.sh (ADR-036): bake-gated,
+wave-ordered, per-service verified. See docs/99-reports/image-updates-$(date +%Y%m%d).txt
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+            git push -u origin "$branch"
+            pr_url="$(gh pr create --fill 2>/dev/null | tail -1)"
+            echo "   PR: $pr_url"
+            if confirm "Squash-merge the PR now?"; then
+                gh pr merge --squash --delete-branch
+                echo "   ✓ merged; back on $(git branch --show-current)"
+            else
+                echo "   PR left open — merge when ready: gh pr merge $pr_url --squash --delete-branch"
+            fi
+        else
+            echo "   ⚠️  Adopted pins are UNCOMMITTED — the git-revert rollback path"
+            echo "      doesn't exist until they're committed. Don't forget."
+        fi
+    fi
+    echo ""
+fi
+
+if $SKIP_OS; then
+    echo "── Step 5/5: skipped (--skip-os) ──"
+    exit 0
+fi
+
+echo "── Step 5/5: OS pre-reboot workflow ──"
+if confirm "Run update-before-reboot.sh (snapshot → graceful shutdown → image ensure)?"; then
+    "$SCRIPT_DIR/update-before-reboot.sh"
+else
+    echo ""
+    echo "Skipped. Container phase is complete; run it later with:"
+    echo "  ./scripts/update-before-reboot.sh"
+fi


### PR DESCRIPTION
## Summary

Implements the two automation layers discussed after ADR-036 (#271): **automate the remembering, keep the trusting human.**

### Layer 1 — the system tells the human (no P1 tension)
- `check-image-updates.sh` now emits `data/backup-metrics/image-updates.prom`: baked/young/failed counts + last-run timestamp. The existing Sunday 10:00 timer keeps it fresh; the existing `discord-info` route (168h repeat) delivers it. Zero new plumbing.
- `image-update-alerts.yml` (3 rules, promtool-validated):
  - **ImageUpdatesBakedReady** — ≥5 updates past their bake interval for 24h → weekly Discord nudge
  - **ImageUpdatesBakedStale** — ≥1 baked update waiting >30 days → don't let the tail rot
  - **ImageUpdateFeedStale** (warning) — sweep silent >8 days → the nudge path itself is broken (this metric family has died silently before; now it self-reports)

### Layer 2 — one script name to remember
`monthly-update.sh` chains the whole ritual interactively: discovery sweep → wave plan → **y/N confirm (the ADR-030 P1 deliberate-trust moment)** → gated adoption → pin index + commit + PR (optional squash-merge) → hand-off to `update-before-reboot.sh`, which already prints the dnf/reboot/verify tail. `--allow-young` passes through the exception lane with a name-the-CVE warning; `--skip-os` stops after the container phase; non-TTY invocation refuses with exit 2 by design.

**Deliberately not built:** unattended adoption — it would dissolve P1 exactly where review matters most (egress tier).

The user's job is now: get the Discord ping → `./scripts/monthly-update.sh` → read the plan → say yes → reboot.

## Verification

- ✓ promtool: 3 rules SUCCESS; rule group confirmed loaded in Prometheus after SIGHUP
- ✓ Metric flows end-to-end: script → textfile (0644, `container_file_t`) → node_exporter → Prometheus query returns `young_count=10`, `baked_count=0`
- ✓ `monthly-update.sh` driven through a Python pty: full no-op path (0 baked), `--allow-young jellyfin` confirm path with exception-lane warning (declined cleanly), non-TTY guard exits 2
- ⚠️ The commit/PR/merge block could not be exercised live (nothing baked today) — it replicates the exact command sequence used in #270/#271. First real run lands ~2026-06-17 when the deferred batch bakes.

## Test Plan

- [ ] ~June 17: run `./scripts/monthly-update.sh` for real on the baked batch — observe the adopt + PR + merge path end-to-end
- [ ] Confirm ImageUpdatesBakedReady fires and lands in Discord once ≥5 candidates bake (expected within the week)
- [ ] Sunday: verify the timer-driven sweep refreshes the metric (`image_updates_last_run_timestamp_seconds` advances)

🤖 Generated with [Claude Code](https://claude.com/claude-code)