### PR TITLE
fix(reboot): dynamic graceful-shutdown fleet + Prometheus memory-snapshot

### DIFF
--- a/quadlets/prometheus.container
+++ b/quadlets/prometheus.container
@@ -31,9 +31,17 @@ Secret=ha-prometheus-token,type=mount,target=/run/secrets/ha-prometheus-token
 # systemd-monitoring network. Accepted for this homelab: the external path is
 # Authelia-fronted (routers.yml), only the snapshot endpoint is used, and the
 # dump job pre-cleans orphaned snapshots. See ADR-029.
+#
+# --enable-feature=memory-snapshot-on-shutdown: on a clean SIGTERM (the path
+# graceful-shutdown.sh / prepare-for-reboot.sh always take) Prometheus writes a
+# head-chunk snapshot and loads it on next start INSTEAD of replaying the WAL
+# (~16s of HDD reads on subvol8-db, among the heaviest fleet boot I/O — the very
+# reason this service sits in boot tier C, see ADR-035). Falls back to WAL replay
+# on an unclean stop, so it never hurts. GH#308.
 Exec=--config.file=/etc/prometheus/prometheus.yml \
      --storage.tsdb.path=/prometheus \
      --storage.tsdb.retention.time=15d \
+     --enable-feature=memory-snapshot-on-shutdown \
      --web.console.libraries=/usr/share/prometheus/console_libraries \
      --web.console.templates=/usr/share/prometheus/consoles \
      --web.enable-lifecycle \

--- a/scripts/graceful-shutdown.sh
+++ b/scripts/graceful-shutdown.sh
@@ -1,14 +1,28 @@
 #!/bin/bash
 # graceful-shutdown.sh
-# Dependency-aware 6-phase graceful shutdown of all homelab containers
+# Dependency-aware, tiered graceful shutdown of all homelab containers.
 #
-# Phases (reverse startup order):
-#   1. Supporting services (exporters, ML, matter)
-#   2. Applications (user-facing services)
-#   3. Infrastructure (monitoring, security)
-#   4. Auth (authentication stack)
-#   5. Data (databases, caches)
-#   6. Gateway (traefik - last to stop, first to start)
+# Fleet membership is DERIVED AT RUNTIME from quadlets/*.container (the systemd
+# source of truth) and classified into shutdown tiers by role — it is NOT a
+# hardcoded list. A hardcoded list silently omits any service deployed after it
+# was last edited: the previous version's static array skipped forgejo-db (a
+# PostgreSQL database) plus 8 other running services, which then fell to the
+# reboot transition instead of being quiesced while the host was up — defeating
+# the script's entire purpose for a database. See GH#307 / lesson L-079.
+#
+# Tiers (reverse startup order — supporting first, gateway last):
+#   1 Supporting     exporters, ML, relays, log shippers
+#   2 Applications   user-facing services (stop before their DBs)   [catch-all]
+#   3 Infrastructure monitoring + security
+#   4 Auth           authentication stack
+#   5 Data           databases & caches (quiesce last-but-one)
+#   6 Gateway        traefik (last to stop, first to start)
+#
+# Classification is by name pattern, first match wins (so *-exporter is caught
+# before the database name patterns — postgres-exporter is tier 1, not tier 5).
+# Anything matching no known role falls to tier 2 (Applications); it still gets
+# stopped and is visible in the roster, never silently skipped. After the run a
+# loud guard fails if ANY container survives (catches non-quadlet orphans too).
 #
 # Usage: ./scripts/graceful-shutdown.sh [--dry-run]
 
@@ -26,22 +40,48 @@ YELLOW='\033[1;33m'
 CYAN='\033[0;36m'
 NC='\033[0m'
 
