### PR TITLE
2026-H2 audit quick wins: hardening sweep, webhook activation, timers-as-code, GH#140/#276

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ This is a digital sovereignty project — self-hosted infrastructure built for i
 
 A learning-focused homelab building production-ready, self-hosted infrastructure using Podman containers managed through systemd quadlets. Platform: Fedora Workstation 43.
 
-**Current Services (29 containers, 16 service groups):**
+**Current Services (37 containers, 17 service groups):**
 - **Core Infrastructure:** Traefik (reverse proxy), CrowdSec (threat intel), Authelia + Redis (SSO + YubiKey MFA)
 - **Applications:** Nextcloud + MariaDB + Redis (file sync), Vaultwarden (passwords), Jellyfin (media), Immich + PostgreSQL + Redis + ML (photos), Gathio + MongoDB (events), Homepage (dashboard)
 - **Audio:** Audiobookshelf (audiobooks/podcasts), Navidrome (music streaming)

--- a/config/alertmanager/alertmanager.yml
+++ b/config/alertmanager/alertmanager.yml
@@ -106,10 +106,10 @@ receivers:
   # Remediation webhook (Phase 4: Alert-Driven Remediation)
   - name: 'remediation-webhook'
     webhook_configs:
-      # SECURITY: Replace REPLACE_WITH_ACTUAL_TOKEN with your webhook token
-      # Token is stored in: ~/.config/remediation-webhook.env
-      # DO NOT commit the actual token to Git!
-      - url: 'http://host.containers.internal:9096/webhook?token=REPLACE_WITH_ACTUAL_TOKEN'
+      # Full URL incl. auth token lives in remediation-url.secret (gitignored via
+      # *secret*, mounted with the config directory). Token source of truth:
+      # ~/.config/remediation-webhook.env (shared with remediation-webhook.service).
+      - url_file: '/etc/alertmanager/remediation-url.secret'
         send_resolved: false  # Only send firing alerts, not resolved
         http_config:
           follow_redirects: true

--- a/config/prometheus/alerts/backup-alerts.yml
+++ b/config/prometheus/alerts/backup-alerts.yml
@@ -11,6 +11,7 @@ groups:
           category: backup
           component: btrfs-snapshot-backup
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/backup-strategy.md"
           summary: "Backup failed for {{ $labels.subvolume }}"
           description: "Last backup attempt for {{ $labels.subvolume }} failed. Check backup logs immediately."
 
@@ -29,6 +30,7 @@ groups:
           category: backup
           component: btrfs-snapshot-backup
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/backup-strategy.md"
           summary: "Backup stale for {{ $labels.subvolume }}"
           description: "No successful backup for {{ $labels.subvolume }} in {{ $value | humanizeDuration }}. Last backup: {{ $labels.subvolume }}."
 
@@ -41,6 +43,7 @@ groups:
           category: backup
           component: btrfs-snapshot-backup
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/backup-strategy.md"
           summary: "Backup script hasn't run in 2+ days"
           description: "Backup script last ran {{ $value | humanizeDuration }} ago. Check systemd timers."
 
@@ -53,6 +56,7 @@ groups:
           category: disaster-recovery
           component: backup-restore-test
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/runbooks/DR-003-accidental-deletion.md"
           summary: "Restore test failed for {{ $labels.subvolume }}"
           description: "Backup restore test validation failed for {{ $labels.subvolume }}. Backups may be corrupted!"
 
@@ -65,6 +69,7 @@ groups:
           category: disaster-recovery
           component: backup-restore-test
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/runbooks/DR-003-accidental-deletion.md"
           summary: "Restore test overdue"
           description: "Restore test hasn't run in {{ $value | humanizeDuration }}. Should run monthly (last Sunday)."
 
@@ -113,6 +118,7 @@ groups:
           category: backup
           component: btrfs-snapshot-backup
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/backup-strategy.md"
           summary: "No external backups for {{ $labels.subvolume }}"
           description: "{{ $labels.subvolume }} is configured for offsite backup but has 0 external snapshots. External drive may not be mounted or sends are failing."
 
@@ -126,6 +132,7 @@ groups:
           category: backup
           component: btrfs-snapshot-backup
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/backup-strategy.md"
           summary: "Backup taking unusually long for {{ $labels.subvolume }}"
           description: "Last backup took {{ $value | humanizeDuration }}. May indicate performance issues. Alert auto-resolves after 1h for weekly/monthly backups."
 
@@ -152,6 +159,7 @@ groups:
           category: backup
           component: btrfs-snapshot-backup
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/backup-strategy.md"
           summary: "Anomalous backup churn on {{ $labels.subvolume }}"
           description: "{{ $labels.subvolume }} is churning {{ $value | humanize }}B/s — over 4x its 14-day baseline and above the 256 KiB/s floor. Expected if you just imported or rewrote a lot of data; otherwise investigate runaway growth or in-place rewrites."
 
@@ -177,6 +185,7 @@ groups:
           category: backup
           component: btrfs-pool
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/backup-strategy.md"
           summary: "BTRFS metadata near exhaustion on {{ $labels.label }} ({{ $labels.role }})"
           description: "Metadata utilization is {{ $value | humanizePercentage }} on pool {{ $labels.label }}. BTRFS can ENOSPC even with free data space — run a metadata balance before it blocks snapshots and dumps."
 
@@ -194,6 +203,7 @@ groups:
           category: backup
           component: btrfs-pool
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/backup-strategy.md"
           summary: "Offsite backup drive {{ $labels.label }} low on space"
           description: "{{ $labels.label }} is {{ $value | humanizePercentage }} free (<15%). Plan retention pruning or a larger drive before external sends start failing."
 
@@ -205,5 +215,6 @@ groups:
           category: backup
           component: btrfs-pool
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/backup-strategy.md"
           summary: "CRITICAL: offsite backup drive {{ $labels.label }} nearly full"
           description: "{{ $labels.label }} is {{ $value | humanizePercentage }} free (<7%). External sends will fail soon — free space or swap drives now."

--- a/config/prometheus/alerts/dependency-alerts.yml
+++ b/config/prometheus/alerts/dependency-alerts.yml
@@ -43,7 +43,7 @@ groups:
             Action: Investigate dependency health immediately to prevent service impact.
               systemctl --user status {{ $labels.dependency }}.service
               podman ps --filter name={{ $labels.dependency }}
-          runbook_url: "https://github.com/patriark/homelab/docs/20-operations/runbooks/DR-001-dependency-failure.md"
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/AUTO-DEPENDENCY-GRAPH.md"
 
       # Alert when a routing target is unhealthy (informational, not critical)
       # Routing dependencies (e.g., Traefik -> Immich) don't affect the router's functionality
@@ -97,7 +97,7 @@ groups:
             Potentially affected services should be checked for cascading failures.
 
             Action: Restart service immediately and assess impact on dependents.
-          runbook_url: "https://github.com/patriark/homelab/docs/20-operations/runbooks/DR-001-dependency-failure.md"
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/AUTO-DEPENDENCY-GRAPH.md"
 
       # Alert when dependency graph becomes stale
       - alert: DependencyGraphStale
@@ -123,7 +123,7 @@ groups:
             Action: Check dependency-discovery.timer status and logs:
               systemctl --user status dependency-discovery.timer
               journalctl --user -u dependency-discovery.service -n 50
-          runbook_url: "https://github.com/patriark/homelab/docs/20-operations/runbooks/DR-001-dependency-failure.md"
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/AUTO-DEPENDENCY-GRAPH.md"
 
       # Alert when a medium blast radius service goes down (warning level)
       - alert: MediumBlastRadiusServiceDown
@@ -179,7 +179,7 @@ groups:
 
             Action: Review drift report and reconcile configuration:
               ~/containers/.claude/skills/homelab-deployment/scripts/check-drift.sh {{ $labels.homelab_service }}
-          runbook_url: "https://github.com/patriark/homelab/docs/20-operations/runbooks/DR-001-dependency-failure.md"
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/AUTO-DEPENDENCY-GRAPH.md"
 
   - name: dependency_capacity
     interval: 60s

