### PR TITLE
feat(qbittorrent): gluetun VPN egress sidecar + ADR-042 (Phase 1)

### DIFF
--- a/docs/00-foundation/decisions/2026-07-01-ADR-042-vpn-egress-sidecar-qbittorrent.md
+++ b/docs/00-foundation/decisions/2026-07-01-ADR-042-vpn-egress-sidecar-qbittorrent.md
@@ -1,0 +1,94 @@
+# ADR-042: VPN Egress Sidecar for qBittorrent (gluetun + ProtonVPN)
+
+**Date:** 2026-07-01
+**Status:** Accepted (Phase 1 — VPN + kill-switch; port forwarding deferred to Phase 2)
+
+---
+
+## Context
+
+qBittorrent runs on the `reverse_proxy` network in passive/outbound-only mode and
+egresses its BitTorrent swarm — ~360 concurrent connections to random peer IPs
+(observed via the Tier 4 egress observatory, ADR-030 P7) — **directly on the home
+WAN IP**. This is the "troublesome traffic" symptom: a residential IP originating
+hundreds of peer connections lands on scan/abuse lists and generates downstream
+noise. It is also the one service the egress observatory cannot classify — it is a
+`peer_swarm_services` member (count-only), a documented blind spot in
+`config/supply-chain/known-egress.md`.
+
+Prior art in this repo deliberately noted qBittorrent has **no VPN** (known-egress.md,
+"Adjacent finding") as a pending privacy/security decision. This ADR takes it.
+
+**Sovereignty tension.** The project minimizes external dependencies (digital
+sovereignty). A commercial VPN is an external trust dependency, which cuts against
+that grain. It is nonetheless the right call *for torrent egress specifically*: the
+goal is an exit IP that is **shared, no-logs, and legally buffered** — properties a
+self-hosted VPS exit cannot provide (a personal VPS just relocates an attributable
+IP and adds no anonymity set). The dependency is scoped to one service's egress and
+introduces no data-ownership loss.
+
+## Decision
+
+**Route qBittorrent's egress through a `gluetun` VPN sidecar via network-namespace
+sharing, with a kill-switch.**
+
+1. **Sidecar + netns sharing.** New `gluetun` container (digest-pinned, ADR-030) holds
+   the `reverse_proxy` slot `10.89.2.85`. qBittorrent joins its namespace
+   (`Network=container:gluetun`) and has **no other interface** — so a tunnel failure
+   cannot leak to the WAN (gluetun's firewall is a kill-switch by construction).
+2. **Provider: ProtonVPN over WireGuard.** Consolidates trust on Proton (already used
+   for `proton-bridge`) — one provider, one bill, WireGuard performance. The WireGuard
+   private key is a **secret sourced from OpenBao via htpc-mgmt `secretctl`**
+   (ADR-041); handle name `gluetun_wireguard_key`. Never `podman secret create` here.
+3. **Phase 1 = outbound-only (no port forwarding).** Matches qBittorrent's current
+   passive mode; the privacy/kill-switch goal is fully met without it. Port forwarding
+   (better ratios; ProtonVPN NAT-PMP via gluetun + a gluetun→qBittorrent port-sync
+   hook) is **Phase 2**, taken only if ratios warrant the added moving parts.
+4. **Routing unchanged in spirit.** Traefik's `qbittorrent` service re-points from
+   `http://qbittorrent:8085` to `http://gluetun:8085`; `torrent.patriark.org`,
+   Authelia, CrowdSec, rate-limit all stay. DNS moves into the tunnel (drop
+   qBittorrent's `DNS=192.168.1.69`) so lookups don't leak outside the VPN.
+5. **Observatory re-baseline (honest scope).** qBittorrent leaves the `reverse_proxy`
+   tier; **gluetun becomes the sampled egress-tier container and inherits
+   `peer_swarm_services` (count-only)** — because the shared-netns socket table still
+   shows the peer IPs (the observatory reads `/proc/<pid>/net/tcp`, which is
+   pre-tunnel at L3). The swarm noise is *not* eliminated from the observatory; what
+   changes is the **wire**: only an encrypted WireGuard flow to the ProtonVPN endpoint
+   leaves the router. gluetun's real off-host destination (the VPN endpoint) is added
+   to the egress baseline as expected.
+
+## Consequences
+
+- **The WAN IP no longer originates torrent traffic** — the presenting problem is
+  fixed. Egress is a single encrypted tunnel to ProtonVPN.
+- **Airtight kill-switch.** qBittorrent cannot transmit if the tunnel is down (no
+  fallback interface exists). qBittorrent `BindsTo=gluetun.service` for clean lifecycle.
+- **New external dependency**, accepted and scoped (this ADR's Context). Availability:
+  if ProtonVPN/gluetun is down, qBittorrent has no network — acceptable for a
+  best-effort download service.
+- **Observatory:** honest — swarm visibility moves to gluetun (still count-only). A
+  kill-switch *leak* is prevented at the firewall layer, not detected at the socket
+  layer (both tunneled and untunneled peer sockets look identical in `/proc`).
+- **Rootless caveat:** gluetun needs `/dev/net/tun` + `NET_ADMIN`; on rootless it uses
+  userspace WireGuard (wireguard-go). Kernel-WG sysctls (`src_valid_mark`) are not
+  required. Verify the tunnel establishes at deploy (leak-test gate below).
+- **Deploy gate (L-049):** not done until (a) `curl -I https://torrent.patriark.org`
+  works through gluetun, (b) qBittorrent's public IP (via its own tracker announce /
+  a checkip through the tunnel) is the **ProtonVPN** IP, not the WAN IP, and (c) a
+  **leak test**: stop gluetun → qBittorrent has zero connectivity (no WAN fallback).
+
+## Alternatives considered
+
+- **Self-hosted VPS WireGuard exit** — rejected: relocates an attributable IP, no
+  shared anonymity set, no legal buffer; more sovereign but worse for the actual goal.
+- **Mullvad / IVPN** — fine privacy, but both removed port forwarding, foreclosing
+  Phase 2; ProtonVPN keeps the option open and consolidates on Proton.
+- **`Internal=true` / do nothing** — N/A (qBittorrent needs internet) / rejected (the
+  presenting problem persists).
+
+## Related
+
+- ADR-030 P7 (Tier 4 egress observatory; `peer_swarm_services`), ADR-036 (bake policy).
+- ADR-041 (OpenBao secret handles; htpc-mgmt ADR-007 canonical for the mechanism).
+- ADR-018 (static-IP multi-network) — gluetun holds the static slot for a clean route.
+- `config/supply-chain/known-egress.md` "Adjacent finding" (the no-VPN note this closes).

--- a/docs/00-foundation/decisions/2026-07-01-ADR-042-vpn-egress-sidecar-qbittorrent.md
+++ b/docs/00-foundation/decisions/2026-07-01-ADR-042-vpn-egress-sidecar-qbittorrent.md
@@ -57,6 +57,18 @@ sharing, with a kill-switch.**
    leaves the router. gluetun's real off-host destination (the VPN endpoint) is added
    to the egress baseline as expected.
 
+**Exit selection (Phase 1 implementation, set 2026-07-01).** Exit country = **Estonia**
+(`SERVER_COUNTRIES=Estonia`), chosen for its strong digital-rights posture. **`PORT_FORWARD_ONLY=on`
+is mandatory, not cosmetic:** gluetun equates port-forward-capable with P2P-enabled, and Estonia's
+Proton footprint is only 5 logical servers — 2 standard P2P (**EE#13, EE#23**, Tallinn) and 3
+**Secure Core** (CH-EE, SE-EE) on which ProtonVPN **blocks P2P**. Without the filter gluetun could
+randomly land on a Secure Core node and torrents would fail "No P2P traffic permitted". This filter
+only *selects* the server; it does not enable port forwarding (Phase 2's `VPN_PORT_FORWARDING=on`).
+Trade-off: only 2 usable servers ⇒ **no in-country fallback** — with the kill-switch, both being down
+means qBittorrent is offline (accepted; monitor tunnel health post-cutover). Note the ProtonVPN
+WireGuard key is **account-wide**, so the country generated in the dashboard need not match
+`SERVER_COUNTRIES` — exit country is a gluetun-side, config-only change (no key regen).
+
 ## Consequences
 
 - **The WAN IP no longer originates torrent traffic** — the presenting problem is

--- a/docs/98-journals/2026-07-01-qbittorrent-vpn-sidecar-handoff.md
+++ b/docs/98-journals/2026-07-01-qbittorrent-vpn-sidecar-handoff.md
@@ -22,7 +22,10 @@ Choices already made: **ProtonVPN** (consolidates on Proton; keeps port-forwardi
 - `quadlets/gluetun.container` — the sidecar. Digest-pinned `qmcgaw/gluetun@sha256:b0ee2135…`
   (ADR-030), `NET_ADMIN` + `/dev/net/tun`, kill-switch firewall, ProtonVPN/WireGuard env,
   `Secret=gluetun_wireguard_key`, holds static IP **`10.89.2.85`** (the slot qBittorrent uses today).
-  Default exit country = **Netherlands** (`SERVER_COUNTRIES=Netherlands` — editable before cutover).
+  Exit country = **Estonia** (`SERVER_COUNTRIES=Estonia`, digital-rights posture) **+
+  `PORT_FORWARD_ONLY=on`** — MANDATORY: Estonia's 5 Proton servers include 3 Secure Core (CH-EE/SE-EE)
+  that BLOCK P2P; the filter pins to the 2 standard P2P servers (EE#13/EE#23, Tallinn). Only 2 usable
+  ⇒ no in-country fallback (kill-switch = offline if both down). Editable before cutover.
 - `docs/00-foundation/decisions/2026-07-01-ADR-042-…md` — the decision + trade-offs + deploy gate.
 - `config/gluetun/.gitkeep` — runtime-state dir for the mount.
 
@@ -38,7 +41,8 @@ next daemon-reload / Traefik auto-reload and could break the running service bef
 **1. Get a ProtonVPN WireGuard key.** `account.protonvpn.com` → **Downloads → WireGuard configuration**:
 - Name it e.g. `gluetun-htpc`; platform **GNU/Linux (Router)**.
 - **NAT-PMP / Port Forwarding OFF** (Phase 2 only).
-- Pick a server/country (matches `SERVER_COUNTRIES` in the quadlet; default Netherlands).
+- Server/country choice here is irrelevant: ProtonVPN WG keys are **account-wide**, so gluetun's
+  `SERVER_COUNTRIES=Estonia` selection works with a key generated for any country (no need to match).
 - Create → copy the **`PrivateKey`** line from the generated config. (gluetun needs only the private key.)
 
 **2. Create the podman secret on the host** (run it yourself; the assistant never sees the key). This

--- a/docs/98-journals/2026-07-01-qbittorrent-vpn-sidecar-handoff.md
+++ b/docs/98-journals/2026-07-01-qbittorrent-vpn-sidecar-handoff.md
@@ -1,0 +1,141 @@
+# Handoff — qBittorrent VPN Egress Sidecar (gluetun + ProtonVPN)
+
+**Date:** 2026-07-01
+**Status:** Phase 1 half-built. Inert artifacts committed; live cutover pending, **blocked on one owner action** (create the VPN secret).
+**Branch:** `feat/qbittorrent-vpn-sidecar` (commit `1f6df39`, signed). Not pushed, no PR yet.
+**Decision record:** `docs/00-foundation/decisions/2026-07-01-ADR-042-vpn-egress-sidecar-qbittorrent.md`
+
+---
+
+## Why
+
+qBittorrent egresses its BitTorrent swarm (~360 concurrent peer connections) **directly on the
+home WAN IP** — the "troublesome traffic". Fix: route qBittorrent through a `gluetun` VPN sidecar
+(ProtonVPN/WireGuard) with a kill-switch, so only an encrypted tunnel leaves the router and a
+tunnel drop leaks nothing. Closes the "no VPN" adjacent finding in `config/supply-chain/known-egress.md`.
+
+Choices already made: **ProtonVPN** (consolidates on Proton; keeps port-forwarding option open),
+**WireGuard**, **Phase 1 = outbound-only (NO port forwarding; that's Phase 2)**.
+
+## What is already done (committed on the branch, all inert — nothing enabled)
+
+- `quadlets/gluetun.container` — the sidecar. Digest-pinned `qmcgaw/gluetun@sha256:b0ee2135…`
+  (ADR-030), `NET_ADMIN` + `/dev/net/tun`, kill-switch firewall, ProtonVPN/WireGuard env,
+  `Secret=gluetun_wireguard_key`, holds static IP **`10.89.2.85`** (the slot qBittorrent uses today).
+  Default exit country = **Netherlands** (`SERVER_COUNTRIES=Netherlands` — editable before cutover).
+- `docs/00-foundation/decisions/2026-07-01-ADR-042-…md` — the decision + trade-offs + deploy gate.
+- `config/gluetun/.gitkeep` — runtime-state dir for the mount.
+
+**Live services are untouched.** qBittorrent, Traefik, and the egress baseline are all still their
+original versions. The hazardous edits were deliberately deferred to the cutover (this worktree IS
+the running config — editing `qbittorrent.container` or `routers.yml` now would take effect on the
+next daemon-reload / Traefik auto-reload and could break the running service before gluetun exists).
+
+---
+
+## ⬜ OWNER ACTION — do this first (unblocks everything)
+
+**1. Get a ProtonVPN WireGuard key.** `account.protonvpn.com` → **Downloads → WireGuard configuration**:
+- Name it e.g. `gluetun-htpc`; platform **GNU/Linux (Router)**.
+- **NAT-PMP / Port Forwarding OFF** (Phase 2 only).
+- Pick a server/country (matches `SERVER_COUNTRIES` in the quadlet; default Netherlands).
+- Create → copy the **`PrivateKey`** line from the generated config. (gluetun needs only the private key.)
+
+**2. Create the podman secret on the host** (run it yourself; the assistant never sees the key). This
+form avoids shell-history leakage and the trailing newline that breaks WireGuard keys:
+```bash
+read -rs WGKEY            # paste the PrivateKey, press Enter (not echoed, not logged)
+printf '%s' "$WGKEY" | podman secret create gluetun_wireguard_key -
+unset WGKEY
+```
+Verify it exists: `podman secret ls | grep gluetun_wireguard_key`
+
+> **Why `podman secret create` and not `secretctl`:** ADR-041/CLAUDE.md describe an OpenBao substrate,
+> but as of 2026-07-01 **OpenBao is not live and `secretctl` does not exist** (verified: no `:8200`,
+> no service; all 30 fleet secrets are still `podman secret` file-driver). This secret follows the
+> current mechanism and migrates into OpenBao with the rest when that goes live (same name).
+
+Then start a session and say: *"the gluetun_wireguard_key secret is created, run the cutover."*
+
+---
+
+## Cutover — assistant runs this once the secret exists (atomic, ~2 min)
+
+**Edit 1 — `quadlets/qbittorrent.container`:**
+```
+# [Unit]: was
+After=network-online.target reverse_proxy-network.service
+Wants=network-online.target reverse_proxy-network.service
+# → becomes
+After=network-online.target gluetun.service
+Wants=network-online.target
+BindsTo=gluetun.service                       # kill-switch lifecycle: qBt stops if gluetun stops
+
+# [Container]: was
+Network=systemd-reverse_proxy:ip=10.89.2.85
+DNS=192.168.1.69
+# → becomes (qBt joins gluetun's netns; DNS now resolves through the tunnel)
+Network=container:gluetun
+# (DNS line removed)
+```
+
+**Edit 2 — `config/traefik/dynamic/routers.yml`:** the `qbittorrent` service loadBalancer url
+`http://qbittorrent:8085` → `http://gluetun:8085`. (Router/middlewares/`torrent.patriark.org` unchanged.)
+
+**Edit 3 — `config/supply-chain/egress-baseline.yaml`:** add `- gluetun` to `peer_swarm_services`
+(gluetun becomes the sampled egress-tier container; its shared-netns socket table shows the swarm,
+so it inherits count-only). Note qBittorrent is now behind it.
+
+**Apply (order matters — frees the 10.89.2.85 IP before gluetun claims it):**
+```bash
+systemctl --user daemon-reload
+systemctl --user stop qbittorrent.service           # releases 10.89.2.85
+systemctl --user start gluetun.service
+# wait for tunnel: watch until healthy
+podman ps --filter name=gluetun --format '{{.Status}}'
+# confirm exit IP is ProtonVPN (gluetun control API):
+podman exec gluetun wget -qO- http://localhost:8000/v1/publicip/ip; echo
+systemctl --user start qbittorrent.service
+```
+
+## Deploy gate — NOT done until all three pass (L-049)
+
+```bash
+# 1. WebUI reachable through gluetun
+curl -I https://torrent.patriark.org                       # expect 200 / auth redirect
+
+# 2. qBittorrent's public IP == ProtonVPN (it shares gluetun's netns)
+podman exec qbittorrent curl -s https://api.ipify.org; echo # expect the ProtonVPN IP, NOT the WAN IP
+
+# 3. LEAK TEST — stop the tunnel, qBittorrent must have ZERO connectivity (no WAN fallback)
+systemctl --user stop gluetun.service
+podman exec qbittorrent curl -s --max-time 5 https://api.ipify.org; echo "rc=$?"   # MUST fail/timeout
+systemctl --user start gluetun.service && systemctl --user start qbittorrent.service
+```
+Then: one real torrent confirmed downloading through the tunnel, `service-validator` /
+`verify-deployment.sh qbittorrent` clean.
+
+## Finish
+
+- Commit the cutover edits on the same branch (signed), then **open the PR** (full verified change =
+  gluetun quadlet + ADR + qBt netns switch + Traefik reroute + baseline). Merge-commit only (ADR-038).
+- Update `config/supply-chain/known-egress.md` "Adjacent finding" (the no-VPN note) to "resolved, ADR-042".
+
+## Gotchas / context for a fresh session
+
+- **Live-config rule:** this worktree is the running config. Don't edit `qbittorrent.container` /
+  `routers.yml` until the cutover, and don't return the worktree to `main` across the applied-but-unmerged
+  branch.
+- **Rootless WireGuard:** gluetun uses userspace wireguard-go (rootless) — `NET_ADMIN` + `/dev/net/tun`
+  are enough; no kernel-WG sysctls. If the tunnel won't establish, that's the first thing to check.
+- **Observatory honesty:** the swarm noise does NOT disappear from the observatory — it moves to gluetun
+  (still count-only). The real win is at the wire (single encrypted tunnel) + the airtight kill-switch.
+- **SSH signing:** `export SSH_AUTH_SOCK=/run/user/1000/gcr/ssh` before `git commit` in a plain SSH session.
+- **Phase 2 (later):** ProtonVPN NAT-PMP port forwarding via gluetun + a gluetun→qBittorrent port-sync
+  hook, for better ratios. Regenerate the WG key with port forwarding enabled.
+
+## References
+
+- ADR-042 (this work) · ADR-030 P7 (egress observatory, `peer_swarm_services`) · ADR-041 (secret handles,
+  target state) · ADR-018 (static-IP) · ADR-038 (merge-commit only).
+- Memory: `project_qbittorrent` (in-progress state), `project_secrets_architecture` (OpenBao not-live note).

--- a/docs/AUTO-DEPENDENCY-GRAPH.md
+++ b/docs/AUTO-DEPENDENCY-GRAPH.md
@@ -1,6 +1,6 @@
 # Service Dependency Graph (Auto-Generated)
 
-**Generated:** 2026-06-23 16:49:16 UTC
+**Generated:** 2026-07-01 22:04:54 UTC
 **System:** fedora-htpc
 
 ---

--- a/docs/AUTO-DOCUMENTATION-INDEX.md
+++ b/docs/AUTO-DOCUMENTATION-INDEX.md
@@ -1,7 +1,7 @@
 # Documentation Index (Auto-Generated)
 
-**Generated:** 2026-06-23 16:49:17 UTC
-**Total Documents:** 460
+**Generated:** 2026-07-01 22:04:55 UTC
+**Total Documents:** 469
 
 ---
 
@@ -22,7 +22,7 @@
 
 ## Documentation by Category
 
-### 00-foundation/ (33 documents)
+### 00-foundation/ (34 documents)
 
 **Fundamentals and core concepts**
 
@@ -60,6 +60,7 @@
 - ADR-038: [2026-06-12-ADR-038-merge-commit-only-strategy](00-foundation/decisions/2026-06-12-ADR-038-merge-commit-only-strategy.md)
 - ADR-037: [2026-06-13-ADR-037-forge-center-of-gravity-per-repo](00-foundation/decisions/2026-06-13-ADR-037-forge-center-of-gravity-per-repo.md)
 - ADR-039: [2026-06-14-ADR-039-crowdsec-cloud-api-egress-scoping](00-foundation/decisions/2026-06-14-ADR-039-crowdsec-cloud-api-egress-scoping.md)
+- ADR-042: [2026-07-01-ADR-042-vpn-egress-sidecar-qbittorrent](00-foundation/decisions/2026-07-01-ADR-042-vpn-egress-sidecar-qbittorrent.md)
 - : [README](00-foundation/decisions/fixtures/README.md)
 - ADR-023: [2026-04-18-ADR-023-btrfs-storage-architecture-databases](00-foundation/decisions/withdrawn/2026-04-18-ADR-023-btrfs-storage-architecture-databases.md)
 
@@ -236,7 +237,7 @@
 
 ---
 
-### 98-journals/ (223 documents)
+### 98-journals/ (228 documents)
 
 **Chronological project history (append-only log)**
 
@@ -244,7 +245,7 @@ Complete dated entries documenting the homelab journey. See directory for full c
 
 ---
 
-### 99-reports/ (59 documents)
+### 99-reports/ (62 documents)
 
 **Automated system reports and point-in-time snapshots**
 
@@ -254,17 +255,19 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 
 ## Recently Updated (Last 7 Days)
 
-- 2026-06-22: [HOMELAB-FIELD-GUIDE.md](00-foundation/guides/HOMELAB-FIELD-GUIDE.md)
-- 2026-06-22: [automation-reference.md](20-operations/guides/automation-reference.md)
-- 2026-06-22: [homelab-architecture.md](20-operations/guides/homelab-architecture.md)
-- 2026-06-22: [2026-06-22-retarget-reboot-prep-verify-before-retire.md](98-journals/2026-06-22-retarget-reboot-prep-verify-before-retire.md)
-- 2026-06-23: [remediation-monthly-202605.md](99-reports/remediation-monthly-202605.md)
-- 2026-06-23: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
-- 2026-06-23: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
-- 2026-06-23: [AUTO-EGRESS-BASELINE-INDEX.md](AUTO-EGRESS-BASELINE-INDEX.md)
-- 2026-06-23: [AUTO-IMAGE-PIN-INDEX.md](AUTO-IMAGE-PIN-INDEX.md)
-- 2026-06-23: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
-- 2026-06-23: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
+- 2026-07-01: [2026-07-01-ADR-042-vpn-egress-sidecar-qbittorrent.md](00-foundation/decisions/2026-07-01-ADR-042-vpn-egress-sidecar-qbittorrent.md)
+- 2026-06-27: [2026-06-26-nextcloud-music-external-storage-writable.md](98-journals/2026-06-26-nextcloud-music-external-storage-writable.md)
+- 2026-06-28: [2026-06-28-ha-4xx-499-false-positive.md](98-journals/2026-06-28-ha-4xx-499-false-positive.md)
+- 2026-07-01: [2026-07-01-qbittorrent-vpn-sidecar-handoff.md](98-journals/2026-07-01-qbittorrent-vpn-sidecar-handoff.md)
+- 2026-07-01: [2026-07-01-skill-usage-report.md](99-reports/2026-07-01-skill-usage-report.md)
+- 2026-07-01: [remediation-monthly-202606.md](99-reports/remediation-monthly-202606.md)
+- 2026-07-01: [security-audit-2026-07-01.md](99-reports/security-audit-2026-07-01.md)
+- 2026-07-02: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
+- 2026-07-02: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
+- 2026-07-01: [AUTO-EGRESS-BASELINE-INDEX.md](AUTO-EGRESS-BASELINE-INDEX.md)
+- 2026-07-01: [AUTO-IMAGE-PIN-INDEX.md](AUTO-IMAGE-PIN-INDEX.md)
+- 2026-07-02: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
+- 2026-07-02: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
 
 ---
 

--- a/docs/AUTO-EGRESS-BASELINE-INDEX.md
+++ b/docs/AUTO-EGRESS-BASELINE-INDEX.md
@@ -1,6 +1,6 @@
 # Egress Observatory — Baseline Index (Auto-Generated)
 
-**Generated:** 2026-06-24 16:45:21 UTC
+**Generated:** 2026-07-01 22:04:56 UTC
 **Implements:** ADR-030 P7 (Tier 4) — egress detection. **Mode:** live (alerting)
 
 Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers (attributable, rootless, scratch-safe, DNS-method-agnostic). Detection, not prevention. See `config/supply-chain/known-egress.md` for method and residual/evasion scope.
@@ -9,8 +9,8 @@ Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers
 
 | Component | Last run | Detail |
 |---|---|---|
-| Collector (`egress-collector.service`) | 12s ago | 22 services sampled |
-| Classifier (`egress-detect.timer`) | 2s ago | mode=live (alerting); last window 1 dest(s) |
+| Collector (`egress-collector.service`) | 3s ago | 22 services sampled |
+| Classifier (`egress-detect.timer`) | 2m ago | mode=live (alerting); last window 7 dest(s) |
 
 ## Per-service egress
 
@@ -21,9 +21,10 @@ Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers
 | audiobookshelf | classify | — | — | — |
 | authelia | classify | — | — | — |
 | blackbox-exporter | classify | — | — | — |
-| crowdsec | classify | 148 | ✅ 0 | — |
+| crowdsec | classify | 187 | ✅ 0 | — |
 | forgejo | classify | — | — | — |
 | gathio | classify | 5 | ✅ 0 | — |
+| gluetun | classify | — | — | — |
 | grafana | classify | 3 | ✅ 0 | — |
 | home-assistant | classify | 64 | ✅ 0 | — |
 | immich-server | classify | 3 | ✅ 0 | — |
@@ -34,8 +35,8 @@ Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers
 | pihole-exporter | classify | — | — | — |
 | prometheus | classify | — | — | — |
 | proton-bridge | classify | 2 | ✅ 0 | — |
-| qbittorrent | peer-swarm (count-only) | — | — | 127 |
-| traefik | classify | 7 | ✅ 0 | — |
+| qbittorrent | peer-swarm (count-only) | — | — | 176 |
+| traefik | classify | 6 | ✅ 0 | — |
 | unpoller | classify | — | — | — |
 | vaultwarden | peer-swarm (count-only) | — | — | — |
 
@@ -43,7 +44,7 @@ Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers
 
 Egress-tier services with **no observed public destination** over the window. Each is a candidate to move to an `Internal=true` network (shrinking the surface Tier 4 watches). **Not an automated change** — manual, per-service review (Feb-2026 21-container outage precedent). A short window will list services that simply hadn't egressed yet (e.g. proton-bridge in `TIME_WAIT`); confirm against a full ≥7-day baseline before acting.
 
-> alertmanager, audiobookshelf, authelia, blackbox-exporter, forgejo, pihole-exporter, prometheus, unpoller
+> alertmanager, audiobookshelf, authelia, blackbox-exporter, forgejo, gluetun, pihole-exporter, prometheus, unpoller
 
 ## Observed destinations (durable state)
 
@@ -53,328 +54,366 @@ Class legend: **✅ expected** (in allow-list) · **⚠️ active** (unexpected,
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `162.159.128.233` | 443 | ✅ expected | 28d ago | 2h ago | 120 |
-| `162.159.135.232` | 443 | ✅ expected | 31d ago | 85m ago | 122 |
-| `162.159.136.232` | 443 | ✅ expected | 23d ago | 4h ago | 103 |
-| `162.159.137.232` | 443 | ✅ expected | 19d ago | 6h ago | 103 |
-| `162.159.138.232` | 443 | ✅ expected | 30d ago | 14h ago | 123 |
+| `162.159.128.233` | 443 | ✅ expected | 35d ago | 3d ago | 126 |
+| `162.159.135.232` | 443 | ✅ expected | 38d ago | 7d ago | 122 |
+| `162.159.136.232` | 443 | ✅ expected | 30d ago | 2d ago | 109 |
+| `162.159.137.232` | 443 | ✅ expected | 26d ago | 4d ago | 105 |
+| `162.159.138.232` | 443 | ✅ expected | 37d ago | 9h ago | 127 |
 
 ### crowdsec
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.20.41.3` | 443 | ✅ expected | 11d ago | 11d ago | 2 |
-| `108.128.137.208` | 443 | ✅ expected | 26d ago | 18d ago | 486 |
-| `108.128.190.179` | 443 | ✅ expected | 27d ago | 18d ago | 515 |
-| `108.128.222.234` | 443 | ✅ expected | 30d ago | 23d ago | 472 |
-| `108.131.237.209` | 443 | ✅ expected | 10d ago | 7d ago | 45 |
-| `108.132.135.16` | 443 | ✅ expected | 16d ago | 15d ago | 68 |
-| `108.132.143.133` | 443 | ✅ expected | 10d ago | 5d ago | 29 |
-| `108.132.165.101` | 443 | ✅ expected | 9d ago | 9d ago | 10 |
-| `108.132.165.136` | 443 | ✅ expected | 22d ago | 17d ago | 237 |
-| `108.132.168.183` | 443 | ✅ expected | 5d ago | 2d ago | 20 |
-| `108.132.178.68` | 443 | ✅ expected | 10d ago | 10d ago | 5 |
-| `108.132.219.253` | 443 | ✅ expected | 7d ago | 5d ago | 20 |
-| `108.132.246.192` | 443 | ✅ expected | 10d ago | 3d ago | 362 |
-| `108.132.72.65` | 443 | ✅ expected | 11d ago | 9d ago | 10 |
-| `108.133.21.194` | 443 | ✅ expected | 11d ago | 8d ago | 35 |
-| `108.133.25.40` | 443 | ✅ expected | 11d ago | 5d ago | 39 |
-| `108.133.30.139` | 443 | ✅ expected | 5d ago | 4d ago | 74 |
-| `172.66.154.109` | 443 | ✅ expected | 11d ago | 11d ago | 2 |
-| `176.34.92.0` | 443 | ✅ expected | 12d ago | 12d ago | 43 |
-| `18.200.183.204` | 443 | ✅ expected | 31d ago | 24d ago | 362 |
-| `18.200.43.102` | 443 | ✅ expected | 11d ago | 11d ago | 5 |
-| `18.202.146.153` | 443 | ✅ expected | 11d ago | 6d ago | 30 |
-| `18.202.172.107` | 443 | ✅ expected | 3d ago | 3d ago | 25 |
-| `18.203.121.198` | 443 | ✅ expected | 11d ago | 7d ago | 40 |
-| `34.240.248.6` | 443 | ✅ expected | 2d ago | 5h ago | 138 |
-| `34.240.98.252` | 443 | ✅ expected | 20d ago | 16d ago | 252 |
-| `34.241.216.41` | 443 | ✅ expected | 11d ago | 6d ago | 39 |
-| `34.241.56.54` | 443 | ✅ expected | 6d ago | 4d ago | 30 |
-| `34.242.107.114` | 443 | ✅ expected | 11d ago | 10d ago | 8 |
-| `34.242.194.148` | 443 | ✅ expected | 24d ago | 18d ago | 406 |
-| `34.246.166.99` | 443 | ✅ expected | 11d ago | 8d ago | 30 |
-| `34.246.188.122` | 443 | ✅ expected | 5d ago | 5d ago | 10 |
-| `34.247.101.158` | 443 | ✅ expected | 7d ago | 24h ago | 59 |
-| `34.248.190.12` | 443 | ✅ expected | 12d ago | 11d ago | 71 |
-| `34.249.149.68` | 443 | ✅ expected | 21d ago | 16d ago | 277 |
-| `34.249.172.50` | 443 | ✅ expected | 11d ago | 10d ago | 20 |
-| `34.249.35.132` | 443 | ✅ expected | 7h ago | 11m ago | 25 |
-| `34.250.187.53` | 443 | ✅ expected | 11d ago | 8d ago | 15 |
-| `34.250.233.53` | 443 | ✅ expected | 9d ago | 9d ago | 5 |
-| `34.250.39.237` | 443 | ✅ expected | 18d ago | 12d ago | 255 |
-| `34.250.77.39` | 443 | ✅ expected | 31d ago | 20d ago | 582 |
-| `34.251.83.134` | 443 | ✅ expected | 13d ago | 13d ago | 42 |
-| `34.251.85.31` | 443 | ✅ expected | 23h ago | 8h ago | 45 |
-| `34.252.238.164` | 443 | ✅ expected | 7d ago | 43h ago | 80 |
-| `34.252.67.120` | 443 | ✅ expected | 6d ago | 38h ago | 59 |
-| `34.253.20.222` | 443 | ✅ expected | 8d ago | 8d ago | 15 |
-| `34.254.73.132` | 443 | ✅ expected | 18d ago | 12d ago | 421 |
-| `34.255.101.100` | 443 | ✅ expected | 11d ago | 10d ago | 20 |
-| `34.255.143.231` | 443 | ✅ expected | 15d ago | 14d ago | 73 |
-| `34.255.59.56` | 443 | ✅ expected | 30d ago | 21d ago | 512 |
-| `46.137.116.145` | 443 | ✅ expected | 7d ago | 4d ago | 15 |
-| `46.137.188.185` | 443 | ✅ expected | 9d ago | 8d ago | 10 |
-| `46.137.35.14` | 443 | ✅ expected | 8d ago | 6d ago | 20 |
-| `52.16.198.105` | 443 | ✅ expected | 4d ago | 3d ago | 12 |
-| `52.16.244.133` | 443 | ✅ expected | 10d ago | 8d ago | 35 |
-| `52.16.64.132` | 443 | ✅ expected | 11d ago | 9d ago | 15 |
-| `52.17.118.72` | 443 | ✅ expected | 5d ago | 3d ago | 15 |
-| `52.17.17.55` | 443 | ✅ expected | 13d ago | 13d ago | 20 |
-| `52.17.173.66` | 443 | ✅ expected | 7d ago | 5d ago | 20 |
-| `52.17.58.50` | 443 | ✅ expected | 30d ago | 28d ago | 181 |
-| `52.18.68.74` | 443 | ✅ expected | 28d ago | 21d ago | 458 |
-| `52.18.95.48` | 443 | ✅ expected | 5h ago | 42m ago | 25 |
-| `52.19.134.40` | 443 | ✅ expected | 10d ago | 4h ago | 610 |
-| `52.19.31.182` | 443 | ✅ expected | 8d ago | 5d ago | 159 |
-| `52.19.64.236` | 443 | ✅ expected | 17d ago | 12d ago | 191 |
-| `52.19.72.100` | 443 | ✅ expected | 10d ago | 10d ago | 5 |
-| `52.209.0.64` | 443 | ✅ expected | 7d ago | 24h ago | 97 |
-| `52.209.173.58` | 443 | ✅ expected | 4d ago | 2d ago | 139 |
-| `52.210.122.225` | 443 | ✅ expected | 7d ago | 5d ago | 44 |
-| `52.210.147.72` | 443 | ✅ expected | 11d ago | 9d ago | 10 |
-| `52.210.229.63` | 443 | ✅ expected | 22d ago | 16d ago | 370 |
-| `52.211.111.6` | 443 | ✅ expected | 23h ago | 14h ago | 45 |
-| `52.211.152.103` | 443 | ✅ expected | 11d ago | 9d ago | 20 |
-| `52.211.29.30` | 443 | ✅ expected | 2d ago | 74m ago | 129 |
-| `52.212.199.20` | 443 | ✅ expected | 10d ago | 10d ago | 5 |
-| `52.212.47.49` | 443 | ✅ expected | 9d ago | 5d ago | 49 |
-| `52.213.226.37` | 443 | ✅ expected | 6d ago | 3d ago | 25 |
-| `52.213.228.152` | 443 | ✅ expected | 16d ago | 9d ago | 408 |
-| `52.213.66.10` | 443 | ✅ expected | 13d ago | 11d ago | 154 |
-| `52.214.21.105` | 443 | ✅ expected | 3d ago | 3d ago | 5 |
-| `52.214.54.249` | 443 | ✅ expected | 7d ago | 5d ago | 15 |
-| `52.215.173.209` | 443 | ✅ expected | 3d ago | 2h ago | 153 |
-| `52.30.165.11` | 443 | ✅ expected | 7d ago | 2d ago | 25 |
-| `52.30.231.178` | 443 | ✅ expected | 7d ago | 44h ago | 63 |
-| `52.30.5.78` | 443 | ✅ expected | 30d ago | 27d ago | 157 |
-| `52.30.63.171` | 443 | ✅ expected | 11d ago | 8d ago | 20 |
-| `52.31.252.131` | 443 | ✅ expected | 6d ago | 3d ago | 64 |
-| `52.31.58.24` | 443 | ✅ expected | 5d ago | 4d ago | 74 |
-| `52.48.23.149` | 443 | ✅ expected | 18d ago | 15d ago | 232 |
-| `52.48.238.219` | 443 | ✅ expected | 15d ago | 10d ago | 349 |
-| `52.48.65.76` | 443 | ✅ expected | 12d ago | 3d ago | 598 |
-| `52.48.90.106` | 443 | ✅ expected | 7d ago | 6d ago | 15 |
-| `52.48.93.17` | 443 | ✅ expected | 12d ago | 12d ago | 35 |
-| `52.49.140.16` | 443 | ✅ expected | 9d ago | 5d ago | 30 |
-| `52.49.212.201` | 443 | ✅ expected | 11d ago | 9d ago | 24 |
-| `52.49.3.35` | 443 | ✅ expected | 10d ago | 10d ago | 10 |
-| `52.49.4.206` | 443 | ✅ expected | 11d ago | 10d ago | 10 |
-| `52.50.224.74` | 443 | ✅ expected | 13d ago | 13d ago | 29 |
-| `52.51.148.109` | 443 | ✅ expected | 3d ago | 2d ago | 81 |
-| `52.84.50.42` | 443 | ✅ expected | 11d ago | 11d ago | 2 |
-| `54.154.135.155` | 443 | ✅ expected | 10d ago | 10d ago | 5 |
-| `54.170.104.57` | 443 | ✅ expected | 13d ago | 13d ago | 15 |
-| `54.170.163.78` | 443 | ✅ expected | 9d ago | 8d ago | 115 |
-| `54.171.78.236` | 443 | ✅ expected | 7d ago | 2d ago | 40 |
-| `54.194.218.193` | 443 | ✅ expected | 5d ago | 5d ago | 5 |
-| `54.194.222.175` | 443 | ✅ expected | 6d ago | 6d ago | 5 |
-| `54.194.85.107` | 443 | ✅ expected | 5d ago | 26h ago | 94 |
-| `54.195.147.237` | 443 | ✅ expected | 7d ago | 2d ago | 60 |
-| `54.195.186.68` | 443 | ✅ expected | 19d ago | 16d ago | 249 |
-| `54.228.169.234` | 443 | ✅ expected | 21h ago | 9h ago | 30 |
-| `54.228.220.78` | 443 | ✅ expected | 13d ago | 12d ago | 30 |
-| `54.228.49.194` | 443 | ✅ expected | 11d ago | 11d ago | 5 |
-| `54.229.184.213` | 443 | ✅ expected | 11d ago | 8d ago | 20 |
-| `54.229.234.23` | 443 | ✅ expected | 7d ago | 4d ago | 30 |
-| `54.246.207.199` | 443 | ✅ expected | 21d ago | 20d ago | 113 |
-| `54.247.128.112` | 443 | ✅ expected | 3d ago | 32s ago | 225 |
-| `54.72.135.60` | 443 | ✅ expected | 11d ago | 8d ago | 23 |
-| `54.72.222.86` | 443 | ✅ expected | 10d ago | 9d ago | 9 |
-| `54.72.42.56` | 443 | ✅ expected | 8h ago | 3h ago | 24 |
-| `54.72.47.167` | 443 | ✅ expected | 10d ago | 9d ago | 15 |
-| `54.73.67.52` | 443 | ✅ expected | 11d ago | 8d ago | 30 |
-| `54.74.43.116` | 443 | ✅ expected | 7d ago | 4d ago | 30 |
-| `54.75.182.87` | 443 | ✅ expected | 5d ago | 3d ago | 25 |
-| `54.75.245.133` | 443 | ✅ expected | 12d ago | 10d ago | 140 |
-| `54.76.118.150` | 443 | ✅ expected | 4d ago | 4d ago | 5 |
-| `54.76.169.38` | 443 | ✅ expected | 15d ago | 14d ago | 64 |
-| `54.76.192.134` | 443 | ✅ expected | 23d ago | 18d ago | 337 |
-| `54.76.217.37` | 443 | ✅ expected | 7d ago | 5d ago | 19 |
-| `54.76.82.20` | 443 | ✅ expected | 11d ago | 10d ago | 54 |
-| `54.77.106.61` | 443 | ✅ expected | 9d ago | 5d ago | 20 |
-| `54.77.130.113` | 443 | ✅ expected | 10d ago | 10d ago | 5 |
-| `54.77.221.81` | 443 | ✅ expected | 7d ago | 4d ago | 30 |
-| `54.77.24.165` | 443 | ✅ expected | 14d ago | 13d ago | 23 |
-| `54.77.8.107` | 443 | ✅ expected | 30d ago | 22d ago | 533 |
-| `54.78.193.70` | 443 | ✅ expected | 6d ago | 2d ago | 49 |
-| `63.32.217.27` | 443 | ✅ expected | 7d ago | 4d ago | 19 |
-| `63.33.5.76` | 443 | ✅ expected | 11d ago | 7d ago | 232 |
-| `63.34.141.128` | 443 | ✅ expected | 30d ago | 26d ago | 196 |
-| `63.34.177.147` | 443 | ✅ expected | 9d ago | 2h ago | 551 |
-| `63.35.170.229` | 443 | ✅ expected | 18d ago | 14d ago | 228 |
-| `63.35.34.90` | 443 | ✅ expected | 6d ago | 2d ago | 44 |
-| `79.125.15.38` | 443 | ✅ expected | 31d ago | 26d ago | 232 |
-| `79.125.93.93` | 443 | ✅ expected | 11d ago | 8d ago | 30 |
-| `99.80.124.24` | 443 | ✅ expected | 12d ago | 12d ago | 49 |
-| `99.80.129.27` | 443 | ✅ expected | 26d ago | 22d ago | 263 |
-| `99.80.232.1` | 443 | ✅ expected | 11d ago | 8d ago | 19 |
-| `99.80.39.243` | 443 | ✅ expected | 7d ago | 4d ago | 40 |
-| `99.81.12.92` | 443 | ✅ expected | 15d ago | 14d ago | 67 |
+| `104.20.41.3` | 443 | ✅ expected | 19d ago | 19d ago | 2 |
+| `108.128.137.208` | 443 | ✅ expected | 33d ago | 25d ago | 486 |
+| `108.128.190.179` | 443 | ✅ expected | 35d ago | 26d ago | 515 |
+| `108.129.14.254` | 443 | ✅ expected | 5d ago | 24h ago | 185 |
+| `108.131.237.209` | 443 | ✅ expected | 18d ago | 15d ago | 45 |
+| `108.132.135.16` | 443 | ✅ expected | 23d ago | 22d ago | 68 |
+| `108.132.143.133` | 443 | ✅ expected | 18d ago | 12d ago | 29 |
+| `108.132.165.101` | 443 | ✅ expected | 16d ago | 16d ago | 10 |
+| `108.132.165.136` | 443 | ✅ expected | 29d ago | 24d ago | 237 |
+| `108.132.168.183` | 443 | ✅ expected | 12d ago | 9d ago | 20 |
+| `108.132.178.68` | 443 | ✅ expected | 18d ago | 18d ago | 5 |
+| `108.132.189.51` | 443 | ✅ expected | 6d ago | 3d ago | 59 |
+| `108.132.219.253` | 443 | ✅ expected | 14d ago | 13d ago | 20 |
+| `108.132.234.82` | 443 | ✅ expected | 6d ago | 5d ago | 15 |
+| `108.132.246.192` | 443 | ✅ expected | 17d ago | 11d ago | 362 |
+| `108.132.37.191` | 443 | ✅ expected | 5h ago | 5h ago | 4 |
+| `108.132.53.78` | 443 | ✅ expected | 6d ago | 3d ago | 74 |
+| `108.132.71.88` | 443 | ✅ expected | 7h ago | 7h ago | 5 |
+| `108.132.72.65` | 443 | ✅ expected | 18d ago | 16d ago | 10 |
+| `108.133.21.194` | 443 | ✅ expected | 18d ago | 16d ago | 35 |
+| `108.133.25.161` | 443 | ✅ expected | 22h ago | 22h ago | 5 |
+| `108.133.25.40` | 443 | ✅ expected | 18d ago | 13d ago | 39 |
+| `108.133.30.139` | 443 | ✅ expected | 12d ago | 11d ago | 74 |
+| `108.133.51.235` | 443 | ✅ expected | 3h ago | 3h ago | 5 |
+| `172.66.154.109` | 443 | ✅ expected | 19d ago | 19d ago | 2 |
+| `176.34.92.0` | 443 | ✅ expected | 20d ago | 19d ago | 43 |
+| `18.200.43.102` | 443 | ✅ expected | 18d ago | 18d ago | 5 |
+| `18.202.146.153` | 443 | ✅ expected | 18d ago | 13d ago | 30 |
+| `18.202.172.107` | 443 | ✅ expected | 10d ago | 10d ago | 25 |
+| `18.203.121.198` | 443 | ✅ expected | 18d ago | 14d ago | 40 |
+| `3.248.169.249` | 443 | ✅ expected | 6d ago | 4d ago | 25 |
+| `3.250.250.65` | 443 | ✅ expected | 6d ago | 4d ago | 20 |
+| `3.253.202.159` | 443 | ✅ expected | 11h ago | 11h ago | 5 |
+| `34.240.248.6` | 443 | ✅ expected | 9d ago | 66m ago | 537 |
+| `34.240.98.252` | 443 | ✅ expected | 27d ago | 23d ago | 252 |
+| `34.241.216.41` | 443 | ✅ expected | 18d ago | 13d ago | 39 |
+| `34.241.56.54` | 443 | ✅ expected | 13d ago | 11d ago | 30 |
+| `34.242.107.114` | 443 | ✅ expected | 18d ago | 17d ago | 8 |
+| `34.242.194.148` | 443 | ✅ expected | 31d ago | 25d ago | 406 |
+| `34.243.213.166` | 443 | ✅ expected | 6d ago | 27h ago | 175 |
+| `34.246.147.139` | 443 | ✅ expected | 3d ago | 66m ago | 209 |
+| `34.246.166.99` | 443 | ✅ expected | 18d ago | 15d ago | 30 |
+| `34.246.188.122` | 443 | ✅ expected | 12d ago | 12d ago | 10 |
+| `34.247.101.158` | 443 | ✅ expected | 14d ago | 8d ago | 59 |
+| `34.247.127.233` | 443 | ✅ expected | 3d ago | 98m ago | 242 |
+| `34.248.190.12` | 443 | ✅ expected | 19d ago | 18d ago | 71 |
+| `34.249.149.68` | 443 | ✅ expected | 28d ago | 23d ago | 277 |
+| `34.249.156.29` | 443 | ✅ expected | 6d ago | 4d ago | 39 |
+| `34.249.172.50` | 443 | ✅ expected | 19d ago | 18d ago | 20 |
+| `34.249.35.132` | 443 | ✅ expected | 7d ago | 7d ago | 30 |
+| `34.250.187.53` | 443 | ✅ expected | 18d ago | 16d ago | 15 |
+| `34.250.233.53` | 443 | ✅ expected | 17d ago | 17d ago | 5 |
+| `34.250.39.237` | 443 | ✅ expected | 25d ago | 20d ago | 255 |
+| `34.250.77.39` | 443 | ✅ expected | 38d ago | 28d ago | 582 |
+| `34.251.83.134` | 443 | ✅ expected | 21d ago | 20d ago | 42 |
+| `34.251.85.31` | 443 | ✅ expected | 8d ago | 7d ago | 45 |
+| `34.252.238.164` | 443 | ✅ expected | 14d ago | 9d ago | 80 |
+| `34.252.67.120` | 443 | ✅ expected | 14d ago | 8d ago | 59 |
+| `34.252.99.143` | 443 | ✅ expected | 9h ago | 9h ago | 5 |
+| `34.253.20.222` | 443 | ✅ expected | 16d ago | 15d ago | 15 |
+| `34.253.250.27` | 443 | ✅ expected | 14h ago | 14h ago | 5 |
+| `34.254.73.132` | 443 | ✅ expected | 25d ago | 19d ago | 421 |
+| `34.255.101.100` | 443 | ✅ expected | 19d ago | 17d ago | 20 |
+| `34.255.13.211` | 443 | ✅ expected | 7d ago | 4d ago | 25 |
+| `34.255.143.231` | 443 | ✅ expected | 22d ago | 21d ago | 73 |
+| `34.255.187.129` | 443 | ✅ expected | 13h ago | 6h ago | 10 |
+| `34.255.59.56` | 443 | ✅ expected | 38d ago | 28d ago | 512 |
+| `46.137.116.145` | 443 | ✅ expected | 14d ago | 11d ago | 15 |
+| `46.137.188.185` | 443 | ✅ expected | 16d ago | 15d ago | 10 |
+| `46.137.35.14` | 443 | ✅ expected | 16d ago | 13d ago | 20 |
+| `52.16.198.105` | 443 | ✅ expected | 11d ago | 10d ago | 12 |
+| `52.16.244.133` | 443 | ✅ expected | 17d ago | 15d ago | 35 |
+| `52.16.64.132` | 443 | ✅ expected | 19d ago | 16d ago | 15 |
+| `52.17.118.72` | 443 | ✅ expected | 12d ago | 11d ago | 15 |
+| `52.17.17.55` | 443 | ✅ expected | 20d ago | 20d ago | 20 |
+| `52.17.173.66` | 443 | ✅ expected | 14d ago | 12d ago | 20 |
+| `52.17.182.227` | 443 | ✅ expected | 21h ago | 21h ago | 5 |
+| `52.17.27.193` | 443 | ✅ expected | 7h ago | 7h ago | 5 |
+| `52.17.91.120` | 443 | ✅ expected | 7d ago | 5d ago | 30 |
+| `52.18.68.74` | 443 | ✅ expected | 35d ago | 28d ago | 458 |
+| `52.18.95.48` | 443 | ✅ expected | 7d ago | 7d ago | 25 |
+| `52.19.134.40` | 443 | ✅ expected | 17d ago | 3d ago | 794 |
+| `52.19.255.174` | 443 | ✅ expected | 6d ago | 6d ago | 40 |
+| `52.19.31.182` | 443 | ✅ expected | 15d ago | 12d ago | 159 |
+| `52.19.64.236` | 443 | ✅ expected | 24d ago | 20d ago | 191 |
+| `52.19.72.100` | 443 | ✅ expected | 17d ago | 17d ago | 5 |
+| `52.19.97.17` | 443 | ✅ expected | 13h ago | 13h ago | 5 |
+| `52.208.44.16` | 443 | ✅ expected | 17h ago | 17h ago | 5 |
+| `52.209.0.64` | 443 | ✅ expected | 15d ago | 8d ago | 97 |
+| `52.209.173.58` | 443 | ✅ expected | 11d ago | 9d ago | 139 |
+| `52.210.122.225` | 443 | ✅ expected | 14d ago | 12d ago | 44 |
+| `52.210.147.72` | 443 | ✅ expected | 18d ago | 17d ago | 10 |
+| `52.210.229.63` | 443 | ✅ expected | 29d ago | 23d ago | 370 |
+| `52.211.111.6` | 443 | ✅ expected | 8d ago | 7d ago | 45 |
+| `52.211.152.103` | 443 | ✅ expected | 18d ago | 16d ago | 20 |
+| `52.211.29.30` | 443 | ✅ expected | 9d ago | 4d ago | 305 |
+| `52.211.56.189` | 443 | ✅ expected | 24h ago | 24h ago | 5 |
+| `52.212.199.20` | 443 | ✅ expected | 18d ago | 18d ago | 5 |
+| `52.212.47.49` | 443 | ✅ expected | 16d ago | 12d ago | 49 |
+| `52.213.226.37` | 443 | ✅ expected | 13d ago | 11d ago | 25 |
+| `52.213.228.152` | 443 | ✅ expected | 23d ago | 16d ago | 408 |
+| `52.213.66.10` | 443 | ✅ expected | 21d ago | 18d ago | 154 |
+| `52.214.21.105` | 443 | ✅ expected | 11d ago | 11d ago | 5 |
+| `52.214.54.249` | 443 | ✅ expected | 14d ago | 12d ago | 15 |
+| `52.215.173.209` | 443 | ✅ expected | 10d ago | 2m ago | 600 |
+| `52.30.165.11` | 443 | ✅ expected | 14d ago | 9d ago | 25 |
+| `52.30.212.227` | 443 | ✅ expected | 20h ago | 17h ago | 10 |
+| `52.30.231.178` | 443 | ✅ expected | 14d ago | 9d ago | 63 |
+| `52.30.63.171` | 443 | ✅ expected | 18d ago | 16d ago | 20 |
+| `52.31.252.131` | 443 | ✅ expected | 13d ago | 10d ago | 64 |
+| `52.31.58.24` | 443 | ✅ expected | 12d ago | 11d ago | 74 |
+| `52.48.142.125` | 443 | ✅ expected | 6d ago | 3d ago | 89 |
+| `52.48.23.149` | 443 | ✅ expected | 26d ago | 23d ago | 232 |
+| `52.48.238.219` | 443 | ✅ expected | 23d ago | 17d ago | 349 |
+| `52.48.65.76` | 443 | ✅ expected | 19d ago | 10d ago | 598 |
+| `52.48.90.106` | 443 | ✅ expected | 14d ago | 13d ago | 15 |
+| `52.48.93.17` | 443 | ✅ expected | 20d ago | 19d ago | 35 |
+| `52.49.140.16` | 443 | ✅ expected | 16d ago | 13d ago | 30 |
+| `52.49.212.201` | 443 | ✅ expected | 18d ago | 16d ago | 24 |
+| `52.49.3.35` | 443 | ✅ expected | 18d ago | 17d ago | 10 |
+| `52.49.4.206` | 443 | ✅ expected | 19d ago | 18d ago | 10 |
+| `52.50.163.172` | 443 | ✅ expected | 12h ago | 11h ago | 5 |
+| `52.50.224.74` | 443 | ✅ expected | 21d ago | 20d ago | 29 |
+| `52.51.137.54` | 443 | ✅ expected | 6d ago | 23h ago | 193 |
+| `52.51.148.109` | 443 | ✅ expected | 10d ago | 9d ago | 81 |
+| `52.51.31.247` | 443 | ✅ expected | 8h ago | 8h ago | 5 |
+| `52.51.5.37` | 443 | ✅ expected | 6d ago | 6d ago | 10 |
+| `52.51.57.14` | 443 | ✅ expected | 19h ago | 15h ago | 10 |
+| `52.84.50.42` | 443 | ✅ expected | 19d ago | 19d ago | 2 |
+| `54.154.135.155` | 443 | ✅ expected | 17d ago | 17d ago | 5 |
+| `54.170.104.57` | 443 | ✅ expected | 20d ago | 20d ago | 15 |
+| `54.170.163.78` | 443 | ✅ expected | 17d ago | 15d ago | 115 |
+| `54.171.78.236` | 443 | ✅ expected | 14d ago | 9d ago | 40 |
+| `54.194.125.196` | 443 | ✅ expected | 18h ago | 18h ago | 5 |
+| `54.194.218.193` | 443 | ✅ expected | 12d ago | 12d ago | 5 |
+| `54.194.222.175` | 443 | ✅ expected | 13d ago | 13d ago | 5 |
+| `54.194.85.107` | 443 | ✅ expected | 13d ago | 8d ago | 94 |
+| `54.195.147.237` | 443 | ✅ expected | 14d ago | 9d ago | 60 |
+| `54.195.186.68` | 443 | ✅ expected | 26d ago | 23d ago | 249 |
+| `54.195.255.109` | 443 | ✅ expected | 5d ago | 5d ago | 5 |
+| `54.216.223.16` | 443 | ✅ expected | 6d ago | 5d ago | 29 |
+| `54.220.110.244` | 443 | ✅ expected | 6d ago | 6d ago | 9 |
+| `54.220.4.25` | 443 | ✅ expected | 6d ago | 4d ago | 39 |
+| `54.228.169.234` | 443 | ✅ expected | 8d ago | 7d ago | 30 |
+| `54.228.220.78` | 443 | ✅ expected | 20d ago | 20d ago | 30 |
+| `54.228.49.194` | 443 | ✅ expected | 18d ago | 18d ago | 5 |
+| `54.229.184.213` | 443 | ✅ expected | 18d ago | 15d ago | 20 |
+| `54.229.234.23` | 443 | ✅ expected | 14d ago | 12d ago | 30 |
+| `54.246.207.199` | 443 | ✅ expected | 28d ago | 27d ago | 113 |
+| `54.247.128.112` | 443 | ✅ expected | 10d ago | 34m ago | 717 |
+| `54.72.135.60` | 443 | ✅ expected | 18d ago | 15d ago | 23 |
+| `54.72.222.86` | 443 | ✅ expected | 17d ago | 16d ago | 9 |
+| `54.72.42.56` | 443 | ✅ expected | 7d ago | 7d ago | 33 |
+| `54.72.47.167` | 443 | ✅ expected | 17d ago | 16d ago | 15 |
+| `54.73.67.52` | 443 | ✅ expected | 18d ago | 15d ago | 30 |
+| `54.74.43.116` | 443 | ✅ expected | 14d ago | 11d ago | 30 |
+| `54.75.182.87` | 443 | ✅ expected | 12d ago | 10d ago | 25 |
+| `54.75.245.133` | 443 | ✅ expected | 19d ago | 17d ago | 140 |
+| `54.76.118.150` | 443 | ✅ expected | 11d ago | 11d ago | 5 |
+| `54.76.150.103` | 443 | ✅ expected | 6d ago | 6d ago | 10 |
+| `54.76.169.38` | 443 | ✅ expected | 22d ago | 21d ago | 64 |
+| `54.76.192.134` | 443 | ✅ expected | 30d ago | 25d ago | 337 |
+| `54.76.217.37` | 443 | ✅ expected | 15d ago | 13d ago | 19 |
+| `54.76.82.20` | 443 | ✅ expected | 18d ago | 17d ago | 54 |
+| `54.77.106.61` | 443 | ✅ expected | 16d ago | 12d ago | 20 |
+| `54.77.130.113` | 443 | ✅ expected | 17d ago | 17d ago | 5 |
+| `54.77.155.168` | 443 | ✅ expected | 12h ago | 8h ago | 10 |
+| `54.77.221.81` | 443 | ✅ expected | 14d ago | 11d ago | 30 |
+| `54.77.231.123` | 443 | ✅ expected | 6d ago | 5d ago | 25 |
+| `54.77.24.165` | 443 | ✅ expected | 21d ago | 21d ago | 23 |
+| `54.78.116.49` | 443 | ✅ expected | 16h ago | 16h ago | 5 |
+| `54.78.193.70` | 443 | ✅ expected | 13d ago | 9d ago | 49 |
+| `63.32.184.247` | 443 | ✅ expected | 23h ago | 2h ago | 15 |
+| `63.32.217.27` | 443 | ✅ expected | 15d ago | 11d ago | 19 |
+| `63.33.5.76` | 443 | ✅ expected | 18d ago | 14d ago | 232 |
+| `63.34.177.147` | 443 | ✅ expected | 16d ago | 34m ago | 961 |
+| `63.35.170.229` | 443 | ✅ expected | 25d ago | 21d ago | 228 |
+| `63.35.34.90` | 443 | ✅ expected | 14d ago | 7d ago | 53 |
+| `79.125.93.93` | 443 | ✅ expected | 18d ago | 15d ago | 30 |
+| `99.80.124.24` | 443 | ✅ expected | 20d ago | 19d ago | 49 |
+| `99.80.129.27` | 443 | ✅ expected | 34d ago | 29d ago | 263 |
+| `99.80.153.48` | 443 | ✅ expected | 9h ago | 9h ago | 10 |
+| `99.80.232.1` | 443 | ✅ expected | 19d ago | 16d ago | 19 |
+| `99.80.39.243` | 443 | ✅ expected | 14d ago | 12d ago | 40 |
+| `99.81.12.92` | 443 | ✅ expected | 22d ago | 21d ago | 67 |
+| `99.81.142.82` | 443 | ✅ expected | 5h ago | 5h ago | 5 |
+| `99.81.28.139` | 443 | ✅ expected | 6d ago | 6d ago | 9 |
 
 ### gathio
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.16.1.34` | 443 | ✅ expected | 11d ago | 11d ago | 6 |
-| `104.16.11.34` | 443 | ✅ expected | 25h ago | 25h ago | 4 |
-| `104.16.4.34` | 443 | ✅ expected | 28d ago | 13d ago | 34 |
-| `104.16.7.34` | 443 | ✅ expected | 15d ago | 15d ago | 4 |
-| `104.16.8.34` | 443 | ✅ expected | 26h ago | 26h ago | 14 |
+| `104.16.1.34` | 443 | ✅ expected | 19d ago | 19d ago | 6 |
+| `104.16.11.34` | 443 | ✅ expected | 8d ago | 8d ago | 4 |
+| `104.16.4.34` | 443 | ✅ expected | 35d ago | 21d ago | 34 |
+| `104.16.7.34` | 443 | ✅ expected | 22d ago | 22d ago | 4 |
+| `104.16.8.34` | 443 | ✅ expected | 8d ago | 8d ago | 14 |
 
 ### grafana
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `192.0.73.2` | 443 | ✅ expected | 29d ago | 3d ago | 10 |
-| `34.120.177.193` | 443 | ✅ expected | 31d ago | 32s ago | 22147 |
-| `34.96.126.106` | 443 | ✅ expected | 30d ago | 6h ago | 151 |
+| `192.0.73.2` | 443 | ✅ expected | 37d ago | 10d ago | 10 |
+| `34.120.177.193` | 443 | ✅ expected | 38d ago | 2m ago | 27288 |
+| `34.96.126.106` | 443 | ✅ expected | 37d ago | 11h ago | 184 |
 
 ### home-assistant
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.26.4.238` | 443 | ✅ expected | 30d ago | 25h ago | 50 |
-| `104.26.5.238` | 443 | ✅ expected | 31d ago | 4h ago | 63 |
-| `151.101.1.195` | 443 | ✅ expected | 30d ago | 43h ago | 41 |
-| `151.101.65.195` | 443 | ✅ expected | 28d ago | 19h ago | 20 |
-| `157.249.81.141` | 443 | ✅ expected | 30d ago | 32s ago | 344 |
-| `172.67.68.90` | 443 | ✅ expected | 30d ago | 116m ago | 56 |
-| `18.156.89.194` | 443 | ✅ expected | 18d ago | 22m ago | 1737 |
-| `18.157.213.101` | 8883 | ✅ expected | 9d ago | 8d ago | 2771 |
-| `18.158.11.29` | 8883 | ✅ expected | 14d ago | 12d ago | 5654 |
-| `18.158.133.191` | 8883 | ✅ expected | 11d ago | 10d ago | 3683 |
-| `18.158.136.104` | 8883 | ✅ expected | 12d ago | 11d ago | 1129 |
-| `18.158.217.49` | 8883 | ✅ expected | 17d ago | 16d ago | 2668 |
-| `18.158.22.138` | 8883 | ✅ expected | 28d ago | 28d ago | 1702 |
-| `18.158.224.141` | 8883 | ✅ expected | 21d ago | 19d ago | 5641 |
-| `18.159.166.33` | 8883 | ✅ expected | 15h ago | 2s ago | 1805 |
-| `18.159.77.159` | 8883 | ✅ expected | 19d ago | 19d ago | 755 |
-| `18.159.79.242` | 8883 | ✅ expected | 23d ago | 22d ago | 2777 |
-| `18.184.121.56` | 8883 | ✅ expected | 25h ago | 15h ago | 1224 |
-| `18.184.241.150` | 8883 | ✅ expected | 17d ago | 17d ago | 58 |
-| `18.184.90.143` | 8883 | ✅ expected | 8d ago | 7d ago | 2820 |
-| `18.185.10.145` | 8883 | ✅ expected | 4d ago | 26h ago | 9731 |
-| `18.185.208.158` | 443 | ✅ expected | 25h ago | 25h ago | 1 |
-| `18.193.19.139` | 8883 | ✅ expected | 12d ago | 12d ago | 1 |
-| `18.194.113.141` | 8883 | ✅ expected | 26d ago | 26d ago | 356 |
-| `18.194.166.209` | 8883 | ✅ expected | 15d ago | 14d ago | 3094 |
-| `18.195.182.246` | 8883 | ✅ expected | 6d ago | 5d ago | 3620 |
-| `18.195.53.77` | 8883 | ✅ expected | 12d ago | 12d ago | 760 |
-| `18.196.104.106` | 8883 | ✅ expected | 24d ago | 23d ago | 2729 |
-| `18.197.66.183` | 8883 | ✅ expected | 4d ago | 4d ago | 1 |
-| `18.198.169.78` | 8883 | ✅ expected | 5d ago | 5d ago | 357 |
-| `18.198.177.41` | 8883 | ✅ expected | 5d ago | 4d ago | 1795 |
-| `18.198.195.194` | 8883 | ✅ expected | 30d ago | 28d ago | 5585 |
-| `18.198.200.175` | 8883 | ✅ expected | 7d ago | 6d ago | 2777 |
-| `3.120.211.84` | 8883 | ✅ expected | 19d ago | 17d ago | 4832 |
-| `3.120.216.195` | 443 | ✅ expected | 27d ago | 18d ago | 800 |
-| `3.120.53.2` | 8883 | ✅ expected | 28d ago | 26d ago | 3923 |
-| `3.121.10.31` | 8883 | ✅ expected | 26d ago | 26d ago | 759 |
-| `3.121.101.237` | 8883 | ✅ expected | 16d ago | 15d ago | 2420 |
-| `3.121.111.53` | 443 | ✅ expected | 22d ago | 16d ago | 599 |
-| `3.121.169.115` | 8883 | ✅ expected | 26d ago | 24d ago | 4472 |
-| `3.122.171.67` | 443 | ✅ expected | 26d ago | 18d ago | 708 |
-| `3.122.70.209` | 8883 | ✅ expected | 22d ago | 21d ago | 2815 |
-| `3.124.29.182` | 443 | ✅ expected | 31d ago | 22d ago | 810 |
-| `3.125.16.42` | 443 | ✅ expected | 18d ago | 16d ago | 239 |
-| `3.125.66.145` | 443 | ✅ expected | 31d ago | 26d ago | 491 |
-| `3.64.241.12` | 8883 | ✅ expected | 10d ago | 9d ago | 2709 |
-| `3.67.142.130` | 443 | ✅ expected | 31d ago | 21d ago | 907 |
-| `3.71.130.230` | 443 | ✅ expected | 11d ago | 11d ago | 1 |
-| `3.72.199.54` | 443 | ✅ expected | 8d ago | 32s ago | 781 |
-| `3.76.164.97` | 443 | ✅ expected | 11d ago | 32s ago | 1018 |
-| `35.156.5.143` | 443 | ✅ expected | 21d ago | 18d ago | 254 |
-| `35.158.64.12` | 443 | ✅ expected | 21d ago | 14d ago | 693 |
-| `52.28.32.0` | 443 | ✅ expected | 16d ago | 11d ago | 500 |
-| `52.29.1.243` | 443 | ✅ expected | 16d ago | 8d ago | 702 |
-| `52.29.210.73` | 443 | ✅ expected | 31d ago | 21d ago | 926 |
-| `52.57.174.242` | 443 | ✅ expected | 31d ago | 27d ago | 429 |
-| `52.58.153.107` | 443 | ✅ expected | 22d ago | 16d ago | 542 |
-| `52.58.33.43` | 443 | ✅ expected | 16d ago | 11d ago | 507 |
-| `52.59.138.18` | 443 | ✅ expected | 11d ago | 11m ago | 1018 |
-| `63.181.21.188` | 443 | ✅ expected | 18d ago | 11m ago | 1645 |
-| `63.181.74.73` | 443 | ✅ expected | 31d ago | 22d ago | 789 |
-| `63.182.123.150` | 443 | ✅ expected | 14d ago | 32s ago | 1225 |
-| `63.185.122.149` | 443 | ✅ expected | 11d ago | 11d ago | 1 |
-| `91.98.4.78` | 443 | ✅ expected | 11d ago | 11d ago | 1 |
+| `104.26.4.238` | 443 | ✅ expected | 38d ago | 7h ago | 67 |
+| `104.26.5.238` | 443 | ✅ expected | 38d ago | 4h ago | 75 |
+| `151.101.1.195` | 443 | ✅ expected | 38d ago | 66m ago | 52 |
+| `151.101.65.195` | 443 | ✅ expected | 36d ago | 4d ago | 23 |
+| `157.249.81.141` | 443 | ✅ expected | 38d ago | 77m ago | 460 |
+| `172.67.68.90` | 443 | ✅ expected | 37d ago | 10h ago | 73 |
+| `18.156.89.194` | 443 | ✅ expected | 25d ago | 3d ago | 2066 |
+| `18.157.213.101` | 8883 | ✅ expected | 16d ago | 15d ago | 2771 |
+| `18.158.11.29` | 8883 | ✅ expected | 21d ago | 19d ago | 5654 |
+| `18.158.133.191` | 8883 | ✅ expected | 19d ago | 17d ago | 3683 |
+| `18.158.136.104` | 8883 | ✅ expected | 19d ago | 19d ago | 1129 |
+| `18.158.217.49` | 8883 | ✅ expected | 24d ago | 23d ago | 2668 |
+| `18.158.224.141` | 8883 | ✅ expected | 28d ago | 26d ago | 5641 |
+| `18.159.166.33` | 8883 | ✅ expected | 7d ago | 6d ago | 2774 |
+| `18.159.77.159` | 8883 | ✅ expected | 26d ago | 26d ago | 755 |
+| `18.159.79.242` | 8883 | ✅ expected | 30d ago | 29d ago | 2777 |
+| `18.184.121.56` | 8883 | ✅ expected | 8d ago | 7d ago | 1224 |
+| `18.184.241.150` | 8883 | ✅ expected | 24d ago | 24d ago | 58 |
+| `18.184.90.143` | 8883 | ✅ expected | 15d ago | 14d ago | 2820 |
+| `18.185.10.145` | 8883 | ✅ expected | 11d ago | 8d ago | 9731 |
+| `18.185.208.158` | 443 | ✅ expected | 8d ago | 8d ago | 1 |
+| `18.185.51.38` | 8883 | ✅ expected | 6d ago | 5d ago | 3631 |
+| `18.193.176.220` | 8883 | ✅ expected | 20h ago | 2m ago | 2419 |
+| `18.193.19.139` | 8883 | ✅ expected | 19d ago | 19d ago | 1 |
+| `18.194.166.209` | 8883 | ✅ expected | 22d ago | 21d ago | 3094 |
+| `18.195.182.246` | 8883 | ✅ expected | 13d ago | 12d ago | 3620 |
+| `18.195.53.77` | 8883 | ✅ expected | 19d ago | 19d ago | 760 |
+| `18.197.66.183` | 8883 | ✅ expected | 11d ago | 11d ago | 1 |
+| `18.198.121.88` | 8883 | ✅ expected | 3d ago | 2d ago | 2734 |
+| `18.198.144.131` | 8883 | ✅ expected | 5d ago | 5d ago | 354 |
+| `18.198.169.78` | 8883 | ✅ expected | 12d ago | 12d ago | 357 |
+| `18.198.177.41` | 8883 | ✅ expected | 12d ago | 11d ago | 1795 |
+| `18.198.200.175` | 8883 | ✅ expected | 14d ago | 13d ago | 2777 |
+| `3.120.211.84` | 8883 | ✅ expected | 26d ago | 24d ago | 4832 |
+| `3.120.216.195` | 443 | ✅ expected | 34d ago | 25d ago | 800 |
+| `3.121.101.237` | 8883 | ✅ expected | 23d ago | 23d ago | 2420 |
+| `3.121.111.53` | 443 | ✅ expected | 29d ago | 23d ago | 599 |
+| `3.122.171.67` | 443 | ✅ expected | 33d ago | 25d ago | 708 |
+| `3.122.70.209` | 8883 | ✅ expected | 29d ago | 28d ago | 2815 |
+| `3.124.29.182` | 443 | ✅ expected | 38d ago | 29d ago | 810 |
+| `3.125.16.42` | 443 | ✅ expected | 25d ago | 23d ago | 239 |
+| `3.64.157.17` | 8883 | ✅ expected | 2d ago | 20h ago | 5594 |
+| `3.64.241.12` | 8883 | ✅ expected | 17d ago | 16d ago | 2709 |
+| `3.67.142.130` | 443 | ✅ expected | 38d ago | 28d ago | 907 |
+| `3.71.130.230` | 443 | ✅ expected | 19d ago | 19d ago | 1 |
+| `3.72.199.54` | 443 | ✅ expected | 15d ago | 3d ago | 1156 |
+| `3.74.79.125` | 443 | ✅ expected | 3d ago | 2m ago | 369 |
+| `3.76.164.97` | 443 | ✅ expected | 18d ago | 2m ago | 1712 |
+| `35.156.210.53` | 8883 | ✅ expected | 5d ago | 3d ago | 4480 |
+| `35.156.5.143` | 443 | ✅ expected | 28d ago | 25d ago | 254 |
+| `35.158.64.12` | 443 | ✅ expected | 28d ago | 21d ago | 693 |
+| `52.28.32.0` | 443 | ✅ expected | 24d ago | 18d ago | 500 |
+| `52.29.1.243` | 443 | ✅ expected | 23d ago | 15d ago | 702 |
+| `52.29.210.73` | 443 | ✅ expected | 38d ago | 28d ago | 926 |
+| `52.58.153.107` | 443 | ✅ expected | 30d ago | 24d ago | 542 |
+| `52.58.33.43` | 443 | ✅ expected | 23d ago | 18d ago | 507 |
+| `52.59.138.18` | 443 | ✅ expected | 18d ago | 5d ago | 1142 |
+| `63.181.101.136` | 443 | ✅ expected | 5d ago | 2m ago | 501 |
+| `63.181.21.188` | 443 | ✅ expected | 25d ago | 3d ago | 1972 |
+| `63.182.123.150` | 443 | ✅ expected | 21d ago | 13m ago | 1908 |
+| `63.182.206.75` | 443 | ✅ expected | 3d ago | 13m ago | 284 |
+| `63.185.122.149` | 443 | ✅ expected | 19d ago | 19d ago | 1 |
+| `63.186.78.77` | 443 | ✅ expected | 3d ago | 34m ago | 321 |
+| `91.98.4.78` | 443 | ✅ expected | 19d ago | 19d ago | 1 |
 
 ### immich-server
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.21.71.92` | 443 | ✅ expected | 30d ago | 11m ago | 863 |
-| `172.67.170.79` | 443 | ✅ expected | 31d ago | 74m ago | 736 |
-| `188.114.97.4` | 443 | ✅ expected | 13d ago | 13d ago | 2 |
+| `104.21.71.92` | 443 | ✅ expected | 38d ago | 3h ago | 1063 |
+| `172.67.170.79` | 443 | ✅ expected | 38d ago | 34m ago | 904 |
+| `188.114.97.4` | 443 | ✅ expected | 20d ago | 20d ago | 2 |
 
 ### jellyfin
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.17.207.5` | 443 | ✅ expected | 31d ago | 25h ago | 16 |
-| `104.17.208.5` | 443 | ✅ expected | 30d ago | 116m ago | 41 |
-| `139.59.139.28` | 443 | ✅ expected | 28d ago | 116m ago | 22 |
-| `140.82.121.3` | 443 | ✅ expected | 26h ago | 26h ago | 1 |
-| `146.190.237.6` | 443 | ✅ expected | 26d ago | 26h ago | 24 |
-| `151.101.1.229` | 443 | ✅ expected | 26d ago | 3d ago | 12 |
-| `151.101.129.229` | 443 | ✅ expected | 25d ago | 5d ago | 13 |
-| `151.101.193.229` | 443 | ✅ expected | 29d ago | 7d ago | 13 |
-| `151.101.65.229` | 443 | ✅ expected | 15d ago | 2d ago | 8 |
-| `157.245.38.19` | 443 | ✅ expected | 27d ago | 5d ago | 19 |
-| `161.35.245.42` | 443 | ✅ expected | 25d ago | 4d ago | 15 |
-| `165.227.169.147` | 443 | ✅ expected | 31d ago | 15d ago | 32 |
-| `165.227.244.161` | 443 | ✅ expected | 30d ago | 116m ago | 38 |
-| `178.105.98.131` | 443 | ✅ expected | 31d ago | 5d ago | 25 |
-| `185.199.109.133` | 443 | ✅ expected | 26h ago | 26h ago | 2 |
-| `206.189.97.173` | 443 | ✅ expected | 24d ago | 25h ago | 48 |
-| `68.183.204.194` | 443 | ✅ expected | 31d ago | 46h ago | 18 |
+| `104.17.207.5` | 443 | ✅ expected | 38d ago | 7h ago | 30 |
+| `104.17.208.5` | 443 | ✅ expected | 37d ago | 7d ago | 41 |
+| `139.59.139.28` | 443 | ✅ expected | 35d ago | 2d ago | 26 |
+| `140.82.121.3` | 443 | ✅ expected | 8d ago | 8d ago | 1 |
+| `146.190.237.6` | 443 | ✅ expected | 33d ago | 7h ago | 29 |
+| `151.101.1.229` | 443 | ✅ expected | 33d ago | 11d ago | 12 |
+| `151.101.129.229` | 443 | ✅ expected | 32d ago | 2d ago | 15 |
+| `151.101.193.229` | 443 | ✅ expected | 36d ago | 3d ago | 19 |
+| `151.101.65.229` | 443 | ✅ expected | 22d ago | 4d ago | 10 |
+| `157.245.38.19` | 443 | ✅ expected | 34d ago | 5d ago | 28 |
+| `161.35.245.42` | 443 | ✅ expected | 32d ago | 12d ago | 15 |
+| `165.227.169.147` | 443 | ✅ expected | 38d ago | 3d ago | 41 |
+| `165.227.244.161` | 443 | ✅ expected | 37d ago | 7h ago | 46 |
+| `178.105.98.131` | 443 | ✅ expected | 38d ago | 31h ago | 35 |
+| `185.199.109.133` | 443 | ✅ expected | 8d ago | 8d ago | 2 |
+| `206.189.97.173` | 443 | ✅ expected | 31d ago | 31h ago | 52 |
+| `68.183.204.194` | 443 | ✅ expected | 38d ago | 7h ago | 23 |
 
 ### loki
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `34.96.126.106` | 443 | ✅ expected | 31d ago | 2h ago | 915 |
+| `34.96.126.106` | 443 | ✅ expected | 38d ago | 3h ago | 1127 |
 
 ### navidrome
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.21.43.229` | 443 | ✅ expected | 15d ago | 15d ago | 1 |
-| `130.211.19.189` | 443 | ✅ expected | 30d ago | 26d ago | 13 |
-| `151.101.237.188` | 443 | ✅ expected | 30d ago | 26d ago | 7 |
-| `151.101.238.53` | 443 | ✅ expected | 30d ago | 26d ago | 6 |
-| `151.101.238.79` | 443 | ✅ expected | 30d ago | 26d ago | 6 |
-| `172.67.186.189` | 443 | ✅ expected | 11d ago | 25h ago | 10 |
-| `2.22.225.107` | 443 | ✅ expected | 26d ago | 26d ago | 3 |
-| `209.141.42.198` | 443 | ✅ expected | 31d ago | 85m ago | 99 |
+| `104.21.43.229` | 443 | ✅ expected | 22d ago | 22d ago | 1 |
+| `130.211.19.189` | 443 | ✅ expected | 3d ago | 3d ago | 31 |
+| `151.101.237.188` | 443 | ✅ expected | 3d ago | 3d ago | 7 |
+| `151.101.238.53` | 443 | ✅ expected | 3d ago | 3d ago | 7 |
+| `151.101.238.79` | 443 | ✅ expected | 3d ago | 3d ago | 18 |
+| `172.67.186.189` | 443 | ✅ expected | 19d ago | 3d ago | 15 |
+| `209.141.42.198` | 443 | ✅ expected | 38d ago | 6h ago | 120 |
+| `23.0.161.107` | 443 | ✅ expected | 3d ago | 3d ago | 8 |
 
 ### nextcloud
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `65.108.197.113` | 443 | ✅ expected | 28d ago | 26h ago | 18 |
-| `65.109.114.179` | 443 | ✅ expected | 30d ago | 31h ago | 29 |
-| `65.21.231.50` | 443 | ✅ expected | 22d ago | 12d ago | 3 |
-| `95.217.53.153` | 443 | ✅ expected | 29d ago | 19h ago | 28 |
+| `65.108.197.113` | 443 | ✅ expected | 35d ago | 4d ago | 20 |
+| `65.109.114.179` | 443 | ✅ expected | 37d ago | 2d ago | 31 |
+| `65.21.231.50` | 443 | ✅ expected | 29d ago | 19d ago | 3 |
+| `95.217.53.153` | 443 | ✅ expected | 36d ago | 5d ago | 33 |
 
 ### proton-bridge
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `185.70.42.41` | 443 | ✅ expected | 31d ago | 32s ago | 25006 |
-| `185.70.42.45` | 443 | ✅ expected | 31d ago | 2h ago | 826 |
+| `185.70.42.41` | 443 | ✅ expected | 38d ago | 2m ago | 30975 |
+| `185.70.42.45` | 443 | ✅ expected | 38d ago | 2h ago | 1010 |
 
 ### traefik
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.19.192.29` | 443 | ✅ expected | 27d ago | 27d ago | 5 |
-| `104.19.193.29` | 443 | ✅ expected | 29d ago | 29d ago | 6 |
-| `104.26.3.101` | 443 | ✅ expected | 29d ago | 11d ago | 24 |
-| `140.82.121.5` | 443 | ✅ expected | 29d ago | 13d ago | 13 |
-| `140.82.121.6` | 443 | ✅ expected | 31d ago | 14d ago | 11 |
-| `172.65.32.248` | 443 | ✅ expected | 29d ago | 27d ago | 25 |
-| `172.67.75.8` | 443 | ✅ expected | 15d ago | 26h ago | 13 |
+| `104.19.193.29` | 443 | ✅ expected | 31h ago | 31h ago | 10 |
+| `104.26.3.101` | 443 | ✅ expected | 36d ago | 19d ago | 24 |
+| `140.82.121.5` | 443 | ✅ expected | 36d ago | 20d ago | 13 |
+| `140.82.121.6` | 443 | ✅ expected | 38d ago | 21d ago | 11 |
+| `172.65.32.248` | 443 | ✅ expected | 31h ago | 31h ago | 17 |
+| `172.67.75.8` | 443 | ✅ expected | 22d ago | 8d ago | 13 |
 
 ---
 

--- a/docs/AUTO-IMAGE-PIN-INDEX.md
+++ b/docs/AUTO-IMAGE-PIN-INDEX.md
@@ -1,6 +1,6 @@
 # Container Image Pin Index (Auto-Generated)
 
-**Generated:** 2026-06-23 16:49:18 UTC
+**Generated:** 2026-07-01 22:04:56 UTC
 **Source:** `/home/patriark/containers/quadlets` — ADR-030 (Container Supply-Chain Trust Model)
 
 Pins live in each quadlet's `Image=` line (where Podman reads them); this is
@@ -12,8 +12,8 @@ For local builds the `Digest` column shows the **base image** pin (FROM …@sha2
 
 | Metric | Count |
 |--------|-------|
-| Total images | 37 |
-| 🔒 Digest-pinned | 35 |
+| Total images | 38 |
+| 🔒 Digest-pinned | 36 |
 | ⚠️ Floating (mutable tag) | 0 |
 | 🔨 Local builds | 2 |
 | 🔨 Local builds with FLOATING base | 0 |
@@ -41,6 +41,7 @@ For local builds the `Digest` column shows the **base image** pin (FROM …@sha2
 | forgejo | yes | 🔒 pinned | `codeberg.org/forgejo/forgejo` | 15 | `sha256:55bb42bec9ab…` | no | — unsigned |
 | gathio-db | no | 🔒 pinned | `docker.io/library/mongo` | 7 | `sha256:8ecb514b00bd…` | no | — unsigned |
 | gathio | yes | 🔒 pinned | `ghcr.io/lowercasename/gathio` | latest | `sha256:ff66a8d2cc52…` | no | — unsigned |
+| gluetun | yes | 🔒 pinned | `docker.io/qmcgaw/gluetun` | latest | `sha256:b0ee2135e6ba…` | no | — unsigned |
 | grafana | yes | 🔒 pinned | `docker.io/grafana/grafana` | latest | `sha256:5dad0df181cb…` | no | — unsigned |
 | home-assistant | yes | 🔒 pinned | `ghcr.io/home-assistant/home-assistant` | stable | `sha256:d4fbec16196d…` | no | ✓ verified |
 | immich-ml | no | 🔒 pinned | `ghcr.io/immich-app/immich-machine-learning` | v2.7.5 | `sha256:a2501141440f…` | no | — unsigned |

--- a/docs/AUTO-NETWORK-TOPOLOGY.md
+++ b/docs/AUTO-NETWORK-TOPOLOGY.md
@@ -1,6 +1,6 @@
 # Network Topology (Auto-Generated)
 
-**Generated:** 2026-06-23 16:49:12 UTC
+**Generated:** 2026-07-01 22:04:48 UTC
 **System:** fedora-htpc | **Networks:** 11 | **Containers:** 37
 
 ---

--- a/docs/AUTO-SERVICE-CATALOG.md
+++ b/docs/AUTO-SERVICE-CATALOG.md
@@ -1,6 +1,6 @@
 # Service Catalog (Auto-Generated)
 
-**Generated:** 2026-06-23 16:49:11 UTC
+**Generated:** 2026-07-01 22:04:47 UTC
 **System:** fedora-htpc | **Services:** 37/37 running | **Health:** 32/32 healthy (5 without healthcheck)
 
 ---
@@ -9,83 +9,83 @@
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| audiobookshelf | advplyr/audiobookshelf@sha256:89276ff2e0b3d2f | ✅ healthy | 2h | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
-| blackbox-exporter | quay.io/prometheus/blackbox-exporter@sha256:e | ✅ healthy | 2h | — | — |
-| forgejo | codeberg.org/forgejo/forgejo@sha256:55bb42bec | ✅ healthy | 2h | [git.patriark.org](https://git.patriark.org) | — |
-| forgejo-db | postgres@sha256:e013e867e712fec275706a6c51c96 | ✅ healthy | 2h | — | — |
-| navidrome | deluan/navidrome@sha256:c4b5cb36a790b3eb63ca6 | ✅ healthy | 2h | [musikk.patriark.org](https://musikk.patriark.org) | — |
-| pihole-exporter | ekofr/pihole-exporter@sha256:a890cc731a39da71 | — no check | 2h | — | — |
-| postgres-exporter | quay.io/prometheuscommunity/postgres-exporter | ✅ healthy | 2h | — | — |
-| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | 2h | — | — |
-| qbittorrent | linuxserver/qbittorrent@sha256:f76c4363cce083 | ✅ healthy | 2h | [torrent.patriark.org](https://torrent.patriark.org) | — |
-| redis-authelia-exporter | quay.io/oliver006/redis_exporter@sha256:2e979 | — no check | 2h | — | — |
-| redis-immich-exporter | quay.io/oliver006/redis_exporter@sha256:2e979 | — no check | 2h | — | — |
-| unifi-syslog | linuxserver/syslog-ng@sha256:53d71945a46f2fa0 | ✅ healthy | 2h | — | — |
+| audiobookshelf | advplyr/audiobookshelf@sha256:89276ff2e0b3d2f | ✅ healthy | 8d | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
+| blackbox-exporter | quay.io/prometheus/blackbox-exporter@sha256:e | ✅ healthy | 8d | — | — |
+| forgejo | codeberg.org/forgejo/forgejo@sha256:55bb42bec | ✅ healthy | 8d | [git.patriark.org](https://git.patriark.org) | — |
+| forgejo-db | postgres@sha256:e013e867e712fec275706a6c51c96 | ✅ healthy | 8d | — | — |
+| navidrome | deluan/navidrome@sha256:c4b5cb36a790b3eb63ca6 | ✅ healthy | 8d | [musikk.patriark.org](https://musikk.patriark.org) | — |
+| pihole-exporter | ekofr/pihole-exporter@sha256:a890cc731a39da71 | — no check | 8d | — | — |
+| postgres-exporter | quay.io/prometheuscommunity/postgres-exporter | ✅ healthy | 8d | — | — |
+| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | 8d | — | — |
+| qbittorrent | linuxserver/qbittorrent@sha256:f76c4363cce083 | ✅ healthy | 8d | [torrent.patriark.org](https://torrent.patriark.org) | — |
+| redis-authelia-exporter | quay.io/oliver006/redis_exporter@sha256:2e979 | — no check | 8d | — | — |
+| redis-immich-exporter | quay.io/oliver006/redis_exporter@sha256:2e979 | — no check | 8d | — | — |
+| unifi-syslog | linuxserver/syslog-ng@sha256:53d71945a46f2fa0 | ✅ healthy | 8d | — | — |
 
 ## Core Infrastructure (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| authelia | authelia/authelia@sha256:1b363e9279e742397966 | ✅ healthy | 2h | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
-| crowdsec | crowdsecurity/crowdsec@sha256:2f527c9bb8b3671 | ✅ healthy | 2h | — | [guide](10-services/guides/crowdsec.md) |
-| redis-authelia | redis@sha256:6ab0b6e7381779332f97b8ca76193e45 | ✅ healthy | 2h | — | — |
-| traefik | traefik@sha256:6b9cbca6fac42ab0075f5437d8dc16 | ✅ healthy | 2h | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
+| authelia | authelia/authelia@sha256:1b363e9279e742397966 | ✅ healthy | 8d | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
+| crowdsec | crowdsecurity/crowdsec@sha256:2f527c9bb8b3671 | ✅ healthy | 8d | — | [guide](10-services/guides/crowdsec.md) |
+| redis-authelia | redis@sha256:6ab0b6e7381779332f97b8ca76193e45 | ✅ healthy | 8d | — | — |
+| traefik | traefik@sha256:6b9cbca6fac42ab0075f5437d8dc16 | ✅ healthy | 8d | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
 
 ## Nextcloud (3)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| nextcloud-db | mariadb@sha256:be1ef4fe5f14589325c08a41c76334 | ✅ healthy | 2h | — | [guide](10-services/guides/nextcloud.md) |
-| nextcloud | nextcloud@sha256:fe5166b04f217c9e3a263bfe76ee | ✅ healthy | 2h | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
-| nextcloud-redis | redis@sha256:6ab0b6e7381779332f97b8ca76193e45 | ✅ healthy | 2h | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-db | mariadb@sha256:be1ef4fe5f14589325c08a41c76334 | ✅ healthy | 8d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud | nextcloud@sha256:fe5166b04f217c9e3a263bfe76ee | ✅ healthy | 5d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-redis | redis@sha256:6ab0b6e7381779332f97b8ca76193e45 | ✅ healthy | 8d | — | [guide](10-services/guides/nextcloud.md) |
 
 ## Immich (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| immich-ml | immich-app/immich-machine-learning@sha256:a25 | ✅ healthy | 2h | — | [guide](10-services/guides/immich.md) |
-| immich-server | immich-app/immich-server@sha256:c15bff75068ef | ✅ healthy | 2h | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
-| postgresql-immich | immich-app/postgres@sha256:bcf63357191b76a916 | ✅ healthy | 2h | — | — |
-| redis-immich | valkey/valkey@sha256:4963247afc4cd33c7d3b2d28 | ✅ healthy | 2h | — | — |
+| immich-ml | immich-app/immich-machine-learning@sha256:a25 | ✅ healthy | 8d | — | [guide](10-services/guides/immich.md) |
+| immich-server | immich-app/immich-server@sha256:c15bff75068ef | ✅ healthy | 8d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
+| postgresql-immich | immich-app/postgres@sha256:bcf63357191b76a916 | ✅ healthy | 8d | — | — |
+| redis-immich | valkey/valkey@sha256:4963247afc4cd33c7d3b2d28 | ✅ healthy | 8d | — | — |
 
 ## Jellyfin (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| jellyfin | jellyfin/jellyfin@sha256:aefb67e6a7ff1debdd15 | ✅ healthy | 2h | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
+| jellyfin | jellyfin/jellyfin@sha256:aefb67e6a7ff1debdd15 | ✅ healthy | 8d | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
 
 ## Vaultwarden (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| vaultwarden | vaultwarden/server@sha256:d626d04934cd1192ad8 | ✅ healthy | 2h | [vault.patriark.org](https://vault.patriark.org) | — |
+| vaultwarden | vaultwarden/server@sha256:d626d04934cd1192ad8 | ✅ healthy | 8d | [vault.patriark.org](https://vault.patriark.org) | — |
 
 ## Home Automation (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| home-assistant | home-assistant/home-assistant@sha256:d4fbec16 | ✅ healthy | 2h | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
+| home-assistant | home-assistant/home-assistant@sha256:d4fbec16 | ✅ healthy | 8d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
 
 ## Gathio (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| gathio-db | mongo@sha256:8ecb514b00bdcc0bde67ef4e6c330385 | ✅ healthy | 2h | — | — |
-| gathio | lowercasename/gathio@sha256:ff66a8d2cc522568c | ✅ healthy | 2h | [events.patriark.org](https://events.patriark.org) | — |
+| gathio-db | mongo@sha256:8ecb514b00bdcc0bde67ef4e6c330385 | ✅ healthy | 8d | — | — |
+| gathio | lowercasename/gathio@sha256:ff66a8d2cc522568c | ✅ healthy | 8d | [events.patriark.org](https://events.patriark.org) | — |
 
 ## Monitoring (9)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| alert-discord-relay | localhost/alert-discord-relay:2026-05-23 | ✅ healthy | 2h | — | [guide](10-services/guides/alert-discord-relay.md) |
-| alertmanager | quay.io/prometheus/alertmanager@sha256:af26fb | ✅ healthy | 2h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| cadvisor | gcr.io/cadvisor/cadvisor@sha256:3de2bd5203120 | ✅ healthy | 2h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| grafana | grafana/grafana@sha256:5dad0df181cb644a14e136 | ✅ healthy | 2h | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| loki | grafana/loki@sha256:191d4fdfb7264f16989f0a57f | — no check | 2h | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| node_exporter | quay.io/prometheus/node-exporter@sha256:0f422 | ✅ healthy | 2h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| prometheus | quay.io/prometheus/prometheus@sha256:69f52414 | ✅ healthy | 3m | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| promtail | grafana/promtail@sha256:6cfa64ec432b24a912d64 | ✅ healthy | 2h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| unpoller | unpoller/unpoller@sha256:bf7bdcc59fcdaa469968 | — no check | 2h | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| alert-discord-relay | localhost/alert-discord-relay:2026-05-23 | ✅ healthy | 8d | — | [guide](10-services/guides/alert-discord-relay.md) |
+| alertmanager | quay.io/prometheus/alertmanager@sha256:af26fb | ✅ healthy | 8d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| cadvisor | gcr.io/cadvisor/cadvisor@sha256:3de2bd5203120 | ✅ healthy | 8d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| grafana | grafana/grafana@sha256:5dad0df181cb644a14e136 | ✅ healthy | 8d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| loki | grafana/loki@sha256:191d4fdfb7264f16989f0a57f | — no check | 8d | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| node_exporter | quay.io/prometheus/node-exporter@sha256:0f422 | ✅ healthy | 8d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| prometheus | quay.io/prometheus/prometheus@sha256:69f52414 | ✅ healthy | 8d | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| promtail | grafana/promtail@sha256:6cfa64ec432b24a912d64 | ✅ healthy | 8d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| unpoller | unpoller/unpoller@sha256:bf7bdcc59fcdaa469968 | — no check | 8d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
 
 ---
 
@@ -93,7 +93,7 @@
 
 - **Total Running:** 37
 - **Total Defined:** 37
-- **System Load:** 1,04, 1,13, 1,08
+- **System Load:** 3,11, 3,41, 2,77
 
 ---
 

--- a/quadlets/gluetun.container
+++ b/quadlets/gluetun.container
@@ -1,0 +1,90 @@
+# ~/.config/containers/systemd/gluetun.container
+# gluetun — VPN egress sidecar for qBittorrent (ADR-042)
+# Created: 2026-07-01
+# Docs: https://github.com/qdm12/gluetun-wiki
+#
+# WHAT: qBittorrent shares THIS container's network namespace
+# (Network=container:gluetun in qbittorrent.container). All qBittorrent traffic
+# exits through gluetun's ProtonVPN WireGuard tunnel. gluetun's firewall is a
+# kill-switch: if the tunnel drops, no traffic leaks — qBittorrent has no other
+# interface. Traefik reaches the qBittorrent WebUI at gluetun's IP:8085.
+
+# ═══════════════════════════════════════════════════════════
+# DEPENDENCIES
+# ═══════════════════════════════════════════════════════════
+[Unit]
+Description=gluetun VPN egress sidecar (qBittorrent)
+Documentation=https://github.com/qdm12/gluetun-wiki
+After=network-online.target reverse_proxy-network.service
+Wants=network-online.target reverse_proxy-network.service
+
+# ═══════════════════════════════════════════════════════════
+# CONTAINER CONFIGURATION
+# ═══════════════════════════════════════════════════════════
+[Container]
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-07-01 (index digest, multi-arch).
+# ADR-030 P1/P4: no AutoUpdate — deliberate updates only (egress-tier: 7d bake per ADR-036).
+# ADR-030 P6: no publisher signature (tracked unsigned).
+Image=docker.io/qmcgaw/gluetun@sha256:b0ee2135e6ba52ad3f102aae9663707cd1c9531485117067a380d3b2b6dd991d
+ContainerName=gluetun
+HostName=gluetun
+# Kill-switch needs the tunnel device + NET_ADMIN to configure it. NoNewPrivileges
+# is kept: explicitly-added caps survive it (it only blocks GAINING new privileges).
+NoNewPrivileges=true
+AddCapability=NET_ADMIN
+AddDevice=/dev/net/tun
+
+# gluetun takes the reverse_proxy slot qBittorrent used to hold, so the Traefik
+# route (http://gluetun:8085) and any /etc/hosts overrides stay a one-line change.
+Network=systemd-reverse_proxy:ip=10.89.2.85
+
+# ── ProtonVPN over WireGuard ───────────────────────────────
+Environment=VPN_SERVICE_PROVIDER=protonvpn
+Environment=VPN_TYPE=wireguard
+# ProtonVPN's WireGuard interface address is fixed; the private key is the secret.
+Environment=WIREGUARD_ADDRESSES=10.2.0.2/32
+# Server selection — narrow to keep the egress endpoint predictable (ADR-042).
+# Adjust country as desired; leaving broad lets gluetun rotate within ProtonVPN.
+Environment=SERVER_COUNTRIES=Netherlands
+# DNS resolves through the tunnel (DoT) — no leak to Pi-hole/LAN.
+Environment=DOT=on
+# Kill-switch firewall: allow the WebUI port inbound + the reverse_proxy subnet
+# (so Traefik can reach the WebUI and gluetun can reply). Everything else that is
+# not the VPN tunnel is dropped.
+Environment=FIREWALL_INPUT_PORTS=8085
+Environment=FIREWALL_OUTBOUND_SUBNETS=10.89.2.0/24
+Environment=TZ=Europe/Oslo
+
+# WireGuard private key from ProtonVPN (Account → WireGuard configuration).
+# Secret handle name is the interface (ADR-041). Target source of truth is OpenBao
+# via htpc-mgmt `secretctl` — but that substrate is NOT live yet (2026-07-01: no
+# :8200, no secretctl). Until it is, this is created like the rest of the fleet:
+#   podman secret create gluetun_wireguard_key -   # paste ProtonVPN PrivateKey, Ctrl-D
+# It then migrates into OpenBao with the others when ADR-041 goes live (same name).
+Secret=gluetun_wireguard_key,type=env,target=WIREGUARD_PRIVATE_KEY
+
+# gluetun runtime state (server lists, port-forward file if enabled later).
+Volume=%h/containers/config/gluetun:/gluetun:Z
+
+# Rely on gluetun's built-in HEALTHCHECK (monitors the tunnel + public IP).
+
+# ═══════════════════════════════════════════════════════════
+# SERVICE BEHAVIOR
+# ═══════════════════════════════════════════════════════════
+[Service]
+# Tier B (default 100) — ADR-035 boot tier. Must be up before qBittorrent (its netns host).
+Slice=container.slice
+Restart=on-failure
+TimeoutStartSec=180
+RestartSec=10s
+
+# Resource Limits (gluetun is light)
+MemoryMax=256M
+MemoryHigh=200M
+CPUQuota=100%
+
+# ═══════════════════════════════════════════════════════════
+# INSTALLATION
+# ═══════════════════════════════════════════════════════════
+[Install]
+WantedBy=default.target

--- a/quadlets/gluetun.container
+++ b/quadlets/gluetun.container
@@ -44,8 +44,17 @@ Environment=VPN_TYPE=wireguard
 # ProtonVPN's WireGuard interface address is fixed; the private key is the secret.
 Environment=WIREGUARD_ADDRESSES=10.2.0.2/32
 # Server selection — narrow to keep the egress endpoint predictable (ADR-042).
-# Adjust country as desired; leaving broad lets gluetun rotate within ProtonVPN.
-Environment=SERVER_COUNTRIES=Netherlands
+# Estonia chosen for its strong digital-rights posture. Small Proton footprint:
+# only 2 standard P2P servers (EE#13, EE#23, both Tallinn) — the tunnel fails
+# closed (kill-switch) if both are down, so this is deliberate, not a fallback pool.
+Environment=SERVER_COUNTRIES=Estonia
+# CRITICAL for torrenting: restrict to port-forward-enabled (== P2P) servers.
+# Estonia also hosts Secure Core servers (CH-EE, SE-EE) on which ProtonVPN BLOCKS
+# P2P; without this filter gluetun could randomly pick one and torrents would fail
+# with "No P2P traffic permitted". This filter selects EE#13/EE#23 only. It only
+# selects the server; it does NOT enable port forwarding (that's Phase 2's
+# VPN_PORT_FORWARDING=on).
+Environment=PORT_FORWARD_ONLY=on
 # DNS resolves through the tunnel (DoT) — no leak to Pi-hole/LAN.
 Environment=DOT=on
 # Kill-switch firewall: allow the WebUI port inbound + the reverse_proxy subnet


### PR DESCRIPTION
## Summary

Phase 1 of the qBittorrent VPN egress sidecar (ADR-042): adds a gluetun WireGuard/ProtonVPN sidecar with kill-switch, pinned to Estonia's two standard P2P servers.

- **New quadlet `quadlets/gluetun.container`** — digest-pinned `qmcgaw/gluetun` (ADR-030), `NET_ADMIN` + `/dev/net/tun`, kill-switch firewall, `Secret=gluetun_wireguard_key`, takes over static IP `10.89.2.85` (qBittorrent's current slot) so Traefik routing is untouched at cutover
- **Exit selection:** `SERVER_COUNTRIES=Estonia` (digital-rights posture) + `PORT_FORWARD_ONLY=on` — mandatory, since Estonia's Proton footprint includes 3 Secure Core servers that block P2P; the filter pins to EE#13/EE#23 (Tallinn). Selection only — port forwarding itself is Phase 2
- **Accepted trade-off:** 2 usable servers ⇒ no in-country fallback; with the kill-switch, both down = qBittorrent offline
- **ADR-042** documents the decision, trade-offs, and deploy gate; handoff journal covers the remaining manual steps (WG key is account-wide — no key regen needed for country choice)
- AUTO-* docs regenerated

## Deployment Context

- Service: gluetun (VPN egress sidecar for qBittorrent)
- Networks: reverse_proxy (static IP 10.89.2.85)
- Not yet started — **deploy gate: the `gluetun_wireguard_key` secret must be created by the owner first** (via htpc-mgmt `secretctl`, per ADR-041)
- Related: `docs/98-journals/2026-07-01-qbittorrent-vpn-sidecar-handoff.md`

## Verification

- ✓ Pre-commit hooks pass (ADR-030 supply-chain invariants, ADR-035 boot tiers, no hardcoded secrets)
- ✓ Config-only merge: gluetun is not enabled/started, so merging changes nothing at runtime

## Test Plan (post-merge, at cutover — per handoff journal)

- [ ] Create `gluetun_wireguard_key` secret via secretctl
- [ ] Start gluetun, verify tunnel up on EE#13/EE#23 and public IP is the VPN exit
- [ ] Cut qBittorrent over to the sidecar netns; verify WebUI via Traefik
- [ ] Kill-switch check: stop tunnel → confirm no traffic leaks from qBittorrent
- [ ] Add VPN endpoint to egress baseline as expected destination

🤖 Generated with [Claude Code](https://claude.com/claude-code)