### PR TITLE
feat(nextcloud): make Music external storage writable for library ingestion

### DIFF
--- a/quadlets/nextcloud.container
+++ b/quadlets/nextcloud.container
@@ -42,7 +42,6 @@ Volume=/mnt/btrfs-pool/subvol7-containers/nextcloud/data:/var/www/html:Z
 # External storage - read-only media (shared with Jellyfin)
 Volume=/mnt/btrfs-pool/subvol3-opptak:/external/opptak:ro,z
 Volume=/mnt/btrfs-pool/subvol4-multimedia:/external/multimedia:ro,z
-Volume=/mnt/btrfs-pool/subvol5-music:/external/music:ro,z
 # REMOVED: /subvol3-opptak/immich mount (redundant - accessible via /external/opptak/immich/)
 # Immich has exclusive :Z access to this subdirectory
 
@@ -50,6 +49,9 @@ Volume=/mnt/btrfs-pool/subvol5-music:/external/music:ro,z
 Volume=/mnt/btrfs-pool/subvol6-tmp/Downloads:/external/downloads:z
 Volume=/mnt/btrfs-pool/subvol1-docs:/external/user-documents:Z
 Volume=/mnt/btrfs-pool/subvol2-pics:/external/user-photos:Z
+# Music: writable for library ingestion via Nextcloud (occ files_external mount 3 readonly=false).
+# SHARED label (:z, not :Z) — Navidrome mounts the same subvol :ro,z. www-data write via POSIX ACL u:100032 (ADR-019).
+Volume=/mnt/btrfs-pool/subvol5-music:/external/music:z
 
 # Networks (reverse_proxy FIRST for internet access!)
 # Static IPs assigned to ensure consistent DNS resolution


### PR DESCRIPTION
## Why
A music copy from the Nextcloud desktop client (`mirall`, from `192.168.1.71`) failed with `405` on `MKCOL` and `403` on `PUT` under `/Music/`. Root cause was **server-side by design**: the `Music` external storage was read-only at two layers — the `:ro` bind mount and the external-storage `readonly: true` flag. The music library is curated from the host and mounted read-only into both Nextcloud and Navidrome.

Owner opted to allow library ingestion via Nextcloud.

## Changes
- **Quadlet (in this PR):** `subvol5-music` bind mount `:ro,z` → `:z`. Kept the **shared** lowercase SELinux label (`:z`, not `:Z`) because Navidrome mounts the same subvol `:ro,z`.
- **Host ACL (out-of-band, not in git):** `setfacl -R` granting `u:100032:rwx` (www-data) + `u:patriark:rwx` + matching `default:` ACLs on `subvol5-music`, per ADR-019 — replicates the proven pattern on `subvol1-docs`/`subvol2-pics`.
- **Runtime state (not in git):** `occ files_external:option 3 readonly false`.

## Trade-off
Nextcloud users can now add/modify/**delete** files in the library Navidrome serves. Navidrome still mounts the subvol **read-only** and cannot mutate it. This reverses the prior deliberate "media is read-only" stance for music specifically.

## Verification
- Mount shows `rw` inside the container ✅
- `www-data` write to `/external/music` succeeds (the exact op a WebDAV PUT performs) ✅
- `occ files_external:list` shows mount 3 `readonly: ""` ✅
- Navidrome unaffected — still `:ro`, still `active`/healthy ✅
- **Pending:** owner to re-run the client copy as final end-to-end (`405`/`403` → `201`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)