--- a/config/prometheus/alerts/infrastructure-critical.yml
+++ b/config/prometheus/alerts/infrastructure-critical.yml
@@ -50,6 +50,7 @@ groups:
           category: capacity
           component: system
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/storage-health-monitoring.md"
           summary: "CRITICAL: System disk space dangerously low"
           description: "System SSD {{ $labels.instance }} has only {{ $value | humanizePercentage }} free space. Immediate cleanup required!"
 
@@ -68,6 +69,7 @@ groups:
           category: capacity
           component: storage
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/storage-health-monitoring.md"
           summary: "CRITICAL: BTRFS data pool (/mnt) space dangerously low"
           description: "Data pool /mnt on {{ $labels.instance }} has only {{ $value | humanizePercentage }} free. A full pool blocks snapshots AND db dumps — free space immediately."
 
@@ -95,6 +97,7 @@ groups:
           severity: critical
           category: monitoring
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/40-monitoring-and-documentation/guides/monitoring-stack.md"
           summary: "Prometheus monitoring system is down"
           description: "The Prometheus service has been down for more than 5 minutes. Monitoring is blind!"
 
@@ -108,6 +111,7 @@ groups:
           severity: critical
           category: monitoring
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/40-monitoring-and-documentation/guides/monitoring-stack.md"
           summary: "Alertmanager is down"
           description: "Alertmanager has been unreachable for more than 10 minutes. No alerts will be delivered!"
 
@@ -134,6 +138,7 @@ groups:
           severity: critical
           category: monitoring
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/40-monitoring-and-documentation/guides/monitoring-stack.md"
           summary: "Grafana dashboard is down"
           description: "Grafana has been unreachable for more than 10 minutes. Dashboard unavailable."
 
@@ -147,6 +152,7 @@ groups:
           severity: critical
           category: monitoring
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/40-monitoring-and-documentation/guides/monitoring-stack.md"
           summary: "Loki log aggregation is down"
           description: "Loki has been unreachable for more than 10 minutes. Log ingestion is stopped!"
 
@@ -160,6 +166,7 @@ groups:
           severity: critical
           category: monitoring
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/40-monitoring-and-documentation/guides/monitoring-stack.md"
           summary: "Node Exporter is down"
           description: "System metrics collection has stopped. Node Exporter has been down for more than 5 minutes."
 
@@ -174,6 +181,7 @@ groups:
           category: security
           component: security
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/30-security/guides/crowdsec-phase1-field-manual.md"
           summary: "CrowdSec security monitoring is down"
           description: "CrowdSec has been unreachable for more than 5 minutes. IP reputation filtering is disabled!"
 
@@ -199,6 +207,7 @@ groups:
           category: monitoring
           component: logging
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/40-monitoring-and-documentation/guides/monitoring-stack.md"
           summary: "Promtail not sending logs to Loki"
           description: |
             No log entries sent in 10 minutes. Log ingestion pipeline may be broken.
@@ -227,6 +236,7 @@ groups:
           category: monitoring
           component: alerting
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/40-monitoring-and-documentation/guides/monitoring-stack.md"
           summary: "Prometheus rule evaluation failing"
           description: |
             {{ $value }} rule evaluations failed in last 5 minutes.
@@ -251,6 +261,7 @@ groups:
           category: monitoring
           component: alerting
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/40-monitoring-and-documentation/guides/monitoring-stack.md"
           summary: "Alertmanager failing to send notifications"
           description: |
             {{ $value }} notifications/sec failing. Alerts are not reaching Discord!

--- a/config/prometheus/alerts/storage-health.yml
+++ b/config/prometheus/alerts/storage-health.yml
@@ -17,6 +17,7 @@ groups:
           category: storage
           component: btrfs-dev-stats
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/runbooks/DR-002-btrfs-pool-corruption.md"
           summary: "BTRFS {{ $labels.type }} errors on {{ $labels.device }} ({{ $labels.filesystem }})"
           description: "btrfs device stats reports {{ $value }} {{ $labels.type }} error(s) on {{ $labels.device }} ({{ $labels.filesystem }}). On the Single-profile pool this is an early disk-failure/bit-rot signal — check SMART, run a scrub to scope damage, verify backups, plan replacement. Counters are persistent; zero with `sudo btrfs dev stats -z <mnt>` after remediation."
 
@@ -28,6 +29,7 @@ groups:
           category: storage
           component: btrfs-dev-stats
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/storage-health-monitoring.md"
           summary: "BTRFS dev-stats collector stale"
           description: "btrfs-dev-stats collector last ran {{ $value | humanizeDuration }} ago (expected every 15m). Check `systemctl --user status btrfs-dev-stats.timer`."
 
@@ -43,6 +45,7 @@ groups:
           category: storage
           component: smartmon
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/storage-health-monitoring.md"
           summary: "SMART health FAILED on {{ $labels.device }} ({{ $labels.model }})"
           description: "smartctl overall-health self-assessment FAILED on {{ $labels.device }} (model {{ $labels.model }}, serial {{ $labels.serial }}). The drive is reporting itself as failing — verify backups and replace it."
 
@@ -54,6 +57,7 @@ groups:
           category: storage
           component: smartmon
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/storage-health-monitoring.md"
           summary: "SMART pending sectors on {{ $labels.device }}"
           description: "{{ $value }} current-pending (unreadable) sector(s) on {{ $labels.device }} — imminent uncorrectable read errors. Run a scrub to surface affected files; plan replacement."
 
@@ -65,6 +69,7 @@ groups:
           category: storage
           component: smartmon
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/storage-health-monitoring.md"
           summary: "SMART offline-uncorrectable sectors on {{ $labels.device }}"
           description: "{{ $value }} offline-uncorrectable sector(s) on {{ $labels.device }} — the drive cannot read these. On Single-profile data, affected files restore from backup. Plan replacement."
 
@@ -76,6 +81,7 @@ groups:
           category: storage
           component: smartmon
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/storage-health-monitoring.md"
           summary: "NVMe critical warning on {{ $labels.device }}"
           description: "NVMe critical_warning bitfield = {{ $value }} (nonzero) on {{ $labels.device }} — spare exhausted / reliability degraded / read-only / temperature alarm. Investigate now (/home + container metadata live here)."
 
@@ -93,6 +99,7 @@ groups:
           category: storage
           component: smartmon
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/storage-health-monitoring.md"
           summary: "SMART reallocated sectors INCREASING on {{ $labels.device }}"
           description: "{{ $labels.device }} reallocated-sector count rose to {{ $value }} over the past week — the drive is actively remapping bad sectors (degrading). Verify backups and plan replacement. (A stable count does not fire; the absolute value is in Grafana.)"
 
@@ -104,6 +111,7 @@ groups:
           category: storage
           component: smartmon
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/storage-health-monitoring.md"
           summary: "Disk {{ $labels.device }} running hot ({{ $value }}°C)"
           description: "{{ $labels.device }} sustained {{ $value }}°C (>55°C for 30m). Check cabinet airflow/cooling (see the active-cooling fan plan)."
 
@@ -115,6 +123,7 @@ groups:
           category: storage
           component: smartmon
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/storage-health-monitoring.md"
           summary: "NVMe {{ $labels.device }} endurance at {{ $value }}%"
           description: "NVMe endurance used {{ $value }}% (>85% of rated write life). Plan SSD replacement; /home, container metadata, and Grafana live here."
 
@@ -126,6 +135,7 @@ groups:
           category: storage
           component: smartmon
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/storage-health-monitoring.md"
           summary: "SMART collector stale"
           description: "smartmon collector last ran {{ $value | humanizeDuration }} ago (expected hourly). Check `systemctl --user status smartmon.timer` and the /etc/sudoers.d/homelab-storage-health grant."
 
@@ -142,6 +152,7 @@ groups:
           category: storage
           component: btrfs-scrub
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/runbooks/DR-002-btrfs-pool-corruption.md"
           summary: "BTRFS scrub found UNCORRECTABLE errors on {{ $labels.filesystem }}"
           description: "The last scrub of {{ $labels.filesystem }} found {{ $value }} uncorrectable error(s) — data the scrub could not repair (no redundant data copy on Single profile). Identify the affected files and restore them from the Urd backups."
 
