### PR TITLE
chore(images): adopt 10 baked updates, fix stdin-eating bug in adopt-baked.sh

### DIFF
--- a/docs/AUTO-IMAGE-PIN-INDEX.md
+++ b/docs/AUTO-IMAGE-PIN-INDEX.md
@@ -1,6 +1,6 @@
 # Container Image Pin Index (Auto-Generated)
 
-**Generated:** 2026-07-01 22:04:56 UTC
+**Generated:** 2026-07-13 10:23:02 UTC
 **Source:** `/home/patriark/containers/quadlets` — ADR-030 (Container Supply-Chain Trust Model)
 
 Pins live in each quadlet's `Image=` line (where Podman reads them); this is
@@ -31,30 +31,30 @@ For local builds the `Digest` column shows the **base image** pin (FROM …@sha2
 | Service | Egress | Status | Repository | Tag | Digest | Auto | Signed (P6) |
 |---------|--------|--------|------------|-----|--------|------|-------------|
 | alert-discord-relay | yes | 🔨 base-pinned | `localhost/alert-discord-relay` | 2026-05-23 | `sha256:a3ab0b966bc4…` | no | n/a (Tier 2) |
-| alertmanager | yes | 🔒 pinned | `quay.io/prometheus/alertmanager` | latest | `sha256:af26fbe4dd18…` | no | — unsigned |
+| alertmanager | yes | 🔒 pinned | `quay.io/prometheus/alertmanager` | latest | `sha256:9e082985f56f…` | no | — unsigned |
 | audiobookshelf | yes | 🔒 pinned | `ghcr.io/advplyr/audiobookshelf` | 2.35.0 | `sha256:89276ff2e0b3…` | no | — unsigned |
 | authelia | yes | 🔒 pinned | `docker.io/authelia/authelia` | latest | `sha256:1b363e9279e7…` | no | — unsigned |
 | blackbox-exporter | yes | 🔒 pinned | `quay.io/prometheus/blackbox-exporter` | latest | `sha256:e753ff9f3fc4…` | no | — unsigned |
 | cadvisor | no | 🔒 pinned | `gcr.io/cadvisor/cadvisor` | latest | `sha256:3de2bd520312…` | no | — unsigned |
 | crowdsec | yes | 🔒 pinned | `docker.io/crowdsecurity/crowdsec` | latest | `sha256:2f527c9bb8b3…` | no | — unsigned |
-| forgejo-db | no | 🔒 pinned | `docker.io/library/postgres` | 16-alpine | `sha256:e013e867e712…` | no | — unsigned |
+| forgejo-db | no | 🔒 pinned | `docker.io/library/postgres` | 16-alpine | `sha256:57c72fd2a128…` | no | — unsigned |
 | forgejo | yes | 🔒 pinned | `codeberg.org/forgejo/forgejo` | 15 | `sha256:55bb42bec9ab…` | no | — unsigned |
-| gathio-db | no | 🔒 pinned | `docker.io/library/mongo` | 7 | `sha256:8ecb514b00bd…` | no | — unsigned |
+| gathio-db | no | 🔒 pinned | `docker.io/library/mongo` | 7 | `sha256:d5b3ca8c3f3c…` | no | — unsigned |
 | gathio | yes | 🔒 pinned | `ghcr.io/lowercasename/gathio` | latest | `sha256:ff66a8d2cc52…` | no | — unsigned |
 | gluetun | yes | 🔒 pinned | `docker.io/qmcgaw/gluetun` | latest | `sha256:b0ee2135e6ba…` | no | — unsigned |
-| grafana | yes | 🔒 pinned | `docker.io/grafana/grafana` | latest | `sha256:5dad0df181cb…` | no | — unsigned |
+| grafana | yes | 🔒 pinned | `docker.io/grafana/grafana` | latest | `sha256:121a7a9ece6d…` | no | — unsigned |
 | home-assistant | yes | 🔒 pinned | `ghcr.io/home-assistant/home-assistant` | stable | `sha256:d4fbec16196d…` | no | ✓ verified |
 | immich-ml | no | 🔒 pinned | `ghcr.io/immich-app/immich-machine-learning` | v2.7.5 | `sha256:a2501141440f…` | no | — unsigned |
 | immich-server | yes | 🔒 pinned | `ghcr.io/immich-app/immich-server` | v2.7.5 | `sha256:c15bff75068e…` | no | — unsigned |
 | jellyfin | yes | 🔒 pinned | `docker.io/jellyfin/jellyfin` | latest | `sha256:aefb67e6a7ff…` | no | — unsigned |
-| loki | yes | 🔒 pinned | `docker.io/grafana/loki` | latest | `sha256:191d4fdfb726…` | no | — unsigned |
+| loki | yes | 🔒 pinned | `docker.io/grafana/loki` | latest | `sha256:70b9f699fc9b…` | no | — unsigned |
 | navidrome | yes | 🔒 pinned | `docker.io/deluan/navidrome` | latest | `sha256:c4b5cb36a790…` | no | — unsigned |
-| nextcloud-db | no | 🔒 pinned | `docker.io/library/mariadb` | 11 | `sha256:be1ef4fe5f14…` | no | — unsigned |
+| nextcloud-db | no | 🔒 pinned | `docker.io/library/mariadb` | 11 | `sha256:efb4959ef2c8…` | no | — unsigned |
 | nextcloud-redis | no | 🔒 pinned | `docker.io/library/redis` | 7-alpine | `sha256:6ab0b6e73817…` | no | — unsigned |
-| nextcloud | yes | 🔒 pinned | `docker.io/library/nextcloud` | 33 | `sha256:fe5166b04f21…` | no | — unsigned |
+| nextcloud | yes | 🔒 pinned | `docker.io/library/nextcloud` | 33 | `sha256:35170a1c67e7…` | no | — unsigned |
 | node_exporter | no | 🔒 pinned | `quay.io/prometheus/node-exporter` | latest | `sha256:0f422f62c15f…` | no | — unsigned |
 | pihole-exporter | yes | 🔒 pinned | `docker.io/ekofr/pihole-exporter` | latest | `sha256:a890cc731a39…` | no | — unsigned |
-| postgres-exporter | no | 🔒 pinned | `quay.io/prometheuscommunity/postgres-exporter` | latest | `sha256:e96064f87622…` | no | — unsigned |
+| postgres-exporter | no | 🔒 pinned | `quay.io/prometheuscommunity/postgres-exporter` | latest | `sha256:ac5ec343104f…` | no | — unsigned |
 | postgresql-immich | no | 🔒 pinned | `ghcr.io/immich-app/postgres` | 14-vectorchord0.4.3-pgvectors0.2.0 | `sha256:bcf63357191b…` | no | — unsigned |
 | prometheus | yes | 🔒 pinned | `quay.io/prometheus/prometheus` | latest | `sha256:69f524141883…` | no | — unsigned |
 | promtail | no | 🔒 pinned | `docker.io/grafana/promtail` | latest | `sha256:6cfa64ec432b…` | no | — unsigned |
@@ -65,8 +65,8 @@ For local builds the `Digest` column shows the **base image** pin (FROM …@sha2
 | redis-immich-exporter | no | 🔒 pinned | `quay.io/oliver006/redis_exporter` | latest | `sha256:2e9795be900d…` | no | — unsigned |
 | redis-immich | no | 🔒 pinned | `docker.io/valkey/valkey` | latest | `sha256:4963247afc4c…` | no | — unsigned |
 | traefik | yes | 🔒 pinned | `docker.io/library/traefik` | latest | `sha256:6b9cbca6fac4…` | no | — unsigned |
-| unifi-syslog | no | 🔒 pinned | `docker.io/linuxserver/syslog-ng` | latest | `sha256:53d71945a46f…` | no | — unsigned |
-| unpoller | yes | 🔒 pinned | `ghcr.io/unpoller/unpoller` | latest | `sha256:bf7bdcc59fcd…` | no | — unsigned |
+| unifi-syslog | no | 🔒 pinned | `docker.io/linuxserver/syslog-ng` | latest | `sha256:b4ab00e39920…` | no | — unsigned |
+| unpoller | yes | 🔒 pinned | `ghcr.io/unpoller/unpoller` | latest | `sha256:9dcccdc931a6…` | no | — unsigned |
 | vaultwarden | yes | 🔒 pinned | `docker.io/vaultwarden/server` | latest | `sha256:d626d04934cd…` | no | ✓ verified |
 
 ---

--- a/quadlets/alertmanager.container
+++ b/quadlets/alertmanager.container
@@ -4,10 +4,10 @@ After=network-online.target monitoring-network.service
 Wants=monitoring-network.service network-online.target
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-06-23 (index digest, multi-arch)
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-07-13 (index digest, multi-arch)
 # ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = adopt new digest (pin-container-image.sh --adopt), bake, restart.
 # ADR-030 P6: no publisher signature (tracked unsigned)
-Image=quay.io/prometheus/alertmanager@sha256:af26fbe4dd1886ac0efd7bd55cd9027da262e105b137a376522b7c14c3626e4a
+Image=quay.io/prometheus/alertmanager@sha256:9e082985f56f4c8c9f724e18f2288c6708f472e56a5286b8863d080434ea065d
 ContainerName=alertmanager
 NoNewPrivileges=true
 HostName=alertmanager

--- a/quadlets/forgejo-db.container
+++ b/quadlets/forgejo-db.container
@@ -4,9 +4,9 @@ After=network-online.target forgejo-network.service
 Wants=network-online.target forgejo-network.service
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: 16-alpine, resolved 2026-06-23 (index digest, multi-arch)
+# ADR-030 P2: digest-pinned (integrity). tag: 16-alpine, resolved 2026-07-13 (index digest, multi-arch)
 # ADR-030 P6: no publisher signature (tracked unsigned)
-Image=docker.io/library/postgres@sha256:e013e867e712fec275706a6c51c966f0bb0c93cfa8f51000f85a15f9865a28cb
+Image=docker.io/library/postgres@sha256:57c72fd2a128e416c7fcc499958864df5301e940bca0a56f58fddf30ffc07777
 ContainerName=forgejo-db
 NoNewPrivileges=true
 HostName=forgejo-db

--- a/quadlets/gathio-db.container
+++ b/quadlets/gathio-db.container
@@ -4,9 +4,9 @@ After=network-online.target gathio-network.service
 Wants=gathio-network.service network-online.target
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: 7, resolved 2026-06-23 (index digest, multi-arch)
+# ADR-030 P2: digest-pinned (integrity). tag: 7, resolved 2026-07-13 (index digest, multi-arch)
 # ADR-030 P6: no publisher signature (tracked unsigned)
-Image=docker.io/library/mongo@sha256:8ecb514b00bdcc0bde67ef4e6c330385377a9dc68e24ee94e28c07c891647348
+Image=docker.io/library/mongo@sha256:d5b3ca8c3f3cdce78d44870dc0871b76d5235e9b2ad4ea6bea5d1fbff8027703
 ContainerName=gathio-db
 NoNewPrivileges=true
 HostName=gathio-db

--- a/quadlets/grafana.container
+++ b/quadlets/grafana.container
@@ -4,10 +4,10 @@ After=network-online.target monitoring-network.service traefik.service
 Wants=monitoring-network.service network-online.target
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-06-10 (index digest, multi-arch)
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-07-13 (index digest, multi-arch)
 # ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = adopt new digest (pin-container-image.sh --adopt), bake, restart.
 # ADR-030 P6: no publisher signature (tracked unsigned)
-Image=docker.io/grafana/grafana@sha256:5dad0df181cb644a14e13617b913b261a54f7d4fd4510721dba420929f35bea2
+Image=docker.io/grafana/grafana@sha256:121a7a9ece6dc10b969f1f96eed64b4f07dfac0d0b8abc070f7cb83bbde86f63
 ContainerName=grafana
 NoNewPrivileges=true
 HostName=grafana

--- a/quadlets/loki.container
+++ b/quadlets/loki.container
@@ -4,8 +4,9 @@ After=network-online.target monitoring-network.service traefik.service
 Wants=monitoring-network.service network-online.target
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-23 (index digest, multi-arch)
-Image=docker.io/grafana/loki@sha256:191d4fdfb7264f16989f0a57f320872620a5a7c2ceeec6229212c4190ec49b86
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-07-13 (index digest, multi-arch)
+# ADR-030 P6: no publisher signature (tracked unsigned)
+Image=docker.io/grafana/loki@sha256:70b9f699fc9bb868b62f1cfd4f787dfa50242f1fd92e6089787d5d7daea75fe8
 ContainerName=loki
 NoNewPrivileges=true
 HostName=loki

--- a/quadlets/nextcloud-db.container
+++ b/quadlets/nextcloud-db.container
@@ -5,9 +5,9 @@ Wants=network-online.target
 
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: 11, resolved 2026-06-10 (index digest, multi-arch)
+# ADR-030 P2: digest-pinned (integrity). tag: 11, resolved 2026-07-13 (index digest, multi-arch)
 # ADR-030 P6: no publisher signature (tracked unsigned)
-Image=docker.io/library/mariadb@sha256:be1ef4fe5f14589325c08a41c76334097ce66c86264b75e1d28342c742782a61
+Image=docker.io/library/mariadb@sha256:efb4959ef2c835cd735dbc388eb9ad6aab0c78dd64febcd51bc17481111890c4
 ContainerName=nextcloud-db
 NoNewPrivileges=true
 

--- a/quadlets/nextcloud.container
+++ b/quadlets/nextcloud.container
@@ -5,9 +5,9 @@ Wants=network-online.target
 
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: 33, resolved 2026-06-23 (index digest, multi-arch)
+# ADR-030 P2: digest-pinned (integrity). tag: 33, resolved 2026-07-13 (index digest, multi-arch)
 # ADR-030 P6: no publisher signature (tracked unsigned)
-Image=docker.io/library/nextcloud@sha256:fe5166b04f217c9e3a263bfe76eef5e13de0dd3919966827de1b47bae2308b01
+Image=docker.io/library/nextcloud@sha256:35170a1c67e759ef874eaa0fde74eb223cf221dacfb67a8ccc14e8d7c5f2c990
 ContainerName=nextcloud
 NoNewPrivileges=true
 

--- a/quadlets/postgres-exporter.container
+++ b/quadlets/postgres-exporter.container
@@ -5,9 +5,10 @@ Wants=network-online.target photos-network.service monitoring-network.service
 Requires=postgresql-immich.service
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-23 (index digest, multi-arch)
-# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart.
-Image=quay.io/prometheuscommunity/postgres-exporter@sha256:e96064f876226d94bb6ce48a4c4b3dd76edba91168ec1ab024e5c4b959310b0f
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-07-13 (index digest, multi-arch)
+# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = adopt new digest (pin-container-image.sh --adopt), bake, restart.
+# ADR-030 P6: no publisher signature (tracked unsigned)
+Image=quay.io/prometheuscommunity/postgres-exporter@sha256:ac5ec343104fae0e2d84a27bb8d69b38430a11910c5382cad85d478d2bab713e
 ContainerName=postgres-exporter
 NoNewPrivileges=true
 HostName=postgres-exporter

--- a/quadlets/unifi-syslog.container
+++ b/quadlets/unifi-syslog.container
@@ -4,10 +4,10 @@ After=network-online.target syslog-network.service traefik.service
 Wants=syslog-network.service network-online.target
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-06-23 (index digest, multi-arch)
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-07-13 (index digest, multi-arch)
 # ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = adopt new digest (pin-container-image.sh --adopt), bake, restart.
 # ADR-030 P6: no publisher signature (tracked unsigned)
-Image=docker.io/linuxserver/syslog-ng@sha256:53d71945a46f2fa094f7412ef2fe583bece7eee2d91f20afc203eab593b076e9
+Image=docker.io/linuxserver/syslog-ng@sha256:b4ab00e399207db81ddd0bf45aca59ce858ba752ffa949d3dd8a13ca54f4bd0a
 ContainerName=unifi-syslog
 NoNewPrivileges=true
 HostName=unifi-syslog
@@ -33,7 +33,8 @@ Volume=/mnt/btrfs-pool/subvol7-containers/unifi-syslog:/var/log/unifi-syslog:Z
 
 DNS=192.168.1.69
 
-HealthCmd=pgrep -x syslog-ng
+# 4.11.0-r0-ls200 (2026-07-13 adopt): upstream comm changed syslog-ng -> syslog-ng-main, breaking `pgrep -x syslog-ng`; match full cmdline instead.
+HealthCmd=pgrep -f /usr/sbin/syslog-ng
 HealthInterval=60s
 HealthRetries=3
 HealthStartPeriod=30s

--- a/quadlets/unpoller.container
+++ b/quadlets/unpoller.container
@@ -5,9 +5,10 @@ After=network-online.target reverse_proxy-network.service prometheus.service tra
 Wants=network-online.target reverse_proxy-network.service
 
 [Container]
-# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-23 (index digest, multi-arch)
-# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = resolve new digest, bake, edit, restart.
-Image=ghcr.io/unpoller/unpoller@sha256:bf7bdcc59fcdaa4699687007aa3ec24ddb3c9d9521f392d8c7aa2bea1bdb781a
+# ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-07-13 (index digest, multi-arch)
+# ADR-030 P1/P4: AutoUpdate removed — deliberate updates only. Bump = adopt new digest (pin-container-image.sh --adopt), bake, restart.
+# ADR-030 P6: no publisher signature (tracked unsigned)
+Image=ghcr.io/unpoller/unpoller@sha256:9dcccdc931a6830735f6978caf8cd67699b0dc33e37cf9ef4638611791c4df62
 ContainerName=unpoller
 
 # Configuration

--- a/scripts/adopt-baked.sh
+++ b/scripts/adopt-baked.sh
@@ -167,7 +167,7 @@ workload_smoke() {
                 return 0
             fi
             local out
-            out="$(ssh -F none -i "$key" -o IdentitiesOnly=yes -o IdentityAgent=none \
+            out="$(ssh -n -F none -i "$key" -o IdentitiesOnly=yes -o IdentityAgent=none \
                        -o StrictHostKeyChecking=accept-new -o UserKnownHostsFile="$HOME/.ssh/known_hosts" \
                        -o BatchMode=yes -o ConnectTimeout=8 -p 2222 -T git@127.0.0.1 2>&1 || true)"
             if grep -q "successfully authenticated" <<< "$out"; then


### PR DESCRIPTION
## Summary
- Wave-ordered adoption per ADR-036 of 10 baked image updates: postgres-exporter, unifi-syslog, unpoller, nextcloud (33.0.5.1→33.0.6.2), alertmanager, grafana, loki, forgejo-db, gathio-db, nextcloud-db. Every service verified healthy; dependent restarts (forgejo, gathio, nextcloud) reverified, including forgejo's SSH push-path smoke test.
- **unifi-syslog 4.11.0** renamed its process comm (`syslog-ng` → `syslog-ng-main`), breaking `pgrep -x` in `HealthCmd`. Switched to matching the full cmdline (`pgrep -f /usr/sbin/syslog-ng`), confirmed healthy and still ingesting real UDM syslog data.
- **adopt-baked.sh bug**: the Forgejo SSH smoke test invoked `ssh` without redirecting stdin. Since it runs inside `while read ... done <<< "$plan"`, `ssh` silently consumed the wave-loop's remaining plan lines — a real run dropped `gathio-db`/`nextcloud-db` from adoption while still printing a normal "✅ Adopted 8" success summary, no halt, no error. Fixed with `ssh -n`.
- Investigated CVE-2026-60104 (initially flagged as urgent for Vaultwarden): confirmed **not applicable** — it's a Bitwarden-Server-only bug in `/auth-requests/admin-request`, an endpoint Vaultwarden's codebase has never implemented (grepped current `src/api/core/accounts.rs`). Vaultwarden is already on the latest signed release (1.36.0). No exception-lane action taken.

## Test plan
- [x] Each adopted service verified `active` + `healthy`/`no-healthcheck` by `adopt-baked.sh`'s own `verify_service`
- [x] Traefik-fronted services re-checked via HTTP: nextcloud (302), grafana (302), loki (302), forgejo (200)
- [x] forgejo SSH push path (`:2222`) re-authenticated after `forgejo-db` restart
- [x] nextcloud `occ upgrade` completed cleanly (`Update successful`), confirmed `/status.php` → `needsDbUpgrade:false`
- [x] unifi-syslog: confirmed real UDM log ingestion continuing post-fix (today's log file actively growing)
- [x] `docs/AUTO-IMAGE-PIN-INDEX.md` regenerated: `pinned=36 floating=0 signers_failed=0`
- [x] Pre-commit hooks passed (secrets scan, ADR-030 invariants, ADR-035 boot-tier)

🤖 Generated with [Claude Code](https://claude.com/claude-code)