### PR TITLE
chore(supply-chain): monthly digest adoption — alertmanager,forgejo-db forgejo,gathio-db jellyfin,navidrome nextcloud,unifi-syslog

### DIFF
--- a/docs/AUTO-IMAGE-PIN-INDEX.md
+++ b/docs/AUTO-IMAGE-PIN-INDEX.md
@@ -1,6 +1,6 @@
 # Container Image Pin Index (Auto-Generated)
 
-**Generated:** 2026-06-13 19:01:40 UTC
+**Generated:** 2026-06-23 14:11:29 UTC
 **Source:** `/home/patriark/containers/quadlets` — ADR-030 (Container Supply-Chain Trust Model)
 
 Pins live in each quadlet's `Image=` line (where Podman reads them); this is
@@ -31,26 +31,26 @@ For local builds the `Digest` column shows the **base image** pin (FROM …@sha2
 | Service | Egress | Status | Repository | Tag | Digest | Auto | Signed (P6) |
 |---------|--------|--------|------------|-----|--------|------|-------------|
 | alert-discord-relay | yes | 🔨 base-pinned | `localhost/alert-discord-relay` | 2026-05-23 | `sha256:a3ab0b966bc4…` | no | n/a (Tier 2) |
-| alertmanager | yes | 🔒 pinned | `quay.io/prometheus/alertmanager` | latest | `sha256:51a825c2a40a…` | no | — unsigned |
+| alertmanager | yes | 🔒 pinned | `quay.io/prometheus/alertmanager` | latest | `sha256:af26fbe4dd18…` | no | — unsigned |
 | audiobookshelf | yes | 🔒 pinned | `ghcr.io/advplyr/audiobookshelf` | 2.35.0 | `sha256:89276ff2e0b3…` | no | — unsigned |
 | authelia | yes | 🔒 pinned | `docker.io/authelia/authelia` | latest | `sha256:1b363e9279e7…` | no | — unsigned |
 | blackbox-exporter | yes | 🔒 pinned | `quay.io/prometheus/blackbox-exporter` | latest | `sha256:e753ff9f3fc4…` | no | — unsigned |
 | cadvisor | no | 🔒 pinned | `gcr.io/cadvisor/cadvisor` | latest | `sha256:3de2bd520312…` | no | — unsigned |
 | crowdsec | yes | 🔒 pinned | `docker.io/crowdsecurity/crowdsec` | latest | `sha256:2f527c9bb8b3…` | no | — unsigned |
-| forgejo-db | no | 🔒 pinned | `docker.io/library/postgres` | 16-alpine | `sha256:16bc17c64a57…` | no | — unsigned |
-| forgejo | yes | 🔒 pinned | `codeberg.org/forgejo/forgejo` | 15 | `sha256:db04c7114b65…` | no | — unsigned |
-| gathio-db | no | 🔒 pinned | `docker.io/library/mongo` | 7 | `sha256:c1a84ab5d0c1…` | no | — unsigned |
+| forgejo-db | no | 🔒 pinned | `docker.io/library/postgres` | 16-alpine | `sha256:e013e867e712…` | no | — unsigned |
+| forgejo | yes | 🔒 pinned | `codeberg.org/forgejo/forgejo` | 15 | `sha256:55bb42bec9ab…` | no | — unsigned |
+| gathio-db | no | 🔒 pinned | `docker.io/library/mongo` | 7 | `sha256:8ecb514b00bd…` | no | — unsigned |
 | gathio | yes | 🔒 pinned | `ghcr.io/lowercasename/gathio` | latest | `sha256:ff66a8d2cc52…` | no | — unsigned |
 | grafana | yes | 🔒 pinned | `docker.io/grafana/grafana` | latest | `sha256:5dad0df181cb…` | no | — unsigned |
 | home-assistant | yes | 🔒 pinned | `ghcr.io/home-assistant/home-assistant` | stable | `sha256:d4fbec16196d…` | no | ✓ verified |
 | immich-ml | no | 🔒 pinned | `ghcr.io/immich-app/immich-machine-learning` | v2.7.5 | `sha256:a2501141440f…` | no | — unsigned |
 | immich-server | yes | 🔒 pinned | `ghcr.io/immich-app/immich-server` | v2.7.5 | `sha256:c15bff75068e…` | no | — unsigned |
-| jellyfin | yes | 🔒 pinned | `docker.io/jellyfin/jellyfin` | latest | `sha256:1694ff069f0c…` | no | — unsigned |
+| jellyfin | yes | 🔒 pinned | `docker.io/jellyfin/jellyfin` | latest | `sha256:aefb67e6a7ff…` | no | — unsigned |
 | loki | yes | 🔒 pinned | `docker.io/grafana/loki` | latest | `sha256:191d4fdfb726…` | no | — unsigned |
-| navidrome | yes | 🔒 pinned | `docker.io/deluan/navidrome` | latest | `sha256:9fa40b3d8dec…` | no | — unsigned |
+| navidrome | yes | 🔒 pinned | `docker.io/deluan/navidrome` | latest | `sha256:c4b5cb36a790…` | no | — unsigned |
 | nextcloud-db | no | 🔒 pinned | `docker.io/library/mariadb` | 11 | `sha256:be1ef4fe5f14…` | no | — unsigned |
 | nextcloud-redis | no | 🔒 pinned | `docker.io/library/redis` | 7-alpine | `sha256:6ab0b6e73817…` | no | — unsigned |
-| nextcloud | yes | 🔒 pinned | `docker.io/library/nextcloud` | 33 | `sha256:b67959acacd5…` | no | — unsigned |
+| nextcloud | yes | 🔒 pinned | `docker.io/library/nextcloud` | 33 | `sha256:fe5166b04f21…` | no | — unsigned |
 | node_exporter | no | 🔒 pinned | `quay.io/prometheus/node-exporter` | latest | `sha256:0f422f62c15f…` | no | — unsigned |
 | pihole-exporter | yes | 🔒 pinned | `docker.io/ekofr/pihole-exporter` | latest | `sha256:a890cc731a39…` | no | — unsigned |
 | postgres-exporter | no | 🔒 pinned | `quay.io/prometheuscommunity/postgres-exporter` | latest | `sha256:e96064f87622…` | no | — unsigned |
@@ -64,7 +64,7 @@ For local builds the `Digest` column shows the **base image** pin (FROM …@sha2
 | redis-immich-exporter | no | 🔒 pinned | `quay.io/oliver006/redis_exporter` | latest | `sha256:2e9795be900d…` | no | — unsigned |
 | redis-immich | no | 🔒 pinned | `docker.io/valkey/valkey` | latest | `sha256:4963247afc4c…` | no | — unsigned |
 | traefik | yes | 🔒 pinned | `docker.io/library/traefik` | latest | `sha256:6b9cbca6fac4…` | no | — unsigned |
-| unifi-syslog | no | 🔒 pinned | `docker.io/linuxserver/syslog-ng` | latest | `sha256:b77c32d93b9e…` | no | — unsigned |
+| unifi-syslog | no | 🔒 pinned | `docker.io/linuxserver/syslog-ng` | latest | `sha256:53d71945a46f…` | no | — unsigned |
 | unpoller | yes | 🔒 pinned | `ghcr.io/unpoller/unpoller` | latest | `sha256:bf7bdcc59fcd…` | no | — unsigned |
 | vaultwarden | yes | 🔒 pinned | `docker.io/vaultwarden/server` | latest | `sha256:d626d04934cd…` | no | ✓ verified |
 

--- a/quadlets/alertmanager.container
+++ b/quadlets/alertmanager.container
@@ -4,9 +4,10 @@ After=network-online.target monitoring-network.service
 Wants=monitoring-network.service network-online.target
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-23 (index digest, multi-arch)
-# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart.
-Image=quay.io/prometheus/alertmanager@sha256:51a825c2a40acc3e338fdd00d622e01ec090f72be2b3ea46be0839cd47a4d286
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-06-23 (index digest, multi-arch)
+# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = adopt new digest (pin-container-image.sh --adopt), bake, restart.
+# ADR-030 P6: no publisher signature (tracked unsigned)
+Image=quay.io/prometheus/alertmanager@sha256:af26fbe4dd1886ac0efd7bd55cd9027da262e105b137a376522b7c14c3626e4a
 ContainerName=alertmanager
 NoNewPrivileges=true
 HostName=alertmanager

--- a/quadlets/forgejo-db.container
+++ b/quadlets/forgejo-db.container
@@ -4,8 +4,9 @@ After=network-online.target forgejo-network.service
 Wants=network-online.target forgejo-network.service
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: 16-alpine, resolved 2026-05-23 (index digest, multi-arch)
-Image=docker.io/library/postgres@sha256:16bc17c64a573ef34162af9298258d1aec548232985b33ed7b1eac33ba35c229
+# ADR-030 P2: digest-pinned (integrity). tag: 16-alpine, resolved 2026-06-23 (index digest, multi-arch)
+# ADR-030 P6: no publisher signature (tracked unsigned)
+Image=docker.io/library/postgres@sha256:e013e867e712fec275706a6c51c966f0bb0c93cfa8f51000f85a15f9865a28cb
 ContainerName=forgejo-db
 NoNewPrivileges=true
 HostName=forgejo-db

--- a/quadlets/forgejo.container
+++ b/quadlets/forgejo.container
@@ -5,8 +5,9 @@ Wants=network-online.target
 Requires=forgejo-db.service
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: 15, resolved 2026-05-23 (index digest, multi-arch)
-Image=codeberg.org/forgejo/forgejo@sha256:db04c7114b656f896e206ba3873fe8d3a7adf2daa44907037f0274f4ba653fb9
+# ADR-030 P2: digest-pinned (integrity). tag: 15, resolved 2026-06-23 (index digest, multi-arch)
+# ADR-030 P6: no publisher signature (tracked unsigned)
+Image=codeberg.org/forgejo/forgejo@sha256:55bb42bec9abef5223744804f164e37d37b20df7e8b8b4807ba213ad4f071d6d
 ContainerName=forgejo
 NoNewPrivileges=true
 HostName=forgejo

--- a/quadlets/gathio-db.container
+++ b/quadlets/gathio-db.container
@@ -4,9 +4,9 @@ After=network-online.target gathio-network.service
 Wants=gathio-network.service network-online.target
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: 7, resolved 2026-06-10 (index digest, multi-arch)
+# ADR-030 P2: digest-pinned (integrity). tag: 7, resolved 2026-06-23 (index digest, multi-arch)
 # ADR-030 P6: no publisher signature (tracked unsigned)
-Image=docker.io/library/mongo@sha256:c1a84ab5d0c17deed1e0dba1d24bd7c76e5c7b281145fe536911939b1551754c
+Image=docker.io/library/mongo@sha256:8ecb514b00bdcc0bde67ef4e6c330385377a9dc68e24ee94e28c07c891647348
 ContainerName=gathio-db
 NoNewPrivileges=true
 HostName=gathio-db

--- a/quadlets/jellyfin.container
+++ b/quadlets/jellyfin.container
@@ -4,9 +4,10 @@ After=network-online.target reverse_proxy-network.service media_services-network
 Wants=media_services-network.service network-online.target reverse_proxy-network.service
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-23 (index digest, multi-arch)
-# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart.
-Image=docker.io/jellyfin/jellyfin@sha256:1694ff069f0c9dafb283c36765175606866769f5d72f2ed56b6a0f1be922fc37
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-06-23 (index digest, multi-arch)
+# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = adopt new digest (pin-container-image.sh --adopt), bake, restart.
+# ADR-030 P6: no publisher signature (tracked unsigned)
+Image=docker.io/jellyfin/jellyfin@sha256:aefb67e6a7ff1debdd154a78a7bbb780fd0c873d8639210a7f6a2016ad2b35db
 ContainerName=jellyfin
 NoNewPrivileges=true
 HostName=jellyfin

--- a/quadlets/navidrome.container
+++ b/quadlets/navidrome.container
@@ -16,9 +16,10 @@ Wants=network-online.target traefik.service
 # CONTAINER CONFIGURATION
 # ═══════════════════════════════════════════════════════════
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-23 (index digest, multi-arch)
-# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart.
-Image=docker.io/deluan/navidrome@sha256:9fa40b3d8dec43ceb2213d1fa551da3dcfef6ac6d19c2e534efb92527c2bafd2
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-06-23 (index digest, multi-arch)
+# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = adopt new digest (pin-container-image.sh --adopt), bake, restart.
+# ADR-030 P6: no publisher signature (tracked unsigned)
+Image=docker.io/deluan/navidrome@sha256:c4b5cb36a790b3eb63ca6a68bbe2fe149c2d7fa2e586f7a480e61db630e6664b
 ContainerName=navidrome
 NoNewPrivileges=true
 HostName=navidrome

--- a/quadlets/nextcloud.container
+++ b/quadlets/nextcloud.container
@@ -5,8 +5,9 @@ Wants=network-online.target
 
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: 33, resolved 2026-05-23 (index digest, multi-arch)
-Image=docker.io/library/nextcloud@sha256:b67959acacd54ed2d110e111c8b28c0a87a20129f9427bf5f721a1dc6121decb
+# ADR-030 P2: digest-pinned (integrity). tag: 33, resolved 2026-06-23 (index digest, multi-arch)
+# ADR-030 P6: no publisher signature (tracked unsigned)
+Image=docker.io/library/nextcloud@sha256:fe5166b04f217c9e3a263bfe76eef5e13de0dd3919966827de1b47bae2308b01
 ContainerName=nextcloud
 NoNewPrivileges=true
 

--- a/quadlets/unifi-syslog.container
+++ b/quadlets/unifi-syslog.container
@@ -4,10 +4,10 @@ After=network-online.target syslog-network.service traefik.service
 Wants=syslog-network.service network-online.target
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-06-10 (index digest, multi-arch)
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-06-23 (index digest, multi-arch)
 # ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = adopt new digest (pin-container-image.sh --adopt), bake, restart.
 # ADR-030 P6: no publisher signature (tracked unsigned)
-Image=docker.io/linuxserver/syslog-ng@sha256:b77c32d93b9e9b84f4fdd9261d7dd1db3b8a6f90391459b1ca51c82af9828bf8
+Image=docker.io/linuxserver/syslog-ng@sha256:53d71945a46f2fa094f7412ef2fe583bece7eee2d91f20afc203eab593b076e9
 ContainerName=unifi-syslog
 NoNewPrivileges=true
 HostName=unifi-syslog


### PR DESCRIPTION
Adopted via monthly-update.sh → adopt-baked.sh (ADR-036): bake-gated,
wave-ordered, per-service verified. See docs/99-reports/image-updates-20260623.txt

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