@@ -153,6 +164,7 @@ groups:
           category: storage
           component: btrfs-scrub
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/runbooks/DR-002-btrfs-pool-corruption.md"
           summary: "BTRFS scrub corrected errors on {{ $labels.filesystem }}"
           description: "The last scrub of {{ $labels.filesystem }} corrected {{ $value }} error(s) from a redundant copy (e.g. the RAID1 metadata mirror). The data is intact, but a disk is whispering — cross-check SMART and btrfs device stats to find the culprit."
 
@@ -164,5 +176,6 @@ groups:
           category: storage
           component: btrfs-scrub
         annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/20-operations/guides/storage-health-monitoring.md"
           summary: "BTRFS scrub overdue on {{ $labels.filesystem }}"
           description: "{{ $labels.filesystem }} has not completed a scrub in {{ $value | humanizeDuration }} (monthly cadence + grace). Bit rot could be accumulating undetected. Check `systemctl --user status btrfs-scrub-internal.timer`."

--- a/config/prometheus/alerts/unifi-alerts.yml
+++ b/config/prometheus/alerts/unifi-alerts.yml
@@ -17,7 +17,6 @@ groups:
         annotations:
           summary: "UDM Pro is unreachable"
           description: "Unpoller cannot scrape metrics from UDM Pro at {{ $labels.source }}. Network gateway may be offline. CRITICAL: All internet access lost."
-          runbook_url: "https://github.com/patriark/containers/blob/main/docs/30-security/runbooks/IR-001-network-outage.md"
 
       # Alert: Unpoller scrape failures
       - alert: UnpollerScrapeFailed

--- a/quadlets/alert-discord-relay.container
+++ b/quadlets/alert-discord-relay.container
@@ -10,6 +10,7 @@ Wants=monitoring-network.service network-online.target reverse_proxy-network.ser
 # Bump = rebuild, retag with new date, update this line + digest, daemon-reload + restart.
 Image=localhost/alert-discord-relay:2026-05-23
 ContainerName=alert-discord-relay
+NoNewPrivileges=true
 HostName=alert-discord-relay
 # reverse_proxy first for default route (Discord API access)
 Network=systemd-reverse_proxy:ip=10.89.2.86

--- a/quadlets/alertmanager.container
+++ b/quadlets/alertmanager.container
@@ -8,12 +8,15 @@ Wants=monitoring-network.service network-online.target
 # ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart.
 Image=quay.io/prometheus/alertmanager@sha256:51a825c2a40acc3e338fdd00d622e01ec090f72be2b3ea46be0839cd47a4d286
 ContainerName=alertmanager
+NoNewPrivileges=true
 HostName=alertmanager
 Network=systemd-reverse_proxy:ip=10.89.2.72
 Network=systemd-monitoring:ip=10.89.4.72
 
 # Configuration and data
-Volume=%h/containers/config/alertmanager/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro,Z
+# Directory mount (GH#276 pattern): avoids the single-file bind inode trap and
+# brings remediation-url.secret (gitignored) in alongside alertmanager.yml.
+Volume=%h/containers/config/alertmanager:/etc/alertmanager:ro,Z
 Volume=%h/containers/data/alertmanager:/alertmanager:Z
 
 # SMTP password for email notifications

--- a/quadlets/audiobookshelf.container
+++ b/quadlets/audiobookshelf.container
@@ -20,6 +20,7 @@ Wants=network-online.target traefik.service
 # ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart.
 Image=ghcr.io/advplyr/audiobookshelf@sha256:89276ff2e0b3d2f07dd334b641f27a34ab7f02e1047c60b7b8a30126cb0813a5
 ContainerName=audiobookshelf
+NoNewPrivileges=true
 HostName=audiobookshelf
 
 # Network (single network - standalone service, no inter-service communication)
@@ -66,6 +67,7 @@ RestartSec=10s
 MemoryMax=2G
 MemoryHigh=1600M
 MemorySwapMax=1G
+CPUQuota=200%
 
 # ═══════════════════════════════════════════════════════════
 # INSTALLATION

--- a/quadlets/authelia.container
+++ b/quadlets/authelia.container
@@ -10,6 +10,7 @@ Requires=redis-authelia.service
 # ADR-030 P6: no publisher signature (tracked unsigned)
 Image=docker.io/authelia/authelia@sha256:1b363e9279e742397966333f364e0876ae02bf5c876de73e83af6d48c57ff51b
 ContainerName=authelia
+NoNewPrivileges=true
 
 # Multi-network: Serves SSO portal + handles auth verification
 # Static IPs assigned to ensure consistent DNS resolution

--- a/quadlets/cadvisor.container
+++ b/quadlets/cadvisor.container
@@ -8,6 +8,7 @@ Wants=monitoring-network.service network-online.target
 # ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart.
 Image=gcr.io/cadvisor/cadvisor@sha256:3de2bd5203120b866d74a9b283b2ffb8ec382fbf9dc321814700c6ea6f44ec57
 ContainerName=cadvisor
+NoNewPrivileges=true
 HostName=cadvisor
 Network=systemd-monitoring
 

--- a/quadlets/crowdsec.container
+++ b/quadlets/crowdsec.container
@@ -8,6 +8,7 @@ Wants=network-online.target
 # ADR-030 P1/P4: AutoUpdate removed — egress-tier, deliberate updates only. Bump = resolve new digest, bake, edit, restart.
 Image=docker.io/crowdsecurity/crowdsec@sha256:2f527c9bb8b367120eb08b82890aa912ce96bfa1ada93dda0721700e4b4e0dde
 ContainerName=crowdsec
+NoNewPrivileges=true
 Network=systemd-reverse_proxy:ip=10.89.2.70
 
 # Volumes
@@ -36,6 +37,7 @@ TimeoutStartSec=900
 # Resource Limits
 MemoryMax=512M
 MemoryHigh=460M
+CPUQuota=200%
 
 [Install]
 WantedBy=default.target

--- a/quadlets/forgejo-db.container
+++ b/quadlets/forgejo-db.container
@@ -7,6 +7,7 @@ Wants=network-online.target forgejo-network.service
 # ADR-030 P2: digest-pinned (integrity). tag: 16-alpine, resolved 2026-05-23 (index digest, multi-arch)
 Image=docker.io/library/postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229
 ContainerName=forgejo-db
+NoNewPrivileges=true
 HostName=forgejo-db
 
 # Database configuration (podman secret, Pattern 2: type=env)

--- a/quadlets/forgejo.container
+++ b/quadlets/forgejo.container
@@ -8,6 +8,7 @@ Requires=forgejo-db.service
 # ADR-030 P2: digest-pinned (integrity). tag: 15, resolved 2026-05-23 (index digest, multi-arch)
 Image=codeberg.org/forgejo/forgejo@sha256:db04c7114b656f896e206ba3873fe8d3a7adf2daa44907037f0274f4ba653fb9
 ContainerName=forgejo
+NoNewPrivileges=true
 HostName=forgejo
 
 Environment=USER_UID=1000
@@ -93,6 +94,7 @@ TimeoutStartSec=300
 # Resource Limits
 MemoryHigh=1G
 MemoryMax=1536M
+CPUQuota=200%
 
 [Install]
 WantedBy=default.target

--- a/quadlets/gathio-db.container
+++ b/quadlets/gathio-db.container
@@ -8,6 +8,7 @@ Wants=gathio-network.service network-online.target
 # ADR-030 P6: no publisher signature (tracked unsigned)
 Image=docker.io/library/mongo@sha256:c1a84ab5d0c17deed1e0dba1d24bd7c76e5c7b281145fe536911939b1551754c
 ContainerName=gathio-db
+NoNewPrivileges=true
 HostName=gathio-db
 
 # Database configuration (using podman secrets - Pattern 2: type=env)

--- a/quadlets/gathio.container
+++ b/quadlets/gathio.container
@@ -9,6 +9,7 @@ Requires=gathio-db.service
 # ADR-030 P6: no publisher signature (tracked unsigned)
 Image=ghcr.io/lowercasename/gathio@sha256:ff66a8d2cc522568c8a8e2772e969e56f90e2089fb33602d27979134dc8bfe8b
 ContainerName=gathio
+NoNewPrivileges=true
 HostName=gathio
 
 # MongoDB connection (password mounted as file at /run/secrets/mongodb_password)
