### PR TITLE
feat(ops): WP2 silent-erosion guards — boot-tier enforcement + dump-coverage audit

### DIFF
--- a/config/prometheus/alerts/db-dump-alerts.yml
+++ b/config/prometheus/alerts/db-dump-alerts.yml
@@ -65,6 +65,34 @@ groups:
           summary: "DB restore test overdue for {{ $labels.database }}"
           description: "No restore test for {{ $labels.database }} in {{ $value | humanizeDuration }} (should run weekly)."
 
+      # Warning: a DB-like service/data dir is not in db-dump.sh's ENGINES array
+      # and not a recorded exception — it is getting ZERO backup with zero other
+      # warning (the forgejo-db gap class that motivated ADR-029 / L-019).
+      # Emitted by scripts/audit-dump-coverage.sh after each nightly dump run.
+      - alert: DbDumpCoverageGap
+        expr: db_dump_coverage_gap == 1
+        for: 15m
+        labels:
+          severity: warning
+          category: backup
+          component: db-dump
+        annotations:
+          summary: "DB dump coverage gap: {{ $labels.database }} is not backed up"
+          description: "{{ $labels.database }} (found via {{ $labels.origin }}) is a DB-like service with no dump coverage. Add it to ENGINES in db-dump.sh + db-restore-test.sh, or record a decided exception in audit-dump-coverage.sh."
+
+      # Warning: the coverage audit itself stopped running (guards the guard).
+      # It runs as ExecStartPost of the nightly db-dump.service.
+      - alert: DbDumpCoverageAuditStale
+        expr: (time() - db_dump_coverage_audit_timestamp) > (86400 * 2)
+        for: 6h
+        labels:
+          severity: warning
+          category: backup
+          component: db-dump
+        annotations:
+          summary: "Dump-coverage audit hasn't run in 2+ days"
+          description: "audit-dump-coverage.sh last ran {{ $value | humanizeDuration }} ago — new uncovered databases would go unnoticed. Check db-dump.service ExecStartPost wiring."
+
       # Warning: a dump ballooned vs its own recent baseline — catches a runaway
       # table/DB or a misconfigured dump before it pressures the offsite dump set.
       # Guards against false positives:

--- a/config/prometheus/tests/alert-rules.test.yml
+++ b/config/prometheus/tests/alert-rules.test.yml
@@ -8,6 +8,7 @@ rule_files:
   - ../alerts/immich-alerts.yml
   - ../alerts/service-health.yml
   - ../alerts/infrastructure-warnings.yml
+  - ../alerts/db-dump-alerts.yml
 
 evaluation_interval: 1m
 
@@ -131,6 +132,25 @@ tests:
             exp_annotations:
               summary: "Container gathio not running"
               description: "gathio has not been seen by cAdvisor for over 10 minutes. It may have crashed or been stopped. Check: systemctl --user status gathio.service"
+
+  # --- L-019: dump-coverage gap (WP2) -----------------------------------------
+  - interval: 1m
+    input_series:
+      - series: 'db_dump_coverage_gap{database="forgejo-db",origin="subvol8-db"}'
+        values: '1x20'
+    alert_rule_test:
+      - eval_time: 16m
+        alertname: DbDumpCoverageGap
+        exp_alerts:
+          - exp_labels:
+              database: forgejo-db
+              origin: subvol8-db
+              severity: warning
+              category: backup
+              component: db-dump
+            exp_annotations:
+              summary: "DB dump coverage gap: forgejo-db is not backed up"
+              description: "forgejo-db (found via subvol8-db) is a DB-like service with no dump coverage. Add it to ENGINES in db-dump.sh + db-restore-test.sh, or record a decided exception in audit-dump-coverage.sh."
 
   # --- regression: MemoryPressureHigh can fire again post-hysteresis-removal -
   - interval: 1m

--- a/quadlets/alert-discord-relay.container
+++ b/quadlets/alert-discord-relay.container
@@ -1,6 +1,6 @@
 [Unit]
 Description=Alert Discord Relay - Alertmanager to Discord Webhook Bridge
-After=network-online.target reverse_proxy-network.service monitoring-network.service traefik.service
+After=network-online.target reverse_proxy-network.service monitoring-network.service
 Wants=monitoring-network.service network-online.target reverse_proxy-network.service
 
 [Container]
@@ -35,7 +35,10 @@ HealthRetries=3
 Slice=container.slice
 Restart=on-failure
 TimeoutStartSec=60
