### PR TITLE
fix(alerts): exclude client-closed 499 from *High4xxRate numerators

### DIFF
--- a/config/prometheus/alerts/slo-multiwindow-alerts.yml
+++ b/config/prometheus/alerts/slo-multiwindow-alerts.yml
@@ -1183,11 +1183,17 @@ groups:
             Check: podman logs home-assistant --tail 100
 
       - alert: NavidromeHigh4xxRate
+        # Min-traffic guard 0.01 req/s (~3 req/5m), matching Nextcloud. Navidrome is
+        # idle most of the time with streaming-session bursts, so without a guard a
+        # single 4xx during a quiet window would show as a high ratio (the HA 499
+        # false-positive class, 2026-06-28). Ratio only evaluated under real use.
         expr: |
           (
             sum(rate(traefik_service_requests_total{exported_service="navidrome@file", code=~"4..", code!="499"}[5m]))
             / clamp_min(sum(rate(traefik_service_requests_total{exported_service="navidrome@file"}[5m])), 1e-10)
           ) > 0.10
+          and
+          sum(rate(traefik_service_requests_total{exported_service="navidrome@file"}[5m])) > 0.01
         for: 10m
         labels:
           severity: warning
@@ -1208,11 +1214,17 @@ groups:
               {container_name="traefik"} |= "navidrome" | json | status >= 400 | status < 500
 
       - alert: AudiobookshelfHigh4xxRate
+        # Min-traffic guard 0.01 req/s (~3 req/5m), matching Nextcloud. Audiobookshelf
+        # is idle most of the time (~278 req/24h, median 0) with playback-session
+        # bursts; without a guard a single 4xx in a quiet window would dominate the
+        # ratio (the HA 499 false-positive class, 2026-06-28).
         expr: |
           (
             sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file", code=~"4..", code!="499"}[5m]))
             / clamp_min(sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file"}[5m])), 1e-10)
           ) > 0.10
+          and
+          sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file"}[5m])) > 0.01
         for: 10m
         labels:
           severity: warning

--- a/config/prometheus/alerts/slo-multiwindow-alerts.yml
+++ b/config/prometheus/alerts/slo-multiwindow-alerts.yml
@@ -1104,6 +1104,14 @@ groups:
   #   - 429: rate limiting firing (possible attack or misconfigured client)
   #   - 403: middleware misconfiguration
   #   - sustained high 404: broken integration or misconfigured client
+  #
+  # All numerators exclude code 499 (code=~"4..", code!="499"). Traefik logs 499 when
+  # the *client* closes the connection before the response is relayed (backgrounded
+  # app, closed tab, network blip on a long-poll/token-refresh) — a client-side
+  # disconnect, never a server-side client error. Counting it inflated the 4xx ratio
+  # on low-traffic services: a single 499 token refresh once pegged Home Assistant at
+  # 50% (1 of 2 requests in the window) and tripped HomeAssistantHigh4xxRate with no
+  # real fault. See docs/98-journals/2026-06-28-ha-4xx-499-false-positive.md.
   # ===========================================================================
   - name: denylist_services_4xx_compensating
     interval: 1m
@@ -1116,7 +1124,7 @@ groups:
         # during restarts or traffic lulls where a single 4xx would show as 100%.
         expr: |
           (
-            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"4.."}[5m]))
+            sum(rate(traefik_service_requests_total{exported_service="nextcloud@file", code=~"4..", code!="499"}[5m]))
             / clamp_min(sum(rate(traefik_service_requests_total{exported_service="nextcloud@file"}[5m])), 1e-10)
           ) > 0.10
           and
@@ -1145,13 +1153,17 @@ groups:
         # Traefik traffic (~37 req/day). With a 5m window, a single 404 would show as
         # 100% error rate and trigger the alert. The 30m window + minimum traffic guard
         # smooths low-traffic variance while still catching sustained 4xx spikes.
+        # Guard is 0.002 req/s (~3.6 req/30m): the prior 0.001 (~1.8 req/30m) still let
+        # a lone event dominate a 1-2 request window (the 50% false positive on
+        # 2026-06-28). Ratio alerting stays inherently noisy at this volume; the 499
+        # exclusion above is the primary fix, this guard is defense-in-depth.
         expr: |
           (
-            sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code=~"4.."}[30m]))
+            sum(rate(traefik_service_requests_total{exported_service="home-assistant@file", code=~"4..", code!="499"}[30m]))
             / clamp_min(sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[30m])), 1e-10)
           ) > 0.10
           and
-          sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[30m])) > 0.001
+          sum(rate(traefik_service_requests_total{exported_service="home-assistant@file"}[30m])) > 0.002
         for: 10m
         labels:
           severity: warning