@@ -55,6 +56,7 @@ TimeoutStartSec=300
 # MemoryMax: hard limit (768M) - OOM kill protection
 MemoryHigh=512M
 MemoryMax=768M
+CPUQuota=100%
 
 [Install]
 WantedBy=default.target

--- a/quadlets/grafana.container
+++ b/quadlets/grafana.container
@@ -9,6 +9,7 @@ Wants=monitoring-network.service network-online.target
 # ADR-030 P6: no publisher signature (tracked unsigned)
 Image=docker.io/grafana/grafana@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
 ContainerName=grafana
+NoNewPrivileges=true
 HostName=grafana
 # Static IPs assigned to ensure consistent DNS resolution
 Network=systemd-reverse_proxy:ip=10.89.2.77

--- a/quadlets/home-assistant.container
+++ b/quadlets/home-assistant.container
@@ -7,6 +7,7 @@ Wants=home_automation-network.service network-online.target reverse_proxy-networ
 # ADR-030 P2: digest-pinned (integrity). tag: stable, resolved 2026-05-23 (index digest, multi-arch)
 Image=ghcr.io/home-assistant/home-assistant@sha256:d4fbec16196d5c8bedf32647f0ca7165f654d92a2e81f35a373508d3226cb867
 ContainerName=home-assistant
+NoNewPrivileges=true
 HostName=home-assistant
 
 # Networks (reverse_proxy FIRST for internet access)
@@ -45,6 +46,7 @@ TimeoutStartSec=300
 MemoryMax=2G
 MemoryHigh=1800M
 MemorySwapMax=512M
+CPUQuota=400%
 
 [Install]
 WantedBy=default.target

--- a/quadlets/immich-ml.container
+++ b/quadlets/immich-ml.container
@@ -7,6 +7,7 @@ Wants=network-online.target photos-network.service
 # ADR-030 P2: digest-pinned (integrity). tag: v2.7.5, resolved 2026-05-23 (index digest, multi-arch)
 Image=ghcr.io/immich-app/immich-machine-learning@sha256:a2501141440f10516d329fdfba2c68082e19eb9ba6016c061ac80d23beadf7f3
 ContainerName=immich-ml
+NoNewPrivileges=true
 
 # Network (isolated - only on photos network)
 Network=systemd-photos

--- a/quadlets/immich-server.container
+++ b/quadlets/immich-server.container
@@ -8,11 +8,16 @@ Requires=postgresql-immich.service redis-immich.service
 # ADR-030 P2: digest-pinned (integrity). tag: v2.7.5, resolved 2026-05-23 (index digest, multi-arch)
 Image=ghcr.io/immich-app/immich-server@sha256:c15bff75068effb03f4355997d03dc7e0fc58720c2b54ad6f7f10d1bc57efaa5
 ContainerName=immich-server
+NoNewPrivileges=true
 
-# Run as non-root user (security: ADR-001 Rootless Containers)
-# NOTE: User=1000:1000 removed due to Immich folder integrity check incompatibility
-# Security provided by rootless Podman (UID 0 inside → UID 1000 outside) + Traefik layers
-# TODO: Revisit after consulting Immich community or upstream fix
+# Run as non-root user (security: ADR-001 Rootless Containers, GH#140)
+# keep-id maps host uid/gid 1000 <-> container 1000 so the upload library
+# (host-owned 1000:1000) stays readable; the old failure was the default
+# rootless mapping handing container-1000 a subuid the files didn't match.
+# keep-groups preserves the render group for /dev/dri VAAPI transcoding.
+User=1000:1000
+UserNS=keep-id:uid=1000,gid=1000
+GroupAdd=keep-groups
 
 # Networks (multiple - order matters for default route)
 # Static IPs assigned to ensure consistent DNS resolution

--- a/quadlets/jellyfin.container
+++ b/quadlets/jellyfin.container
@@ -8,6 +8,7 @@ Wants=media_services-network.service network-online.target reverse_proxy-network
 # ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart.
 Image=docker.io/jellyfin/jellyfin@sha256:1694ff069f0c9dafb283c36765175606866769f5d72f2ed56b6a0f1be922fc37
 ContainerName=jellyfin
+NoNewPrivileges=true
 HostName=jellyfin
 
 # Networks (reverse_proxy FIRST for internet access)

--- a/quadlets/loki.container
+++ b/quadlets/loki.container
@@ -7,6 +7,7 @@ Wants=monitoring-network.service network-online.target
 # ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-23 (index digest, multi-arch)
 Image=docker.io/grafana/loki@sha256:191d4fdfb7264f16989f0a57f320872620a5a7c2ceeec6229212c4190ec49b86
 ContainerName=loki
+NoNewPrivileges=true
 HostName=loki
 # Static IPs assigned to ensure consistent DNS resolution
 Network=systemd-reverse_proxy:ip=10.89.2.83

--- a/quadlets/navidrome.container
+++ b/quadlets/navidrome.container
@@ -20,6 +20,7 @@ Wants=network-online.target traefik.service
 # ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart.
 Image=docker.io/deluan/navidrome@sha256:9fa40b3d8dec43ceb2213d1fa551da3dcfef6ac6d19c2e534efb92527c2bafd2
 ContainerName=navidrome
+NoNewPrivileges=true
 HostName=navidrome
 
 # Networks (reverse_proxy FIRST for internet access)
@@ -65,6 +66,7 @@ RestartSec=10s
 MemoryMax=1G
 MemoryHigh=800M
 MemorySwapMax=512M
+CPUQuota=200%
 
 # ═══════════════════════════════════════════════════════════
 # INSTALLATION

--- a/quadlets/nextcloud-db.container
+++ b/quadlets/nextcloud-db.container
@@ -9,6 +9,7 @@ Wants=network-online.target
 # ADR-030 P6: no publisher signature (tracked unsigned)
 Image=docker.io/library/mariadb@sha256:be1ef4fe5f14589325c08a41c76334097ce66c86264b75e1d28342c742782a61
 ContainerName=nextcloud-db
+NoNewPrivileges=true
 
 # MariaDB configuration (using podman secrets)
 Secret=nextcloud_db_root_password,type=env,target=MYSQL_ROOT_PASSWORD

--- a/quadlets/nextcloud-redis.container
+++ b/quadlets/nextcloud-redis.container
@@ -8,6 +8,7 @@ Wants=network-online.target
 # ADR-030 P2: digest-pinned (integrity). tag: 7-alpine, resolved 2026-05-23 (index digest, multi-arch)
 Image=docker.io/library/redis@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
 ContainerName=nextcloud-redis
+NoNewPrivileges=true
 
 # Redis password authentication via REDISCLI_AUTH env (avoids password on argv).
 # redis-cli auto-reads REDISCLI_AUTH; redis-server gets it via shell expansion

--- a/quadlets/nextcloud.container
+++ b/quadlets/nextcloud.container
@@ -8,6 +8,7 @@ Wants=network-online.target
 # ADR-030 P2: digest-pinned (integrity). tag: 33, resolved 2026-05-23 (index digest, multi-arch)
 Image=docker.io/library/nextcloud@sha256:b67959acacd54ed2d110e111c8b28c0a87a20129f9427bf5f721a1dc6121decb
 ContainerName=nextcloud
+NoNewPrivileges=true
 
 # Database configuration (using podman secrets)
 Secret=nextcloud_db_password,type=env,target=MYSQL_PASSWORD

--- a/quadlets/node_exporter.container
+++ b/quadlets/node_exporter.container
@@ -8,6 +8,7 @@ Wants=monitoring-network.service network-online.target
 # ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart.
 Image=quay.io/prometheus/node-exporter@sha256:0f422f62c15f154af8d8572b23d623aebfb10cec73a5c654d18f911f3f9df241
 ContainerName=node_exporter
+NoNewPrivileges=true
 HostName=node_exporter
 Network=systemd-monitoring
 

--- a/quadlets/postgres-exporter.container
+++ b/quadlets/postgres-exporter.container
@@ -9,6 +9,7 @@ Requires=postgresql-immich.service
 # ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart.
 Image=quay.io/prometheuscommunity/postgres-exporter@sha256:e96064f876226d94bb6ce48a4c4b3dd76edba91168ec1ab024e5c4b959310b0f
 ContainerName=postgres-exporter
