### PR TITLE
fix(egress): add 2nd Google Cloud range to loki baseline

### DIFF
--- a/config/supply-chain/egress-baseline.yaml
+++ b/config/supply-chain/egress-baseline.yaml
@@ -171,6 +171,13 @@ services:
     - owner: Google LLC
       cidrs: [34.64.0.0/10]
       note: Grafana Labs usage reporting behind GCLB (observed 34.96.126.106)
+    - owner: Google LLC
+      cidrs: [34.32.0.0/11]
+      note: Grafana Labs usage reporting behind GCLB, 2nd GCP range — same telemetry
+        call as the entry above, rotated onto a non-overlapping Google-owned block
+        (observed 34.49.170.206, 2026-07-09; PTR generic *.bc.googleusercontent.com
+        on both IPs). 2nd of the ADR-039 >=3-rebaseline gate before escalating to a
+        generated Google-published range.
   navidrome:
     - owner: AKAMAI-PA
       cidrs: [2.22.225.0/24]


### PR DESCRIPTION
## Summary
- Repeated `EgressUnexpectedDestination` Discord alerts for Loki traced to Grafana Labs' built-in anonymous usage-reporting call (`analytics.reporting_enabled`, default on) landing on `34.49.170.206`, outside the existing baselined range
- Confirmed benign via the standard triage runbook: both the new and previously-baselined IPs are Google LLC (GOOGL-2), share the same generic `*.bc.googleusercontent.com` PTR pattern typical of GCLB-fronted backends, and no anomalous activity appears in the Loki journal at the alert window (just routine WAL checkpoint noise)
- Adds a second tight entry (`34.32.0.0/11`, the WHOIS-registered block containing the observed IP) to `config/supply-chain/egress-baseline.yaml` for `loki`, per ADR-039 ethos — 2nd of the ≥3 benign-rebaseline gate before escalating to a generated Google-published range

## Test plan
- [x] Pre-commit ADR-030 supply-chain invariant check passed
- [ ] After merge + baseline reload, confirm `loki` classifies `34.49.170.206` as expected and `egress_unexpected_destination_count` for loki returns to 0 within the 24h recency window

🤖 Generated with [Claude Code](https://claude.com/claude-code)