### PR TITLE
docs(adr-041): OpenBao secrets substrate boundary (supersedes ADR-040)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Rollback: `git revert` of the digest line + restart; BTRFS snapshots as second p
 
 ### Architecture Decision Records
 
-**Architectural decisions recorded as ADRs — latest is ADR-039** (see `docs/*/decisions/` for full details; number new ADRs sequentially from the latest)
+**Architectural decisions recorded as ADRs — latest is ADR-041** (see `docs/*/decisions/` for full details; number new ADRs sequentially from the latest)
 
 **Design-Guiding ADRs (affect future decisions):**
 - **ADR-001:** Rootless Containers — UID 1000, `:Z` SELinux labels on all mounts
@@ -137,6 +137,7 @@ Rollback: `git revert` of the digest line + restart; BTRFS snapshots as second p
 - **ADR-037:** Forge Center-of-Gravity (Per-Repo Placement) — each repo has one authoritative forge (GitHub-primary + Forgejo ledger, or Forgejo-first + GitHub mirror); rubric = audience × sovereignty × CI locus; signing/merge consequences (incl. accepting GitHub-signed merge nodes) follow from placement. `containers` = GitHub-primary
 - **ADR-038:** Merge-Commit-Only Strategy — squash/rebase disabled repo-side (squash replaces owner SSH signatures with GitHub's web-flow key and breaks stacked-PR ancestry against the live-config worktree); branch + PR per work package, stacked branches merge in order. Operationalized in the Git & PR Workflow section above
 - **ADR-039:** Egress Baseline Scoping for High-Rotation Cloud-API Endpoints (amends ADR-030 P7) — crowdsec's CAPI is AWS-API-Gateway-fronted in eu-west-1 and rotates across the published pool, so per-IP allow-listing was a re-baseline treadmill (3 PRs in 48h). crowdsec's AWS allowance is now generated from AWS-published eu-west-1 EC2 ranges by `scripts/sync-aws-egress-ranges.sh` (deliberate offline sync, never hot-path; notify-only drift check in `monthly-update.sh`). Crowdsec-only carve-out gated by ≥3 benign re-baselines; CloudFront/Cloudflare stay tight static entries; `infrastructure: []` unchanged. Sharpens the off-region exfil signal rather than discarding it
+- **ADR-041:** Runtime Secrets via OpenBao Substrate (supersedes ADR-040) — the ~30 runtime/workload secrets are sourced from a self-hosted **OpenBao** system-service owned by **htpc-mgmt** (substrate, *not* the fleet — not a container/quadlet; localhost TLS, TPM-auto-unsealed). A root sync oneshot recreates podman secrets in a **tmpfs** cache (ADR-028 path) so **every `Secret=` handle (env *and* mount) stays byte-for-byte unchanged**. This repo owns *only* the consumption handles — the interface is the secret **name** (three-way consistency check OpenBao ↔ quadlets ↔ manifest); mechanism/policies/rotation/`secretctl`/DR live in **htpc-mgmt ADR-007**. At-rest leak closed by OpenBao's barrier; **no LLM read-wall** (privilege separation deferred). The old "podman secrets encrypted at rest" claim was FALSE (file driver = base64). To create/rotate a secret, use htpc-mgmt `secretctl`, **never** `podman secret rm/create` here.
 
 Check if an ADR exists before proposing changes. Reference the ADR and explain what changed if suggesting alternatives. New decisions get new ADRs (don't edit existing ones).
 

--- a/docs/30-security/decisions/2026-06-14-ADR-040-secrets-substrate-operator-boundary.md
+++ b/docs/30-security/decisions/2026-06-14-ADR-040-secrets-substrate-operator-boundary.md
@@ -1,0 +1,208 @@
+# ADR-040: Secrets Substrate & Operator Boundary
+
+**Date:** 2026-06-14
+**Status:** **Superseded by [ADR-041](./2026-06-14-ADR-041-secrets-openbao-substrate-boundary.md)**
+(2026-06-14, same day). What changed is the **substrate mechanism**: the substrate side
+(htpc-mgmt ADR-007) chose **OpenBao as a system-scope service** as the Phase-1 source of
+truth, so the per-podman-secret TPM-seal + boot-oneshot specified in **D2** was **not built**
+(OpenBao's encrypted storage barrier subsumes it), and "OpenBao = deferred Phase 2" (**D6**)
+is now Phase 1. The cross-repo boundary (D3), the operator-boundary stance (D1: no read-wall
+without privilege separation, deferred), the cycling-by-class schema (D4), and DR (D5) carry
+forward into ADR-041. ADR-040 is **retained for its still-valid findings**: the Podman `file`
+driver is not encrypted at rest; Vaultwarden cannot be a live broker; the LLM read-wall
+requires privilege separation. Body unchanged below.
+
+---
+
+## Context
+
+`secrets-management.md` (2025-12-26) is stale, and an audit on 2026-06-14 found two of its
+central claims false:
+
+- **"Podman secrets are encrypted at rest" is wrong.** The default `file` driver stores the
+  30 live secrets **base64-encoded** in `secretsdata.json` — plaintext-equivalent. Worse,
+  that file sits on the **unencrypted** btrfs pool. A pool disk that later fails or is
+  disposed of cannot always be securely wiped (a failing drive can't be rewritten; an RMA
+  hands it over un-erased), so any secret ever written to it is a disposal leak. This is the
+  most concrete present vulnerability, and it is unrelated to any LLM threat.
+- **Vaultwarden cannot be a live secrets broker.** Bitwarden Secrets Manager / `bws` is a
+  proprietary-licensed feature Vaultwarden has declined to implement. Vaultwarden stays a
+  cold human-vault and DR escrow only.
+
+The triggering goal was broader: a secrets system **more secure and more user-friendly**
+than the base64 store, that ideally lets an LLM operator (Claude Code) **inject secrets it
+cannot read**. Following that requirement to its end produced the load-bearing finding:
+
+> **As long as the agent runs as `patriark`, it can read every runtime secret.** It owns
+> the rootless containers, so it can always `podman exec <svc> env` or
+> `podman secret inspect --showsecret`. No secret store, no TPM scheme, and no broker
+> changes this — even OpenBao's deny-read token is bypassed by reading the value out of the
+> container that legitimately pulled it. **A real "the LLM cannot read secrets" property
+> requires privilege separation** (running the agent as a non-`patriark` user that cannot
+> exec the containers). There is no substitute.
+
+Two hardware/OS facts from the same diagnostics shaped the substrate:
+
+- **TPM2 is present and usable, but `systemd-creds` TPM keys are system-scope only.**
+  `systemd-creds --user --with-key=tpm2` returns *"Selected key not available in --uid=
+  scoped mode, refusing"*; `patriark` is not in `tss` and cannot reach `/dev/tpmrm0`. So the
+  clean "rootless quadlet does `LoadCredential=` from the TPM" path **does not exist** here.
+  TPM sealing/unsealing must happen at root scope and be handed to the rootless world.
+- **The host's boot chain is not measured** (no measured-boot / UKI). PCR-binding sealed blobs would buy
+  ~zero tamper-resistance while forcing a re-seal on every firmware/kernel change. So:
+  no-PIN, **no PCR binding**.
+
+Finally, the **endgame is already known**: a planned storage role-reversal will move the
+pool onto already-encrypted (LUKS) drives.
+A LUKS pool encrypts *everything* at rest, which **subsumes** per-secret at-rest crypto. So
+the substrate decided here is explicitly a **bridge**, not a destination.
+
+## Decision
+
+### D1 — Operator boundary: privilege separation is the only read-wall, and it is *deferred*
+
+The "LLM cannot read" property is recorded as achievable **only** via privilege separation,
+and is **deferred** as a discrete future project. In the interim the agent stays `patriark`
+and **can** read runtime secrets — this is accepted, because the realistic threat is
+*accidental* leakage (a value into a transcript / log / commit) and the need for an audit
+trail, not a malicious local Claude. The interim design therefore targets
+**accidental-leak prevention + at-rest encryption + audit + rotation**, and does **not**
+claim a runtime read-wall. The honest scope is stated so a future reader does not mistake a
+broker (D6) for the wall it cannot provide.
+
+### D2 — At-rest substrate: TPM-seal + tmpfs store + root boot-oneshot (rootless preserved)
+
+Each secret is sealed at **root scope** (`systemd-creds --with-key=tpm2 encrypt`) into a
+`.cred` blob (useless without *this* TPM). The rootless podman secret store is moved onto
+**tmpfs** so cleartext never persists on disk (swap is `zram0` — RAM-backed — so tmpfs
+cannot bleed to disk either). A **root boot-oneshot** unseals the blobs and repopulates the
+store at boot. Unattended (no-PIN), **no PCR binding** (justified above). **All 30 `Secret=`
+quadlet lines stay unchanged** — services keep consuming via `type=env`/`type=mount`. Net:
+a pulled/disposed pool disk decrypts to nothing; at runtime values remain `patriark`-readable
+(D1). This is the **bridge** to the LUKS-pool endgame, after which the TPM-seal layer becomes
+optional belt-and-suspenders (the tmpfs "no cleartext persists" property and the
+seal-path-behind-root boundary remain valuable regardless).
+
+### D3 — Repo boundary: material in htpc-mgmt, handles in containers
+
+The **mechanism, the sealed blobs, the secrets ledger, and the DR/escrow runbook live in
+htpc-mgmt** (the substrate repo — Forgejo-private; this is *host provisioning*, the same
+class as LUKS/storage/kernel-hardening, and the most sensitive operational material has no
+business on the GitHub-primary containers repo). The **handles stay in containers**: the
+quadlets' `Secret=…,type=env,target=…` lines and Authelia `file://` references are
+*consumption contracts* — they name a secret and how it is read, holding no value. **The
+interface between the two repos is the secret name.** This ADR records the decision and the
+boundary; htpc-mgmt builds the mechanism as an **Ansible role** (its "declarative over
+imperative" principle) and writes its **own ADR reconciling with htpc-mgmt ADR-006**
+(which previously scoped workload secrets *out* of the substrate — this refines that line:
+the substrate now owns *provisioning the workload secret store*, never the routing). A
+consistency check diffs ledger handles against `grep Secret= ~/containers/quadlets/`; the
+ledger is the source of truth.
+
+### D4 — Cycling schema: class-based cadence; the migration *is* a rotation event
+
+Rotation is driven by blast-radius and rotation-safety, not a blanket interval, tracked in a
+**no-values ledger** (`name, owning-service(s), class, issue-date, last-rotated,
+rotation-method, blast-radius`):
+
+| Class | Members (examples) | At migration | Ongoing |
+|---|---|---|---|
+| Single-service tokens | grafana, crowdsec_api_key, pihole, unpoller, exporters | seal + rotate | 90 d, scripted |
+| External-issued | cloudflare_dns_token, navidrome lastfm, discord webhook | seal + rotate (re-mint at provider) | per provider / on exposure |
+| Session/JWT (rotate ⇒ re-login) | authelia_jwt_secret, authelia_session_secret, immich-jwt-secret | seal + rotate | on exposure |
+| DB-coupled | nextcloud/forgejo/gathio/immich DB creds | seal + rotate **in a maintenance window, ADR-029 dump first** | on-event only (annual ceiling) |
+| **Crypto keys w/ data-at-rest meaning** | **authelia_storage_key** (encrypts DB), **forgejo_signing_key** (commit-verification history) | **seal IN PLACE — do NOT rotate** | only with a migration plan |
+| Roots of trust | TPM recovery, Vaultwarden master, (later) OpenBao unseal | escrow offline | on device/personnel change |
+
+Because the at-rest migration recreates every secret, it **doubles as a rotation event**:
+seal-and-rotate the rotatable classes so cleartext recoverable from a disposed/failed pool disk goes
+stale; **seal-in-place** the data-meaning keys. Phase 1 scope = high-value subset first
+(Authelia keys, DB creds, forgejo signing key, Cloudflare token).
+
+### D5 — DR: Vaultwarden + offline paper, with the circular dependencies broken
+
+Plaintext and the TPM-recovery path are escrowed in **Vaultwarden**; the irreducible roots
+(Vaultwarden master password, TPM recovery key) are **printed offline**. Two circular
+dependencies are explicitly broken: (a) Vaultwarden's own admin token must be recoverable
+*without* the secret store it backs (master password is human-memorized + offline-printed);
+(b) TPM-sealed blobs are host-bound, so OS reinstall / board failure recovers by **re-sealing
+from escrow**, never from git. The htpc-mgmt reinstall-runbook gains a "re-seal podman
+secrets from Vaultwarden escrow" step in its DR order.
+
+### D6 — Phase 2: OpenBao, deferred and deliberate
+
+OpenBao (sovereign Vault fork) is the deferred Phase 2. It does **not** deliver the read-wall
+(D1), but it buys what the bridge cannot: a tamper-evident **audit log** of every secret
+access, **deny-read on the agent token** (kills *accidental* reads by construction), and
+**dynamic/leased DB credentials** + a rotation engine that operationalizes D4. It reuses the
+same TPM-auto-unseal-at-boot pattern (D2) for its own unseal — it layers on the bridge, it
+does not replace it. Triggered when the audit/dynamic-secrets value is wanted, or as the
+substrate matures.
+
+## Consequences
+
+**Positive**
+- Closes the concrete disposal/theft leak (D2): a pulled pool disk — including a failing,
+  un-wipeable one — decrypts to nothing.
+- Zero churn on the workload side: all 30 `Secret=` lines and Authelia `file://` refs
+  unchanged (D3); the containers repo learns *less* about secret topology, not more.
+- Honest posture: the read-wall's true cost (privilege separation) is recorded, not papered
+  over by a broker (D1/D6); rotation is finally safe-by-class (D4).
+- Sovereignty: the most sensitive operational material lives only on owned infrastructure
+  (Forgejo-private htpc-mgmt), never on the GitHub mirror.
+
+**Negative / accepted**
+- No runtime read-wall in the interim — the agent as `patriark` can read secrets (D1).
+  Accepted; revisited only by adopting privilege separation.
+- New cross-repo coupling: a secret is defined in two repos (handle in containers, blob +
+  ledger in htpc-mgmt). Mitigated by the D3 consistency check; drift is possible if it lapses.
+- New host machinery (root boot-oneshot, tmpfs store, cross-scope ordering) — fiddly to get
+  right, and a boot-time dependency for every secret-consuming service.
+
+**Neutral**
+- The TPM-seal layer is a bridge; when the LUKS-pool role-reversal lands it becomes optional.
+  Not wasted (tmpfs + seal-behind-root persist their value), but its at-rest role sunsets.
+
+## Alternatives Considered
+
+- **Keep the base64 store / friction-only on it.** Rejected: leaves the disposal leak
+  standing and keeps the false "encrypted at rest" claim.
+- **Podman `pass`/`shell` secret driver (GPG-encrypted).** Real encryption, but the GPG key
+  must live somewhere: on a YubiKey (touch-gated → breaks unattended boot, the exact
+  constraint that bars the forgejo signing key from hardware) or on disk adjacent to the data
+  (no real protection). TPM solves precisely this "hardware key the host can use unattended."
+- **SOPS + age in git.** Its value is decrypt-anywhere multi-machine — the *opposite* of the
+  decision that runtime secrets never leave fedora-htpc. Good for config-as-code, wrong as the
+  secrets backbone here. (htpc-mgmt ADR-006 already named sops+age its own future successor
+  for *substrate* secrets — a separate question.)
+- **OpenBao now.** Rejected as the *first* step: it does not provide the read-wall (D1), and
+  its at-rest/secret-zero story still needs the TPM-unseal machinery D2 builds. Sequenced as
+  Phase 2 (D6).
+- **Privilege separation now.** The only real read-wall, but it reshapes the entire agent
+  workflow (repo ACLs, git-signing, service control all need explicit grants). Deferred (D1),
+  not dropped.
+- **LUKS-encrypt the whole pool now.** The endgame answer, but in-place re-encryption of a
+  live multi-TB btrfs pool is a large, risky, separately-funded project (the role-reversal).
+  The targeted TPM-seal bridge gets the secrets-specific win now without it.
+
+## References
+
+- `docs/30-security/guides/secrets-management.md` — the stale guide this supersedes (to be
+  rewritten as a pointer).
+- **ADR-028** — Podman secret-store path split (the secret store lives on
+  `subvol7-containers/storage` with an XDG symlink; the tmpfs move MUST account for this).
+- **ADR-030** — Container Supply-Chain Trust Model (digest pinning narrows the
+  compromise path that makes D1's residual risk acceptable); **ADR-029** — DB dump backbone
+  (required before any DB-coupled rotation, D4); **ADR-038** — merge-commit workflow.
+- **htpc-mgmt ADR-006** (substrate secrets strategy this refines), **ADR-001**
+  (substrate-not-workloads — the boundary D3 evolves), **ADR-005** (storage-as-code) — in the
+  private substrate repo.
+- Superseded by **ADR-041** (workload-side boundary) and **htpc-mgmt ADR-007** (OpenBao mechanism).
+
+---
+
+**Decision made by:** User (patriark) + Claude Code analysis (design session 2026-06-14).
+**Trigger:** A request to modernize secrets management surfaced that the documented store was
+plaintext-on-unencrypted-disk and that the "LLM cannot read" goal is unreachable without
+privilege separation — forcing an explicit, honest split between the achievable at-rest
+bridge and the deferred operator boundary.

--- a/docs/30-security/decisions/2026-06-14-ADR-041-secrets-openbao-substrate-boundary.md
+++ b/docs/30-security/decisions/2026-06-14-ADR-041-secrets-openbao-substrate-boundary.md
@@ -1,0 +1,106 @@
+# ADR-041: Runtime Secrets via OpenBao Substrate — Workload-Side Boundary
+
+**Date:** 2026-06-14
+**Status:** Accepted. **Supersedes ADR-040** (its substrate *mechanism* and Phase
+sequencing; ADR-040's *findings* are retained by reference). Documents the **workload side**
+of **htpc-mgmt ADR-007** ("Runtime secrets via a self-hosted OpenBao substrate service",
+2026-06-14), which is canonical for the mechanism.
+
+---
+
+## Context
+
+ADR-040 explored a bridge in which each podman secret was individually TPM-sealed and a root
+boot-oneshot repopulated a tmpfs store. The substrate side instead adopted **OpenBao** (FOSS
+Vault fork) as a system-scope service and the Phase-1 source of truth (htpc-mgmt ADR-007;
+Infisical was rejected — it paywalls dynamic secrets and phones home). OpenBao's encrypted
+storage barrier **subsumes** the per-blob TPM seal, so ADR-040's D2 mechanism was **not
+built**, and "OpenBao = deferred Phase 2" (D6) is now Phase 1.
+
+This ADR records only what **this** repo (the GitHub-primary workload repo) owns, so the two
+repos state the same boundary with zero contradiction. ADR-040's still-valid findings carry
+by reference: the Podman `file` driver is not encrypted at rest (base64); Vaultwarden cannot
+be a live broker; the LLM read-wall requires privilege separation.
+
+## Decision
+
+### D1 — Source of truth is OpenBao, a substrate system service (not in this fleet)
+
+OpenBao runs system-scope under a dedicated non-`patriark` `openbao` user, localhost-only
+(127.0.0.1:8200, TLS), TPM-auto-unsealed at boot (no PIN). It is **not a container, not a
+quadlet, not in the service fleet** — it is host substrate, owned entirely by htpc-mgmt
+(ADR-001/002 over there). This repo's containers **never** talk to it.
+
+### D2 — Consumption is byte-for-byte unchanged
+
+A root sync oneshot reads OpenBao and recreates podman secrets in a **tmpfs** cache at the
+existing store path (ADR-028). Therefore **every `Secret=` consumption handle in this repo's
+quadlets — whether `type=env` or `type=mount`/file — stays byte-for-byte unchanged.** (~30
+secret names; several are file mounts: Authelia's three, the forgejo signing key + `.pub`,
+`gathio_mongodb_password`, `ha-prometheus-token`.) Zero workload churn. The
+base64-on-unencrypted-pool at-rest leak is closed by OpenBao's storage
+barrier; the podman-secret cache is cleartext but **tmpfs-only** (`zram` swap, never disk).
+
+### D3 — The interface between the repos is the secret NAME
+
+- **htpc-mgmt owns** (substrate, Forgejo-private): the OpenBao install/config, unseal/TPM
+  machinery, policies + AppRoles, the sync oneshot, the tmpfs mount, the `secretctl` wrapper,
+  the generated no-values ledger/manifest, the consistency check, and DR/escrow.
+- **This repo owns:** only the unchanged `Secret=` consumption handles and the three secrets
+  docs (this ADR, the superseded ADR-040, the `secrets-management.md` pointer).
+- A **three-way consistency check** (OpenBao names ↔ `grep Secret= quadlets/` ↔ htpc-mgmt
+  manifest) enforces agreement by name. No secret topology, values, or mechanism live here
+  beyond the consumption contract.
+
+### D4 — Creation/rotation go through htpc-mgmt, not `podman secret` here
+
+`secretctl` (htpc-mgmt) is the sanctioned create/rotate/list path. This repo does **not**
+document `podman secret rm/create` as the way to change a secret — that would diverge from
+OpenBao (the source of truth) and be overwritten at the next sync/reboot. Because consumption
+is **read-once at container start**, live per-lease dynamic credentials are **not generally
+consumable** — rotation means a service restart, and dynamic creds are a **per-service
+opt-in**, not the baseline. What is realized fleet-wide is OpenBao-as-source-of-truth + audit
++ scheduled/static-role rotation.
+
+### D5 — Honest scope (stated, not oversold)
+
+There is **no LLM read-wall**: an agent running as `patriark` can still read secret *values*
+out of the containers that consume them. **Privilege separation is the only real wall and is
+deferred** — though the system-service shape *seeds* it (the agent already cannot reach
+OpenBao itself, only the consuming containers). DR carries a deliberate circular dependency —
+OpenBao's recovery keys are escrowed in Vaultwarden while Vaultwarden's admin token is an
+OpenBao-managed secret — broken by the offline Vaultwarden master password; the procedure
+lives in htpc-mgmt ADR-007.
+
+## Consequences
+
+**Positive**
+- Zero workload churn: every `Secret=` handle unchanged; secret topology stays off the
+  GitHub-primary repo (the name is the only interface).
+- The concrete at-rest leak (base64 on the unencrypted pool, recoverable from a disposed disk) is
+  closed by OpenBao's barrier + tmpfs cache.
+- Audit and scheduled rotation are gained; the boundary is tight (no mechanism overlap).
+
+**Negative / accepted**
+- No runtime read-wall in the interim (D5); revisited only by adopting privilege separation.
+- Cross-repo coupling — a secret is named in two repos — mitigated by the D3 consistency check.
+
+**Neutral**
+- Dynamic per-lease credentials remain a future per-service opt-in, not a fleet baseline (D4).
+
+## References
+
+- **htpc-mgmt ADR-007** — *canonical* for the OpenBao mechanism, policies, unseal, sync,
+  `secretctl`, ledger, and DR (substrate repo, Forgejo-private).
+- **ADR-040** (superseded) — retained findings: file driver not encrypted; Vaultwarden not a
+  live broker; the read-wall needs privilege separation.
+- **ADR-028** — the podman secret-store path the tmpfs cache lands on; **ADR-030** — digest
+  pinning narrows the compromise path that makes D5's residual risk acceptable.
+- `docs/30-security/guides/secrets-management.md` — rewritten as the thin workload-side pointer.
+
+---
+
+**Decision made by:** User (patriark) + Claude Code (cross-repo close-out, 2026-06-14).
+**Trigger:** Finalization of the substrate-side OpenBao design (htpc-mgmt ADR-007) required
+this repo's three secrets documents to supersede ADR-040's mechanism and state the identical
+boundary, with the workload side documenting only consumption-by-name.

--- a/docs/30-security/guides/secrets-management.md
+++ b/docs/30-security/guides/secrets-management.md
@@ -1,693 +1,82 @@
-# Secrets Management Guide
+# Secrets Management (workload side)
 
-**Created:** 2025-12-26
-**Purpose:** Secure handling of authentication tokens, passwords, and API keys
+**Rewritten:** 2026-06-14. This replaces the previous version (2025-12-26), whose model was
+stale and **wrong on one key point**: it claimed "Podman secrets are encrypted at rest." They
+are **not** — the default Podman `file` driver stores secrets **base64-encoded**
+(plaintext-equivalent). At-rest protection is now provided by the **OpenBao substrate**
+(below), not by the podman store.
 
----
-
-## Overview
-
-This homelab uses **three approaches** for secrets management, depending on the service type:
-
-1. **Podman Secrets** (PREFERRED for containers) - Encrypted, native integration
-2. **Environment Variables** (for systemd services) - Simple, systemd-native
-3. **Secure Files** (legacy fallback) - Last resort only
-
-**Key Principle:** Choose the most secure method appropriate for your service type.
+> **Canonical references**
+> - **Mechanism** (how secrets are stored, unsealed, synced, rotated): **htpc-mgmt ADR-007** — *substrate repo, Forgejo-private.*
+> - **Boundary & decision** (this repo): [ADR-041](../decisions/2026-06-14-ADR-041-secrets-openbao-substrate-boundary.md) (supersedes [ADR-040](../decisions/2026-06-14-ADR-040-secrets-substrate-operator-boundary.md)).
 
 ---
 
-## Decision Tree: Which Secrets Method?
+## The model
 
 ```
-Is your service running in a container?
-│
-├─ YES → Use Podman Secrets (PREFERRED)
-│         • Encrypted storage
-│         • Native podman integration
-│         • Mount as file or environment variable
-│         • Example: Database passwords, API keys for containerized apps
-│
-└─ NO → Is it a systemd service?
-    │
-    ├─ YES → Use EnvironmentFile (RECOMMENDED)
-    │         • Simple and secure for bare-metal services
-    │         • Systemd-native
-    │         • Example: Webhook handler, backup scripts
-    │
-    └─ NO → Use secure files with strict permissions
-              • Last resort only
-              • Mode 600, outside Git
-              • Example: Scripts without systemd integration
+OpenBao  (system service, htpc-mgmt-owned substrate; TPM-auto-unsealed; localhost TLS)
+   │   source of truth for the ~30 runtime secrets
+   ▼
+root sync oneshot  →  podman secrets recreated in a TMPFS cache (ADR-028 store path)
+   ▼
+your containers consume them UNCHANGED via   Secret=<name>,type=env|mount,target=…
 ```
 
----
+- OpenBao is **substrate**, not a workload — not a container, not a quadlet, not in the fleet.
+  This repo never talks to it.
+- The podman-secret cache is **tmpfs-only** (RAM; `zram` swap, never disk). The
+  base64-on-unencrypted-pool leak (recoverable from a disposed disk) is closed by OpenBao's encrypted
+  storage barrier.
+- **Every `Secret=` handle is byte-for-byte unchanged.** Consumption is identical from each
+  container's point of view — that is the entire point.
 
-## Method 1: Podman Secrets (PREFERRED for Containers)
+## The consumption contract (what this repo owns)
 
-### When to Use
-
-✅ **Use Podman secrets when:**
-- Service runs in a container (via podman or quadlet)
-- Need encrypted storage
-- Want native container integration
-- Secret is used by container application
-
-❌ **Don't use Podman secrets when:**
-- Service runs as bare systemd service (not containerized)
-- Need to share secret across host and containers easily
-- Debugging secret access is critical (harder to inspect)
-
-### How It Works
-
-Podman secrets are **encrypted at rest** and only decrypted when mounted into containers.
-
-**Storage:** `~/.local/share/containers/storage/secrets/`
-**Access:** Via `podman secret` commands
-**Encryption:** Yes (libsecret or basic encryption)
-
-### Examples
-
-#### Create Secret
-
-```bash
-# Create from stdin
-echo "my-secret-password" | podman secret create db_password -
-
-# Create from file
-podman secret create api_token ~/path/to/token.txt
-
-# Verify
-podman secret ls
-```
-
-#### Use in Container
-
-**Option A: Mount as file (recommended)**
-```bash
-podman run -d \
-  --name myapp \
-  --secret db_password,type=mount,target=/run/secrets/db_password \
-  myimage:latest
-```
-
-Container reads: `/run/secrets/db_password`
-
-**Option B: Mount as environment variable**
-```bash
-podman run -d \
-  --name myapp \
-  --secret db_password,type=env,target=DB_PASSWORD \
-  myimage:latest
-```
-
-Container reads: `$DB_PASSWORD` environment variable
-
-#### Use in Quadlet
-
-**File:** `~/.config/containers/systemd/myapp.container`
+A service declares the secrets it needs in its quadlet. The secret **name** is the whole
+interface between this repo and the substrate:
 
 ```ini
 [Container]
-Image=myimage:latest
-ContainerName=myapp
+# environment-variable injection (most services)
+Secret=grafana_admin_password,type=env,target=GF_SECURITY_ADMIN_PASSWORD
 
-# Mount secret as file
-Secret=db_password,type=mount,target=/run/secrets/db_password
-
-# Or as environment variable
-# Secret=db_password,type=env,target=DB_PASSWORD
-
-[Service]
-Restart=on-failure
+# file mount (Authelia file://, the forgejo signing key, gathio, ha-prometheus-token)
+Secret=forgejo_signing_key,type=mount,target=/run/secrets/forgejo_signing_key,uid=1000,gid=1000,mode=0600
 ```
 
-### Rotation
+- The name in `Secret=<name>` must exist in OpenBao and in htpc-mgmt's manifest. A **three-way
+  consistency check** (OpenBao ↔ `grep Secret= quadlets/` ↔ manifest) catches drift.
+- To see what a service consumes: `grep Secret= quadlets/<service>.container`.
+- After editing a quadlet: `systemctl --user daemon-reload && systemctl --user restart <service>.service` (unchanged).
 
-```bash
-# Remove old secret
-podman secret rm db_password
+## Creating or rotating a secret
 
-# Create new secret
-echo "new-password" | podman secret create db_password -
+**Do this through the substrate, not here.** `podman secret rm/create` is **not** the
+sanctioned path — it would diverge from OpenBao (the source of truth) and be overwritten at
+the next sync/reboot.
 
-# Restart container to pick up new secret
-systemctl --user restart myapp.service
-```
+- Create / rotate / list → htpc-mgmt's **`secretctl`** wrapper (see htpc-mgmt ADR-007).
+- Rotation is **read-once at container start**, so rotating a secret means **restarting the
+  consuming service**. Live per-lease dynamic credentials are a per-service opt-in, not the
+  default.
 
----
+## What is NOT here
 
-## Method 2: EnvironmentFile (for Systemd Services)
+Mechanism, secret values, AppRoles/policies, the unseal/TPM machinery, the ledger, and
+DR/escrow all live in **htpc-mgmt (ADR-007)**. This repo deliberately holds only the
+consumption-by-name contract — keeping secret topology off the GitHub-primary mirror.
 
-### When to Use
+## Honest scope
 
-✅ **Use EnvironmentFile when:**
-- Service runs as systemd service (NOT containerized)
-- Simple token/password needs
-- Easy rotation required
-- Service runs on bare metal
+There is **no "LLM cannot read" wall**: an agent running as `patriark` can read secret values
+out of the containers that consume them. Privilege separation is the only real wall and is
+**deferred** (the OpenBao system-service shape seeds it — the agent cannot reach OpenBao
+itself, only the consuming containers). See ADR-041 D5 and ADR-040's retained findings.
 
-❌ **Don't use EnvironmentFile when:**
-- Service runs in container (use Podman secrets instead)
-- Need encrypted storage
-- Sharing secrets across multiple services
+## Related
 
-### How It Works
-
-Systemd loads environment variables from a file before starting the service.
-
-**Storage:** `~/.config/*.env` (outside Git, mode 600)
-**Access:** Via `EnvironmentFile=` directive in systemd service
-**Encryption:** No (plain text file with strict permissions)
-
----
-
-## Webhook Authentication Token (Example: EnvironmentFile)
-
-**Why EnvironmentFile here?** The webhook handler runs as a bare systemd service (Python script), not in a container. Podman secrets are only accessible to containers, so EnvironmentFile is the appropriate choice.
-
-**Alternative approach:** If we containerized the webhook handler, we would use Podman secrets instead.
-
-### Storage Location
-
-```bash
-~/.config/remediation-webhook.env
-```
-
-**Permissions:** `600` (read/write owner only)
-**Format:**
-```bash
-WEBHOOK_AUTH_TOKEN=<base64-encoded-secret>
-```
-
-### Setup
-
-1. **Generate new token** (if needed):
-   ```bash
-   openssl rand -base64 32
-   ```
-
-2. **Create secrets file**:
-   ```bash
-   cat > ~/.config/remediation-webhook.env << EOF
-   WEBHOOK_AUTH_TOKEN=<your-generated-token>
-   EOF
-   chmod 600 ~/.config/remediation-webhook.env
-   ```
-
-3. **Verify systemd loads it**:
-   ```bash
-   systemctl --user cat remediation-webhook.service | grep EnvironmentFile
-   # Expected: EnvironmentFile=%h/.config/remediation-webhook.env
-   ```
-
-4. **Restart service**:
-   ```bash
-   systemctl --user restart remediation-webhook.service
-   ```
-
-### Security Features
-
-- ✅ **Not committed to Git** - Secrets file is in `~/.config/` (outside repository)
-- ✅ **Strict permissions** - Mode 600 (owner-only access)
-- ✅ **Environment variable** - Loaded by systemd, not hardcoded in scripts
-- ✅ **Fail-closed** - Service refuses to start without valid token
-- ✅ **Rotation-friendly** - Edit `.env` file and restart service
-
----
-
-## Alertmanager Webhook URL
-
-### Problem
-
-Alertmanager needs the webhook token in its configuration to call the remediation webhook:
-
-```yaml
-- url: 'http://host.containers.internal:9096/webhook?token=<TOKEN>'
-```
-
-Alertmanager doesn't support environment variable substitution in config files.
-
-### Solution
-
-**Local file** (`config/alertmanager/alertmanager.yml`) contains real token
-**Template file** (`config/alertmanager/alertmanager.yml.example`) has placeholder
-**Git ignores** `alertmanager.yml` to prevent committing secrets
-
-### Setup
-
-1. **Copy template** (first-time setup):
-   ```bash
-   cp ~/containers/config/alertmanager/alertmanager.yml.example \
-      ~/containers/config/alertmanager/alertmanager.yml
-   ```
-
-2. **Get webhook token**:
-   ```bash
-   grep WEBHOOK_AUTH_TOKEN ~/.config/remediation-webhook.env
-   # Output: WEBHOOK_AUTH_TOKEN=CB5sbWz55FUDTdcAHu0c9otJE5pDshr/QnpRXHjOiDs=
-   ```
-
-3. **Update alertmanager.yml**:
-   ```bash
-   TOKEN=$(grep WEBHOOK_AUTH_TOKEN ~/.config/remediation-webhook.env | cut -d= -f2)
-   sed -i "s|token=REPLACE_WITH_ACTUAL_TOKEN|token=$TOKEN|" \
-     ~/containers/config/alertmanager/alertmanager.yml
-   ```
-
-4. **Restart Alertmanager**:
-   ```bash
-   systemctl --user restart alertmanager.service
-   ```
-
-### Git Protection
-
-```bash
-# .gitignore includes:
-config/alertmanager/alertmanager.yml
-```
-
-This prevents the file with real secrets from being committed.
-
-**Important:** If the file is already tracked by Git, you must untrack it:
-
-```bash
-# Remove from Git index (keep local file)
-git rm --cached config/alertmanager/alertmanager.yml
-
-# Commit the removal
-git commit -m "chore: Remove alertmanager.yml from Git (contains secrets)"
-
-# File is now ignored, local changes won't be committed
-```
-
----
-
-## Discord Webhook URL
-
-### Storage
-
-Discord webhook URL is stored in the `alert-discord-relay` container environment.
-
-**Access:**
-```bash
-podman exec alert-discord-relay env | grep DISCORD_WEBHOOK_URL
-```
-
-### Security
-
-- Container-only access (not in filesystem)
-- Not committed to Git
-- Accessed via podman exec when needed
-
----
-
-## Other Secrets
-
-### Let's Encrypt Certificates
-
-**Location:** `~/containers/data/letsencrypt/acme.json`
-**Protection:** Automatically excluded by `.gitignore` pattern `acme.json`
-
-### Authelia User Database
-
-**Location:** `~/containers/config/authelia/users_database.yml`
-**Contains:** Argon2 password hashes (not plaintext)
-**Protection:** Hashes are safe to commit (computationally infeasible to reverse)
-
-### YubiKey Credentials
-
-**Location:** Stored in YubiKey hardware, never on filesystem
-**Protection:** Hardware-protected, cannot be extracted
-
----
-
-## Secret Rotation
-
-### Webhook Token Rotation
-
-1. **Generate new token**:
-   ```bash
-   NEW_TOKEN=$(openssl rand -base64 32)
-   echo "New token: $NEW_TOKEN"
-   ```
-
-2. **Update secrets file**:
-   ```bash
-   sed -i "s/WEBHOOK_AUTH_TOKEN=.*/WEBHOOK_AUTH_TOKEN=$NEW_TOKEN/" \
-     ~/.config/remediation-webhook.env
-   ```
-
-3. **Update Alertmanager config**:
-   ```bash
-   sed -i "s|token=[^']*|token=$NEW_TOKEN|" \
-     ~/containers/config/alertmanager/alertmanager.yml
-   ```
-
-4. **Restart services**:
-   ```bash
-   systemctl --user restart remediation-webhook.service
-   systemctl --user restart alertmanager.service
-   ```
-
-5. **Verify**:
-   ```bash
-   # Test webhook with new token
-   curl -s -w "%{http_code}\n" -X POST \
-     "http://localhost:9096/webhook?token=$NEW_TOKEN" \
-     -d '{"alerts": []}'
-   # Expected: 200
-   ```
-
----
-
-## Verification Checklist
-
-### Pre-Commit Check
-
-Before committing to Git, verify no secrets are exposed:
-
-```bash
-# Check for webhook token
-git -C ~/containers grep "CB5sbWz55FUDTdcAHu0c9otJE5pDshr" 2>&1
-# Expected: No output (or "not found")
-
-# Check for Discord URLs
-git -C ~/containers grep "discord.com/api/webhooks" 2>&1
-# Expected: No output (or "not found")
-
-# Check .gitignore is working
-git -C ~/containers status --ignored
-# Should see:
-#   config/alertmanager/alertmanager.yml (ignored)
-#   Any *.env files (ignored)
-```
-
-### Runtime Check
-
-Verify services are using environment variables:
-
-```bash
-# Webhook handler should log environment usage
-journalctl --user -u remediation-webhook.service -n 50 | \
-  grep -i "auth_token\|WEBHOOK_AUTH_TOKEN"
-
-# Should NOT see:
-#   "Using auth_token from config file"
-# Should see:
-#   "Starting webhook handler on 127.0.0.1:9096"
-#   (No warnings about config file usage)
-```
-
----
-
-## Architecture
-
-```
-┌─────────────────────────────────────────────────────────────┐
-│ SECRETS ARCHITECTURE                                        │
-├─────────────────────────────────────────────────────────────┤
-│                                                             │
-│  ~/.config/remediation-webhook.env (600, NOT in Git)       │
-│  ┌────────────────────────────────────────┐                │
-│  │ WEBHOOK_AUTH_TOKEN=<secret>            │                │
-│  └───────────────┬────────────────────────┘                │
-│                  │                                          │
-│                  │ EnvironmentFile=                        │
-│                  ▼                                          │
-│  remediation-webhook.service                                │
-│  ┌────────────────────────────────────────┐                │
-│  │ Environment: WEBHOOK_AUTH_TOKEN=*****  │                │
-│  │ ExecStart: webhook-handler.py          │                │
-│  └───────────────┬────────────────────────┘                │
-│                  │                                          │
-│                  │ os.environ.get('WEBHOOK_AUTH_TOKEN')    │
-│                  ▼                                          │
-│  remediation-webhook-handler.py                             │
-│  ┌────────────────────────────────────────┐                │
-│  │ expected_token = os.environ.get(...)   │                │
-│  │ if token == expected_token: allow      │                │
-│  └────────────────────────────────────────┘                │
-│                                                             │
-│  ┌─────────────────────────────────────────────┐           │
-│  │ Alertmanager (separate config)              │           │
-│  │ ┌─────────────────────────────────────────┐ │           │
-│  │ │ webhook URL includes token as query     │ │           │
-│  │ │ param (not ideal, but Alertmanager      │ │           │
-│  │ │ limitation)                              │ │           │
-│  │ └─────────────────────────────────────────┘ │           │
-│  │ File: alertmanager.yml (in .gitignore)      │           │
-│  └─────────────────────────────────────────────┘           │
-│                                                             │
-└─────────────────────────────────────────────────────────────┘
-```
-
----
-
-## Comparison Table
-
-| Feature | Podman Secrets | EnvironmentFile | Secure Files |
-|---------|----------------|-----------------|--------------|
-| **Encryption** | ✅ Yes | ❌ No | ❌ No |
-| **For containers** | ✅ Yes | ❌ No | ⚠️ Via mount |
-| **For systemd services** | ❌ No | ✅ Yes | ✅ Yes |
-| **Native integration** | ✅ Podman | ✅ Systemd | ❌ Manual |
-| **Ease of rotation** | ✅ Easy | ✅ Easy | ⚠️ Manual |
-| **Git protection** | ✅ Automatic | ⚠️ Need .gitignore | ⚠️ Need .gitignore |
-| **Debugging** | ⚠️ Harder | ✅ Easy | ✅ Easy |
-| **Permissions** | 🔒 Encrypted | 🔒 Mode 600 | 🔒 Mode 600 |
-| **Best for** | Containers | Systemd services | Legacy scripts |
-
-**Recommendation hierarchy:**
-1. **Podman Secrets** - if running in container
-2. **EnvironmentFile** - if systemd service (not containerized)
-3. **Secure Files** - only if neither above applies
-
----
-
-## Best Practices
-
-1. **Choose the right method for your service type**
-   - Containers → Podman secrets (encrypted)
-   - Systemd services → EnvironmentFile
-   - Scripts → Secure files (mode 600)
-
-2. **Never commit secrets to Git**
-   - Use `.env` files in `~/.config/` or `~/.secret/`
-   - Add to `.gitignore` immediately
-   - Use Podman secrets for containers (auto-protected)
-
-3. **Prefer encryption when available**
-   - Podman secrets provide encryption at rest
-   - EnvironmentFile is plain text (but mode 600)
-   - Consider migrating services to containers to use Podman secrets
-
-4. **Strict file permissions**
-   - Secrets files: `chmod 600` (owner-only)
-   - Config directories: `chmod 700` (owner-only access)
-   - Podman secrets: Automatic (encrypted storage)
-
-5. **Rotate regularly**
-   - Webhook tokens: Annually or after suspected exposure
-   - API keys: Per service policy
-   - Passwords: 90 days or per policy
-
-6. **Audit before commits**
-   - Run `git diff` before committing
-   - Check for patterns like `token=`, `password=`, `webhook_url=`
-   - Use pre-commit hooks if available
-
-7. **Document everything**
-   - Keep this guide updated
-   - Document new secrets in this file
-   - Include rotation procedures
-
----
-
-## Podman Secrets Patterns & Migration Strategy
-
-**(ADR-016: Secrets via Platform Primitives)**
-
-### Pattern Hierarchy (Preference Order)
-
-**Pattern 2 (RECOMMENDED): `type=env` - Environment Variable Injection**
-```bash
-# Create secret
-echo -n "my-secret-value" | podman secret create service_password -
-
-# Use in quadlet
-[Container]
-Secret=service_password,type=env,target=SERVICE_PASSWORD
-
-# App reads from environment variable
-SERVICE_PASSWORD=my-secret-value
-```
-
-✅ **Use Pattern 2 when:**
-- Application supports environment variable configuration
-- Secret is a simple string/token/password
-- No complex file format required
-
-**Pattern 1 (ACCEPTABLE): `type=mount` - File Mount**
-```bash
-# Create secret
-podman secret create authelia_config - < config.yml
-
-# Use in quadlet
-[Container]
-Secret=authelia_config,type=mount,target=/config/configuration.yml,mode=0400
-
-# App reads from file path
-/config/configuration.yml
-```
-
-✅ **Use Pattern 1 when:**
-- Application REQUIRES file-based configuration (e.g., `file://` URL schemes)
-- Complex YAML/JSON structure needed
-- Pattern 2 not feasible (Authelia, some apps with file:// URIs)
-
-**Pattern 3 (MIGRATE): Shell Expansion - `${SECRET_VAR}`**
-```bash
-# DEPRECATED - Migrate to Pattern 2
-Environment=${SOME_SECRET}
-
-# INSTEAD USE:
-Secret=some_secret,type=env,target=SOME_SECRET
-```
-
-⚠ **Migrate Pattern 3 to Pattern 2:**
-1. Back up current .env file to Vaultwarden
-2. Create podman secrets from values
-3. Update quadlet to use Secret= with type=env
-4. Test service restart
-5. Decommission .env file after successful migration
-
-**Pattern 4 (FIX): EnvironmentFile**
-```bash
-# LEGACY - Migrate to Pattern 2 for containers
-[Container]
-EnvironmentFile=/path/to/.env
-
-# INSTEAD USE:
-Secret=var1,type=env,target=VAR1
-Secret=var2,type=env,target=VAR2
-```
-
-⚠ **Fix Pattern 4:**
-- Acceptable for bare systemd services (non-containerized)
-- For containers, migrate to Podman secrets Pattern 2
-- Vaultwarden: migrate EnvironmentFile to podman secrets
-
-### Migration Procedure
-
-**Step-by-step migration from .env files to podman secrets:**
-
-```bash
-# 1. Backup to Vaultwarden (CRITICAL)
-# Create secure note in Vaultwarden with current .env contents
-
-# 2. Create podman secrets from .env
-while IFS='=' read -r key value; do
-  [[ "$key" =~ ^#.*$ ]] && continue  # Skip comments
-  echo -n "$value" | podman secret create "${service}_${key,,}" -
-done < ~/.config/service/.env
-
-# 3. Update quadlet (replace EnvironmentFile with Secret=)
-nano ~/.config/containers/systemd/service.container
-
-# Before:
-EnvironmentFile=%h/.config/service/.env
-
-# After:
-Secret=service_var1,type=env,target=VAR1
-Secret=service_var2,type=env,target=VAR2
-
-# 4. Test restart
-systemctl --user daemon-reload
-systemctl --user restart service.service
-
-# 5. Verify service health
-systemctl --user status service.service
-podman logs service
-
-# 6. Decommission .env file (ONLY after successful verification)
-mv ~/.config/service/.env ~/.config/service/.env.decommissioned-$(date +%Y%m%d)
-```
-
-**Decommissioning policy:**
-- ✅ Decommission files ONLY after:
-  - Secret imported to podman secrets ✓
-  - Backed up in Vaultwarden ✓
-  - Service tested and verified working ✓
-- ⏸ Keep .env.decommissioned-YYYYMMDD for 30 days as safety net
-- 🗑 Securely delete after 30 days: `shred -u file`
-
-### Current Status (As of 2025-12-31)
-
-**Services using Pattern 2 (type=env):** 15 secrets ✅ (RECOMMENDED)
-- Most services successfully migrated
-
-**Services using Pattern 1 (type=mount):** 0 secrets (Acceptable)
-- Authelia uses file:// URIs - Pattern 1 is appropriate
-
-**Services using Pattern 3 (shell expansion):** TBD (MIGRATE)
-- Candidate for migration to Pattern 2
-
-**Services using Pattern 4 (EnvironmentFile):** 1 file (MIGRATE)
-- Candidate: migrate to Pattern 2 with Vaultwarden backup
-
-**Migration goal:** 100% Pattern 2 where feasible, Pattern 1 where file:// required
-
----
-
-## Troubleshooting
-
-### "No auth_token configured" error
-
-**Cause:** Environment variable not loaded or secrets file missing
-
-**Fix:**
-```bash
-# Check secrets file exists
-ls -l ~/.config/remediation-webhook.env
-
-# Check systemd service references it
-systemctl --user cat remediation-webhook.service | grep EnvironmentFile
-
-# Reload and restart
-systemctl --user daemon-reload
-systemctl --user restart remediation-webhook.service
-```
-
-### "Using auth_token from config file" warning
-
-**Cause:** Environment variable not set, falling back to config file (less secure)
-
-**Fix:**
-```bash
-# Ensure WEBHOOK_AUTH_TOKEN is set in secrets file
-grep WEBHOOK_AUTH_TOKEN ~/.config/remediation-webhook.env
-
-# Restart service to reload environment
-systemctl --user restart remediation-webhook.service
-```
-
-### Alertmanager returns 401 Unauthorized
-
-**Cause:** Token in alertmanager.yml doesn't match webhook handler token
-
-**Fix:**
-```bash
-# Sync tokens
-TOKEN=$(grep WEBHOOK_AUTH_TOKEN ~/.config/remediation-webhook.env | cut -d= -f2)
-sed -i "s|token=[^']*|token=$TOKEN|" ~/containers/config/alertmanager/alertmanager.yml
-systemctl --user restart alertmanager.service
-```
-
----
-
-## Related Documentation
-
+- [ADR-041](../decisions/2026-06-14-ADR-041-secrets-openbao-substrate-boundary.md) — workload-side boundary (current).
+- [ADR-040](../decisions/2026-06-14-ADR-040-secrets-substrate-operator-boundary.md) — superseded; retained findings (file driver not encrypted, Vaultwarden not a broker, read-wall needs privilege separation).
+- **htpc-mgmt ADR-007** — the OpenBao mechanism (substrate repo).
 - [Security Audit Guide](./security-audit.md)
-- [Remediation Webhook Documentation](../../20-operations/guides/remediation-webhook.md)
-- [Alertmanager Configuration](../../40-monitoring-and-documentation/guides/alertmanager-config.md)


### PR DESCRIPTION
## What

Closes the **workload-side** loop on the cross-repo secrets redesign. The substrate side (private **htpc-mgmt** repo) finalized **ADR-007 — runtime secrets via a self-hosted OpenBao system service**; this PR makes the public containers repo's three secrets documents agree, with zero contradiction.

## Changes (docs only)

- **ADR-041 (new)** — workload-side boundary: OpenBao is the source of truth for runtime secrets, synced into a **tmpfs** podman-secret cache so **every `Secret=` handle (env _and_ mount) stays byte-for-byte unchanged**. This repo owns only the consumption handles; the interface is the secret **name** (three-way consistency check OpenBao ↔ quadlets ↔ manifest). **No LLM read-wall** — privilege separation is the only real wall and is deferred. Supersedes ADR-040.
- **ADR-040** — status set to **Superseded by ADR-041** (body retained for its still-valid findings: Podman `file` driver is not encrypted at rest; Vaultwarden cannot be a live broker; the read-wall needs privilege separation).
- **`secrets-management.md`** — rewritten into a thin pointer; the false **"Podman secrets are encrypted at rest"** claim deleted and corrected.
- **`CLAUDE.md`** — ADR pointer 039 → 041 + a design-guiding secrets-boundary bullet.

## Scope & safety

- **Docs/ADR only** — no quadlet, `Secret=` line, or service config touched.
- **Public-release sanitization** (this repo is public): host-specific recon scrubbed from the superseded ADR-040 and others — disk health, boot-hardening posture, drive inventory/funding, the private substrate repo's internal paths, and gitignored-memory refs. Already-public architecture (the btrfs pool, `subvol7`, the store path, the username) kept, consistent with the existing public ADR corpus.
- Excludes unrelated `docs/AUTO-*.md` auto-gen drift that predated this work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)