### PR TITLE
Trajectory 1: sidecar alert coverage — blindness canaries + documented waivers

### DIFF
--- a/config/alertmanager/alertmanager.yml
+++ b/config/alertmanager/alertmanager.yml
@@ -178,3 +178,13 @@ inhibit_rules:
     target_matchers:
       - alertname =~ ".*(Down|Unhealthy|Unavailable).*"
     equal: ['instance']
+
+  # cAdvisor down ⇒ every container_last_seen series goes stale ~10m later and
+  # the cadvisor-derived alerts storm for all 37 services at once. CadvisorDown
+  # (for: 5m) names the cause first; suppress exactly its derivatives, nothing
+  # else (precise matchers by design — see GH#277 on over-broad inhibits).
+  # No `equal:` — single host, the blindness is global.
+  - source_matchers:
+      - alertname = "CadvisorDown"
+    target_matchers:
+      - alertname =~ "ContainerNotRunning|ContainerMemoryPressure|ContainerRestarting"

--- a/config/prometheus/alerts/infrastructure-critical.yml
+++ b/config/prometheus/alerts/infrastructure-critical.yml
@@ -171,6 +171,28 @@ groups:
           description: "System metrics collection has stopped. Node Exporter has been down for more than 5 minutes."
 
       # ========================================================================
+      # ALERT 9b: cAdvisor Down (added 2026-06-12, sidecar-coverage review)
+      # ========================================================================
+      # cAdvisor feeds ALL container-level alerting (ContainerNotRunning,
+      # ContainerMemoryPressure, ContainerRestarting in service-health.yml).
+      # When it dies, two things happen: (1) the container-liveness layer goes
+      # blind, and (2) ~10m later every container_last_seen series goes stale
+      # and ContainerNotRunning fires for all 37 services at once — a storm
+      # that buries the cause. This alert names the cause first (for: 5m beats
+      # the storm's 10m+5m) and an alertmanager inhibit rule suppresses the
+      # cadvisor-derived alerts while it fires.
+      - alert: CadvisorDown
+        expr: up{job="cadvisor"} == 0
+        for: 5m
+        labels:
+          severity: critical
+          category: monitoring
+        annotations:
+          runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/40-monitoring-and-documentation/guides/monitoring-stack.md"
+          summary: "cAdvisor is down — container observability blind"
+          description: "cAdvisor has been unreachable for more than 5 minutes. All container-level alerts (liveness, memory pressure, restarts) are blind until it returns. Check: systemctl --user status cadvisor.service"
+
+      # ========================================================================
       # ALERT 10: CrowdSec Down
       # ========================================================================
       - alert: CrowdSecDown

--- a/config/prometheus/alerts/service-health.yml
+++ b/config/prometheus/alerts/service-health.yml
@@ -94,3 +94,54 @@ groups:
         annotations:
           summary: "Container {{ $labels.container }} not running"
           description: "{{ $labels.container }} has not been seen by cAdvisor for over 10 minutes. It may have crashed or been stopped. Check: systemctl --user status {{ $labels.container }}.service"
