### PR TITLE
chore(process): WP3 closures — rate-limit soak verdict + L-024/L-030/L-049/L-020 doc gates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,8 +80,10 @@ Why: Separation of concerns (quadlets = deployment, Traefik = routing), centrali
 2. Add route to `config/traefik/dynamic/routers.yml` with standard middleware chain:
    - **Default (Authelia):** `crowdsec-bouncer@file, rate-limit@file, authelia@file, security-headers@file` — used by qBittorrent, Homepage, Grafana, etc.
    - **Native auth** (Jellyfin, Nextcloud, Immich, Vaultwarden, HA, Navidrome, Audiobookshelf): `crowdsec-bouncer@file, rate-limit-public@file, compression@file, security-headers@file` — NO authelia
+   - **Endpoint audit first (L-030):** if any route mixes public and protected paths (Authelia bypass rules), enumerate every route/API call the app's workflows touch *before* deploying — Gathio needed 5 iterative bypass fixes, each discovered through a broken user workflow
 3. `systemctl --user daemon-reload && systemctl --user enable --now <service>.service`
 4. Verify: `curl -I https://service.patriark.org`
+5. **Smoke-test the real workload (L-049) — deployment is not done until this passes.** Run `verify-deployment.sh <service>` (7-level check, `.claude/skills/homelab-deployment/scripts/`) **plus one end-to-end exercise of the actual workload** (one upload, one login, one inference, one playback). "Service started" is not "service works."
 
 Pattern-based deployment available via `homelab-deployment` skill (see `.claude/skills/homelab-deployment/`).
 

--- a/config/traefik/dynamic/middleware.yml
+++ b/config/traefik/dynamic/middleware.yml
@@ -89,7 +89,9 @@ http:
     # Average steady-state browse rate; burst absorbs PROPFIND tree walks
     # (Music library is ~2080 PROPFINDs, but client parallelism caps the
     # 1-minute window at a few hundred). Tier 2 staged downsize 1500→800
-    # (2026-04-28); next step pending 7-day soak with zero 429s.
+    # (2026-04-28). RATIFIED 2026-06-12: zero 429s across the full soak +
+    # 6 weeks after; measured 15d peak is 93 req/min (burst = 8.6x headroom).
+    # See docs/98-journals/2026-06-12-rate-limit-soak-closure.md.
     rate-limit-nextcloud:
       rateLimit:
         average: 300
@@ -102,6 +104,10 @@ http:
     # qBittorrent (per-IP post-ADR-022, also behind Authelia SSO).
     # Burst covers initial WebUI page load (~500 resources). Average matches
     # WebUI poll cadence (~30-60 req/min) with headroom.
+    # KEPT at 600 (decided 2026-06-12, closing the T2.2 thread): zero WebUI
+    # traffic in the 15d measurement window, so data-driven sizing (3x p99)
+    # is meaningless here — the structural floor is the ~500-resource initial
+    # page load, and cutting below it breaks the UI's only use case.
     rate-limit-qbittorrent:
       rateLimit:
         average: 100
@@ -114,10 +120,14 @@ http:
     # Immich (per-IP post-ADR-022) — sized for one device's worst-case op.
     # Burst covers rapid timeline scroll / mobile-app upload burst.
     # Average drops from NAT-era 500 to realistic browsing rate.
+    # Tier 2 staged downsize 1500→800 (2026-06-12), batched after Nextcloud's
+    # clean soak per the 2026-04-28 plan. Measured 15d peak: 33 req/min — 800
+    # still gives 24x headroom for an unobserved first-sync/bulk-upload burst.
+    # Watch for 429s; drop further only with sync-window measurements.
     rate-limit-immich:
       rateLimit:
         average: 200
-        burst: 1500
+        burst: 800
         period: 1m
         sourceCriterion:
           ipStrategy:

--- a/docs/10-services/guides/pattern-selection-guide.md
+++ b/docs/10-services/guides/pattern-selection-guide.md
@@ -512,6 +512,15 @@ After selecting a pattern:
 3. Verify prerequisites in validation_checks section
 4. Deploy using command above
 5. Follow post_deployment checklist