-# Phase definitions: name and services
-declare -A PHASES
-PHASES=(
-    [1_name]="Supporting services"
-    [1_services]="alert-discord-relay cadvisor node_exporter promtail unpoller immich-ml"
-    [2_name]="Applications"
-    [2_services]="nextcloud gathio immich-server jellyfin home-assistant vaultwarden audiobookshelf navidrome qbittorrent"
-    [3_name]="Infrastructure"
-    [3_services]="grafana prometheus loki alertmanager crowdsec"
-    [4_name]="Auth"
-    [4_services]="authelia"
-    [5_name]="Data"
-    [5_services]="nextcloud-db nextcloud-redis gathio-db postgresql-immich redis-immich redis-authelia"
-    [6_name]="Gateway"
-    [6_services]="traefik"
+QUADLET_DIR="${QUADLET_DIR:-$HOME/containers/quadlets}"
+
+declare -A TIER_NAME=(
+    [1]="Supporting services"
+    [2]="Applications"
+    [3]="Infrastructure"
+    [4]="Auth"
+    [5]="Data (databases & caches)"
+    [6]="Gateway"
 )
+
+# classify <service> -> tier 1..6. First matching pattern wins.
+classify() {
+    case "$1" in
+        traefik)
+            echo 6 ;;                                              # gateway
+        authelia)
+            echo 4 ;;                                              # auth
+        *-exporter|cadvisor|node_exporter|promtail|unpoller|*-ml|*-relay)
+            echo 1 ;;                                              # supporting
+        prometheus|loki|grafana|alertmanager|crowdsec)
+            echo 3 ;;                                              # infrastructure
+        *-db|*-redis|redis-*|postgres*|postgresql-*|mariadb*|mongo*)
+            echo 5 ;;                                              # data
+        *)
+            echo 2 ;;                                              # apps + catch-all
+    esac
+}
+
+# --- Discover the fleet from quadlet sources -------------------------------
+declare -A SVC_TIER
+shopt -s nullglob
+for f in "$QUADLET_DIR"/*.container; do
+    svc="$(basename "$f" .container)"
+    SVC_TIER["$svc"]="$(classify "$svc")"
+done
+shopt -u nullglob
+
+if [ "${#SVC_TIER[@]}" -eq 0 ]; then
+    echo -e "${RED}No quadlet .container files found in $QUADLET_DIR — refusing to run.${NC}" >&2
+    exit 1
+fi
 
 TOTAL_STOPPED=0
 TOTAL_SKIPPED=0
@@ -73,25 +113,30 @@ stop_service() {
 }
 
 echo "============================================"
-echo "  GRACEFUL SHUTDOWN - 6-Phase Dependency Order"
+echo "  GRACEFUL SHUTDOWN - tiers derived from quadlets/"
 if $DRY_RUN; then
     echo -e "  ${CYAN}(DRY RUN - no services will be stopped)${NC}"
 fi
 echo "============================================"
+echo "  Discovered ${#SVC_TIER[@]} quadlet services"
 echo ""
 
-for phase in 1 2 3 4 5 6; do
-    name="${PHASES[${phase}_name]}"
-    services="${PHASES[${phase}_services]}"
+for tier in 1 2 3 4 5 6; do
+    # Services in this tier, sorted for stable, readable output.
+    mapfile -t svcs < <(
+        for svc in "${!SVC_TIER[@]}"; do
+            [[ "${SVC_TIER[$svc]}" == "$tier" ]] && echo "$svc"
+        done | sort
+    )
+    [ "${#svcs[@]}" -eq 0 ] && continue
 
-    echo -e "${CYAN}Phase $phase: $name${NC}"
-
-    for service in $services; do
+    echo -e "${CYAN}Tier $tier: ${TIER_NAME[$tier]}${NC}"
+    for service in "${svcs[@]}"; do
         stop_service "$service"
     done
 
-    # Brief pause between phases to allow clean TCP teardown
-    if ! $DRY_RUN && [ "$phase" -lt 6 ]; then
+    # Brief pause between tiers to allow clean TCP teardown.
+    if ! $DRY_RUN && [ "$tier" -lt 6 ]; then
         sleep 2
     fi
 
@@ -112,12 +157,15 @@ if [ "$TOTAL_FAILED" -gt 0 ]; then
 fi
 
 if ! $DRY_RUN; then
-    # Verify nothing is running
+    # Loud drift guard: nothing must survive. A container left running here is
+    # either a unit that failed to stop or one with no quadlet behind it (an
+    # orphan) — exactly the silent gap GH#307 closed. Fail, don't whisper.
     REMAINING=$(podman ps --format '{{.Names}}' 2>/dev/null | wc -l)
     if [ "$REMAINING" -gt 0 ]; then
-        echo -e "${YELLOW}Warning: $REMAINING containers still running:${NC}"
+        echo -e "${RED}Drift: $REMAINING container(s) still running after shutdown:${NC}"
         podman ps --format '  {{.Names}} ({{.Status}})' 2>/dev/null
-    else
-        echo -e "${GREEN}All containers stopped successfully.${NC}"
+        echo -e "${YELLOW}If these have no quadlets/*.container, they were never covered.${NC}"
+        exit 1
     fi
+    echo -e "${GREEN}All containers stopped successfully.${NC}"
 fi


### PR DESCRIPTION
Two reboot-path fixes surfaced by the 2026-06-23 update+reboot review.

## fix(reboot): derive graceful-shutdown fleet from quadlets — `Closes #307`

`graceful-shutdown.sh` stopped the fleet from a **hardcoded `PHASES` array** that
had drifted. It silently omitted **9 running services, including `forgejo-db`
(PostgreSQL)** — they fell to the systemd reboot transition (pasta/aardvark
teardown errors + `status=125`) instead of being quiesced while the host was up,
which is the one thing this script exists to guarantee. PostgreSQL flushed within
budget this time so nothing corrupted, but the guarantee wasn't actually
delivered for a database.

Now the stop set is **discovered at runtime from `quadlets/*.container`** and
classified into the same six tiers by name pattern (DBs/caches late, gateway
last). First-match-wins ordering keeps exporters in Supporting
(`postgres-exporter` → tier 1, not the DB tier). A post-run guard fails loudly if
any container survives — catching non-quadlet orphans too.

**Verified** with `--dry-run`: all **37** services covered; `forgejo-db` now in
Tier 5 (Data); the 9 previously-missing services (forgejo, forgejo-db,
unifi-syslog, proton-bridge, and 5 exporters) all classified correctly.

## perf(prometheus): memory-snapshot-on-shutdown — `Closes #308`

On the reboot, Prometheus shut down cleanly yet still spent **16.1s replaying the
WAL** (`chunk_snapshot_load_duration=0s` — feature off). Adding
`--enable-feature=memory-snapshot-on-shutdown` makes a clean SIGTERM (the path
`prepare-for-reboot.sh` always takes) write a head-chunk snapshot that loads on
next start instead of replaying the WAL — removing ~16s of subvol8-db HDD reads,
among the heaviest fleet boot I/O and the reason this service sits in boot tier C
(ADR-035). Falls back to WAL replay on an unclean stop, so it never hurts.

> ⚠️ **Not yet applied to the running service.** Needs `systemctl --user
> daemon-reload && systemctl --user restart prometheus.service` (a deliberate
> step — brief metrics gap + one more WAL replay on restart). The snapshot
> benefit appears on the **next clean shutdown/boot**. The quadlet digest pin,
> boot-tier declaration, and admin-api notes are unchanged.

## Notes

- Two clean, SSH-signed commits (one per issue), no rebasing — ADR-038.
- No live services were stopped or restarted by this PR (graceful-shutdown.sh ran
  in `--dry-run` only; the prometheus change is file-only until applied).
- Lesson **L-079** records the hardcoded-fleet-list trap behind #307.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
