### PR TITLE
fix(audiobookshelf): mount qBittorrent's utdanning category folder

### DIFF
--- a/quadlets/audiobookshelf.container
+++ b/quadlets/audiobookshelf.container
@@ -42,6 +42,9 @@ Volume=/mnt/btrfs-pool/subvol7-containers/audiobookshelf/metadata:/metadata:Z
 Volume=/mnt/btrfs-pool/subvol4-multimedia/Lydbøker:/audiobooks:ro,z
 Volume=/mnt/btrfs-pool/subvol4-multimedia/Bøker:/ebooks:ro,z
 Volume=/mnt/btrfs-pool/subvol4-multimedia/Podder:/podcasts-archive:ro,z
+# qBittorrent 'utdanning' category save path — never had an ABS library folder,
+# so its 23 items scanned into stale /ebooks library rows with no matching disk path (isMissing=1)
+Volume=/mnt/btrfs-pool/subvol4-multimedia/utdanning:/utdanning:ro,z
 
 # Podcast downloads (writable, shared context under multimedia)
 Volume=/mnt/btrfs-pool/subvol4-multimedia/audiobookshelf:/podcasts:z


### PR DESCRIPTION
## Summary

Audiobookshelf reported 25 titles as unreadable, initially suspected to be an ACL/qBittorrent-permissions issue. Systematic investigation (`/systematic-debugging`) ruled that out via ABS's own SQLite database and found two distinct, unrelated causes — no permission problem existed anywhere.

- **23 titles** (incl. "(D&D) Mordenkainen Presents Monsters of the Multiverse"): qBittorrent's `utdanning` category saves to `/mnt/btrfs-pool/subvol4-multimedia/utdanning`, a sibling of `Bøker`/`Lydbøker` that was **never mounted into the audiobookshelf container**. ABS held stale `/ebooks/...` library rows (`isMissing=1`) with no matching path on disk.
- **2 titles** (Andy Serkis "Fellowship"/"Return of the King" discs, Hughes "Tales from Ovid"): unrelated stale/duplicate database rows pointing at the wrong library folder — the real files are healthy under `Lydbøker`. Requires an ABS-side rescan to clean up, not a code change.

ACLs were checked and found identical (`user:100999:rwx` + matching default ACL) on both broken and healthy files — confirming the ACL theory was a red herring.

## Changes

- `quadlets/audiobookshelf.container`: add `Volume=/mnt/btrfs-pool/subvol4-multimedia/utdanning:/utdanning:ro,z`

## Verification

- ✓ `systemctl --user restart audiobookshelf.service` — active
- ✓ `podman exec audiobookshelf ls -la /utdanning` — readable, owned by the container's `node` user
- ✓ `curl -I https://audiobookshelf.patriark.org` — 200

## Follow-up (manual, needs ABS UI session)

- [ ] Create a new ABS library (Book) pointed at `/utdanning` to surface the 23 items
- [ ] Rescan `Bøker`/`Podder` libraries and remove the 2 stale duplicate rows (Andy Serkis discs, Hughes "Tales from Ovid")
- [ ] Decide whether qBittorrent's `utdanning` category should keep saving outside `Bøker`/`Lydbøker` long-term

🤖 Generated with [Claude Code](https://claude.com/claude-code)