### PR TITLE
feat(adopt): smoke-test Forgejo SSH push path during adoption (closes #314)

### DIFF
--- a/scripts/adopt-baked.sh
+++ b/scripts/adopt-baked.sh
@@ -146,6 +146,41 @@ verify_service() {
     else
         echo "    ❌ $svc: active but healthcheck stuck in '$health'"; return 1
     fi
+
+    # Workload smoke (GH#314): HTTP health can stay green while the service's
+    # real path is broken. Assert it; a failure halts the adoption right here.
+    workload_smoke "$svc"
+}
+
+# Smoke-test a service's NON-HTTP workload when it has one. Forgejo 15.0.3
+# shipped the go1.26.4 fix for CVE-2026-39831 (x/crypto/ssh enforces FIDO
+# User-Presence) and silently broke git-over-SSH while :3000 stayed healthy —
+# the mirror push only failed hours later, after a reboot. Probe the SSH push
+# path with the dedicated deploy key: "successfully authenticated" = good,
+# connection-drop/deny = bad.
+workload_smoke() {
+    case "$1" in
+        forgejo)
+            local key="${MIRROR_SSH_KEY:-$HOME/.ssh/id_ed25519_forgejo_mirror}"
+            if [ ! -f "$key" ]; then
+                echo "    ⚠ forgejo: SSH smoke skipped (deploy key $key not on this host)"
+                return 0
+            fi
+            local out
+            out="$(ssh -F none -i "$key" -o IdentitiesOnly=yes -o IdentityAgent=none \
+                       -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
+                       -o BatchMode=yes -o ConnectTimeout=8 -p 2222 -T git@127.0.0.1 2>&1 || true)"
+            if grep -q "successfully authenticated" <<< "$out"; then
+                echo "    ✓ forgejo: SSH push path (:2222) authenticates"
+                return 0
+            fi
+            echo "    ❌ forgejo: SSH push path (:2222) BROKEN — the mirror would fail."
+            echo "       probe: $(grep -iE 'closed|denied|authenticated|timeout' <<< "$out" | head -1)"
+            echo "       (Forgejo SSH-auth regression — cf. CVE-2026-39831 / GH#314)"
+            return 1
+            ;;
+        *) return 0 ;;
+    esac
 }
 
 halt() {


### PR DESCRIPTION
Closes #314 — the systemic fix behind the Forgejo-mirror incident.

`adopt-baked.sh` verified Forgejo over **HTTP only**, so the 15.0.3 adoption
(CVE-2026-39831: `x/crypto/ssh` now enforces FIDO User-Presence) silently broke
git-over-SSH while `:3000` stayed healthy — the mirror push only failed hours
later, after a reboot.

`verify_service` now calls a **`workload_smoke()`** hook after the HTTP/health
checks. For `forgejo` it probes the SSH push path (`:2222`) with the dedicated
deploy key (`-F none`, agent-less): *"successfully authenticated"* passes; a
connection drop / denial **halts the adoption on the spot**. It re-runs for
`forgejo` when restarted as a `forgejo-db` dependent. Other services are a
no-op — the hook is the seam for further non-HTTP workload assertions (DB
query, etc.).

**Validated:** the probe returns the deploy-key auth banner today (mirror
works), so adoption passes; a broken SSH path would now halt immediately
instead of surfacing later as a dead hourly push.

With the deploy-key follow-ups already done in htpc-mgmt (ADR-008 / `c0e5d2b`),
this lands the primary fix → all #314 acceptance criteria met.

🤖 Generated with [Claude Code](https://claude.com/claude-code)