-# Boot tier C: yield during fan-out; After=traefik.service defers past the storm
+# Boot tier C weights (yield disk during fan-out), but UN-deferred: ADR-035 D2
+# says the alerting path (Alertmanager + relay) stays early so paging is not
+# blinded post-reboot. The After=traefik.service deferral from PR #242 predated
+# that decision and contradicted it — removed 2026-06-12.
 StartupCPUWeight=50
 StartupIOWeight=50
 

--- a/quadlets/alertmanager.container
+++ b/quadlets/alertmanager.container
@@ -44,6 +44,12 @@ HealthRetries=3
 Slice=container.slice
 Restart=on-failure
 TimeoutStartSec=120
+# Boot tier A (200): the alerting path must not be starved during the boot
+# I/O storm — ADR-035 keeps Alertmanager early and un-deferred so paging works
+# while everything else is still thrashing. Promoted explicitly 2026-06-12
+# (was implicit default 100, the only alert-path unit without a weight).
+StartupCPUWeight=200
+StartupIOWeight=200
 
 # Resource Limits
 MemoryMax=256M

--- a/quadlets/audiobookshelf.container
+++ b/quadlets/audiobookshelf.container
@@ -56,6 +56,7 @@ HealthStartPeriod=30s
 # SERVICE BEHAVIOR
 # ═══════════════════════════════════════════════════════════
 [Service]
+# Tier B (default 100) — ADR-035 boot tier: application class, deliberate default weight
 Slice=container.slice
 Restart=on-failure
 TimeoutStartSec=300

--- a/quadlets/crowdsec.container
+++ b/quadlets/crowdsec.container
@@ -28,6 +28,7 @@ HealthTimeout=10s
 HealthRetries=3
 
 [Service]
+# Tier B (default 100) — ADR-035 boot tier: application class, deliberate default weight
 Slice=container.slice
 Restart=on-failure
 TimeoutStartSec=900

--- a/quadlets/forgejo.container
+++ b/quadlets/forgejo.container
@@ -85,6 +85,7 @@ HealthRetries=3
 HealthStartPeriod=60s
 
 [Service]
+# Tier B (default 100) — ADR-035 boot tier: application class, deliberate default weight
 Slice=container.slice
 Restart=on-failure
 TimeoutStartSec=300

--- a/quadlets/gathio.container
+++ b/quadlets/gathio.container
@@ -45,6 +45,7 @@ HealthRetries=3
 HealthStartPeriod=60s
 
 [Service]
+# Tier B (default 100) — ADR-035 boot tier: application class, deliberate default weight
 Slice=container.slice
 Restart=on-failure
 TimeoutStartSec=300

--- a/quadlets/home-assistant.container
+++ b/quadlets/home-assistant.container
@@ -36,6 +36,7 @@ HealthRetries=3
 HealthStartPeriod=90s
 
 [Service]
+# Tier B (default 100) — ADR-035 boot tier: application class, deliberate default weight
 Slice=container.slice
 Restart=on-failure
 TimeoutStartSec=300

--- a/quadlets/immich-ml.container
+++ b/quadlets/immich-ml.container
@@ -26,6 +26,7 @@ HealthRetries=3
 HealthStartPeriod=600s
 
 [Service]
+# Tier B (default 100) — ADR-035 boot tier: application class, deliberate default weight
 Slice=container.slice
 Restart=on-failure
 TimeoutStartSec=1800

--- a/quadlets/immich-server.container
+++ b/quadlets/immich-server.container
@@ -59,6 +59,7 @@ HealthRetries=3
 HealthStartPeriod=300s
 
 [Service]
+# Tier B (default 100) — ADR-035 boot tier: application class, deliberate default weight
 Slice=container.slice
 Restart=on-failure
 TimeoutStartSec=900

--- a/quadlets/jellyfin.container
+++ b/quadlets/jellyfin.container
@@ -48,6 +48,7 @@ HealthRetries=3
 HealthStartPeriod=60s
 
 [Service]
+# Tier B (default 100) — ADR-035 boot tier: application class, deliberate default weight
 Slice=container.slice
 Restart=on-failure
 TimeoutStartSec=900

--- a/quadlets/navidrome.container
+++ b/quadlets/navidrome.container
@@ -55,6 +55,7 @@ HealthStartPeriod=30s
 # SERVICE BEHAVIOR
 # ═══════════════════════════════════════════════════════════
 [Service]