+
+      # ========================================================================
+      # ALERT 4 + 5: metrics-path blindness canaries (2026-06-12 sidecar review)
+      # ========================================================================
+      # COVERAGE MODEL (the "15 unalerted sidecars" finding from the 2026-06-12
+      # audit, resolved): every one of the 37 quadlet services is covered for
+      # crash/stop by ContainerNotRunning above (verified live: the cgroup expr
+      # tracks all 37). Functional coverage is per-service (SLO burn rates,
+      # blackbox probes, up{} alerts, db-dump/restore alerts). The remaining
+      # class was WEDGED-BUT-RUNNING metrics components, where the container
+      # lives but its scrape dies silently — the 2026-06-04 pihole-exporter
+      # incident shape. These two close that class for the exporters that had
+      # no up{} alert. DELIBERATE WAIVERS (no bespoke per-sidecar alerts, by
+      # design): nextcloud-db/-redis, gathio-db, forgejo-db, immich-ml,
+      # proton-bridge, qbittorrent, unifi-syslog, alert-discord-relay — each is
+      # covered by ContainerNotRunning for death plus a loud parent signal for
+      # dysfunction (Nextcloud maintenance probe + SLO, Gathio/Forgejo HTTP,
+      # Immich SLO + job queue, Discord delivery failures in alertmanager
+      # notifications, db-dump backbone alerts for all DBs). Adding per-sidecar
+      # liveness alerts would duplicate ContainerNotRunning at higher noise.
+
+      # Redis exporters: redis-authelia + redis-immich are scraped but had no
+      # up{} alert — a wedged exporter (running, not serving) was invisible.
+      # Redis DEATH is loud elsewhere (authelia/immich break, ContainerNotRunning
+      # fires); this is only about the metrics path, hence warning + 10m.
+      - alert: RedisMetricsDown
+        expr: up{job=~"redis-authelia|redis-immich"} == 0
+        for: 10m
+        labels:
+          severity: warning
+          category: monitoring
+          component: container
+        annotations:
+          summary: "Redis exporter {{ $labels.job }} not serving metrics"
+          description: "The {{ $labels.job }} exporter scrape has failed for >10m. Redis itself is likely fine (its consumers would page otherwise) — this is the metrics path. Check the exporter container first: systemctl --user status {{ $labels.job }}-exporter.service"
+
+      # Blackbox exporter wedged => ALL probe-based alerting (DNS functional/
+      # blocked, Nextcloud maintenance) goes dark without firing anything:
+      # probe_success==0 alerts can't fire on ABSENT series. max() over the
+      # blackbox jobs collapses to one signal that fires only when no blackbox
+      # job is scrapable (= the exporter itself, not an individual probe).
+      - alert: BlackboxProbeLayerDown
+        expr: max(up{job=~"blackbox-.*"}) == 0
+        for: 10m
+        labels:
+          severity: warning
+          category: monitoring
+          component: container
+        annotations:
+          summary: "Blackbox exporter unreachable — probe layer dark"
+          description: "No blackbox-* job has been scrapable for >10m. DNS functional/blocked probes and the Nextcloud maintenance probe are all blind (their probe_success alerts cannot fire on absent series). Check: systemctl --user status blackbox-exporter.service"

--- a/config/prometheus/tests/alert-rules.test.yml
+++ b/config/prometheus/tests/alert-rules.test.yml
@@ -8,6 +8,7 @@ rule_files:
   - ../alerts/immich-alerts.yml
   - ../alerts/service-health.yml
   - ../alerts/infrastructure-warnings.yml
+  - ../alerts/infrastructure-critical.yml
   - ../alerts/db-dump-alerts.yml
   - ../alerts/supply-chain-alerts.yml
 
@@ -212,3 +213,81 @@ tests:
             exp_annotations:
               summary: "Memory pressure high"
               description: "System memory usage is 95%. May cause OOM kills."
