### PR TITLE
feat(forgejo): automated push-mirror to the sovereignty ledger with integrity gates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,7 @@ Rollback: `git revert` of the digest line + restart; BTRFS snapshots as second p
 - **Branch discipline:** 1–2 clean, SSH-signed commits per branch (no fixup litter — it lands on main forever); branch + PR per work package; stacked branches merge in order with no rebasing needed
 - **Trivia lane:** journals, comment fixes, and doc-only commits may be pushed directly to main (signed) — PR ceremony adds nothing there. Substantive work always gets a PR (the PR body is the owner's review surface)
 - **Live-config rule stands:** never return the worktree to main or rebase across applied-but-unmerged changes — running services read this tree
+- **Forgejo ledger (automated — do NOT push manually):** `forgejo-mirror.timer` (hourly) push-mirrors main to the private Forgejo (`patriark/homelab`) via `scripts/mirror-to-forgejo.sh`. The mirror is append-only with integrity gates: non-fast-forward upstream or unsigned/bad-signature commits in the delta BLOCK the mirror and fire `ForgejoMirrorFailed` — treat that as a tamper canary, never `--force` the ledger
 
 ### Architecture Decision Records
 

--- a/config/prometheus/alerts/supply-chain-alerts.yml
+++ b/config/prometheus/alerts/supply-chain-alerts.yml
@@ -17,6 +17,38 @@ groups:
           summary: "Image signature verification FAILED for {{ $labels.service }}"
           description: "{{ $labels.service }} ({{ $labels.repo }}) failed cosign verification against its known signer identity (ADR-030 P6). Possible tampering or a changed publisher identity. The pin was refused. Do NOT adopt; investigate `scripts/verify-image-signature.sh`."
 
+      # Warning: the Forgejo ledger mirror run FAILED. This is either Forgejo
+      # being down (benign) or one of the mirror's integrity gates firing:
+      # non-fast-forward origin/main (history rewrite upstream = tamper canary)
+      # or an unsigned/bad-signature commit in the delta. Check the journal —
+      # journalctl --user -u forgejo-mirror.service — BEFORE any manual push;
+      # never --force the ledger.
+      - alert: ForgejoMirrorFailed
+        expr: forgejo_mirror_success == 0
+        for: 15m
+        labels:
+          severity: warning
+          category: security
+          component: forgejo-mirror
+        annotations:
+          summary: "Forgejo ledger mirror failed"
+          description: "The push-mirror to the private Forgejo ledger failed or was gate-blocked. If the journal shows TAMPER CANARY or a signature-gate refusal, treat as a security event (ADR-030 ethos), not a sync problem. journalctl --user -u forgejo-mirror.service -n 30"
+
+      # Warning: no successful mirror in 26h (hourly timer → this means the
+      # timer itself died or failures persisted past ForgejoMirrorFailed).
+      # The manual-push era drifted 18 commits in 3 days with zero signal —
+      # this alert is why that cannot recur (L-031: alert on absence of success).
+      - alert: ForgejoMirrorStale
+        expr: (time() - forgejo_mirror_last_success_timestamp) > (26 * 3600)
+        for: 1h
+        labels:
+          severity: warning
+          category: security
+          component: forgejo-mirror
+        annotations:
+          summary: "Forgejo ledger has not mirrored successfully in 26h+"
+          description: "Last successful ledger mirror was {{ $value | humanizeDuration }} ago. Check forgejo-mirror.timer and forgejo.service."
+
       # Warning: a signer's pin hasn't been re-verified in 90+ days (P3 drift — a
       # deliberately-pinned signed image has gone stale and unre-checked).
       - alert: SupplyChainSignatureStale

--- a/config/prometheus/tests/alert-rules.test.yml
+++ b/config/prometheus/tests/alert-rules.test.yml
@@ -9,6 +9,7 @@ rule_files:
   - ../alerts/service-health.yml
   - ../alerts/infrastructure-warnings.yml
   - ../alerts/db-dump-alerts.yml
+  - ../alerts/supply-chain-alerts.yml
 
 evaluation_interval: 1m
 
@@ -151,6 +152,46 @@ tests:
             exp_annotations:
               summary: "DB dump coverage gap: forgejo-db is not backed up"
               description: "forgejo-db (found via subvol8-db) is a DB-like service with no dump coverage. Add it to ENGINES in db-dump.sh + db-restore-test.sh, or record a decided exception in audit-dump-coverage.sh."
+
+  # --- Forgejo ledger mirror: failure + staleness (guards the guard) --------
+  - interval: 1m
+    input_series:
+      - series: 'forgejo_mirror_success{repo="containers"}'
+        values: '0x20'
+    alert_rule_test:
+      - eval_time: 16m
+        alertname: ForgejoMirrorFailed
+        exp_alerts:
+          - exp_labels:
+              repo: containers
+              severity: warning
+              category: security
+              component: forgejo-mirror
+            exp_annotations:
+              summary: "Forgejo ledger mirror failed"
+              description: "The push-mirror to the private Forgejo ledger failed or was gate-blocked. If the journal shows TAMPER CANARY or a signature-gate refusal, treat as a security event (ADR-030 ethos), not a sync problem. journalctl --user -u forgejo-mirror.service -n 30"
+
+  # 1m cadence: the textfile metric is scraped every 15s; hourly synthetic
+  # samples would go stale between points and defeat `for:`.
+  - interval: 1m
+    input_series:
+      - series: 'forgejo_mirror_last_success_timestamp{repo="containers"}'
+        values: '0x1700'
+    alert_rule_test:
+      - eval_time: 28h
+        alertname: ForgejoMirrorStale
+        exp_alerts:
+          - exp_labels:
+              repo: containers
+              severity: warning
+              category: security
+              component: forgejo-mirror
+            exp_annotations:
+              summary: "Forgejo ledger has not mirrored successfully in 26h+"
+              description: "Last successful ledger mirror was 1d 4h 0m 0s ago. Check forgejo-mirror.timer and forgejo.service."
+      - eval_time: 20h
+        alertname: ForgejoMirrorStale
+        exp_alerts: []
 
   # --- regression: MemoryPressureHigh can fire again post-hysteresis-removal -
   - interval: 1m

--- a/scripts/mirror-to-forgejo.sh
+++ b/scripts/mirror-to-forgejo.sh
@@ -1,0 +1,111 @@
+#!/bin/bash
+# mirror-to-forgejo.sh — push-mirror main to the private Forgejo ledger
+#
+# Role (decided 2026-06-12, see journal + CLAUDE.md Git & PR Workflow):
+# Forgejo (git.patriark.org, patriark/homelab) is the SOVEREIGNTY LEDGER —
+# the owner-controlled record of main, independent of GitHub as an authority.
+# It is NOT a disaster-recovery copy (Forgejo runs on this same host; Urd
+# owns DR). Design consequences:
+#
+#   - LOCAL PUSH, never a Forgejo pull-mirror of GitHub: the machine that
+#     signs is the machine that publishes. Merges materialize on GitHub
+#     (merge-commit-only strategy), but they reach the ledger only after
+#     this host fetches them and the gates below pass.
+#   - APPEND-ONLY: a non-fast-forward origin/main (history rewrite) FAILS
+#     the mirror — that is a tamper canary, not a sync problem. No --force,
+#     ever. Forgejo-side branch protection is the second lock.
+#   - SIGNATURE GATE: any commit in the new delta with NO signature (N) or a
+#     BAD signature (B) fails the mirror. Commits that merely can't be
+#     verified locally (E — e.g. GitHub web-flow merge commits, pre-switch
+#     squash commits) pass but are counted in a metric, so drift is visible.
+#
+# Wiring: forgejo-mirror.timer (hourly). History: the manual-push "mirror"
+# silently fell 18 commits behind within 3 days of its last push — this
+# script + ForgejoMirror* alerts exist so that cannot recur (L-031 class).
+#
+# Exit: 0 mirrored/up-to-date, 1 push or gate failure (alert fires via metric).
+
+set -uo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$HOME/containers}"
+REMOTE="${MIRROR_REMOTE:-forgejo}"
+METRICS_DIR="${HOME}/containers/data/backup-metrics"
+METRICS_FILE="${METRICS_FILE:-${METRICS_DIR}/forgejo-mirror.prom}"
+
+log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [$1] ${*:2}" >&2; }
+
+SUCCESS=0
+UNVERIFIED=0
+LAG=0
+
+finish() {
+    mkdir -p "$METRICS_DIR"
+    {
+        echo "# HELP forgejo_mirror_success Last mirror run result (1=ok, 0=failed/gate-blocked)"
+        echo "# TYPE forgejo_mirror_success gauge"
+        echo "forgejo_mirror_success{repo=\"containers\"} ${SUCCESS}"
+        echo "# HELP forgejo_mirror_last_run_timestamp Unix time of last mirror attempt"
+        echo "# TYPE forgejo_mirror_last_run_timestamp gauge"
+        echo "forgejo_mirror_last_run_timestamp{repo=\"containers\"} $(date +%s)"
+        if [[ "$SUCCESS" == "1" ]]; then
+            echo "# HELP forgejo_mirror_last_success_timestamp Unix time of last successful mirror"
+            echo "# TYPE forgejo_mirror_last_success_timestamp gauge"
+            echo "forgejo_mirror_last_success_timestamp{repo=\"containers\"} $(date +%s)"
+        else
+            # carry the previous success timestamp forward so staleness ages correctly
+            prev="$(grep -oP 'forgejo_mirror_last_success_timestamp\{[^}]*\} \K[0-9]+' "$METRICS_FILE" 2>/dev/null | tail -1)"
+            if [[ -n "$prev" ]]; then
+                echo "# HELP forgejo_mirror_last_success_timestamp Unix time of last successful mirror"
+                echo "# TYPE forgejo_mirror_last_success_timestamp gauge"
+                echo "forgejo_mirror_last_success_timestamp{repo=\"containers\"} ${prev}"
+            fi
+        fi
+        echo "# HELP forgejo_mirror_unverified_commits Locally-unverifiable (E) commits in the last mirrored delta"
+        echo "# TYPE forgejo_mirror_unverified_commits gauge"
+        echo "forgejo_mirror_unverified_commits{repo=\"containers\"} ${UNVERIFIED}"
+    } > "${METRICS_FILE}.tmp" && mv "${METRICS_FILE}.tmp" "$METRICS_FILE"
+}
+trap finish EXIT
+
+cd "$REPO_ROOT" || { log ERROR "repo not found: $REPO_ROOT"; exit 1; }
+
+if ! git fetch --quiet origin main || ! git fetch --quiet "$REMOTE" main; then
+    log ERROR "fetch failed (origin or $REMOTE unreachable)"
+    exit 1
+fi
+
+NEW="$(git rev-parse origin/main)"
+OLD="$(git rev-parse "$REMOTE/main")"
+
+if [[ "$NEW" == "$OLD" ]]; then
+    log INFO "ledger up to date at ${NEW:0:7}"
+    SUCCESS=1
+    exit 0
+fi
+
+# Gate 1 — append-only: the ledger must be an ancestor of what we publish.
+if ! git merge-base --is-ancestor "$OLD" "$NEW"; then
+    log ERROR "TAMPER CANARY: origin/main (${NEW:0:7}) does not descend from ledger main (${OLD:0:7}) — history rewrite upstream? Refusing to mirror. Investigate before doing ANYTHING manual."
+    exit 1
+fi
+
+LAG="$(git rev-list --count "$OLD".."$NEW")"
+
+# Gate 2 — signatures: no unsigned (N) or bad (B) commits enter the ledger.
+BAD="$(git log --format='%G? %h %s' "$OLD".."$NEW" | grep -E '^[NB] ' || true)"
+if [[ -n "$BAD" ]]; then
+    log ERROR "signature gate: unsigned/bad commits in delta — refusing to mirror:"
+    printf '%s\n' "$BAD" >&2
+    exit 1
+fi
+UNVERIFIED="$(git log --format='%G?' "$OLD".."$NEW" | grep -c '^E' || true)"
+
+if ! git push --quiet "$REMOTE" origin/main:refs/heads/main; then
+    log ERROR "push to $REMOTE failed"
+    exit 1
+fi
+git push --quiet "$REMOTE" --tags || log WARN "tag push failed (non-fatal)"
+
+SUCCESS=1
+log INFO "mirrored ${LAG} commit(s) ${OLD:0:7}..${NEW:0:7} to $REMOTE (${UNVERIFIED} locally-unverifiable)"
+exit 0