+# Tier B (default 100) — ADR-035 boot tier: application class, deliberate default weight
 Slice=container.slice
 Restart=on-failure
 TimeoutStartSec=300

--- a/quadlets/nextcloud.container
+++ b/quadlets/nextcloud.container
@@ -71,6 +71,7 @@ Label=prometheus.port=80
 Label=prometheus.path=/ocs/v2.php/apps/serverinfo/api/v1/info
 
 [Service]
+# Tier B (default 100) — ADR-035 boot tier: application class, deliberate default weight
 Slice=container.slice
 Restart=on-failure
 TimeoutStartSec=300

--- a/quadlets/proton-bridge.container
+++ b/quadlets/proton-bridge.container
@@ -31,6 +31,7 @@ HealthRetries=3
 HealthStartPeriod=120s
 
 [Service]
+# Tier B (default 100) — ADR-035 boot tier: application class, deliberate default weight
 Slice=container.slice
 Restart=on-failure
 RestartSec=30s

--- a/quadlets/qbittorrent.container
+++ b/quadlets/qbittorrent.container
@@ -40,6 +40,7 @@ HealthRetries=3
 HealthStartPeriod=60s
 
 [Service]
+# Tier B (default 100) — ADR-035 boot tier: application class, deliberate default weight
 Slice=container.slice
 Restart=on-failure
 TimeoutStartSec=120

--- a/quadlets/vaultwarden.container
+++ b/quadlets/vaultwarden.container
@@ -61,6 +61,7 @@ HealthStartPeriod=10s
 # SERVICE BEHAVIOR
 # ═══════════════════════════════════════════════════════════
 [Service]
+# Tier B (default 100) — ADR-035 boot tier: application class, deliberate default weight
 Slice=container.slice
 Restart=on-failure
 TimeoutStartSec=300

