### PR TITLE
feat(supply-chain): vaultwarden attestation signer — 2nd verified publisher (ADR-030 P6)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,7 +89,7 @@ Pattern-based deployment available via `homelab-deployment` skill (see `.claude/
 
 ### Update Strategy
 
-Governed by **ADR-030 (Container Supply-Chain Trust Model):** **fully implemented (Tier 1 + Tier 2)** — every registry image is digest-pinned (`tag@sha256:…`, tag = discovery handle, digest = execution contract), all `AutoUpdate=registry` lines are stripped, and the 2 local builds pin their `FROM` bases by digest. Nothing updates automatically; superseded ADR-015's `:latest`/auto-update trust model. A pre-commit hook enforces the invariants (egress tier pinned + de-automated, local bases pinned, no signature failures); `docs/AUTO-IMAGE-PIN-INDEX.md` is the daily audit view.
+Governed by **ADR-030 (Container Supply-Chain Trust Model):** **all four tiers implemented** (Tier 3 deliberate-path signature verification merged 2026-05-24 PR #224; Tier 4 egress observatory PR #229) — every registry image is digest-pinned (`tag@sha256:…`, tag = discovery handle, digest = execution contract), all `AutoUpdate=registry` lines are stripped, and the 2 local builds pin their `FROM` bases by digest. Nothing updates automatically; superseded ADR-015's `:latest`/auto-update trust model. A pre-commit hook enforces the invariants (egress tier pinned + de-automated, local bases pinned, no signature failures); `docs/AUTO-IMAGE-PIN-INDEX.md` is the daily audit view.
 
 **Deliberate update loop (ADR-036)** — single entry point: `scripts/monthly-update.sh` (chains all steps below interactively; Discord nudges via `ImageUpdatesBaked*` alerts when ≥5 updates are baked):
 1. **Discover:** `scripts/check-image-updates.sh` — skopeo digest-diff, notify-only; annotates each candidate BAKED/TOO-YOUNG against the P3 bake policy (`config/supply-chain/bake-policy.yml`: egress 7d, internal 3d) and writes machine-readable JSON
@@ -102,7 +102,7 @@ Governed by **ADR-030 (Container Supply-Chain Trust Model):** **fully implemente
 - **Immich:** server + ML + postgres version-locked as a set (tight coupling)
 - **Local builds** (proton-bridge, alert-discord-relay): Tier 2 — built locally from digest-pinned bases, no registry trust
 
-Rollback: `git revert` of the digest line + restart; BTRFS snapshots as second path. Remaining ADR-030 work: Tier 3/4 (broader signature coverage). Workflow: `scripts/update-before-reboot.sh` before DNF updates (ensures pinned digests present, never re-floats them).
+Rollback: `git revert` of the digest line + restart; BTRFS snapshots as second path. Remaining ADR-030 work: signer-coverage growth — periodically re-survey publishers (`config/supply-chain/known-unsigned.md` has the procedure; 2/33 verified as of 2026-06-13: home-assistant, vaultwarden). Workflow: `scripts/update-before-reboot.sh` before DNF updates (ensures pinned digests present, never re-floats them).
 
 ### Git & PR Workflow (merge commits — decided 2026-06-12)
 

--- a/config/supply-chain/known-unsigned.md
+++ b/config/supply-chain/known-unsigned.md
@@ -1,21 +1,25 @@
 # Known-Unsigned Images (ADR-030 P6 — tracked, not silently trusted)
 
-**Survey date:** 2026-05-24 · **Tool:** containerized cosign v3.0.6 (`cosign tree`)
-+ skopeo tag-scheme probe + `gh attestation verify` (GHCR app images).
+**Survey date:** 2026-06-13 (re-survey; original 2026-05-24) · **Tool:** containerized
+cosign v3.0.6 (`cosign tree`) + skopeo tag-scheme probe + `gh attestation verify`.
 
 ADR-030 P6 enforces authenticity *where publishers support it* and **tracks** the
 publishers who do not — rather than silently trusting them. This is that record. Of
-32 external image references, **1 is signed** (`ghcr.io/home-assistant/home-assistant`,
-verified on the deliberate-update path via `signers.yaml`); the rest are listed below.
+33 unique external repositories, **2 are signed** (`ghcr.io/home-assistant/home-assistant`,
+`docker.io/vaultwarden/server` — both verified on the deliberate-update path via
+`signers.yaml`); the rest are listed below.
 
 This is a point-in-time snapshot. Re-run the survey when adding a service or when a
 publisher may have started signing; promote any new signer into `signers.yaml`.
+The 2026-06-13 re-survey proves coverage *does* grow: vaultwarden gained GitHub
+Artifact Attestations between the two surveys.
 
 ## Signed (enforced via deliberate-path cosign gate)
 
 | Repository | Mechanism |
 |---|---|
 | `ghcr.io/home-assistant/home-assistant` | keyless GitHub-Actions cosign signature (Rekor-logged) — see `signers.yaml` |
+| `docker.io/vaultwarden/server` | GitHub Artifact Attestation — SLSA provenance v1, referrer-attached sigstore bundle (first seen on release 1.36.0) — see `signers.yaml` |
 
 ## Unsigned — no registry-attached sigstore signature (31 refs)
 
@@ -25,6 +29,7 @@ No `cosign tree` artifacts and no tag-scheme `.sig`/`.att`. Trusted by **digest 
 ### docker.io
 - `docker.io/authelia/authelia`
 - `docker.io/crowdsecurity/crowdsec`
+- `docker.io/ekofr/pihole-exporter` *(added post-survey; confirmed unsigned 2026-06-13)*
 - `docker.io/library/postgres`
 - `docker.io/library/mongo`
 - `docker.io/library/mariadb`
@@ -39,12 +44,10 @@ No `cosign tree` artifacts and no tag-scheme `.sig`/`.att`. Trusted by **digest 
 - `docker.io/valkey/valkey`
 - `docker.io/linuxserver/qbittorrent`
 - `docker.io/linuxserver/syslog-ng`
-- `docker.io/vaultwarden/server`
 
 ### ghcr.io
 - `ghcr.io/advplyr/audiobookshelf`
 - `ghcr.io/lowercasename/gathio`
-- `ghcr.io/gethomepage/homepage`
 - `ghcr.io/immich-app/immich-server`
 - `ghcr.io/immich-app/immich-machine-learning`
 - `ghcr.io/immich-app/postgres`
@@ -52,6 +55,7 @@ No `cosign tree` artifacts and no tag-scheme `.sig`/`.att`. Trusted by **digest 
 
 ### quay.io
 - `quay.io/prometheus/alertmanager`
+- `quay.io/prometheus/blackbox-exporter` *(added post-survey; confirmed unsigned 2026-06-13)*
 - `quay.io/prometheus/node-exporter`
 - `quay.io/prometheus/prometheus`
 - `quay.io/prometheuscommunity/postgres-exporter`
@@ -67,10 +71,11 @@ No `cosign tree` artifacts and no tag-scheme `.sig`/`.att`. Trusted by **digest 
 
 `gh attestation verify` against the GHCR application images returned **no GitHub
 build-provenance attestations** for any of: `immich-server`, `immich-machine-learning`,
-`immich/postgres`, `gethomepage/homepage`, `lowercasename/gathio`,
-`advplyr/audiobookshelf`, `unpoller/unpoller`. The outline expected "GHCR OIDC-built
-images" to be the most likely first signers; that assumption is **falsified** for this
-fleet's GHCR publishers.
+`immich/postgres`, `lowercasename/gathio`, `advplyr/audiobookshelf`,
+`unpoller/unpoller` (re-confirmed 2026-06-13; `gethomepage/homepage` dropped —
+service decommissioned). The outline expected "GHCR OIDC-built images" to be the most
+likely first signers; that assumption is **falsified** for this fleet's GHCR
+publishers — the first attestation adopter was a docker.io publisher (vaultwarden).
 
 ## Local builds (Tier 2, not registry-signed)
 

--- a/config/supply-chain/signers.yaml
+++ b/config/supply-chain/signers.yaml
@@ -11,6 +11,10 @@
 #   repo             exact image repository (no tag, no digest)
 #   oidc_issuer      expected OIDC issuer   -> cosign --certificate-oidc-issuer
 #   identity_regexp  regexp for the cert SAN -> cosign --certificate-identity-regexp
+#   mechanism        optional; default `signature` (tag-scheme cosign .sig ->
+#                    `cosign verify`). `attestation` = referrer-attached sigstore
+#                    bundle with SLSA provenance (GitHub Artifact Attestations) ->
+#                    `cosign verify-attestation --new-bundle-format --type slsaprovenance1`.
 #   note             human context
 #
 # To add an email-identity signer (e.g. a publisher using user-OAuth keyless), the
@@ -25,3 +29,13 @@ signers:
       Survey 2026-05-24: the ONLY signed image in the fleet (1/32). Identity is a
       workflow URI SAN, not an email, so it is NOT expressible in podman 5.8.2
       policy.json (subjectEmail mandatory) — verified here on the deliberate path.
+
+  - repo: docker.io/vaultwarden/server
+    oidc_issuer: https://token.actions.githubusercontent.com
+    identity_regexp: '^https://github\.com/dani-garcia/vaultwarden/\.github/workflows/release\.yml@refs/tags/.*$'
+    mechanism: attestation
+    note: >-
+      Vaultwarden — GitHub Artifact Attestation (SLSA provenance v1, referrer-attached
+      sigstore bundle, Rekor-logged). Appeared between the 2026-05-24 survey and the
+      2026-06-13 re-survey (first present on the 1.36.0 release). Not a tag-scheme
+      .sig, so verified via cosign verify-attestation --new-bundle-format.

--- a/docs/AUTO-IMAGE-PIN-INDEX.md
+++ b/docs/AUTO-IMAGE-PIN-INDEX.md
@@ -1,6 +1,6 @@
 # Container Image Pin Index (Auto-Generated)
 
-**Generated:** 2026-06-12 05:03:56 UTC
+**Generated:** 2026-06-12 22:09:21 UTC
 **Source:** `/home/patriark/containers/quadlets` — ADR-030 (Container Supply-Chain Trust Model)
 
 Pins live in each quadlet's `Image=` line (where Podman reads them); this is
@@ -19,7 +19,7 @@ For local builds the `Digest` column shows the **base image** pin (FROM …@sha2
 | 🔨 Local builds with FLOATING base | 0 |
 | Egress-tier still floating | 0 |
 | Egress-tier still auto-updating | 0 |
-| 🔏 P6 signers (authenticity-verified on adopt) | 1 |
+| 🔏 P6 signers (authenticity-verified on adopt) | 2 |
 | ✗ P6 signature FAILED | 0 |
 
 > ✅ **Supply-chain invariant holds:** no reverse_proxy-tier service is floating
@@ -66,7 +66,7 @@ For local builds the `Digest` column shows the **base image** pin (FROM …@sha2
 | traefik | yes | 🔒 pinned | `docker.io/library/traefik` | latest | `sha256:6b9cbca6fac4…` | no | — unsigned |
 | unifi-syslog | no | 🔒 pinned | `docker.io/linuxserver/syslog-ng` | latest | `sha256:b77c32d93b9e…` | no | — unsigned |
 | unpoller | yes | 🔒 pinned | `ghcr.io/unpoller/unpoller` | latest | `sha256:bf7bdcc59fcd…` | no | — unsigned |
-| vaultwarden | yes | 🔒 pinned | `docker.io/vaultwarden/server` | latest | `sha256:d626d04934cd…` | no | — unsigned |
+| vaultwarden | yes | 🔒 pinned | `docker.io/vaultwarden/server` | latest | `sha256:d626d04934cd…` | no | ✓ verified |
 
 ---
 

--- a/scripts/verify-image-signature.sh
+++ b/scripts/verify-image-signature.sh
@@ -77,7 +77,8 @@ with open(path) as f:
     doc = yaml.safe_load(f) or {}
 for s in (doc.get("signers") or []):
     if s.get("repo") == repo:
-        print(s.get("oidc_issuer", "")); print(s.get("identity_regexp", "")); break
+        print(s.get("oidc_issuer", "")); print(s.get("identity_regexp", ""))
+        print(s.get("mechanism", "signature")); break
 PY
 )" || { echo "verify-image-signature: failed to parse $SIGNERS_FILE" >&2; exit 2; }
 
@@ -87,7 +88,12 @@ if [ -z "$entry" ]; then
 fi
 issuer="$(printf '%s\n' "$entry" | sed -n 1p)"
 identity="$(printf '%s\n' "$entry" | sed -n 2p)"
+mechanism="$(printf '%s\n' "$entry" | sed -n 3p)"
 [ -n "$issuer" ] && [ -n "$identity" ] || { echo "verify-image-signature: incomplete signer entry for $repo" >&2; exit 2; }
+case "$mechanism" in
+    signature|attestation) ;;
+    *) echo "verify-image-signature: unknown mechanism '$mechanism' for $repo" >&2; exit 2 ;;
+esac
 
 # --- tooling + connectivity pre-checks (separate network errors from FAILURE) -
 podman image exists "$COSIGN_IMAGE" || {
@@ -97,13 +103,23 @@ if ! skopeo inspect --raw "docker://$ref" >/dev/null 2>&1; then
 fi
 
 # --- verify ------------------------------------------------------------------
-log "🔎 verifying $ref"
+log "🔎 verifying $ref ($mechanism)"
 log "   identity ~ $identity"
 log "   issuer     $issuer"
-out="$(cosign verify \
-        --certificate-identity-regexp "$identity" \
-        --certificate-oidc-issuer "$issuer" \
-        "$ref" 2>&1)"; rc=$?
+if [ "$mechanism" = "attestation" ]; then
+    # Referrer-attached sigstore bundle (GitHub Artifact Attestations): the SLSA
+    # provenance statement's subject digest is checked against $ref by cosign.
+    out="$(cosign verify-attestation --new-bundle-format \
+            --type slsaprovenance1 \
+            --certificate-identity-regexp "$identity" \
+            --certificate-oidc-issuer "$issuer" \
+            "$ref" 2>&1)"; rc=$?
+else
+    out="$(cosign verify \
+            --certificate-identity-regexp "$identity" \
+            --certificate-oidc-issuer "$issuer" \
+            "$ref" 2>&1)"; rc=$?
+fi
 
 if [ $rc -eq 0 ]; then
     log "✅ VERIFIED: $repo signed by expected identity"


### PR DESCRIPTION
## What

The 2026-06-13 re-survey of all 33 external image repositories found that **`docker.io/vaultwarden/server` started publishing GitHub Artifact Attestations** (SLSA provenance v1, referrer-attached sigstore bundle) since the 2026-05-24 survey — first present on the 1.36.0 release. This PR promotes it into the Tier 3 deliberate-path verification framework, doubling signer coverage to **2/33**.

## Why a verifier change was needed

This is not a tag-scheme cosign `.sig` like Home Assistant's — `cosign verify` can't see it. It's a referrer-attached sigstore bundle, verified with `cosign verify-attestation --new-bundle-format --type slsaprovenance1` (same pinned cosign v3.0.6, no new tooling; the attestation's in-toto subject digest is checked against the pinned digest by cosign).

- `signers.yaml`: new optional `mechanism: signature|attestation` field (default `signature` — HA entry unchanged), plus the vaultwarden entry with identity `^https://github\.com/dani-garcia/vaultwarden/\.github/workflows/release\.yml@refs/tags/.*$`
- `verify-image-signature.sh`: branches on `mechanism`; exit-code contract (0/1/2/3) unchanged

## Tested

| Case | Expected | Result |
|---|---|---|
| vaultwarden pinned digest, real identity | exit 0 | ✅ |
| vaultwarden, tampered identity (evil/fork) | exit 1 fail-closed | ✅ (clear SAN-mismatch error) |
| home-assistant regression (signature mechanism) | exit 0 | ✅ |
| unsigned repo (traefik) | exit 3 tracked-unsigned | ✅ |
| `pin-container-image.sh vaultwarden --adopt <current>` dry-run | gate verifies via attestation path | ✅ |

Metric written (`supply_chain_signature_verify{service="vaultwarden"} 1`); pin index regenerated — vaultwarden now `✓ verified`.

## Housekeeping in the same sweep

- `known-unsigned.md`: survey date refreshed; `pihole-exporter` + `blackbox-exporter` (deployed post-survey) confirmed unsigned and listed; decommissioned `gethomepage/homepage` dropped; GHCR apps re-confirmed unattested — the outline's "GHCR will sign first" assumption stays falsified (first new signer was a docker.io publisher)
- `CLAUDE.md`: corrected stale ADR-030 status — all four tiers are implemented (Tier 3 merged 2026-05-24 #224, Tier 4 #229); remaining work is signer-coverage growth. The 2026-06-12 audit/handoff/roadmap had propagated "Tier 3 remains" — falsified against git history this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)