@@ -1173,7 +1185,7 @@ groups:
       - alert: NavidromeHigh4xxRate
         expr: |
           (
-            sum(rate(traefik_service_requests_total{exported_service="navidrome@file", code=~"4.."}[5m]))
+            sum(rate(traefik_service_requests_total{exported_service="navidrome@file", code=~"4..", code!="499"}[5m]))
             / clamp_min(sum(rate(traefik_service_requests_total{exported_service="navidrome@file"}[5m])), 1e-10)
           ) > 0.10
         for: 10m
@@ -1198,7 +1210,7 @@ groups:
       - alert: AudiobookshelfHigh4xxRate
         expr: |
           (
-            sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file", code=~"4.."}[5m]))
+            sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file", code=~"4..", code!="499"}[5m]))
             / clamp_min(sum(rate(traefik_service_requests_total{exported_service="audiobookshelf@file"}[5m])), 1e-10)
           ) > 0.10
         for: 10m

--- a/docs/98-journals/2026-06-28-ha-4xx-499-false-positive.md
+++ b/docs/98-journals/2026-06-28-ha-4xx-499-false-positive.md
@@ -34,9 +34,12 @@ Two changes to `config/prometheus/alerts/slo-multiwindow-alerts.yml`, group `den
 
 Ratio alerting is inherently noisy at HA's volume. To *guarantee* a single stray 4xx (e.g. the HA iOS app's periodic `GET /api/ios/config` 404s) can't trip a 10% threshold, the window needs ≥10 requests — but HA averages <1 req/30m, so a guard that strict would effectively disable the alert. The 499 exclusion is the real fix; the guard bump is a modest hardening, not a full solution. An absolute-4xx-count gate would be the cleaner long-term design if these keep recurring.
 
+## Follow-on hardening (same PR)
+
+- **Added a min-traffic guard to Navidrome and Audiobookshelf** (`> 0.01` req/s ≈ 3 req/5m, matching Nextcloud). Both are idle most of the time with session bursts (Navidrome ~0 req/24h at measurement, Audiobookshelf ~278 req/24h, median 0, peak ~34 req/5m) — the same single-event-trip profile HA had, previously unguarded. The ratio is now only evaluated under real use.
+
 ## Side findings (not actioned)
 
-- **Navidrome and Audiobookshelf have no min-traffic guard at all** — same single-event-trip exposure as HA had, pending their (higher) baseline traffic. Noted, not changed in this PR.
 - The repo's `data/traefik-logs/` is a stale orphan (0-byte `access.log`, rotated `.gz` frozen at 2026-01-16). Live logs are on the BTRFS pool (`/mnt/btrfs-pool/subvol7-containers/traefik-logs`, per `quadlets/traefik.container:29`). Harmless; a candidate for deletion.
 
 **Diagnostic note:** Traefik access-log timestamps are **UTC**; the system runs `+0200`. The log's `12:38:59` is `14:38:59` local — reconcile timezones before concluding a log "stopped updating."

--- a/docs/98-journals/2026-06-28-ha-4xx-499-false-positive.md
+++ b/docs/98-journals/2026-06-28-ha-4xx-499-false-positive.md
@@ -1,0 +1,42 @@
+# HomeAssistantHigh4xxRate fired on a single client-closed connection — 499 was being counted as a 4xx error
+
+**Date:** 2026-06-28
+**Status:** Fixed — 499 excluded from all four `*High4xxRate` numerators; HA min-traffic guard `0.001 → 0.002`. promtool clean, Prometheus reloaded, live rule confirmed.
+**Origin:** A Discord `HomeAssistantHigh4xxRate` warning ("4xx rate above 10% for 10 minutes") fired with no owner activity on HA. Investigation traced it to a benign client disconnect.
+
+---
+
+## What happened
+
+The alert watches the Traefik `home-assistant@file` service for `>10%` 4xx over a 30m window, `for: 10m`. HA's Traefik traffic is ~37 req/day, so any 30m window holds only 1–2 requests.
+
+At **14:38:59 CEST** the HA companion app did a routine token refresh — `POST /auth/token` from `192.168.1.1` (a phone on home wifi, hairpin-NAT'd through the UDM Pro) — and **closed the connection ~114ms in, before Traefik relayed the response**. Traefik logged it as **code 499** ("client closed request").
+
+The alert numerator matched `code=~"4.."`, which **includes 499**. With only ~2 requests in the window and one being the 499, the ratio pegged at exactly **50%**, held there past the 10m `for:`, and fired.
+
+## Why it's a false positive
+
+499 is a **client-side disconnect** (backgrounded app, closed tab, network blip on a long-poll / token refresh) — it never indicates a server-side client error. The alert's own description lists 403/404/429 as the concern; 499 doesn't belong there. There was zero real fault:
+
+- HA service `active`, healthcheck exit 0, no errors in container logs.
+- Absolute counts over the alert window: `499=1`, connection-level `code-0=1`, **zero** real 403/404/429/500.
+
+It self-resolved once the 499 aged out of the 30m window (~15:09 CEST).
+
+## The fix
+
+Two changes to `config/prometheus/alerts/slo-multiwindow-alerts.yml`, group `denylist_services_4xx_compensating`:
+
+1. **Exclude 499 from all four numerators** (`code=~"4.."` → `code=~"4..", code!="499"`): Nextcloud, Home Assistant, Navidrome, Audiobookshelf. The 499 exclusion alone would have prevented this incident — the numerator drops to 0%.
+2. **HA min-traffic guard `0.001 → 0.002` req/s** (~1.8 → ~3.6 req/30m): defense-in-depth so a lone event can't dominate a 1–2 request window. The prior 0.001 cleared on the single 499.
+
+## Honest limits
+
+Ratio alerting is inherently noisy at HA's volume. To *guarantee* a single stray 4xx (e.g. the HA iOS app's periodic `GET /api/ios/config` 404s) can't trip a 10% threshold, the window needs ≥10 requests — but HA averages <1 req/30m, so a guard that strict would effectively disable the alert. The 499 exclusion is the real fix; the guard bump is a modest hardening, not a full solution. An absolute-4xx-count gate would be the cleaner long-term design if these keep recurring.
+
+## Side findings (not actioned)
+
+- **Navidrome and Audiobookshelf have no min-traffic guard at all** — same single-event-trip exposure as HA had, pending their (higher) baseline traffic. Noted, not changed in this PR.
+- The repo's `data/traefik-logs/` is a stale orphan (0-byte `access.log`, rotated `.gz` frozen at 2026-01-16). Live logs are on the BTRFS pool (`/mnt/btrfs-pool/subvol7-containers/traefik-logs`, per `quadlets/traefik.container:29`). Harmless; a candidate for deletion.
+
+**Diagnostic note:** Traefik access-log timestamps are **UTC**; the system runs `+0200`. The log's `12:38:59` is `14:38:59` local — reconcile timezones before concluding a log "stopped updating."


### PR DESCRIPTION
## Summary

A Discord `HomeAssistantHigh4xxRate` warning fired with **no real fault**. Root cause: a single HA companion-app token refresh (`POST /auth/token`) closed its connection ~114ms in, which Traefik logs as **code 499** ("client closed request"). The alert numerator matched `code=~"4.."` — which **includes 499** — so against HA's ~37 req/day baseline that lone disconnect pegged the 30m ratio at **50%** (1 of 2 requests) and tripped the alert.

499 is a **client-side disconnect** (backgrounded app, closed tab, network blip on a long-poll/token refresh), never a server-side client error. HA was healthy throughout: service `active`, healthcheck exit 0, zero real 403/404/429/500 in the window.

## Changes (`config/prometheus/alerts/slo-multiwindow-alerts.yml`, group `denylist_services_4xx_compensating`)

**Commit 1 — exclude 499 + harden HA guard:**
1. **Exclude 499 from all four numerators** (`code=~"4.."` → `code=~"4..", code!="499"`): Nextcloud, Home Assistant, Navidrome, Audiobookshelf. This alone would have prevented the incident — the HA numerator drops to **0%**.
2. **HA min-traffic guard `0.001 → 0.002` req/s** (~1.8 → ~3.6 req/30m): defense-in-depth so a lone event can't dominate a 1–2 request window.

**Commit 2 — add missing guards:**
3. **Navidrome & Audiobookshelf gained a min-traffic guard** (`> 0.01` req/s ≈ 3 req/5m, matching Nextcloud). Both were previously **unguarded** despite being idle-with-bursts (Navidrome ~0 req/24h at measurement; Audiobookshelf ~278 req/24h, median 0, peak ~34 req/5m) — the same single-event-trip exposure HA had. The ratio is now only evaluated under real use.

Shared group comment + per-alert inline comments explain the rationale; journal added.

## Verification

- `promtool check rules` → **SUCCESS: 42 rules found** (after each commit)
- Prometheus reloaded; live `/api/v1/rules` confirms `code!="499"` on all four, `> 0.002` on HA, and `> 0.01` on Navidrome + Audiobookshelf
- New HA 4xx ratio reads **0.0%** (499 excluded)

## Honest limits

Ratio alerting stays inherently noisy below ~10 req/window (a single event can't be ≤10% until n≥10). The guards mark where we stop trusting the ratio; they don't remove the floor. An **absolute-4xx-count gate** is the cleaner long-term design if these recur. Captured as lessons L-082 (499-as-4xx + ratio guards) and L-083 (UTC-vs-local log-timestamp forensic gotcha).

## Side finding (not actioned)

Repo's `data/traefik-logs/` is a stale orphan (0-byte log, rotated `.gz` frozen at 2026-01-16); live logs are on the BTRFS pool (`quadlets/traefik.container:29`). Candidate for separate cleanup.

Journal: `docs/98-journals/2026-06-28-ha-4xx-499-false-positive.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)