--- a/scripts/audit-dump-coverage.sh
+++ b/scripts/audit-dump-coverage.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+# audit-dump-coverage.sh — ADR-029 / L-019 dump-coverage erosion guard (WP2, 2026-06-12)
+#
+# db-dump.sh has a hardcoded ENGINES=() array: a new Tier-2 database that is
+# never added there (and to db-restore-test.sh) gets ZERO backup with ZERO
+# warning — exactly the forgejo-db/loki gap that motivated ADR-029. This script
+# closes the loop mechanically:
+#
+#   EXPECTED = quadlets running a real DB engine image (postgres|mariadb|mongo|mysql)
+#            ∪ top-level dirs on /mnt/btrfs-pool/subvol8-db (ADR-029 DB domicile)
+#   COVERED  = ENGINES array parsed live from db-dump.sh (single source of truth)
+#   GAP      = EXPECTED − COVERED − EXCEPTIONS
+#
+# EXCEPTIONS are *recorded decisions*, not conveniences — each needs a rationale:
+#   loki — Tier 3 / discard-and-reingest by design (ADR-029; nightly dump froze
+#          it ~15 min on a cold cache and log data is not source-of-truth).
+#
+# Output: textfile metrics (node_exporter textfile collector, same channel as
+# db-dumps.prom). Labels use database= per the established db_dump_* scheme —
+# NOT a service= label (L-045: that clobbers/collides in the inhibit rules).
+# Alerts: DbDumpCoverageGap / DbDumpCoverageAuditStale in db-dump-alerts.yml.
+#
+# Wiring: ExecStartPost=-%h/containers/scripts/audit-dump-coverage.sh in
+# db-dump.service ("-" so a coverage gap flags via metrics/alerts without
+# marking the dump run itself failed). Exit 1 on gap for ad-hoc / CI use.
+
+set -euo pipefail
+
+QUADLET_DIR="${HOME}/containers/quadlets"
+DB_DUMP_SCRIPT="${HOME}/containers/scripts/db-dump.sh"
+DB_SUBVOL="/mnt/btrfs-pool/subvol8-db"
+METRICS_DIR="${HOME}/containers/data/backup-metrics"
+METRICS_FILE="${METRICS_DIR}/dump-coverage.prom"
+
+EXCEPTIONS=(loki)
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [$1] ${*:2}" >&2; }
+
+# --- COVERED: parse ENGINES=( ... ) from db-dump.sh -----------------------------
+mapfile -t COVERED < <(grep -oP '^ENGINES=\(\K[^)]+' "$DB_DUMP_SCRIPT" | tr ' ' '\n' | grep -v '^$')
+if [[ ${#COVERED[@]} -eq 0 ]]; then
+    log ERROR "could not parse ENGINES array from $DB_DUMP_SCRIPT"
+    exit 2
+fi
+
+# --- EXPECTED --------------------------------------------------------------------
+declare -A EXPECTED
+
+# (a) quadlets running real DB engine images. The [@:] anchor after the engine
+# name keeps exporters out (e.g. .../postgres-exporter@... must not match).
+for f in "$QUADLET_DIR"/*.container; do
+    img="$(grep -oP '^Image=\K.*' "$f" || true)"
+    [[ -z "$img" ]] && continue
+    if [[ "$img" =~ /(postgres|mariadb|mongo|mysql)[@:] ]]; then
+        name="$(grep -oP '^ContainerName=\K.*' "$f" || basename "$f" .container)"
+        EXPECTED["$name"]="quadlet:$(basename "$f")"
+    fi
+done
+
+# (b) DB-class data domiciles on subvol8-db (ADR-029)
+if [[ -d "$DB_SUBVOL" ]]; then
+    for d in "$DB_SUBVOL"/*/; do
+        [[ -d "$d" ]] || continue
+        EXPECTED["$(basename "$d")"]="subvol8-db"
+    done
+fi
+
+# --- GAP ---------------------------------------------------------------------------
+GAPS=()
+for svc in "${!EXPECTED[@]}"; do
+    covered=0
+    for c in "${COVERED[@]}"; do [[ "$svc" == "$c" ]] && covered=1 && break; done
+    for e in "${EXCEPTIONS[@]}"; do [[ "$svc" == "$e" ]] && covered=1 && break; done
+    [[ $covered -eq 0 ]] && GAPS+=("$svc")
+done
+
+# --- report + metrics ----------------------------------------------------------------
+mkdir -p "$METRICS_DIR"
+{
+    echo "# HELP db_dump_coverage_gap DB-like service/data dir not covered by db-dump.sh ENGINES (1=uncovered)"
+    echo "# TYPE db_dump_coverage_gap gauge"
+    for g in "${GAPS[@]+"${GAPS[@]}"}"; do
+        echo "db_dump_coverage_gap{database=\"$g\",origin=\"${EXPECTED[$g]}\"} 1"
+    done
+    echo "# HELP db_dump_coverage_gap_total Number of uncovered DB-like services"
+    echo "# TYPE db_dump_coverage_gap_total gauge"
+    echo "db_dump_coverage_gap_total ${#GAPS[@]}"
+    echo "# HELP db_dump_coverage_audit_timestamp Unix timestamp of last coverage audit"
+    echo "# TYPE db_dump_coverage_audit_timestamp gauge"
+    echo "db_dump_coverage_audit_timestamp $(date +%s)"
+} > "${METRICS_FILE}.tmp"
+mv "${METRICS_FILE}.tmp" "$METRICS_FILE"
+
+if [[ ${#GAPS[@]} -gt 0 ]]; then
+    log WARN "dump-coverage GAP: ${GAPS[*]} (in ${#EXPECTED[@]} expected, ${#COVERED[@]} covered)"
+    log WARN "fix: add to ENGINES in db-dump.sh + db-restore-test.sh, or record a decided exception here"
+    exit 1
+fi
+log INFO "dump coverage OK: ${#EXPECTED[@]} DB-like services/dirs all covered or excepted"
+exit 0

--- a/scripts/check-boot-tier.sh
+++ b/scripts/check-boot-tier.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# check-boot-tier.sh — ADR-035 boot-tier enforcement (WP2, 2026-06-12)
+#
+# Every quadlet .container file must take an explicit position on its boot tier:
+#   - declare StartupCPUWeight= AND StartupIOWeight= (Tier A=200 / Tier C=50), or
+#   - carry a literal "# Tier B (default 100)" comment.
+# Without this gate, new services silently land at default weight and the
+# tiering scheme decays one service at a time (the exact erosion that put
+# prometheus/loki/grafana — the heaviest boot I/O producers — at default
+# weight until the 2026-06-09 storm; see ADR-035).
+#
+# Wired into the local pre-commit chain (.git/hooks/pre-commit, which is not
+# version-controlled — re-add a call to this script if the hook is rebuilt):
+#   if ! ~/containers/scripts/check-boot-tier.sh; then CHECK_FAILED=1; fi
+#
+# Exit: 0 = all quadlets compliant, 1 = violations listed on stdout.
+
+set -euo pipefail
+
+QUADLET_DIR="${HOME}/containers/quadlets"
+FAIL=0
+
+for f in "$QUADLET_DIR"/*.container; do
+    name="$(basename "$f")"
+    if grep -q '^StartupCPUWeight=' "$f" && grep -q '^StartupIOWeight=' "$f"; then
+        continue
+    fi
+    if grep -q '# Tier B (default 100)' "$f"; then
+        continue
+    fi
+    if [[ $FAIL -eq 0 ]]; then
+        echo "ADR-035 boot-tier violations (declare Startup{CPU,IO}Weight or a '# Tier B (default 100)' comment):"
+    fi
+    echo "  ✗ $name"
+    FAIL=1
+done
+
+if [[ $FAIL -eq 0 ]]; then
+    echo "  ✓ All quadlets declare a boot tier (ADR-035)"
+fi
+exit $FAIL

--- a/systemd/db-dump.service
+++ b/systemd/db-dump.service
@@ -7,6 +7,10 @@ Wants=network-online.target
 [Service]
 Type=oneshot
 ExecStart=%h/containers/scripts/db-dump.sh
+# WP2 (L-019): coverage audit after each dump run — flags DB-like services
+# missing from the ENGINES array via db_dump_coverage_gap metrics. "-" prefix:
+# a gap alerts through Prometheus, it must not mark the dump run failed.
+ExecStartPost=-%h/containers/scripts/audit-dump-coverage.sh
 TimeoutStartSec=1h
 
 # Low priority — do not interfere with interactive use or other I/O


### PR DESCRIPTION
## Summary

WP2 from the 2026-06-12 lessons.md loose-threads handoff. **Stacked on #281** (this repo is the live config — branching from main would have reverted running WP1 files on disk; merge #281 first, this PR will retarget to main).

### ADR-035 boot-tier enforcement
- **alertmanager**: `StartupCPU/IOWeight=200` — it was the only alert-path unit without a weight. (Note: ADR-035's Tier A keystone list doesn't name alertmanager explicitly; promoted per the handoff and ADR-035's own stated intent that the alerting path must work during the boot storm. Flagging for review.)
- **alert-discord-relay**: handoff premise was stale — its Tier C weights landed in PR #242. But a real inconsistency surfaced: PR #242 gave it `After=traefik.service` (deferral), while the later ADR-035 D2 explicitly keeps the alerting path **un-deferred**. Removed the deferral; weights kept.
- **13 app quadlets** stamped `# Tier B (default 100)` so default-by-omission becomes default-by-decision.
- **`scripts/check-boot-tier.sh`** wired as Check 4 in the local pre-commit chain: every `.container` declares weights or a Tier B marker. Ran on this very commit. (`.git/hooks/pre-commit` is unversioned; the wiring line is documented in the script header for hook rebuilds.)
- Verified: clean daemon-reload, quadlet generator emits all 48 units, `systemctl show` confirms 200/200 and no traefik ordering on the relay.

### ADR-029 / L-019 dump-coverage audit
- **`scripts/audit-dump-coverage.sh`**: `EXPECTED` (quadlets running postgres/mariadb/mongo/mysql images ∪ subvol8-db dirs) − `ENGINES` (parsed live from db-dump.sh) − recorded exceptions (loki: Tier 3 discard-by-design). Emits `db_dump_coverage_gap` textfile metrics (`database=` label per house scheme, L-045-safe).
- **Kill-tested**: doctored ENGINES without forgejo-db → gap metric + exit 1, reproducing the exact gap class that motivated ADR-029.
- Wired as `ExecStartPost=-` of `db-dump.service` (repo + installed copy) — a gap alerts via Prometheus without failing the dump run.
- New alerts `DbDumpCoverageGap` + `DbDumpCoverageAuditStale` (guards the guard), promtool unit-tested, loaded live; current state: `db_dump_coverage_gap_total 0`.

## Verification
- promtool test suite (now 10 scenarios incl. WP1): SUCCESS
- Prometheus restarted; all 8 db_dump rules loaded; all targets up
- Pre-commit chain incl. the new Check 4: green

🤖 Generated with [Claude Code](https://claude.com/claude-code)