### PR TITLE
ADR-031 Phase 3: containers-side staging + IP re-address (VIP .72, node B .169)

### DIFF
--- a/config/prometheus/alerts/dns-resolver-alerts.yml
+++ b/config/prometheus/alerts/dns-resolver-alerts.yml
@@ -174,3 +174,45 @@ groups:
             podman exec -u www-data nextcloud php occ status
             podman exec -u www-data nextcloud php occ upgrade
             podman exec -u www-data nextcloud php occ maintenance:mode --off
+
+      # --- STAGED: ADR-031 Phase 3 (GH#292) — uncomment at build evening ------
+      # The VIP (192.168.1.72) and node B (raspberrypi-b @ 192.168.1.169) do not
+      # exist yet; activating these now would page immediately. The VIP probe is
+      # the post-cutover PRIMARY availability signal (clients resolve via the VIP);
+      # single-node failures become warnings once redundancy exists (ADR-031 D1).
+      # Failover *events* are logged by the keepalived notify hook to syslog on the
+      # nodes — surfacing those via the Loki syslog path is plan step "log
+      # centralisation (D6)", not a Prometheus alert.
+      #
+      # - alert: DnsVipResolutionBroken
+      #   expr: probe_success{job="blackbox-dns-functional", instance="192.168.1.72"} == 0
+      #   for: 3m
+      #   labels:
+      #     severity: critical
+      #     category: availability
+      #     component: dns_resolver
+      #     service: pihole
+      #   annotations:
+      #     summary: "DNS VIP not resolving — both resolvers or VRRP failed"
+      #     description: |
+      #       The keepalived VIP (192.168.1.72) is not answering functional DNS
+      #       probes for >3m. Under HA this means BOTH nodes are broken or VRRP
+      #       holds the VIP nowhere. Check per-node probes (.69 / .169) to see
+      #       which side survives; alert-path containers fall back to node IPs.
+      #     runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/97-plans/2026-06-12-adr031-phase3-design-node-b-vip.md"
+      #
+      # - alert: PiHoleNodeBDown
+      #   expr: up{job="node-exporter-pi-b"} == 0
+      #   for: 5m
+      #   labels:
+      #     severity: warning
+      #     category: availability
+      #     component: dns_resolver
+      #     service: pihole
+      #   annotations:
+      #     summary: "Resolver node B (raspberrypi-b) unreachable"
+      #     description: |
+      #       node_exporter on raspberrypi-b (192.168.1.169) not responding >5m.
+      #       Redundancy degraded: node A + VIP still serving (else
+      #       DnsVipResolutionBroken fires). Warning severity by design — single
+      #       node loss under HA is not an outage (ADR-031 D1).

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -215,6 +215,16 @@ scrape_configs:
           service: 'node_exporter'
           role: 'dns_resolver'
 
+  # STAGED — ADR-031 Phase 3 (GH#292): uncomment at build evening when node B
+  # (raspberrypi-b @ 192.168.1.169) exists. Uncommenting earlier pages PiHoleNodeDown.
+  # - job_name: 'node-exporter-pi-b'
+  #   static_configs:
+  #     - targets: ['192.168.1.169:9100']
+  #       labels:
+  #         instance: 'raspberrypi-b'
+  #         service: 'node_exporter'
+  #         role: 'dns_resolver'
+
   # Pi-hole exporter — query/block stats from the Pi-hole v6 API.
   # Timeout/interval (2026-06-07): the exporter serves /metrics SYNCHRONOUSLY —
   # each scrape runs a full Pi-hole v6 login→query cycle. Steady-state latency is
@@ -252,7 +262,11 @@ scrape_configs:
       module: [dns_functional]
     static_configs:
       - targets:
-          - 192.168.1.69  # node A (only resolver today; node B + VIP added in Phase 3)
+          - 192.168.1.69  # node A
+          # STAGED — ADR-031 Phase 3 (GH#292): uncomment at build evening (probing
+          # a nonexistent VIP/node would page DnsResolutionBroken).
+          # - 192.168.1.169  # node B (raspberrypi-b)
+          # - 192.168.1.72   # VIP — THE primary signal post-cutover
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target
@@ -278,6 +292,9 @@ scrape_configs:
     static_configs:
       - targets:
           - 192.168.1.69
+          # STAGED — ADR-031 Phase 3 (GH#292): uncomment at build evening.
+          # - 192.168.1.169  # node B — gravity parity check (nebula-sync verification)
+          # - 192.168.1.72   # VIP
     relabel_configs:
       - source_labels: [__address__]
         target_label: __param_target