+NoNewPrivileges=true
 HostName=postgres-exporter
 
 # Reach postgresql-immich on photos; expose metrics on monitoring.

--- a/quadlets/postgresql-immich.container
+++ b/quadlets/postgresql-immich.container
@@ -7,6 +7,7 @@ Wants=network-online.target photos-network.service
 # ADR-030 P2: digest-pinned (integrity). tag: 14-vectorchord0.4.3-pgvectors0.2.0, resolved 2026-05-23 (index digest, multi-arch)
 Image=ghcr.io/immich-app/postgres@sha256:bcf63357191b76a916ae5eb93464d65c07511da41e3bf7a8416db519b40b1c23
 ContainerName=postgresql-immich
+NoNewPrivileges=true
 
 # Network
 Network=systemd-photos

--- a/quadlets/prometheus.container
+++ b/quadlets/prometheus.container
@@ -8,15 +8,17 @@ Wants=monitoring-network.service network-online.target node_exporter.service
 # ADR-030 P6: no publisher signature (tracked unsigned)
 Image=quay.io/prometheus/prometheus@sha256:69f5241418838263316593f7274a304b095c40bcf22e57272865da91bd60a8ac
 ContainerName=prometheus
+NoNewPrivileges=true
 HostName=prometheus
 # Static IPs assigned to ensure consistent DNS resolution
 Network=systemd-reverse_proxy:ip=10.89.2.79
 Network=systemd-monitoring:ip=10.89.4.79
 
 # Prometheus configuration and data
-Volume=%h/containers/config/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro,Z
-Volume=%h/containers/config/prometheus/alerts:/etc/prometheus/alerts:ro,Z
-Volume=%h/containers/config/prometheus/rules:/etc/prometheus/rules:ro,Z
+# Directory mount (GH#276): single-file binds pin the host inode at start, so
+# atomic-replace writes (editor save, sed -i, git checkout) silently orphan the
+# bind and /-/reload applies nothing. Bit 4 times; directory mounts don't.
+Volume=%h/containers/config/prometheus:/etc/prometheus:ro,Z
 Volume=/mnt/btrfs-pool/subvol8-db/prometheus:/prometheus:Z
 
 # Podman secrets for authentication

--- a/quadlets/promtail.container
+++ b/quadlets/promtail.container
@@ -8,6 +8,7 @@ Wants=loki.service monitoring-network.service network-online.target
 # ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart.
 Image=docker.io/grafana/promtail@sha256:6cfa64ec432b24a912d640e2edb940eeae2666f61861a66c121d763dd7241381
 ContainerName=promtail
+NoNewPrivileges=true
 HostName=promtail
 Network=systemd-monitoring
 

--- a/quadlets/proton-bridge.container
+++ b/quadlets/proton-bridge.container
@@ -6,6 +6,7 @@ Wants=network-online.target reverse_proxy-network.service mail-network.service
 [Container]
 Image=localhost/proton-bridge:3.23.1
 ContainerName=proton-bridge
+NoNewPrivileges=true
 
 # Map host UID into container (ADR-001: rootless containers)
 UserNS=keep-id

--- a/quadlets/qbittorrent.container
+++ b/quadlets/qbittorrent.container
@@ -8,6 +8,7 @@ Wants=network-online.target reverse_proxy-network.service
 # ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart.
 Image=docker.io/linuxserver/qbittorrent@sha256:f76c4363cce0834df43b097682928d217f9f0e0fa1d13781c0934848d543e4ab
 ContainerName=qbittorrent
+NoNewPrivileges=true
 HostName=qbittorrent
 Network=systemd-reverse_proxy:ip=10.89.2.85
 # No PublishPort - WebUI (port 8085, set via WEBUI_PORT below) accessible only

--- a/quadlets/redis-authelia-exporter.container
+++ b/quadlets/redis-authelia-exporter.container
@@ -10,6 +10,7 @@ Requires=redis-authelia.service
 # ADR-030 P6: no publisher signature (tracked unsigned)
 Image=quay.io/oliver006/redis_exporter@sha256:2e9795be900db073e9475fdb9c5124db309b07a3e4e75a1770705cb03be1a1c8
 ContainerName=redis-authelia-exporter
+NoNewPrivileges=true
 HostName=redis-authelia-exporter
 
 # Reach redis-authelia on auth_services; expose metrics on monitoring (static IPs per ADR-018).

--- a/quadlets/redis-authelia.container
+++ b/quadlets/redis-authelia.container
@@ -7,6 +7,7 @@ Wants=auth_services-network.service network-online.target
 # ADR-030 P2: digest-pinned (integrity). tag: 7-alpine, resolved 2026-05-23 (index digest, multi-arch)
 Image=docker.io/library/redis@sha256:6ab0b6e7381779332f97b8ca76193e45b0756f38d4c0dcda72dbb3c32061ab99
 ContainerName=redis-authelia
+NoNewPrivileges=true
 
 # Network
 Network=systemd-auth_services

--- a/quadlets/redis-immich-exporter.container
+++ b/quadlets/redis-immich-exporter.container
@@ -10,6 +10,7 @@ Requires=redis-immich.service
 # ADR-030 P6: no publisher signature (tracked unsigned)
 Image=quay.io/oliver006/redis_exporter@sha256:2e9795be900db073e9475fdb9c5124db309b07a3e4e75a1770705cb03be1a1c8
 ContainerName=redis-immich-exporter
+NoNewPrivileges=true
 HostName=redis-immich-exporter
 
 # Reach redis-immich (Valkey, Redis-protocol-compatible) on photos; expose metrics on monitoring.

--- a/quadlets/redis-immich.container
+++ b/quadlets/redis-immich.container
@@ -8,6 +8,7 @@ Wants=network-online.target photos-network.service
 # ADR-030 P6: no publisher signature (tracked unsigned)
 Image=docker.io/valkey/valkey@sha256:4963247afc4cd33c7d3b2d2816b9f7f8eeebab148d29056c2ca4d7cbc966f2d9
 ContainerName=redis-immich
+NoNewPrivileges=true
 
 # Network
 Network=systemd-photos

--- a/quadlets/traefik.container
+++ b/quadlets/traefik.container
@@ -10,6 +10,7 @@ Requires=http.socket https.socket
 # ADR-030 P1/P4: AutoUpdate removed — highest blast-radius (internet-facing reverse proxy), deliberate updates only. Bump = resolve new digest, bake, edit, restart.
 Image=docker.io/library/traefik@sha256:6b9cbca6fac42ab0075f5437d8dc1685cfd188626d8d515839ea94f8b6271c42
 ContainerName=traefik
+NoNewPrivileges=true
 HostName=traefik
 Network=systemd-reverse_proxy:ip=10.89.2.69
 # Ports 80/443 come in via socket activation (see systemd/{http,https}.socket

--- a/quadlets/unifi-syslog.container
+++ b/quadlets/unifi-syslog.container
@@ -9,6 +9,7 @@ Wants=syslog-network.service network-online.target
 # ADR-030 P6: no publisher signature (tracked unsigned)
 Image=docker.io/linuxserver/syslog-ng@sha256:b77c32d93b9e9b84f4fdd9261d7dd1db3b8a6f90391459b1ca51c82af9828bf8
 ContainerName=unifi-syslog
+NoNewPrivileges=true
 HostName=unifi-syslog
 Network=systemd-syslog:ip=10.89.7.69
 

--- a/quadlets/vaultwarden.container
+++ b/quadlets/vaultwarden.container
@@ -19,6 +19,7 @@ Wants=network-online.target traefik.service
 # ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-23 (index digest, multi-arch)
 Image=docker.io/vaultwarden/server@sha256:d626d04934cd1192ad8ced1adb975099fca78cec33ab467d2d3c923cde7f3b0c
 ContainerName=vaultwarden
+NoNewPrivileges=true
 # User directive removed - Vaultwarden image uses vaultwarden user (UID 1000) internally
 
 # Networks
@@ -71,6 +72,7 @@ RestartSec=10s
 # Vaultwarden is critical infrastructure - prevent OOM conditions
 MemoryMax=1G
 MemoryHigh=800M
+CPUQuota=200%
 
 # ═══════════════════════════════════════════════════════════
 # INSTALLATION