+6. **Mandatory smoke-test gate (L-049):** run
+   `verify-deployment.sh <service>` (7-level verification) **and** exercise
+   the real workload end-to-end once (one upload / login / inference /
+   playback). A deployment is not done until both pass — "service started"
+   is not "service works".
+7. **If the route mixes public and protected paths (L-030):** audit every
+   endpoint the app's workflows touch against the Authelia bypass rules
+   *before* calling it deployed — missing bypasses surface as broken user
+   workflows, one at a time.
 
 **Related Documentation:**
 - Skill usage: `.claude/skills/homelab-deployment/SKILL.md`

--- a/docs/20-operations/guides/homelab-architecture.md
+++ b/docs/20-operations/guides/homelab-architecture.md
@@ -246,6 +246,13 @@ Layer 2: Threat Intelligence (CrowdSec IP reputation, behavioral analysis)
 Layer 1: Port Filtering (UDM Pro firewall, only 80/443 exposed)
 ```
 
+> **Scoping note (L-024):** the full 7-layer stack applies only to
+> Authelia-protected services. For **native-auth** services (the list under
+> Middleware Chains below), Layer 4 is the application's own login — so the
+> perimeter defense for them is layers 1–3 plus app-layer auth, and their
+> session/device hygiene lives in the app, not in Authelia. Don't read the
+> diagram as "everything sits behind WebAuthn."
+
 ### Middleware Chains (per-service in routers.yml)
 
 **Authelia-protected services:**

--- a/docs/98-journals/2026-06-12-rate-limit-soak-closure.md
+++ b/docs/98-journals/2026-06-12-rate-limit-soak-closure.md
@@ -1,0 +1,62 @@
+# Rate-limit soak closure — T2.2 thread ratified and finished
+
+**Date:** 2026-06-12
+**Status:** Closes the last open thread of T2.2 (rate-limit burst downsize) from
+[2026-04-23-security-posture-punchlist-private.md](2026-04-23-security-posture-punchlist-private.md),
+left "awaiting the 7-day soak" by
+[2026-04-28-tier2-perip-verification-and-nextcloud-burst-downsize-private.md](2026-04-28-tier2-perip-verification-and-nextcloud-burst-downsize-private.md).
+Origin: WP3 item 6 of the 2026-06-12 lessons.md loose-threads handoff.
+
+## What the soak showed
+
+The Nextcloud downsize (burst 1500→800, applied 2026-04-28) was watched for 7
+days with a zero-429 pass criterion. No journal ever recorded the verdict. As
+of today, **six weeks** past the change:
+
+- `traefik_service_requests_total{code="429"}` has **zero series** — not zero
+  rate, zero *series*: no request has ever been rate-limited within the
+  Prometheus retention window. (Retention is 15d, so this directly proves the
+  recent window; no 429 alert or Discord trace exists for the April–May gap
+  either.)
+- Measured 15d peak request rates (max 1-minute window, `max_over_time` over
+  `rate()[1m]` subquery, by `exported_service`):
+
+  | service | peak req/min | configured burst | headroom |
+  |---|---|---|---|
+  | nextcloud | 93 | 800 | 8.6x |
+  | immich | 33 | 1500 → **800** | 24x (after downsize) |
+  | qbittorrent | *(no traffic at all)* | 600 (kept) | n/a |
+
+## Decisions
+
+1. **Nextcloud burst=800 RATIFIED.** Clean soak, 8.6x headroom over the
+   observed worst minute.
+2. **Immich burst 1500→800 applied** — the batched follow-up the 2026-04-28
+   plan staged behind Nextcloud's clean soak. Even 800 is 24x the observed
+   peak; kept deliberately fat because the worst case (mobile-app first-sync /
+   bulk upload) did not occur in the measurement window. A further drop needs
+   a measurement taken *during* an actual sync, per the T2.2 decision tree.
+3. **qBittorrent burst=600 KEPT** (decided, not deferred). Zero WebUI traffic
+   in 15d makes the 3×-p99 rule meaningless; the structural floor is the
+   ~500-resource initial WebUI page load, and 600 is already the tightest
+   value that doesn't break it. Average 100/min is unchanged. It remains
+   behind Authelia, so the rate limit is layer 2, not the gate.
+
+## Verification
+
+- `middleware.yml` is Traefik dynamic config — auto-reloaded, no restart.
+  The Traefik API is not exposed on :8080 (metrics only), so verification was:
+  (1) provider re-read logged at edit time with zero errors, and (2)
+  `https://photos.patriark.org/` returns 200 through the full middleware
+  chain including `rate-limit-immich@file` — an unparseable middleware would
+  have dropped the router (404). Note for future sessions: Immich's host is
+  `photos.patriark.org`, Navidrome's is `musikk.patriark.org` — probing
+  `immich./navidrome.patriark.org` 404s by design, not by breakage.
+- Watch item (passive): any `ImmichHigh4xxRate`-class signal or first 429
+  series appearing on `immich@file` during the next mobile-app bulk upload.
+
+## Lessons
+
+Nothing new for lessons.md — the only near-lesson ("soaks need a written
+verdict or they dangle forever") is already covered by the handoff/status.md
+process this entry executes.

--- a/scripts/db-dump.sh
+++ b/scripts/db-dump.sh
@@ -21,6 +21,16 @@
 #
 # Schedule: db-dump.timer @ 01:30 (before Urd's 04:00 send).
 # Usage:    db-dump.sh [--service <name>] [--help]
+#
+# ADDING A NEW ENGINE — cold-cache checklist (L-020):
+#   A new dump job MUST be timed cold-cache before being declared viable:
+#   either in the real nightly slot, or after `echo 3 | sudo tee
+#   /proc/sys/vm/drop_caches`. A warm-cache test run lies — the nightly slot
+#   runs right after Prometheus has evicted the page cache, and that is how a
+#   "fast" Loki dump turned into a ~15-minute freeze (pause + 70k-file copy on
+#   a cold cache) before being cut from the engine set (ADR-029).
+#   Also add the engine to db-restore-test.sh, or audit-dump-coverage.sh /
+#   DbDumpCoverageGap will (correctly) flag it.
 ################################################################################
 
 set -uo pipefail   # deliberately NOT -e: per-engine isolation


### PR DESCRIPTION
## Summary

WP3 from the 2026-06-12 lessons.md loose-threads handoff. **Stacked on #282** (→ #281 → main): merge in order; GitHub retargets as bases merge.

### Rate-limit soak closure (item 6 — open since 2026-04-28)
The thread was more specific than the handoff suggested: Nextcloud's downsize (1500→800) was applied 2026-04-28 with a 7-day zero-429 criterion **whose verdict was never written**, and the Immich/qBt downsizes were staged *behind* that soak and never applied.

Evidence, 6 weeks later: `traefik_service_requests_total{code="429"}` has **zero series** in the whole retention window, and measured 15-day peak request rates (max 1-min window, by `exported_service`) are: nextcloud 93/min, immich 33/min, qbittorrent **no traffic at all**.

- **Nextcloud burst=800 ratified** (8.6× observed peak)
- **Immich burst 1500→800 applied** (24× observed peak retained for an unobserved mobile first-sync; further drops need a measurement during an actual sync per the T2.2 decision tree)
- **qBittorrent burst=600 kept** — a decision, not a deferral: with zero observed traffic, the sizing floor is the structural one (~500-resource WebUI initial page load)
- Verified: clean file-provider reload at edit time; `photos.patriark.org` returns 200 through the `rate-limit-immich@file` chain (a broken middleware would drop the router). Closing journal: `docs/98-journals/2026-06-12-rate-limit-soak-closure.md`

### Doc gates (items 8, 9, 10 + deprioritized L-030 rider)
- **L-024**: scoping footnote on the 7-layer defense diagram — native-auth services get layers 1–3 + app auth, don't read it as "everything behind WebAuthn"
- **L-049**: smoke-test gate is now step 5 of CLAUDE.md's Deployment Procedure and steps 6–7 of the pattern guide: `verify-deployment.sh` **plus one end-to-end real-workload exercise**, or the deployment isn't done
- **L-030**: endpoint-audit-before-deploy for mixed public/protected routes, codified next to the L-049 gate (the Gathio 5-iteration lesson)
- **L-020**: cold-cache checklist in `db-dump.sh`'s header — the file anyone adding an engine must touch — including the pointer that `audit-dump-coverage.sh` (#282) will flag unlisted engines

### Not in this PR
- **Item 7 (native-auth session/device audit residual, L-051)** — filed as an issue instead (bounded but interactive-judgment-heavy; the exposure window is Apr 2026, hygiene-flavored now)
- **Predictive-maintenance retirement (L-062)** — owner decision, issue filed with the retire recommendation

🤖 Generated with [Claude Code](https://claude.com/claude-code)