### PR TITLE
fix(images): skopeo --no-tags to stop check-image-updates.sh hanging on immich-ml

### DIFF
--- a/scripts/check-image-updates.sh
+++ b/scripts/check-image-updates.sh
@@ -77,10 +77,17 @@ for f in "$QUADLET_DIR"/*.container; do
     repo="${img%@*}"; pinned="${img##*@}"
     tag="$(grep -m1 -oE 'tag: [^,]+' "$f" | sed 's/tag: //')"; [ -n "$tag" ] || tag="latest"
 
-    probe="$(timeout 30 skopeo inspect "docker://${repo}:${tag}" --format '{{.Digest}}|{{.Created}}' 2>/dev/null)"
+    # --no-tags: `inspect` unconditionally paginates the full repo tag list to
+    # populate RepoTags (unused here) even when --format only needs Digest/Created.
+    # immich-machine-learning's tag list is blown up by per-commit x per-hardware-
+    # variant CI tagging (cuda/openvino/armnn/rocm/rknn) and never finishes within
+    # any reasonable timeout without this flag (root-caused 2026-07-13 via
+    # `skopeo --debug inspect`, which showed it looping on tags/list?last=... instead
+    # of returning after the manifest+config fetch that already succeeded).
+    probe="$(timeout 30 skopeo inspect --no-tags "docker://${repo}:${tag}" --format '{{.Digest}}|{{.Created}}' 2>/dev/null)"
     if [ -z "$probe" ]; then
         sleep 2  # registries (esp. GHCR/Docker Hub) throttle bursts — retry once
-        probe="$(timeout 30 skopeo inspect "docker://${repo}:${tag}" --format '{{.Digest}}|{{.Created}}' 2>/dev/null)"
+        probe="$(timeout 30 skopeo inspect --no-tags "docker://${repo}:${tag}" --format '{{.Digest}}|{{.Created}}' 2>/dev/null)"
     fi
     if [ -z "$probe" ]; then
         failed+=("$name (${repo}:${tag})"); continue


### PR DESCRIPTION
## Summary
- `check-image-updates.sh` was reporting `immich-server` and `immich-machine-learning` as `CHECK FAILED` every run, silently blocking the Immich update lane (server+ML+postgres are version-locked as a set).
- Root cause: `skopeo inspect` unconditionally paginates the **entire repository tag list** to populate `RepoTags`, even when `--format` only asks for `.Digest`/`.Created` (neither of which the script consumes). Most repos have few enough tags this is invisible; `immich-app/immich-machine-learning` tags every commit × 5 hardware variants (cuda/openvino/armnn/rocm/rknn) going back through v1.63.0, so the pagination loop never completes inside any reasonable timeout.
- Confirmed via `skopeo --debug inspect`: the manifest, platform-specific manifest, and config blob all fetch in under a second — the hang is entirely a *second*, separate `GET .../tags/list?last=<cursor>&n=0` loop that starts only after the real data is already in hand.
- Fix: add `-n/--no-tags` to both `skopeo inspect` invocations (initial + retry). Confirmed the same command now returns the correct digest+timestamp in <1s.

## Test plan
- [x] `skopeo --debug inspect docker://ghcr.io/immich-app/immich-machine-learning:v2.7.5` — confirmed manifest/config fetch succeeds fast, hang isolated to `tags/list` pagination
- [x] `skopeo inspect --no-tags ... --format '{{.Digest}}|{{.Created}}'` — returns correct output in <1s (was: 240s+ timeout, zero output)
- [x] Full `check-image-updates.sh` re-run: `failed=0` (was 2), both immich images confirmed already up-to-date, no other image's result changed (up-to-date count: 16 baseline + 10 adopted in #322 + 2 immich = 28, math checks out)
- [x] Grepped other scripts for the same `skopeo inspect` pattern — only `verify-image-signature.sh` calls it, already using `--raw` (bypasses tag enumeration entirely), so no other latent instances
- [x] Pre-commit hooks passed (ADR-030 invariants)

🤖 Generated with [Claude Code](https://claude.com/claude-code)