--- a/systemd/autonomous-operations.service
+++ b/systemd/autonomous-operations.service
@@ -1,0 +1,30 @@
+[Unit]
+Description=Autonomous Operations Check and Execute
+Documentation=file:///home/patriark/containers/.claude/skills/autonomous-operations/SKILL.md
+After=network-online.target
+Wants=network-online.target
+
+# Run after daily backups and resource forecast
+After=btrfs-daily-backup.service
+After=daily-resource-forecast.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/patriark/containers
+
+# Run check, then execute approved actions
+ExecStart=/home/patriark/containers/scripts/autonomous-execute.sh --from-check
+
+# Environment
+Environment=HOME=/home/patriark
+Environment=XDG_RUNTIME_DIR=/run/user/1000
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+
+# Timeouts
+TimeoutStartSec=300
+
+[Install]
+WantedBy=default.target

--- a/systemd/autonomous-operations.timer
+++ b/systemd/autonomous-operations.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Daily Autonomous Operations Check
+Documentation=file:///home/patriark/containers/.claude/skills/autonomous-operations/SKILL.md
+
+[Timer]
+# Run at 06:30 daily (after backups at 05:00 and forecast at 06:00)
+OnCalendar=*-*-* 06:30:00
+
+# Random delay up to 5 minutes to avoid thundering herd
+RandomizedDelaySec=300
+
+# Run immediately if we missed the scheduled time
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/systemd/check-image-updates.service
+++ b/systemd/check-image-updates.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Check for container image updates
+Documentation=file:/home/patriark/containers/docs/00-foundation/decisions/2025-12-22-ADR-015-container-update-strategy.md
+
+[Service]
+Type=oneshot
+ExecStart=%h/containers/scripts/check-image-updates.sh
+StandardOutput=journal
+StandardError=journal

--- a/systemd/check-image-updates.timer
+++ b/systemd/check-image-updates.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Weekly container image update check
+Documentation=file:/home/patriark/containers/docs/00-foundation/decisions/2025-12-22-ADR-015-container-update-strategy.md
+
+[Timer]
+# Run every Sunday at 10:00 AM
+OnCalendar=Sun *-*-* 10:00:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/systemd/cloudflare-ddns.service
+++ b/systemd/cloudflare-ddns.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Cloudflare Dynamic DNS Update
+
+[Service]
+Type=oneshot
+ExecStart=%h/containers/scripts/cloudflare-ddns.sh

--- a/systemd/cloudflare-ddns.timer
+++ b/systemd/cloudflare-ddns.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Cloudflare DDNS Update Timer
+Requires=cloudflare-ddns.service
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=30min
+
+[Install]
+WantedBy=timers.target

--- a/systemd/daily-drift-check.service
+++ b/systemd/daily-drift-check.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Daily Configuration Drift Check
+Documentation=file:///home/patriark/containers/scripts/daily-drift-check.sh
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/home/patriark/containers/scripts/daily-drift-check.sh
+StandardOutput=journal
+StandardError=journal
+
+# Security hardening
+PrivateTmp=yes
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=default.target

--- a/systemd/daily-drift-check.timer
+++ b/systemd/daily-drift-check.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Daily Configuration Drift Check Timer
+Documentation=file:///home/patriark/containers/docs/20-operations/guides/automation-reference.md
+
+[Timer]
+# Run daily at 06:00
+OnCalendar=*-*-* 06:00:00
+
+# If system was off, run on next boot
+Persistent=true
+
+# Randomize by up to 10 minutes
+RandomizedDelaySec=10min
+
+[Install]
+WantedBy=timers.target

--- a/systemd/daily-error-digest.service
+++ b/systemd/daily-error-digest.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Daily Error Digest from Loki
+Documentation=https://github.com/vonrobak/fedora-homelab-containers
+After=loki.service grafana.service
+Requires=loki.service grafana.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/patriark/containers
+
+# Execute daily error digest script
+ExecStart=/home/patriark/containers/scripts/daily-error-digest.sh
+
+# Environment
+Environment=HOME=/home/patriark
+Environment=XDG_RUNTIME_DIR=/run/user/1000
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=daily-error-digest
+
+# Timeouts (generous for Loki queries)
+TimeoutStartSec=120
+
+# Resource limits (lightweight operation)
+CPUQuota=10%
+MemoryMax=256M
+
+[Install]
+WantedBy=default.target

--- a/systemd/daily-error-digest.timer
+++ b/systemd/daily-error-digest.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=Daily Error Digest Timer
+Documentation=https://github.com/vonrobak/fedora-homelab-containers
+
+[Timer]
+# Run daily at 07:00
+OnCalendar=daily
+OnCalendar=*-*-* 07:00:00
+
+# Persistent (run on next boot if missed)
+Persistent=true
+
+# Randomize start time by up to 5 minutes to avoid thundering herd
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target

--- a/systemd/daily-morning-digest.service
+++ b/systemd/daily-morning-digest.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Consolidated Daily Morning Digest
+Documentation=file:///home/patriark/containers/docs/20-operations/guides/automation-reference.md
+
+# Run after all morning scripts
+After=daily-drift-check.service
+After=daily-resource-forecast.service
+After=autonomous-operations.service
+After=daily-error-digest.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/patriark/containers
+ExecStart=/home/patriark/containers/scripts/daily-morning-digest.sh
+Environment=HOME=/home/patriark
+Environment=XDG_RUNTIME_DIR=/run/user/1000
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=60
+
+[Install]
+WantedBy=default.target

--- a/systemd/daily-morning-digest.timer
+++ b/systemd/daily-morning-digest.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Consolidated Daily Morning Digest Timer
+Documentation=file:///home/patriark/containers/docs/20-operations/guides/automation-reference.md
+
+[Timer]
+# Run at 07:30 daily (after all morning scripts: drift 06:00, forecast 06:05,
+# autonomous 06:30, error-digest 07:00 + RandomizedDelaySec margin)
+OnCalendar=*-*-* 07:30:00
+Persistent=true
+RandomizedDelaySec=60
+
+[Install]
+WantedBy=timers.target

--- a/systemd/daily-slo-snapshot.service
+++ b/systemd/daily-slo-snapshot.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Daily SLO Performance Snapshot
+Documentation=file:///home/patriark/containers/docs/40-monitoring-and-documentation/guides/slo-framework.md
+After=prometheus.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/containers
+ExecStart=%h/containers/scripts/daily-slo-snapshot.sh
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=daily-slo-snapshot
+
+[Install]
+WantedBy=default.target

--- a/systemd/daily-slo-snapshot.timer
+++ b/systemd/daily-slo-snapshot.timer
@@ -1,0 +1,17 @@
+[Unit]
+Description=Daily SLO Performance Snapshot Timer
+Documentation=file:///home/patriark/containers/docs/40-monitoring-and-documentation/guides/slo-framework.md
+
+[Timer]
+# Run daily at 23:50 (before midnight, after all services have been used)
+OnCalendar=daily
+OnCalendar=*-*-* 23:50:00
+
+# Randomize by up to 5 minutes to avoid exact scheduling conflicts
+RandomizedDelaySec=300
+
+# If system was off, run on next boot
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/systemd/database-maintenance.service
+++ b/systemd/database-maintenance.service
@@ -1,0 +1,22 @@
+[Unit]
+Description=Database Maintenance - PostgreSQL VACUUM and Redis Analysis
+Documentation=file:///home/patriark/containers/.claude/remediation/README.md
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+WorkingDirectory=%h/containers/.claude/remediation/scripts
+ExecStart=%h/containers/.claude/remediation/scripts/apply-remediation.sh --playbook database-maintenance
+StandardOutput=journal
+StandardError=journal
+
+# Resource limits
+MemoryMax=512M
+CPUQuota=50%
+
+# Timeout (database maintenance can take 2-10 minutes)
+TimeoutStartSec=15min
+
+[Install]
+WantedBy=default.target

--- a/systemd/database-maintenance.timer
+++ b/systemd/database-maintenance.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Weekly Database Maintenance Timer
+Documentation=file:///home/patriark/containers/.claude/remediation/README.md
+
+[Timer]
+# Run every Sunday at 03:00 (low-traffic window)
+OnCalendar=Sun *-*-* 03:00:00
+
+# If the system was off during scheduled time, run on next boot
+Persistent=true
+
+# Randomize start time by up to 5 minutes to avoid thundering herd
+RandomizedDelaySec=5min
+
+[Install]
+WantedBy=timers.target

