### PR TITLE
fix(egress): re-baseline crowdsec CAPI — widen 79.125.0.0/18 → /17 for 79.125.93.93

### DIFF
--- a/config/supply-chain/egress-baseline.yaml
+++ b/config/supply-chain/egress-baseline.yaml
@@ -60,10 +60,16 @@ services:
       note: Discord webhook API (observed 162.159.135.232, 162.159.138.232)
   crowdsec:
     - owner: Amazon Data Services Ireland Ltd
-      cidrs: [79.125.0.0/18, 176.34.0.0/16]
+      cidrs: [79.125.0.0/17, 176.34.0.0/16]
       note: CrowdSec CAPI/blocklists, AWS eu-west (observed 79.125.15.38; 176.34.92.0
         added 2026-06-12 after first live alert — served valid api.crowdsec.net cert,
-        CAPI ELB rotated into this range)
+        CAPI ELB rotated into this range; 79.125.0.0/18 widened to /17 on 2026-06-14
+        for 79.125.93.93 — CAPI rotated into the upper half (/18 only covered
+        .0-.63.x). TLS-at-IP proof — 79.125.93.93:443 with SNI api.crowdsec.net served
+        CN=api.crowdsec.net, issuer Amazon RSA 2048 M01, SAN DNS api.crowdsec.net;
+        default vhost *.execute-api.eu-west-1.amazonaws.com (API Gateway). Corroborated
+        by crowdsec capi-metrics and community-blocklist log lines. /17 is the exact
+        AWS-published eu-west-1 EC2 prefix containing both 79.125.15.38 and 79.125.93.93)
     - owner: Amazon Technologies Inc.
       cidrs: [18.128.0.0/9, 34.192.0.0/10, 52.0.0.0/10, 52.208.0.0/13, 52.220.0.0/15, 52.223.128.0/18, 52.64.0.0/12, 52.84.0.0/15, 54.160.0.0/11, 54.192.0.0/12, 54.208.0.0/13, 54.224.0.0/11, 54.64.0.0/11]
       note: CrowdSec CAPI/blocklist mirrors (observed 18.200.183.204, 34.240.98.252,


### PR DESCRIPTION
## What

Tier-4 egress observatory (ADR-030 P7) flagged **one open anomaly**:

| service | dest | port | first seen | obs | PTR |
|---|---|---|---|---|---|
| crowdsec | `79.125.93.93` | 443 | 2026-06-13 | 5 | `ec2-79-125-93-93.eu-west-1.compute.amazonaws.com` |

This fired `EgressUnexpectedDestination` (warning) and, since it held past 1h, `EgressUnexpectedDestinationPersistent` (critical). It is **benign** — CrowdSec CAPI traffic that rotated into an AWS range just outside the frozen baseline. Same class as #275 / #296.

The existing crowdsec allowance had `79.125.0.0/18`, which only covers `.0–.63.x`; `79.125.93.93` landed in the upper half. **AWS publishes the whole block as one eu-west-1 EC2 prefix `79.125.0.0/17`**, so this widens the existing `/18` to that — covering both the prior observed IP (`79.125.15.38`) and the new one, with no narrower-or-broader invention.

## Verification (logs → DNS → TLS-at-IP, not guessed)

- **TLS-at-IP (strongest):** `79.125.93.93:443` with SNI `api.crowdsec.net` served `CN=api.crowdsec.net`, issuer *Amazon RSA 2048 M01*, SAN `DNS:api.crowdsec.net`. Default vhost is `*.execute-api.eu-west-1.amazonaws.com` → AWS API Gateway fronting CrowdSec's Central API.
- **App logs:** crowdsec emits `capi metrics: sending` (every 30m) and `community-blocklist` updates (every 2h) — the CAPI chatter that targets `api.crowdsec.net`.
- **DNS:** `api.crowdsec.net` A-resolves to a *different* eu-west-1 set right now → confirms a rotating API-Gateway pool, not a fixed host (explains why the shadow window missed this IP).
- **AWS authority:** `ip-ranges.json` lists `79.125.0.0/17` as `region=eu-west-1, service=EC2`.

## Result

Detector re-run after the edit:

```
egress_unexpected_destination_count{service="crowdsec"}  1 → 0
```

No restart needed — the classifier reloads `egress-baseline.yaml` each run; the warning + persistent-critical resolve on the next scrape.

## Scope / risk

- One-line CIDR widening (`/18` → `/17`) on an already digest-pinned, signature-verified service, plus an evidence note. `infrastructure: []` stays empty (no broadening of the shared allowance).
- **Pattern flag for the owner:** this is the **3rd** crowdsec→AWS rotation to trip the observatory (#275, #296, now this). Reactive `/18`→`/17` keeps working, but it may be worth a deliberate decision to scope crowdsec's AWS allowance to the published eu-west-1 ranges once, vs. continuing to chase rotations. Not done here — flagging for ADR/owner judgement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)