### PR TITLE
chore(docs): stop-forward — gitignore 97-plans and 98-journals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,13 @@ docs/90-archive/
 # in a public repo. (lessons.md briefly existed on GitHub via PR #278.)
 docs/96-project-supervisor/
 
+# Journals & plans — internal institutional memory (topology, host inventory,
+# incident narrative). Stop-forward decision 2026-07-13: no new files here go
+# public; the 270 already-tracked files stay tracked until the vault migration
+# untracks them (git rm --cached). See obsidian-knowledge-vault-proposal.
+docs/97-plans/
+docs/98-journals/
+
 # Active-probe posture script — tuned attack tool for this specific perimeter
 # (curated attack paths, CrowdSec burst logic, Region Block negative test).
 # Low reconstruction cost but publishing it hands adversaries a pre-built


### PR DESCRIPTION
## What

Adds `docs/97-plans/` and `docs/98-journals/` to `.gitignore`.

## Why

Phase 0 of the Obsidian knowledge-vault migration (proposal: `subvol1-docs/homelab/obsidian-knowledge-vault-proposal.md`). These directories are internal institutional memory — network topology, host inventory, incident narratives — exactly the content class the local-docs policy exists to keep off public GitHub. The policy held in `urd` but not here; this closes the gap going forward.

## Scope

- **Stops new files** from being staged (three untracked journals in the working tree are the immediate beneficiaries).
- **Does NOT untrack** the 270 already-tracked files — that happens in Phase 2 of the migration (`git rm --cached` when the directories move into the vault and symlink back). Stop-forward, no history rewrite: with 3 forks, rewriting un-publishes nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)