### PR TITLE
chore(egress): allow-list Deezer Akamai edge for navidrome (23.0.161.0/24)

### DIFF
--- a/config/supply-chain/egress-baseline.yaml
+++ b/config/supply-chain/egress-baseline.yaml
@@ -165,6 +165,16 @@ services:
     - owner: AKAMAI-PA
       cidrs: [2.22.225.0/24]
       note: last.fm scrobbling (observed 2.22.225.107, 2.22.225.83)
+    - owner: Akamai (Deezer edge)
+      cidrs: [23.0.161.0/24]
+      note: api.deezer.com / www.deezer.com via deezer.com.edgekey.net →
+        e221914.b.akamaiedge.net (Akamai Edge). Navidrome built-in Deezer agent
+        (artist images/bios, default-on, no API key). Observed 23.0.161.107, .120
+        on 2026-06-28 (10-min one-off during active playback; fired
+        EgressUnexpectedDestination, benign). NOTE — Akamai edge IPs rotate across a
+        large space, so a future fetch may land outside this /24 and re-alert once.
+        Kept tight (ADR-039 ethos); widen to a generated range only if it
+        re-baselines >=3 times.
     - owner: Cloudflare, Inc.
       cidrs: [104.16.0.0/12, 172.64.0.0/13]
       note: observed 104.21.43.229; 172.64.0.0/13 added 2026-06-12 evening —


### PR DESCRIPTION
## Summary

Re-baselines the Tier 4 egress observatory (ADR-030 P7) for **navidrome** after an `EgressUnexpectedDestination` warning fired (×2) on 2026-06-28.

**Investigated → benign.** The unexpected destination `23.0.161.107:443` is **Deezer's API behind Akamai**:
- PTR: `a23-0-161-107.deploy.static.akamaitechnologies.com`
- `api.deezer.com` / `www.deezer.com` → `deezer.com.edgekey.net` → `e221914.b.akamaiedge.net` → `23.0.161.107`, `.120`

Navidrome's **built-in Deezer agent** (artist images/bios, default-on, no API key) queried it during active playback. The journal at the exact `14:19–14:29 UTC` window shows `Artist not found in deezer` interleaved with `Streaming file` / `Scrobbled` lines.

## Why it's not a threat
- Transient one-off: 10-min span, 8 observations, never recurred.
- Did **not** trip the critical `EgressUnexpectedDestinationPersistent` (requires ≥1h sustained span).
- Already auto-resolved — live `egress_unexpected_destination_count{navidrome}` is back to `0`; the destination now sits as `🕒 retained` (forensic only).
- The two Discord messages were the **initial firing + the 24h `repeat_interval` re-notification** (warnings have `send_resolved: false`), both for the same single IP — not two distinct events.

## Change
Adds one tight allow-list entry under `navidrome:` in `config/supply-chain/egress-baseline.yaml`:

```yaml
- owner: Akamai (Deezer edge)
  cidrs: [23.0.161.0/24]
```

## Scope decision
Kept **tight (`/24`)** rather than widening to a large Akamai block, per the **ADR-039** ethos (CloudFront/Cloudflare stay tight static entries). Caveat documented inline: Akamai edge IPs rotate, so a future Deezer fetch may land outside this `/24` and produce one more benign one-off warning — escalate to a generated range only if it re-baselines **≥3 times** (same gate ADR-039 set for crowdsec's CAPI).

## Validation
- YAML parses; navidrome now has 6 owner entries; `23.0.161.0/24` contains the observed `.107`/`.120`.
- Pre-commit ADR-030 supply-chain invariants pass.
- Commit SSH-signed (owner key).

🤖 Generated with [Claude Code](https://claude.com/claude-code)