--- a/systemd/forgejo-mirror.service
+++ b/systemd/forgejo-mirror.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Mirror main to the private Forgejo sovereignty ledger
+Documentation=file:///home/patriark/containers/scripts/mirror-to-forgejo.sh
+After=network-online.target forgejo.service
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/containers/scripts/mirror-to-forgejo.sh
+TimeoutStartSec=2min
+
+# Background plumbing — never compete with interactive use
+Nice=19
+IOSchedulingClass=idle
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/systemd/forgejo-mirror.timer
+++ b/systemd/forgejo-mirror.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Hourly push-mirror of main to the Forgejo ledger
+
+[Timer]
+# Hourly: local push over loopback SSH, subsecond when up to date. The old
+# manual-push "mirror" drifted 18 commits behind in 3 days unnoticed — the
+# cadence here is about bounding ledger lag, not load (negligible).
+OnBootSec=10min
+OnUnitActiveSec=1h
+RandomizedDelaySec=5min
+Persistent=true
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
The Forgejo mirror was manual pushes that silently stopped — **18 commits / 3 days behind** when checked today, with no signal. This makes the ledger self-maintaining and self-guarding.

**Design (role: sovereignty ledger, not backup — Forgejo shares this host, Urd owns DR):**
- **Local push, never pull-mirror**: GitHub stays out of the ledger's trust path as an authority; merges reach the ledger only after this host fetches and gates them
- **Append-only**: non-FF upstream → mirror refuses with `TAMPER CANARY` in the journal; no force, ever
- **Signature gate**: unsigned/bad commits in the delta block the mirror; locally-unverifiable commits (GitHub merge commits) pass but are metered (`forgejo_mirror_unverified_commits` — steady state under merge-commit strategy: merge commits only)
- **Observed**: hourly timer + `ForgejoMirrorFailed` / `ForgejoMirrorStale` alerts (L-031 absence-of-success class)

**Verification:**
- Catch-up run mirrored the 18-commit backlog; ledger tip == main ✅
- Scratch-repo kill-tests: unsigned-commit delta → blocked naming the offender; rewritten origin/main → tamper canary; up-to-date → clean exit ✅
- Timer run under the real systemd user environment (SSH auth from timer context) ✅
- promtool suite (13 scenarios) SUCCESS; rules loaded; `forgejo_mirror_success=1` ingested ✅

**One manual step left (needs owner credentials):** Forgejo web UI → `patriark/homelab` → Settings → Branches → protect `main` (block force-push + deletion) as the server-side second lock. Alternatively `fj auth login git.patriark.org` and I can do it via API next session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)