### PR TITLE
fix(hooks): make pre-commit validation worktree-aware

### DIFF
--- a/scripts/check-boot-tier.sh
+++ b/scripts/check-boot-tier.sh
@@ -11,13 +11,20 @@
 #
 # Wired into the local pre-commit chain (.git/hooks/pre-commit, which is not
 # version-controlled — re-add a call to this script if the hook is rebuilt):
-#   if ! ~/containers/scripts/check-boot-tier.sh; then CHECK_FAILED=1; fi
+#   if ! "$REPO_ROOT/scripts/check-boot-tier.sh"; then CHECK_FAILED=1; fi
 #
 # Exit: 0 = all quadlets compliant, 1 = violations listed on stdout.
 
 set -euo pipefail
 
-QUADLET_DIR="${HOME}/containers/quadlets"
+# Worktree-aware root: pre-commit hooks run with cwd = the committing
+# worktree's toplevel, so prefer the enclosing repo — validate the tree being
+# committed, not the live one. REPO_ROOT env overrides; fall back to the live
+# tree for ad-hoc runs outside any repo.
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
+REPO_ROOT="${REPO_ROOT:-$HOME/containers}"
+QUADLET_DIR="$REPO_ROOT/quadlets"
+[[ -d "$QUADLET_DIR" ]] || { echo "ERROR: quadlet dir not found: $QUADLET_DIR" >&2; exit 2; }
 FAIL=0
 
 for f in "$QUADLET_DIR"/*.container; do

--- a/scripts/check-supply-chain-gate.sh
+++ b/scripts/check-supply-chain-gate.sh
@@ -13,9 +13,16 @@
 # Exit: 0 all invariants hold, 1 one or more violated.
 set -uo pipefail
 
+# Worktree-aware root: pre-commit hooks run with cwd = the committing
+# worktree's toplevel, so prefer the enclosing repo — validate the tree being
+# committed, not the live one. REPO_ROOT env overrides; fall back to the live
+# tree for ad-hoc runs outside any repo.
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
 REPO_ROOT="${REPO_ROOT:-$HOME/containers}"
 QUADLET_DIR="${QUADLET_DIR:-$REPO_ROOT/quadlets}"
-METRIC_FILE="${METRIC_FILE:-$REPO_ROOT/data/backup-metrics/supply-chain-signatures.prom}"
+# Runtime state, NOT tree content: data/ is gitignored (absent in worktrees),
+# and the latest signature verdict is a property of the live system either way.
+METRIC_FILE="${METRIC_FILE:-$HOME/containers/data/backup-metrics/supply-chain-signatures.prom}"
 fail=0
 
 # (P4) egress integrity + de-automation — reuse the existing guard verbatim.

--- a/scripts/validate-traefik-config.sh
+++ b/scripts/validate-traefik-config.sh
@@ -18,8 +18,14 @@
 
 set -euo pipefail
 
-CONFIG_DIR="$HOME/containers/config/traefik/dynamic"
-BACKUP_DIR="$HOME/containers/config/traefik/.backups"
+# Worktree-aware root: pre-commit hooks run with cwd = the committing
+# worktree's toplevel, so prefer the enclosing repo — validate the tree being
+# committed, not the live one. REPO_ROOT env overrides; fall back to the live
+# tree for ad-hoc runs outside any repo.
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || true)}"
+REPO_ROOT="${REPO_ROOT:-$HOME/containers}"
+CONFIG_DIR="$REPO_ROOT/config/traefik/dynamic"
+BACKUP_DIR="$REPO_ROOT/config/traefik/.backups"
 CREATE_BACKUP=true
 
 # Parse arguments


### PR DESCRIPTION
The pre-commit chain validated `~/containers` by absolute path — a commit authored in a side git-worktree was checked against the **live** tree's files (false passes for worktree violations, false failures from live-tree state). This was flagged in the worktree guidance discussion and the 2026-06-12 journal.

**Changes:** the three tracked check scripts (`check-boot-tier.sh`, `validate-traefik-config.sh`, `check-supply-chain-gate.sh`) resolve `REPO_ROOT` via `git rev-parse --show-toplevel` (env-overridable, live-tree fallback for ad-hoc runs). The supply-chain gate's signature `METRIC_FILE` deliberately stays on the live tree (`data/` is gitignored → absent in worktrees; the verdict is runtime state, not tree content). The unversioned `.git/hooks/pre-commit` driver now resolves the committing worktree once and calls *its* scripts, with the `.claude` secrets hook guarded (live-tree-only by nature, but operates on the committing worktree's staged diff via cwd).

**Verified end-to-end from a real side worktree** (`git worktree add` off this branch):
- boot-tier violation present only in the worktree → `COMMIT REJECTED` naming `jellyfin.container` ✅
- broken YAML present only in the worktree's `routers.yml` → `✗ INVALID YAML` → rejected, while the live (serving) config was never consulted ✅
- live-tree commits (including this one) still pass the full chain ✅
- bonus finding during testing: the driver correctly runs the *committing tree's* script versions — two test rounds silently used the old scripts because the worktree predated the fix commit, which is exactly the right behavior pointed at the wrong revision

🤖 Generated with [Claude Code](https://claude.com/claude-code)