+
+  # --- 2026-06-12 sidecar-coverage review: metrics-path blindness canaries ----
+  # CadvisorDown: fires after 5m of up==0; not before.
+  - interval: 1m
+    input_series:
+      - series: 'up{job="cadvisor", instance="cadvisor:8080"}'
+        values: '1x10 0x10'
+    alert_rule_test:
+      - eval_time: 8m
+        alertname: CadvisorDown
+        exp_alerts: []
+      - eval_time: 16m
+        alertname: CadvisorDown
+        exp_alerts:
+          - exp_labels:
+              job: cadvisor
+              instance: cadvisor:8080
+              severity: critical
+              category: monitoring
+            exp_annotations:
+              runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/40-monitoring-and-documentation/guides/monitoring-stack.md"
+              summary: "cAdvisor is down — container observability blind"
+              description: "cAdvisor has been unreachable for more than 5 minutes. All container-level alerts (liveness, memory pressure, restarts) are blind until it returns. Check: systemctl --user status cadvisor.service"
+
+  # RedisMetricsDown: wedged exporter (up==0) fires after 10m; healthy peer does not.
+  - interval: 1m
+    input_series:
+      - series: 'up{job="redis-authelia", instance="redis-authelia-exporter:9121"}'
+        values: '1x5 0x15'
+      - series: 'up{job="redis-immich", instance="redis-immich-exporter:9121"}'
+        values: '1x21'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: RedisMetricsDown
+        exp_alerts:
+          - exp_labels:
+              job: redis-authelia
+              instance: redis-authelia-exporter:9121
+              severity: warning
+              category: monitoring
+              component: container
+            exp_annotations:
+              summary: "Redis exporter redis-authelia not serving metrics"
+              description: "The redis-authelia exporter scrape has failed for >10m. Redis itself is likely fine (its consumers would page otherwise) — this is the metrics path. Check the exporter container first: systemctl --user status redis-authelia-exporter.service"
+
+  # BlackboxProbeLayerDown: fires only when ALL blackbox jobs are unscrapable —
+  # one failing job (partial outage) must NOT fire it.
+  - interval: 1m
+    input_series:
+      - series: 'up{job="blackbox-dns-functional", instance="192.168.1.69"}'
+        values: '1x5 0x15'
+      - series: 'up{job="blackbox-dns-blocked", instance="192.168.1.69"}'
+        values: '1x5 0x15'
+      - series: 'up{job="blackbox-nextcloud-status", instance="nextcloud"}'
+        values: '1x21'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: BlackboxProbeLayerDown
+        exp_alerts: []
+  - interval: 1m
+    input_series:
+      - series: 'up{job="blackbox-dns-functional", instance="192.168.1.69"}'
+        values: '1x5 0x15'
+      - series: 'up{job="blackbox-dns-blocked", instance="192.168.1.69"}'
+        values: '1x5 0x15'
+      - series: 'up{job="blackbox-nextcloud-status", instance="nextcloud"}'
+        values: '1x5 0x15'
+    alert_rule_test:
+      - eval_time: 20m
+        alertname: BlackboxProbeLayerDown
+        exp_alerts:
+          - exp_labels:
+              severity: warning
+              category: monitoring
+              component: container
+            exp_annotations:
+              summary: "Blackbox exporter unreachable — probe layer dark"
+              description: "No blackbox-* job has been scrapable for >10m. DNS functional/blocked probes and the Nextcloud maintenance probe are all blind (their probe_success alerts cannot fire on absent series). Check: systemctl --user status blackbox-exporter.service"


### PR DESCRIPTION
## Summary

Executes the audit's "liveness alerts or explicit waivers for ~15 unalerted sidecars" item — with a corrected premise: **`ContainerNotRunning` already covers all 37 services** for crash/stop (verified live via the cgroup query; the audit explorer grepped service names and missed the generic rule). What was actually missing is the **wedged-but-running metrics-component class**:

| New alert | Severity | Closes |
|---|---|---|
| `CadvisorDown` | critical | Container-observability layer blind + names the cause before the 37-service `ContainerNotRunning` storm that follows ~10m later; paired with a precise inhibit rule (exact alertnames, no lumping — GH#277's lesson) |
| `RedisMetricsDown` | warning | redis-authelia/redis-immich scraped but no `up{}` alert — wedged exporter invisible |
| `BlackboxProbeLayerDown` | warning | `probe_success==0` alerts can't fire on absent series — dead blackbox-exporter silently blinded all DNS/maintenance probes; `max()` fires only on full-layer loss |

Deliberate waivers (nextcloud-db/-redis, gathio-db, forgejo-db, immich-ml, proton-bridge, qbittorrent, unifi-syslog, alert-discord-relay) are now documented in `service-health.yml` with per-service rationale: each has `ContainerNotRunning` for death plus a loud parent signal for dysfunction.

## Verification
- promtool unit tests added for all three alerts (incl. a partial-outage must-NOT-fire case for the blackbox layer); full suite `SUCCESS`
- Deployed live: all three registered in `/api/v1/rules`, none firing spuriously, alertmanager validates with 6 inhibit rules

## Note
During live verification the Tier-4 egress observatory was found firing on restart-time destinations from today's hardening-wave restarts — triaged separately, re-baseline PR follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)