--- a/systemd/dependency-discovery.service
+++ b/systemd/dependency-discovery.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Dependency Discovery (Service Dependency Mapping)
+Documentation=file:///home/patriark/containers/.claude/plans/snoopy-hatching-pumpkin.md
+After=podman.socket
+
+[Service]
+Type=oneshot
+ExecStart=/home/patriark/containers/scripts/discover-dependencies.sh
+StandardOutput=journal
+StandardError=journal
+
+# Environment
+Environment="PATH=/usr/local/bin:/usr/bin:/bin"
+
+# Resource limits
+MemoryMax=100M
+CPUQuota=50%

--- a/systemd/dependency-discovery.timer
+++ b/systemd/dependency-discovery.timer
@@ -1,0 +1,20 @@
+[Unit]
+Description=Daily Dependency Discovery Timer
+Documentation=file:///home/patriark/containers/.claude/plans/snoopy-hatching-pumpkin.md
+
+[Timer]
+# Run daily at 06:00
+OnCalendar=daily
+OnCalendar=*-*-* 06:00:00
+
+# Run 5 minutes after boot (for development/testing)
+OnBootSec=5min
+
+# Persist timer across reboots
+Persistent=true
+
+# Randomize start time by up to 10 minutes to avoid load spikes
+RandomizedDelaySec=10min
+
+[Install]
+WantedBy=timers.target

--- a/systemd/dependency-metrics-export.service
+++ b/systemd/dependency-metrics-export.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Export Dependency Metrics to Prometheus
+Documentation=file:///home/patriark/.claude/plans/snoopy-hatching-pumpkin.md
+After=podman.socket
+
+[Service]
+Type=oneshot
+ExecStart=/home/patriark/containers/scripts/export-dependency-metrics.sh
+StandardOutput=journal
+StandardError=journal
+
+# Environment
+Environment="PATH=/usr/local/bin:/usr/bin:/bin"
+Environment="SUPPRESS_BOLTDB_WARNING=1"
+
+# Resource limits
+MemoryMax=50M
+CPUQuota=25%

--- a/systemd/dependency-metrics-export.timer
+++ b/systemd/dependency-metrics-export.timer
@@ -1,0 +1,19 @@
+[Unit]
+Description=Dependency Metrics Export Timer (Every 15 minutes)
+Documentation=file:///home/patriark/.claude/plans/snoopy-hatching-pumpkin.md
+
+[Timer]
+# Run every 15 minutes (dependency graph changes ~monthly, 5min was excessive)
+OnCalendar=*:0/15
+
+# Run 1 minute after boot
+OnBootSec=1min
+
+# Persist timer across reboots
+Persistent=true
+
+# Randomize start time by up to 30 seconds to avoid load spikes
+RandomizedDelaySec=30s
+
+[Install]
+WantedBy=timers.target

--- a/systemd/journal-logrotate.service
+++ b/systemd/journal-logrotate.service
@@ -1,0 +1,6 @@
+[Unit]
+Description=Rotate journal export log file
+
+[Service]
+Type=oneshot
+ExecStart=%h/containers/scripts/rotate-journal-export.sh

--- a/systemd/journal-logrotate.timer
+++ b/systemd/journal-logrotate.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Rotate journal export logs when over 100MB
+
+[Timer]
+# Check every hour
+OnCalendar=hourly
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/systemd/maintenance-cleanup.service
+++ b/systemd/maintenance-cleanup.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Homelab Maintenance Cleanup
+Documentation=file:///home/patriark/containers/scripts/maintenance-cleanup.sh
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/home/patriark/containers/scripts/maintenance-cleanup.sh
+StandardOutput=journal
+StandardError=journal
+
+# Security hardening
+PrivateTmp=yes
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=default.target

--- a/systemd/maintenance-cleanup.timer
+++ b/systemd/maintenance-cleanup.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Weekly Homelab Maintenance Cleanup Timer
+Documentation=file:///home/patriark/containers/scripts/maintenance-cleanup.sh
+
+[Timer]
+# Run every Sunday at 3:00 AM
+OnCalendar=Sun *-*-* 03:00:00
+
+# If system was off, run 1 hour after boot
+Persistent=true
+
+# Randomize execution by up to 30 minutes to avoid precise timing
+RandomizedDelaySec=30min
+
+[Install]
+WantedBy=timers.target

--- a/systemd/monthly-skill-report.service
+++ b/systemd/monthly-skill-report.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Monthly Skill Usage Report
+Documentation=file:///home/patriark/containers/docs/10-services/guides/skill-recommendation.md
+
+[Service]
+Type=oneshot
+ExecStart=/home/patriark/containers/scripts/analyze-skill-usage.sh --monthly-report
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/systemd/monthly-skill-report.timer
+++ b/systemd/monthly-skill-report.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Monthly Skill Usage Report Timer
+Documentation=file:///home/patriark/containers/docs/10-services/guides/skill-recommendation.md
+
+[Timer]
+# Run on the 1st of each month at 10:30 AM (after monthly SLO report)
+OnCalendar=*-*-01 10:30:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/systemd/monthly-slo-report.service
+++ b/systemd/monthly-slo-report.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Monthly SLO Report to Discord
+Documentation=file:///home/patriark/containers/scripts/monthly-slo-report.sh
+
+[Service]
+Type=oneshot
+ExecStart=/home/patriark/containers/scripts/monthly-slo-report.sh
+StandardOutput=journal
+StandardError=journal
+
+# Don't restart on failure (it's a one-shot report)
+Restart=no

--- a/systemd/monthly-slo-report.timer
+++ b/systemd/monthly-slo-report.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Monthly SLO Report Timer
+Documentation=file:///home/patriark/containers/scripts/monthly-slo-report.sh
+
+[Timer]
+# Run on the 1st of every month at 10:00 AM
+OnCalendar=*-*-01 10:00:00
+
+# If system was off, run on next boot
+Persistent=true
+
+# Randomize by up to 5 minutes
+RandomizedDelaySec=5min
+
+[Install]
+WantedBy=timers.target

--- a/systemd/nextcloud-cron.service
+++ b/systemd/nextcloud-cron.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=Nextcloud Background Jobs (Cron)
+Documentation=https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/background_jobs_configuration.html
+After=nextcloud
+Requires=nextcloud
+
+[Service]
+Type=oneshot
+WorkingDirectory=/home/patriark/containers
+
+# Execute Nextcloud cron.php (processes 1 job per run - designed for frequent execution)
+ExecStart=/usr/bin/podman exec --user www-data nextcloud php -f /var/www/html/cron.php
+
+# Environment
+Environment=HOME=/home/patriark
+Environment=XDG_RUNTIME_DIR=/run/user/1000
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+SyslogIdentifier=nextcloud-cron
+
+# Timeouts (generous for first runs and occasional heavy jobs)
+TimeoutStartSec=300
+
+# Resource limits (lightweight operation)
+CPUQuota=10%
+MemoryMax=256M
+
+[Install]
+WantedBy=default.target

--- a/systemd/nextcloud-cron.timer
+++ b/systemd/nextcloud-cron.timer
@@ -1,0 +1,20 @@
+[Unit]
+Description=Nextcloud Background Jobs Timer (Every 5 Minutes)
+Documentation=https://docs.nextcloud.com/server/stable/admin_manual/configuration_server/background_jobs_configuration.html
+
+[Timer]
+# Run every 5 minutes (Nextcloud recommended interval)
+# OnCalendar format: *-*-* *:00/5:00 means every 5 minutes starting at :00
+OnCalendar=*-*-* *:00/5:00
+
+# Add small random delay to avoid exact-minute load spikes
+RandomizedDelaySec=30
+
+# If system was off, run on next boot (catch up missed jobs)
+Persistent=true
+
+# High precision not needed for background jobs
+AccuracySec=1m
+
+[Install]
+WantedBy=timers.target

--- a/systemd/query-cache-refresh.service
+++ b/systemd/query-cache-refresh.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Refresh Query Cache
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/containers/scripts/precompute-queries.sh
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=10m
+
+# Low priority, don't impact system
+Nice=15
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7

