### PR TITLE
fix(grafana): disable analytics/update-check telemetry causing egress alerts

### DIFF
--- a/quadlets/grafana.container
+++ b/quadlets/grafana.container
@@ -25,6 +25,9 @@ Environment=GF_AUTH_PROXY_ENABLED=true
 Environment=GF_AUTH_PROXY_HEADER_NAME=X-Forwarded-User
 Environment=GF_AUTH_PROXY_HEADER_PROPERTY=username
 Environment=GF_AUTH_PROXY_AUTO_SIGN_UP=true
+Environment=GF_ANALYTICS_REPORTING_ENABLED=false
+Environment=GF_ANALYTICS_CHECK_FOR_UPDATES=false
+Environment=GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES=false
 
 # Storage
 Volume=%h/containers/data/grafana:/var/lib/grafana:Z


### PR DESCRIPTION
## Summary
- Grafana's default anonymous usage-stats reporting and plugin/version update checker were phoning home to Grafana Labs' GCP-hosted endpoints (`googleusercontent.com` PTR) every ~10-30min
- This tripped `EgressUnexpectedDestinationPersistent` (ADR-030 P7 sustained/critical) against a static IP, since the traffic recurred hourly rather than looking like one-off CDN edge rotation
- Fix disables the telemetry at the source (`GF_ANALYTICS_REPORTING_ENABLED=false`, `GF_ANALYTICS_CHECK_FOR_UPDATES=false`, `GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES=false`) rather than widening the egress allow-list — no legitimate feature depends on this traffic

## Test plan
- [x] `daemon-reload` + restart applied locally; Grafana healthy, config-override log lines confirm all 3 env vars loaded
- [x] Confirmed `plugins.update.checker` / `infra.usagestats` log lines stopped firing after restart
- [x] `curl -I https://grafana.patriark.org` still 302s to Authelia SSO as expected
- [ ] Confirm `EgressUnexpectedDestinationPersistent` alert self-clears within 24h with no new anomalies.jsonl entries for grafana

🤖 Generated with [Claude Code](https://claude.com/claude-code)