--- a/config/traefik/dynamic/routers.yml
+++ b/config/traefik/dynamic/routers.yml
@@ -299,7 +299,7 @@ http:
     # Requires an Authelia access_control rule (two_factor, group:admins) — added 2026-05-26.
     # Chain (ADR-031 D4 / ADR-016 — routing here, not labels):
     #   crowdsec -> rate-limit -> ip-allowlist (LAN+WG) -> authelia SSO -> headers
-    # Phase 3: repoint the `pihole` service at the keepalived VIP (192.168.1.53).
+    # Phase 3: repoint the `pihole` service at the keepalived VIP (192.168.1.72; re-addressed 2026-06-12).
     pihole-admin:
       rule: "Host(`pihole.patriark.org`)"
       service: "pihole"
@@ -390,7 +390,8 @@ http:
     # Pi-hole resolver admin (ADR-031 D4). Literal LAN IP — no /etc/hosts (ADR-018)
     # entry needed (that's only for podman aardvark-dns ordering of *container*
     # names). Traefik reaches it via reverse_proxy LAN egress (same path Prometheus
-    # uses to scrape the Pi). Phase 3: change to the keepalived VIP http://192.168.1.53:80.
+    # uses to scrape the Pi). Phase 3 cutover (GH#292): change to the keepalived VIP
+    # http://192.168.1.72:80 (VIP re-addressed 2026-06-12: .53 sat in DHCP space).
     pihole:
       loadBalancer:
         servers:

--- a/docs/97-plans/2026-05-25-pihole-resolver-first-class-and-ha.md
+++ b/docs/97-plans/2026-05-25-pihole-resolver-first-class-and-ha.md
@@ -26,6 +26,10 @@ first** and **redundancy lands before** the work that depends on it.
 - DHCP is on the **UDM Pro**, not Pi-hole → resolvers can be DNS-only; HA stays simple.
 - IP plan: node A `192.168.1.69` (existing), node B `192.168.1.68` (new reservation),
   **VIP `192.168.1.53`** (mnemonic: port 53). Adjust to taste.
+  > **Adjusted 2026-06-12 (Phase 3 design session):** `.53`/`.68` sit in DHCP/reserved space
+  > (usable static range is `.69–.254`). Final: **node B `192.168.1.169`, VIP `192.168.1.72`**,
+  > VRID 53 keeps the mnemonic. Phase 3 IPs in this doc are superseded by
+  > [the design doc](2026-06-12-adr031-phase3-design-node-b-vip.md) — follow that at build evening.
 
 ---
 

--- a/docs/97-plans/2026-06-12-adr031-phase3-design-node-b-vip.md
+++ b/docs/97-plans/2026-06-12-adr031-phase3-design-node-b-vip.md
@@ -6,6 +6,19 @@
 **Parent plan:** [2026-05-25-pihole-resolver-first-class-and-ha.md](2026-05-25-pihole-resolver-first-class-and-ha.md) (Phase 3 section)
 **Resolver IaC home:** `htpc-mgmt` repo (private Forgejo) — roles `pihole`, `unbound`, `keepalived`, `pihole_backup`, `log2ram`, `node_exporter`, `ssh_hardening` already exist and are Phase-3-ready (keepalived template has VRID 53, templated priority, vault-supplied auth)
 
+> **Addendum 2026-06-12 (post-handoff, IPs revised in place):** the originally chosen VIP
+> `192.168.1.53` and node B `192.168.1.68` both sat inside DHCP/reserved space — the usable
+> static range on this LAN is `.69–.254`. Owner reassigned: **VIP = `192.168.1.72`**,
+> **node B = `192.168.1.169`** (inventory hostname `raspberrypi-b`). VRID 53 unchanged — the
+> port-53 mnemonic lives in the VRID, not the IP. All addresses below reflect the new values.
+>
+> **htpc-mgmt pre-build half: DONE same day** (commits `4a3a325` + `98be16a` on htpc-mgmt main;
+> record: `~/htpc-mgmt/docs/journals/2026-06-12-adr031-phase3-prebuilt.md`). Unicast VRRP,
+> BACKUP+nopreempt at 150/100, FAULT-on-failure `chk_dns.sh` (handoff defects 1–2 fixed), notify
+> hook to syslog, node B inventoried, vault auth_pass rotated + `diff: false` on the template
+> task. keepalived remains inert (`keepalived_enabled: false`); node A carries intended config
+> drift until build evening's real apply.
+
 ## Decisions
 
 **D-1 — Node B hardware: Raspberry Pi 5, PoE-powered, in the server cabinet.**