--- a/systemd/query-cache-refresh.timer
+++ b/systemd/query-cache-refresh.timer
@@ -1,0 +1,12 @@
+[Unit]
+Description=Refresh query cache for homelab natural language queries
+Documentation=file:///home/patriark/containers/docs/20-operations/guides/automation-reference.md
+
+[Timer]
+# Run daily at 07:05 (after auto-doc-update at 07:00 when fresh data is available)
+OnCalendar=*-*-* 07:05:00
+Persistent=true
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target

--- a/systemd/remediation-webhook.service
+++ b/systemd/remediation-webhook.service
@@ -7,10 +7,19 @@ Wants=network-online.target
 [Service]
 Type=simple
 WorkingDirectory=%h/containers/.claude/remediation/scripts
+
+# Load secrets from environment file (secure: not committed to Git)
+# File location: ~/.config/remediation-webhook.env
+# Contains: WEBHOOK_AUTH_TOKEN=<secret>
+EnvironmentFile=%h/.config/remediation-webhook.env
+
+# Bind: LAN IP, not loopback — rootless containers cannot reach host 127.0.0.1,
+# and Alertmanager (the only caller) reaches the host via host.containers.internal.
+# Exposure accepted 2026-06-12 (owner decision): token auth + UDM perimeter firewall.
 ExecStart=/usr/bin/python3 %h/containers/.claude/remediation/scripts/remediation-webhook-handler.py \
     --config %h/containers/.claude/remediation/webhook-routing.yml \
     --port 9096 \
-    --bind 127.0.0.1 \
+    --bind 192.168.1.70 \
     --log-level INFO
 
 # Restart policy

--- a/systemd/security-comprehensive-audit.service
+++ b/systemd/security-comprehensive-audit.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Biweekly Comprehensive Security Audit
+After=autonomous-execute.service
+
+[Service]
+Type=oneshot
+ExecStart=%h/containers/scripts/security-audit.sh --level 3 --json --report
+WorkingDirectory=%h/containers

--- a/systemd/security-comprehensive-audit.timer
+++ b/systemd/security-comprehensive-audit.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Biweekly Comprehensive Security Audit
+
+[Timer]
+OnCalendar=*-*-01,15 06:45:00
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/systemd/urd-backup.service
+++ b/systemd/urd-backup.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Urd BTRFS backup
+
+[Service]
+Type=oneshot
+ExecStart=%h/.cargo/bin/urd backup --auto --confirm-retention-change
+Environment=RUST_LOG=info
+
+# Allow long backup runs (large btrfs sends can take hours)
+TimeoutStartSec=6h
+# Allow 5 minutes for graceful shutdown (cleanup partial snapshots)
+TimeoutStopSec=300
+
+# Low priority — don't interfere with interactive use
+Nice=19
+IOSchedulingClass=idle
+
+# Logging
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/systemd/urd-backup.timer
+++ b/systemd/urd-backup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Urd nightly backup
+
+[Timer]
+OnCalendar=*-*-* 04:00:00
+Persistent=true
+RandomizedDelaySec=300
+
+[Install]
+WantedBy=timers.target

--- a/systemd/vulnerability-scan.service
+++ b/systemd/vulnerability-scan.service
@@ -1,0 +1,21 @@
+[Unit]
+Description=Weekly Container Vulnerability Scan (Trivy)
+Documentation=file:///home/patriark/containers/docs/99-reports/PROJECT-B-SECURITY-HARDENING.md
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=%h/containers/scripts/scan-vulnerabilities.sh --all --notify --quiet
+StandardOutput=journal
+StandardError=journal
+TimeoutStartSec=30m
+# Exit 1 = vulnerabilities found (expected), not a service failure
+SuccessExitStatus=1
+
+# Lower priority to not impact system performance
+Nice=15
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7
+
+[Install]
+WantedBy=default.target

--- a/systemd/vulnerability-scan.timer
+++ b/systemd/vulnerability-scan.timer
@@ -1,0 +1,14 @@
+[Unit]
+Description=Weekly Container Vulnerability Scan Timer
+Documentation=file:///home/patriark/containers/docs/99-reports/PROJECT-B-SECURITY-HARDENING.md
+
+[Timer]
+# Run every Sunday at 06:00
+OnCalendar=Sun *-*-* 06:00:00
+# Randomize start time by up to 30 minutes to avoid thundering herd
+RandomizedDelaySec=1800
+# Run missed scans if system was off
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/systemd/weekly-intelligence.service
+++ b/systemd/weekly-intelligence.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Weekly Homelab Intelligence Report
+Documentation=file:///home/patriark/containers/scripts/weekly-intelligence-report.sh
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/home/patriark/containers/scripts/weekly-intelligence-report.sh
+StandardOutput=journal
+StandardError=journal
+
+# Security hardening
+PrivateTmp=yes
+NoNewPrivileges=yes
+
+[Install]
+WantedBy=default.target

--- a/systemd/weekly-intelligence.timer
+++ b/systemd/weekly-intelligence.timer
@@ -1,0 +1,16 @@
+[Unit]
+Description=Weekly Homelab Intelligence Report Timer
+Documentation=file:///home/patriark/containers/scripts/weekly-intelligence-report.sh
+
+[Timer]
+# Run every Friday at 7:30 AM (start of workday, end of week summary)
+OnCalendar=Fri *-*-* 07:30:00
+
+# If system was off, run on next boot
+Persistent=true
+
+# Randomize by up to 5 minutes (keep predictable)
+RandomizedDelaySec=5min
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Executes the quick-wins list from the 2026-06-12 holistic evaluation (`docs/97-plans/2026-06-12-strategic-development-trajectories-2026H2.md`). All changes are **applied live and verified** — full stack restarted in dependency-ordered waves, zero unhealthy containers, public endpoints checked (sso 200, photos 200, nextcloud 302, jellyfin 302).

### 1. Hardening sweep (`257f63c`)
- `NoNewPrivileges=true` on all 37 quadlets (was 3/37)
- `CPUQuota` for the 7 services that had neither quota nor CPUWeight

### 2. Ops state as code (`6ac11a0`)
- **GH#276 fixed**: prometheus + alertmanager switched to directory mounts; acceptance criterion verified live (atomic-replace + `/-/reload` propagates without restart — the failed-then-fixed reload during testing itself proved the new inode was being tracked)
- **Remediation webhook activated end-to-end** (was inert since Dec: placeholder token AND an unreachable 127.0.0.1 bind — rootless containers can't reach host loopback). Handler rebound to LAN IP (owner-approved; token auth + UDM perimeter), alertmanager reads the URL from a gitignored `url_file`. Live test: container → host → token validated → alert routed.
- **20 timer+service pairs imported** into `systemd/` — 22 of 37 live timers were untracked by git/drift detection (this gap produced a false finding during the audit itself)
- CLAUDE.md container count corrected (29 → 37)

### 3. Runbook wiring (`8a80a95`)
- 35 `runbook_url` annotations on infrastructure-critical/backup/storage alerts, mapped only to docs that actually exist
- 5 existing runbook links were dead (wrong org, wrong repo, nonexistent files) — 4 fixed, 1 removed
- All rules pass promtool

### 4. GH#140 fixed (`d6eb6ce`)
Root cause was the rootless uid mapping, not Immich: container-1000 mapped to a subuid the host-1000-owned library didn't match. `keep-id:uid=1000,gid=1000` + `GroupAdd=keep-groups` restores non-root with working GPU. Verified: uid 1000, no integrity errors, `/dev/dri` R/W, library writable, healthcheck healthy.

Closes #276, closes #140

## Residuals / notes for owner
- **First real Immich upload** should be eyeballed (no API credential for an authenticated upload smoke test)
- `podman-auto-update-weekly.{timer,service}` remnants in `~/.config/systemd/user/` are disabled leftovers of superseded ADR-015 — I was not authorized to delete them; remove manually if desired
- `remediation-url.secret` (gitignored) must be mode 644 — alertmanager runs as `nobody`
- Traefik logs a benign WRN about the `traefik` (dashboard) entrypoint lacking a socket-activation listener — pre-existing, unrelated

🤖 Generated with [Claude Code](https://claude.com/claude-code)