### PR TITLE
fix(mirror): dedicated deploy key for Forgejo push (CVE-2026-39831) — closes #306

### DIFF
--- a/scripts/mirror-to-forgejo.sh
+++ b/scripts/mirror-to-forgejo.sh
@@ -32,6 +32,19 @@ REMOTE="${MIRROR_REMOTE:-forgejo}"
 METRICS_DIR="${HOME}/containers/data/backup-metrics"
 METRICS_FILE="${METRICS_FILE:-${METRICS_DIR}/forgejo-mirror.prom}"
 
+# SSH identity for the Forgejo loopback push (ADR-032). A DEDICATED, non-FIDO
+# ed25519 deploy key — NOT the FIDO signing key. Forgejo 15.0.3 carries the
+# go1.26.4 fix for CVE-2026-39831: x/crypto/ssh now enforces FIDO User-Presence,
+# so the no-touch signing key's touch-less auth signatures are rejected mid-auth
+# (the connection drops right after it sends the signature) and the push fails.
+# A plain ed25519 key has no User-Presence concept, so it authenticates
+# unattended on the patched server. `-F none` keeps this independent of the
+# (chezmoi-managed) user SSH config so ONLY this one key is ever offered; the
+# explicit ssh:// remote URL supplies host/port/user. Commit signing is a
+# separate client-side path and is unaffected — the FIDO key still signs commits.
+MIRROR_SSH_KEY="${MIRROR_SSH_KEY:-$HOME/.ssh/id_ed25519_forgejo_mirror}"
+export GIT_SSH_COMMAND="ssh -F none -i $MIRROR_SSH_KEY -o IdentitiesOnly=yes -o IdentityAgent=none -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile=$HOME/.ssh/known_hosts"
+
 log() { echo "[$(date '+%Y-%m-%d %H:%M:%S')] [$1] ${*:2}" >&2; }
 
 SUCCESS=0
@@ -68,6 +81,17 @@ finish() {
 trap finish EXIT
 
 cd "$REPO_ROOT" || { log ERROR "repo not found: $REPO_ROOT"; exit 1; }
+
+# Ensure the ledger remote is the explicit ssh:// URL, not the forgejo-local
+# ssh_config alias: with `-F none` in GIT_SSH_COMMAND above an alias would not
+# resolve, and the alias also carries the FIDO signing key (rejected post-CVE).
+# Idempotent; pins host/port/user for the dedicated deploy key.
+FORGEJO_URL="${FORGEJO_URL:-ssh://git@127.0.0.1:2222/patriark/homelab.git}"
+if [[ "$(git remote get-url "$REMOTE" 2>/dev/null)" != "$FORGEJO_URL" ]]; then
+    git remote set-url "$REMOTE" "$FORGEJO_URL" 2>/dev/null \
+        || git remote add "$REMOTE" "$FORGEJO_URL"
+    log INFO "pinned $REMOTE remote URL -> $FORGEJO_URL"
+fi
 
 if ! git fetch --quiet origin main || ! git fetch --quiet "$REMOTE" main; then
     log ERROR "fetch failed (origin or $REMOTE unreachable)"


### PR DESCRIPTION
Resolves #306 — with a subtle root cause. This month's Forgejo bump
(15.0.2→15.0.3, go1.26.3→go1.26.4) shipped the fix for **CVE-2026-39831**:
`x/crypto/ssh` now enforces FIDO **User-Presence**. The mirror authenticated
with the **no-touch FIDO signing key**, so the patched Forgejo SSH server now
rejects its touch-less signatures mid-auth — every hourly push failed after the
adoption + reboot. The old setup relied on the very bypass the CVE closed;
rolling Forgejo back would re-open it.

## Fix (security-correct, no rollback)
The unattended mirror now uses a dedicated, repo-scoped, **non-FIDO ed25519
deploy key** (no User-Presence concept → authenticates unattended on the
patched server):
- `GIT_SSH_COMMAND` pins that one key with `-F none` (independent of the
  chezmoi-managed user ssh config) so only it is ever offered;
- the ledger remote is pinned to an explicit `ssh://` URL via an idempotent
  guard (the `forgejo-local` alias carried the signing key and won't resolve
  under `-F none`).

## Forgejo-side changes (not in this repo)
- Registered write deploy key `forgejo-mirror-deploy` on `patriark/homelab`.
- `main` branch protection: `push_whitelist_deploy_keys=true`.
  **Force-push stays blocked → append-only tamper-canary intact**;
  `require_signed_commits` unchanged; `push_whitelist_usernames=[patriark]`.

## Unaffected (answering the obvious worry)
- The FIDO signing key is untouched and still signs commits — a separate
  client-side path, not the server-side CVE fix.
- Unattended `git commit -S` and push-to-GitHub (HTTPS) — the remote/travel
  workflow — are unchanged.

## Verified
Mirror `Finished`, pushed 7 commits `7e92652..6ee9dd5`,
`forgejo_mirror_success=1`, ledger `forgejo/main == origin/main`.

## Follow-ups (filed separately)
- **Verification gap (L-049 class):** `adopt-baked.sh` + the container
  healthcheck only exercise Forgejo over HTTP, so an SSH-auth-breaking image
  change passed adoption silently.
- **Config-as-code:** persist the deploy key (and optionally the ssh wiring)
  in the htpc-mgmt substrate; today it lives only on disk.
- `~/htpc-mgmt` uses the same `forgejo-local` remote — its manual pushes will
  hit the same wall; migrate it similarly when convenient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)