@@ -22,7 +35,7 @@ wired-Ethernet hardware constraint; clean cabling, no wall-wart).
   case/mount ≈ 100–200 kr. **Total ≈ 1,700–2,200 kr.**
 
 **D-2 — VRRP transport: unicast peers, not multicast.**
-`unicast_src_ip`/`unicast_peer` between `.69` and `.68`. Multicast VRRP (224.0.0.18, proto 112)
+`unicast_src_ip`/`unicast_peer` between `.69` and `.169`. Multicast VRRP (224.0.0.18, proto 112)
 can be silently eaten by IGMP-snooping settings on UniFi gear; unicast is ordinary IP between
 two static LAN addresses and removes that entire debugging class. Requires a small extension to
 the existing keepalived role template.
@@ -39,7 +52,7 @@ probes). `track_script`: resolve a known local record (`patriark.org` A via `127
 `dig +time=2 +tries=1`; interval 5s, fall 2, rise 2. A wedged-but-running Pi-hole releases the
 VIP; a dead process does too. Script failure → FAULT state (do not merely lower priority).
 
-**D-5 — VIP `192.168.1.53/24`, VRID 53** (as pre-decided in the plan; VRID already in the role
+**D-5 — VIP `192.168.1.72/24`, VRID 53** (as pre-decided in the plan; VRID already in the role
 template). VRRP auth_pass via ansible-vault — never committed.
 
 **D-6 — Config replication: nebula-sync as a quadlet on fedora-htpc**, in the containers repo
@@ -47,17 +60,17 @@ template). VRRP auth_pass via ansible-vault — never committed.
 schedule + manual trigger before drills. Pi-hole v6 Teleporter API both ends.
 
 **D-7 — Alert-path DNS end-state** (replaces the Phase-0 `9.9.9.9` interim):
-`alertmanager` + `alert-discord-relay` get `DNS=192.168.1.53` (VIP), `DNS=192.168.1.69`,
-`DNS=192.168.1.68` — survives VIP loss (VRRP dead) as long as either node answers. Host
-`/etc/resolv.conf` (immutable) gains `nameserver 192.168.1.68` as internal-only fallback.
+`alertmanager` + `alert-discord-relay` get `DNS=192.168.1.72` (VIP), `DNS=192.168.1.69`,
+`DNS=192.168.1.169` — survives VIP loss (VRRP dead) as long as either node answers. Host
+`/etc/resolv.conf` (immutable) gains `nameserver 192.168.1.169` as internal-only fallback.
 Afterwards the D7 perimeter-lockdown exception for `.70 → 9.9.9.9:53` becomes unnecessary —
 remove it when enabling the UDM lockdown.
 
 **D-8 — Cross-repo work split.**
-- `htpc-mgmt`: node B inventory entry (`192.168.1.68`, per-host `keepalived_priority`),
+- `htpc-mgmt`: node B inventory entry (`192.168.1.169`, per-host `keepalived_priority`),
   keepalived role extension (unicast peers, nopreempt, track_script), vault secret.
 - `containers` repo: nebula-sync quadlet; Prometheus scrape additions (`node-exporter-pi-b`,
-  blackbox dns probes for `.68` + VIP); alert additions (VIP-failover event, per-node down —
+  blackbox dns probes for `.169` + VIP); alert additions (VIP-failover event, per-node down —
   single-node-down is a *warning*, VIP-probe-failure is *critical*); `routers.yml` pihole
   target → VIP; alert-container `DNS=` updates.
 
@@ -72,30 +85,29 @@ from Horizon on its own concrete need. Phase 3 ships a resolver.
 
 ## Pre-build work (no hardware required — can start any session)
 
-1. **htpc-mgmt:** extend keepalived role (unicast_peer block, `nopreempt`, track_script with the
-   functional check script + notify hook that logs transitions); add node B to inventory +
-   `keepalived_priority` host vars; create vault entry for `auth_pass`.
+1. ~~**htpc-mgmt:** extend keepalived role + node B inventory + vault~~ — **DONE 2026-06-12**
+   (see addendum above).
 2. **containers repo:** draft the nebula-sync quadlet and the new scrape/alert config as
    commented-out staging (a VIP probe before the VIP exists would page).
 3. **Owner (UDM, copy-paste runbook):** DHCP reservation for the Pi 5 MAC on arrival; confirm
-   nothing in the Policy Table would block unicast `.69 ↔ .68` traffic (ordinary IP — expected
+   nothing in the Policy Table would block unicast `.69 ↔ .169` traffic (ordinary IP — expected
    fine).
 
 ## Build sequence (hardware-arrival evening, ~2–3h)
 
-1. Flash Pi OS Lite 64-bit → boot → reserve `.68` → cable to PoE port.
+1. Flash Pi OS Lite 64-bit → boot → reserve `.169` → cable to PoE port.
 2. `ansible-playbook site.yml --limit node-b` (common, ssh_hardening, node_exporter, unbound,
    pihole, pihole_backup, keepalived; log2ram only if SD-booted).
 3. Deploy nebula-sync quadlet → verify config parity (gravity counts, local records match).
 4. Start keepalived on A, then B → VIP lands on A (first-up under nopreempt; start A first).
 5. **Drills (all three, in order):**
    - *Kill MASTER:* `systemctl stop keepalived` on A → VIP on B within ~3×advert_int,
-     `dig @192.168.1.53` loop never times out, failover + node-down alerts fire.
+     `dig @192.168.1.72` loop never times out, failover + node-down alerts fire.
    - *Wedged resolver:* stop `pihole-FTL` only on the MASTER → track_script releases VIP.
    - *Recovery without flap:* restart A fully → VIP stays on B (nopreempt verified).
-6. Cutover: UDM DHCP DNS = VIP + `.69` + `.68`; `routers.yml` pihole target → VIP;
+6. Cutover: UDM DHCP DNS = VIP + `.69` + `.169`; `routers.yml` pihole target → VIP;
    alert-container `DNS=` lines per D-7; host resolv.conf fallback.
-7. Verify Phase-3 success criteria from the parent plan + blackbox probes green for `.68` and VIP.
+7. Verify Phase-3 success criteria from the parent plan + blackbox probes green for `.169` and VIP.
 8. Schedule the D7 perimeter lockdown follow-up (drop the `9.9.9.9` exception).
 
 ## Success criteria

--- a/quadlets/alert-discord-relay.container
+++ b/quadlets/alert-discord-relay.container
@@ -18,7 +18,8 @@ Network=systemd-monitoring
 
 # ADR-031 Phase 0 (D2): explicit resolvers with an independent fallback (previously inherited
 # reverse_proxy DNS=192.168.1.69 only). A Pi-hole outage must not stop alert delivery.
-# 9.9.9.9 is INTERIM — replace with the keepalived VIP + both node IPs in Phase 3.
+# 9.9.9.9 is INTERIM — Phase 3 cutover (GH#292, design D-7) replaces these with:
+#   DNS=192.168.1.72   (VIP)  /  DNS=192.168.1.69  /  DNS=192.168.1.169
 DNS=192.168.1.69
 DNS=9.9.9.9
 

--- a/quadlets/alertmanager.container
+++ b/quadlets/alertmanager.container
@@ -30,7 +30,8 @@ Secret=smtp_password
 Exec=--config.file=/etc/alertmanager/alertmanager.yml --storage.path=/alertmanager --log.level=info --web.external-url=https://alertmanager.patriark.org
 
 # ADR-031 Phase 0 (D2): independent fallback so a Pi-hole outage can't silence alerting.
-# 9.9.9.9 is INTERIM — replace with the keepalived VIP + both node IPs in Phase 3.
+# 9.9.9.9 is INTERIM — Phase 3 cutover (GH#292, design D-7) replaces these with:
+#   DNS=192.168.1.72   (VIP)  /  DNS=192.168.1.69  /  DNS=192.168.1.169
 DNS=192.168.1.69
 DNS=9.9.9.9
 

--- a/quadlets/nebula-sync.container.phase3-staged
+++ b/quadlets/nebula-sync.container.phase3-staged
@@ -1,0 +1,61 @@
+# STAGED — ADR-031 Phase 3 (GH#292). NOT ACTIVE: the .phase3-staged extension keeps the
+# quadlet generator from picking this up. Activation = build evening, after node B exists:
+#   1. Resolve + pin the image:  ./scripts/pin-container-image.sh nebula-sync --adopt <digest> --apply
+#      (image: ghcr.io/lovelaze/nebula-sync — pin per ADR-030 before first start)
+#   2. Create the secret (see below), rename to nebula-sync.container, daemon-reload, start.
+#
+# Purpose: Pi-hole config replication node A (192.168.1.69) → node B (192.168.1.169) via the
+# v6 Teleporter API (design D-6). Schedule: every 6h + manual `systemctl --user start` before
+# drills.
+#
+# ⚠ CREDENTIAL LANDMINE (discovered Phase 2, see project memory / 2026-05-28): Pi-hole v6
+# app-password sessions CANNOT modify config (api.app_sudo=false default) — Teleporter IMPORT
+# on the replica is a config write. The replica credential must be either the full admin
+# password or an app password with app_sudo=true enabled on node B only (preferred: node B is
+# the only writable target, node A keeps app_sudo off). Decide at build evening; the read from
+# node A works with a plain app password.
+
+[Unit]
+Description=Nebula-Sync — Pi-hole A→B config replication (ADR-031 D-6)
+Documentation=https://github.com/lovelaze/nebula-sync
+After=network-online.target reverse_proxy-network.service
+Wants=network-online.target reverse_proxy-network.service
+
+[Container]
+# ADR-030: digest-pin at activation (tag: latest → @sha256:... via pin-container-image.sh)
+Image=ghcr.io/lovelaze/nebula-sync:latest
+ContainerName=nebula-sync
+NoNewPrivileges=true
+
+# reverse_proxy first → default route to LAN (both resolvers are LAN hosts).
+Network=systemd-reverse_proxy
+
+# Connection strings carry credentials → both live in one Podman secret, format:
+#   SYNC_PRIMARY=http://192.168.1.69|<node-A-app-password>
+#   SYNC_REPLICAS=http://192.168.1.169|<node-B-admin-or-sudo-app-password>
+# Create:  podman secret create nebula-sync-env <file-with-both-lines>
+# (delivered as env file — nebula-sync reads SYNC_PRIMARY / SYNC_REPLICAS from env)
+Secret=nebula-sync-primary,type=env,target=SYNC_PRIMARY
+Secret=nebula-sync-replicas,type=env,target=SYNC_REPLICAS
+
+Environment=FULL_SYNC=true
+Environment=RUN_GRAVITY=true
+# Every 6h (design D-6); container stays resident and runs its own cron.
+Environment=CRON=0 */6 * * *
+Environment=TZ=Europe/Oslo
+
+[Service]
+# Tier C: replication is never boot-critical
+Slice=container.slice
+Restart=on-failure
+RestartSec=30s
+TimeoutStartSec=120s
+StartupCPUWeight=50
+StartupIOWeight=50
+
+MemoryMax=128M
+MemoryHigh=112M
+CPUQuota=50%
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
## Summary

Containers half of the ADR-031 Phase 3 pre-build (GH#292), executed on return-handoff from htpc-mgmt (whose half landed there same day: keepalived role with unicast/nopreempt/FAULT-on-failure health check, node B inventory, vault rotation).

### IP re-address propagated
Owner decision post-design: original VIP `.53` and node B `.68` sat in DHCP-reserved space (usable static range `.69–.254`). Final: **VIP `192.168.1.72`, node B `192.168.1.169`** (`raspberrypi-b`), VRID 53 unchanged. Updated: design doc (addendum + in-place), parent plan (dated banner pointing to the design doc), routers.yml cutover comments, private UDM runbook (gitignored, fixed locally), GH#292 body.

### Staged, all inert — nothing active changes
- `quadlets/nebula-sync.container.phase3-staged` — the `.phase3-staged` extension keeps the quadlet generator away. Full activation recipe in the header, including the **Pi-hole v6 `app_sudo` credential landmine**: Teleporter *import* on the replica is a config write, which app-password sessions cannot do — node B needs admin or `app_sudo`-enabled credentials (node A read works with a plain app password).
- Commented scrape targets: `node-exporter-pi-b` (`.169:9100`), blackbox dns_functional/dns_blocked for `.169` + `.72`.
- Commented alerts: `DnsVipResolutionBroken` (critical — post-cutover primary signal), `PiHoleNodeBDown` (warning — single-node loss under HA is not an outage, per D1). Uncommenting any of these before the VIP exists would page; every staged block says so.
- Cutover breadcrumbs at the `DNS=` lines in alertmanager + alert-discord-relay quadlets (D-7 end-state `.72`/`.69`/`.169`).

### Verification
- `promtool check rules` + `promtool check config` pass (staged blocks are comments)
- Traefik validator passes (comment-only change)
- Quadlet generator confirmed to ignore the staged file (extension not `.container`)

With this merged, every no-hardware task on GH#292 is done — the arc is purely gated on the Pi 5 purchase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)