### PR TITLE
docs(adr): ADR-042 — documentation boundary as per-document sensitivity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ Rollback: `git revert` of the digest line + restart; BTRFS snapshots as second p
 
 ### Architecture Decision Records
 
-**Architectural decisions recorded as ADRs — latest is ADR-041** (see `docs/*/decisions/` for full details; number new ADRs sequentially from the latest)
+**Architectural decisions recorded as ADRs — latest is ADR-042** (see `docs/*/decisions/` for full details; number new ADRs sequentially from the latest)
 
 **Design-Guiding ADRs (affect future decisions):**
 - **ADR-001:** Rootless Containers — UID 1000, `:Z` SELinux labels on all mounts
@@ -138,6 +138,7 @@ Rollback: `git revert` of the digest line + restart; BTRFS snapshots as second p
 - **ADR-038:** Merge-Commit-Only Strategy — squash/rebase disabled repo-side (squash replaces owner SSH signatures with GitHub's web-flow key and breaks stacked-PR ancestry against the live-config worktree); branch + PR per work package, stacked branches merge in order. Operationalized in the Git & PR Workflow section above
 - **ADR-039:** Egress Baseline Scoping for High-Rotation Cloud-API Endpoints (amends ADR-030 P7) — crowdsec's CAPI is AWS-API-Gateway-fronted in eu-west-1 and rotates across the published pool, so per-IP allow-listing was a re-baseline treadmill (3 PRs in 48h). crowdsec's AWS allowance is now generated from AWS-published eu-west-1 EC2 ranges by `scripts/sync-aws-egress-ranges.sh` (deliberate offline sync, never hot-path; notify-only drift check in `monthly-update.sh`). Crowdsec-only carve-out gated by ≥3 benign re-baselines; CloudFront/Cloudflare stay tight static entries; `infrastructure: []` unchanged. Sharpens the off-region exfil signal rather than discarding it
 - **ADR-041:** Runtime Secrets via OpenBao Substrate (supersedes ADR-040) — the ~30 runtime/workload secrets are sourced from a self-hosted **OpenBao** system-service owned by **htpc-mgmt** (substrate, *not* the fleet — not a container/quadlet; localhost TLS, TPM-auto-unsealed). A root sync oneshot recreates podman secrets in a **tmpfs** cache (ADR-028 path) so **every `Secret=` handle (env *and* mount) stays byte-for-byte unchanged**. This repo owns *only* the consumption handles — the interface is the secret **name** (three-way consistency check OpenBao ↔ quadlets ↔ manifest); mechanism/policies/rotation/`secretctl`/DR live in **htpc-mgmt ADR-007**. At-rest leak closed by OpenBao's barrier; **no LLM read-wall** (privilege separation deferred). The old "podman secrets encrypted at rest" claim was FALSE (file driver = base64). To create/rotate a secret, use htpc-mgmt `secretctl`, **never** `podman secret rm/create` here.
+- **ADR-042:** Documentation Boundary as Per-Document Sensitivity (amends the vault decision) — every doc carries `sensitivity:` frontmatter; ADRs all public; runbook split test (generic → public scrubbed, specific → vault + public stub); birth rule = type decides, repo-public default; three-zone link policy (public→vault never as paths, name-only when strictly necessary; vault→public free); **docs are written AFTER the PR lands** (code → PR → vault journal → vault commit); workflow operationalized as `/commit-push-pr` (refresh), `/commit-push-docs`, `/journal`, `/session-close`
 
 Check if an ADR exists before proposing changes. Reference the ADR and explain what changed if suggesting alternatives. New decisions get new ADRs (don't edit existing ones).
 

--- a/docs/40-monitoring-and-documentation/decisions/2026-07-14-ADR-042-documentation-boundary-per-document-sensitivity.md
+++ b/docs/40-monitoring-and-documentation/decisions/2026-07-14-ADR-042-documentation-boundary-per-document-sensitivity.md
@@ -1,0 +1,143 @@
+# ADR-042: Documentation Boundary as a Per-Document Sensitivity Property
+
+**Date:** 2026-07-14
+**Status:** Accepted. **Amends** the Huldr knowledge-vault decision (vault mechanics are
+canonical in the htpc-mgmt ADR series — the vault is substrate, hosted and versioned
+outside this repo) the way ADR-036 amends ADR-030: the vault decision created the private
+home; this ADR decides what belongs in each home and how documents and commits flow
+between them.
+
+---
+
+## Context
+
+The Huldr vault migration (PRs #326/#327, 2026-07-13) made the `docs/9x` directories
+physically private: journals, plans, reports, supervisor docs, and archive live in a
+private Obsidian vault (private Forgejo repo), reachable from this repo only through
+gitignored symlinks. `git add` here cannot stage them; a pre-commit gate
+(`scripts/check-vault-boundary.sh`) rejects staged markdown carrying
+`sensitivity: internal|secret`.
+
+That left the public half of the estate undecided. Measured 2026-07-14: `docs/00-40`
+holds 124 markdown files, of which **18 contain RFC1918 addresses** — mostly incidental
+mentions in guides, concentrated in `30-security` (7/20). The IR runbooks are largely
+clean (IR-001/002: zero internal references; IR-005: six). This is a materially
+different exposure than the journals were (270 files of full topology narrative and
+credential-adjacent prose, three live credentials): the public tree is a
+mostly-deliberate teaching corpus, not a leak in progress. The repo has active
+followers (40 stars, 3 forks) who consume its documentation and ADRs.
+
+Five trajectories were evaluated and scored in the 2026-07-14 documentation-boundary
+plan (vault-resident; cited here by name per D5's own rule — it is this ADR's
+deliberation record): hold-the-line (45), **per-document sensitivity (87)**,
+vault-first-publish-by-exception (58), single-source export pipeline (55), full
+privatization (30). The per-document trajectory was ratified in a full owner interview,
+absorbing the vault-first idea narrowly (for sensitive-first drafts) and keeping the
+export pipeline as a named future option.
+
+## Decision
+
+### D1 — The boundary is a property of the document, not of a directory
+
+Every markdown document in the fleet carries frontmatter including
+`sensitivity: public | internal | secret`. Directory placement *follows from*
+classification: `internal`/`secret` documents live in the vault (physically unstageable
+here), `public` documents live in this repo's `docs/00-40` with `sensitivity: public`
+explicit. The pre-commit gate enforces the boundary for anything misplaced. The public
+tree receives mechanical frontmatter backfill (`type`, `title`, `description`, dates,
+`sensitivity`) to make classification universal and machine-checkable.
+
+### D2 — ADRs are public, all of them, and new ones are born public
+
+ADRs are design rationale, not topology; they are the repo's primary teaching value and
+reveal little the public quadlets and Traefik configs do not. When an ADR needs internal
+specifics, those go in a vault-side companion note linked *from* the vault — never the
+reverse.
+
+### D3 — Runbooks pass a split test; other flagged files scrub in place
+
+A runbook stays public when the *procedure* is generic and specifics are incidental
+(IR-001..004, DR-001..004 — stray internal references scrubbed). It moves to the vault
+when specificity *is* its value (IR-005, nextcloud-operations), leaving a public stub:
+title, one-line purpose, "operational specifics live in the private vault." For the
+remaining flagged guides the default is **scrub-in-place** (placeholder incidental
+IPs/hostnames); a file moves to the vault only when the review shows specificity is
+load-bearing.
+
+### D4 — Birth rule: type decides, repo-public default
+
+Guides, ADRs, and patterns are born in this repo, public, with frontmatter from day
+one. A document whose *first draft* needs internal specifics (incident post-mortems,
+host-specific runbooks) is born in the vault; publishing it later is a deliberate
+copy-and-scrub, never a move-and-hope. Journals, plans, reports, and supervisor docs
+are always vault-born (settled by the vault migration). Public docs are **not** worded
+for an external audience — they are written for the owner; the public reader is a
+welcome eavesdropper. Only genuinely outward-facing files (README, CONTRIBUTING) are
+audience-specific.
+
+### D5 — Link policy: three zones, asymmetric across the boundary
+
+1. **Vault → vault:** relative markdown links, Obsidian-managed (OKF graph edges).
+   Link liberally; broken links are work items, not errors.
+2. **Public → public:** relative paths and textual `ADR-NNN` references, unchanged.
+3. **Across the boundary, asymmetric:** public → vault **never as paths or links**;
+   a public PR body or ADR may mention a vault document **by name only, when strictly
+   necessary** (as this ADR does for its deliberation record). Vault → public is free
+   and encouraged — GitHub PRs, commit hashes, URLs, repo paths in prose. The vault
+   journal is the record an LLM should counsel as source of truth, so its citations
+   point outward.
+
+### D6 — Two homes, two commit disciplines, documentation after the PR
+
+This repo keeps ADR-038 (branch + PR, merge commits, owner-signed; trivia lane for
+public-doc/comment-only changes). The vault commits direct-to-main on private Forgejo,
+signed with the agentless software key, no PR ceremony — the journal is the review
+surface. **Ordering: documentation is written after the code lands** (code →
+commit/PR → vault journal → vault commit), because docs written before a PR get the
+tense wrong and mislead future sessions about what is closed versus in progress. The
+workflow is operationalized as skills — refreshed `/commit-push-pr` (trivia lane
+encoded, no in-skill main-push override for config-touching diffs), new
+`/commit-push-docs` (vault-side, frontmatter-gated, fleet-generic and bundle-aware,
+user-level), and project-local `/journal` + `/session-close` — with asymmetric
+cross-home dirty-check nudges at each skill's tail.
+
+### D7 — Each home documents itself
+
+`CONTRIBUTING.md` (public) fully covers the public tree's conventions and states only
+that private documentation lives in a private vault with its own conventions — no
+paths, no titles. The vault carries its own companion conventions document (OKF
+frontmatter schema, journal templates, session ritual).
+
+## Consequences
+
+- The 00-40 frontmatter backfill and the 18-file scrub/split become scheduled work
+  (plan WP-C), after which the pre-commit gate is meaningful across the whole tree and
+  a standing audit view ("`sensitivity: public` AND body matches `192.168`") can hold
+  the line.
+- Classification work is done to the standard a future single-source export pipeline
+  (the T4 trajectory) would require, keeping that evolution open at zero extra cost —
+  but no generator is built now; the human pause of a manual publish is retained
+  deliberately.
+- Two authoring homes require a per-document call at birth; D4 makes it mechanical.
+- Public runbook stubs and their vault twins can drift; the split test (move only when
+  specificity is the value) keeps the affected set small (2 files today).
+- Journals already on public GitHub history/forks remain there (stop-forward,
+  reaffirmed). Rotation of the three exposed credentials is prerequisite work tracked
+  elsewhere and is not affected by any boundary policy.
+
+## Alternatives Considered
+
+- **Hold the line (directory boundary only), 45/100** — leaves 18 public files
+  unclassified, the gate blind where authoring continues, and the two-home workflow
+  improvised; unstable equilibrium.
+- **Vault-first everything, publish by exception, 58/100** — maximum drafting freedom,
+  but the public repo's living docs decay into a brochure and config-adjacent guides
+  drift from the config they describe. Its birth-rule idea is absorbed narrowly in D4.
+- **Single-source export pipeline (vault → generated public tree), 55/100** — elegant
+  single source of truth, but `git blame` lies, PRs stop reviewing authored diffs,
+  outside doc contributions become impossible, and an automated export *removes* the
+  human pause a manual publish provides. Named future option; D1's frontmatter work is
+  its prerequisite, so nothing is lost by waiting.
+- **Full privatization of docs/, 30/100** — disproportionate to measured exposure,
+  amputates the learning-in-public philosophy, and the public quadlets/AUTO-* would
+  still reveal the service inventory anyway.

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -6,6 +6,21 @@ This guide covers when, where, and how to write documentation. It does not repea
 
 ---
 
+## The Two Homes (ADR-042)
+
+Documentation lives in two places, and the boundary is a **per-document property**, not a directory convention:
+
+- **This repo (`docs/00-40`)** — public on GitHub. Guides, ADRs, runbooks, patterns. Every document carries frontmatter with `sensitivity: public` explicit.
+- **The private vault** — journals, plans, reports, supervisor docs, archive, and any document classified `internal` or `secret`. The `docs/9x` paths still resolve (gitignored symlinks), but the content is physically unstageable here; a pre-commit gate (`scripts/check-vault-boundary.sh`) rejects staged markdown carrying `sensitivity: internal|secret`. The vault has its own conventions document — consult it there.
+
+**Birth rule (type decides, repo-public default):** guides, ADRs, and patterns are born here, public, with frontmatter from day one. A document whose *first draft* needs internal specifics (incident post-mortems, host-specific runbooks) is born in the vault; publishing it later is a deliberate copy-and-scrub. Do not word public docs for an external audience — write for the owner; the public reader is a welcome eavesdropper.
+
+**Runbook split test:** a runbook stays public when the procedure is generic and specifics are incidental (scrub stray IPs/hostnames to placeholders). It lives in the vault when specificity *is* its value — leaving a public stub here: title, one-line purpose, "operational specifics live in the private vault."
+
+**Commit discipline differs per home:** this repo follows ADR-038 (branch + PR, merge commits; trivia lane for public-doc/comment-only changes). Vault docs commit direct-to-main on the private forge — never here. **Documentation is written after the code lands** (code → commit/PR → journal), so records use past tense and never describe closed work as in progress.
+
+---
+
 ## Decision Tree: Should You Document?
 
 ### Step 1: Is documentation needed?
@@ -36,18 +51,18 @@ This guide covers when, where, and how to write documentation. It does not repea
 
 ### Step 3: Where does it go?
 
-| Domain | Directory |
-|---|---|
-| Core design patterns, philosophy | `00-foundation/` |
-| Service-specific (Jellyfin, Immich, etc.) | `10-services/` |
-| Operational procedures, DR runbooks | `20-operations/` |
-| Security, incident response | `30-security/` |
-| Monitoring, SLOs, documentation meta | `40-monitoring-and-documentation/` |
-| Distilled lessons, situational awareness | `96-project-supervisor/` (local-only, gitignored) |
-| Strategic plans, roadmaps | `97-plans/` |
-| Chronological logs, session notes | `98-journals/` |
-| Automated reports (JSON, snapshots) | `99-reports/` |
-| Superseded documentation | `90-archive/` |
+| Domain | Directory | Home |
+|---|---|---|
+| Core design patterns, philosophy | `00-foundation/` | public (this repo) |
+| Service-specific (Jellyfin, Immich, etc.) | `10-services/` | public (this repo) |
+| Operational procedures, DR runbooks | `20-operations/` | public — split test applies |
+| Security, incident response | `30-security/` | public — split test applies; incidents born in vault |
+| Monitoring, SLOs, documentation meta | `40-monitoring-and-documentation/` | public (this repo) |
+| Distilled lessons, situational awareness | `96-project-supervisor/` | **vault** (symlink; versioned privately) |
+| Strategic plans, roadmaps | `97-plans/` | **vault** (symlink) |
+| Chronological logs, session notes | `98-journals/` | **vault** (symlink) |
+| Automated reports (JSON, snapshots) | `99-reports/` | **vault** (symlink; untracked churn) |
+| Superseded documentation | `90-archive/` | **vault** (symlink) |
 
 Within domain directories, use subdirectories: `guides/` for living docs, `decisions/` for ADRs, `runbooks/` for procedures.
 
@@ -75,7 +90,7 @@ Update in place when information changes. Focus on current state, not history.
 
 ### Journal Entry
 
-**Location:** `98-journals/YYYY-MM-DD-<description>.md`
+**Location:** `98-journals/YYYY-MM-DD-<description>.md` — **vault-resident.** Written after the related PR lands (past tense); may freely reference GitHub PRs, commits, and URLs. Carries OKF frontmatter per the vault's conventions doc. Committed in the vault, never here.
 
 ```markdown
 # <Title>
@@ -97,7 +112,7 @@ Never edited after creation. Records the journey and decision context.
 
 ### Plan
 
-**Location:** `97-plans/YYYY-MM-DD-<description>.md`
+**Location:** `97-plans/YYYY-MM-DD-<description>.md` — **vault-resident**, OKF frontmatter, committed in the vault.
 
 ```markdown
 # <Plan Title>
@@ -154,11 +169,11 @@ Machine-generated or rare authoritative snapshots. Do not create reports for con
 
 ### Supervisor Document (situational awareness)
 
-**Location:** `96-project-supervisor/` | **Local-only (gitignored)**
+**Location:** `96-project-supervisor/` | **Vault-resident (private, versioned)**
 
-The whole directory is gitignored — like `*-private.md` files, it aggregates operational
-detail that doesn't belong in the public repo. It exists on the host (and in local backups),
-not on GitHub. Consequence: work tracked only here has no public trace — file GitHub
+The directory is a gitignored symlink into the private vault — it aggregates operational
+detail that doesn't belong in the public repo, and since 2026-07-13 it is version-controlled
+there (no longer local-only). Work tracked only here still has no public trace — file GitHub
 issues for anything that needs one.
 
 Two document kinds live here:
@@ -213,15 +228,15 @@ report yields a durable, generalizable lesson, promote it to `lessons.md` per it
 | Document Type | Date Prefix? | Location | Example |
 |---|---|---|---|
 | Guide | No | `*/guides/` | `jellyfin.md` |
-| Journal | Yes | `98-journals/` | `2025-11-07-deployment-log.md` |
-| Plan | Yes | `97-plans/` | `2025-11-22-disaster-recovery.md` |
-| ADR | Yes | `*/decisions/` | `2025-11-07-decision-001-title.md` |
-| Report | N/A | `99-reports/` | `intel-*.json` |
-| Supervisor doc (core) | No | `96-project-supervisor/` (gitignored) | `lessons.md` |
-| Supervisor handoff | Yes | `96-project-supervisor/` (gitignored) | `2026-06-12-lessons-loose-threads-handoff.md` |
+| Journal | Yes | `98-journals/` (vault) | `2025-11-07-deployment-log.md` |
+| Plan | Yes | `97-plans/` (vault) | `2025-11-22-disaster-recovery.md` |
+| ADR | Yes | `*/decisions/` | `2026-07-14-ADR-042-title.md` |
+| Report | N/A | `99-reports/` (vault) | `intel-*.json` |
+| Supervisor doc (core) | No | `96-project-supervisor/` (vault) | `lessons.md` |
+| Supervisor handoff | Yes | `96-project-supervisor/` (vault) | `2026-06-12-lessons-loose-threads-handoff.md` |
 | Runbook (DR) | Yes | `20-operations/runbooks/` | `DR-001-system-ssd-failure.md` |
 | Runbook (IR) | Yes | `30-security/runbooks/` | `IR-005-network-security-event.md` |
-| Incident | Yes | `30-security/incidents/` | `2025-11-23-incident-data-loss.md` |
+| Incident | Yes | `30-security/incidents/` (born in vault; publish = copy-and-scrub) | `2025-11-23-incident-data-loss.md` |
 
 **Filename rules:** lowercase, hyphens (no underscores or spaces), `.md` extension, descriptive but concise.
 
@@ -239,18 +254,21 @@ report yields a durable, generalizable lesson, promote it to `lessons.md` per it
 - Code blocks must specify the language (`bash`, `yaml`, `markdown`)
 - Keep lines under ~120 characters for terminal readability
 
-**Cross-linking:**
-- Link to related docs using relative paths: `[SLO framework](40-monitoring-and-documentation/guides/slo-framework.md)`
-- When referencing an ADR, use the format: `ADR-NNN` (readers can find it via `docs/*/decisions/`)
+**Cross-linking (three zones, ADR-042 D5):**
+- **Public → public:** relative paths: `[SLO framework](40-monitoring-and-documentation/guides/slo-framework.md)`; ADRs by textual `ADR-NNN` reference
+- **Public → vault: never as paths or links.** A PR body or ADR may mention a vault document by name only, when strictly necessary
+- **Vault → public:** free — GitHub PRs, commit hashes, URLs, repo paths in prose (vault-internal linking rules live in the vault's conventions doc)
 - Do not duplicate content across docs -- link instead
 
-**Metadata:** Every document needs at minimum a title (`# ...`) and a date (either in the filename or a `Last Updated` field). Guides must have `Last Updated`.
+**Metadata (frontmatter):** Every public document carries YAML frontmatter: `type`, `title`, `description`, `sensitivity: public` (explicit), and dates. Until the backfill completes (plan WP-C), legacy docs may still carry only a title and `Last Updated` — new documents must not. Guides additionally keep `Last Updated` current.
 
 ---
 
 ## Archiving
 
 **The archive location is always `docs/90-archive/`.** Do not create archive subdirectories inside other categories (no `98-journals/archive/`, no `10-services/archive/`, etc.). The single flat location is intentional — everything archived lives in one place, regardless of which category it came from.
+
+Note: `90-archive/` is **vault-resident** (symlink). Archiving a *public* doc therefore crosses the boundary: `git rm` it here (a tracking change in this repo, committed via PR or trivia lane) and place the file in `90-archive/` (a vault commit). Archiving an already-private doc is a vault-only move. Reclassification generally (public → internal) is a *move*, not an edit — allowed for any document type, including otherwise-immutable ones.
 
 ### When to Archive
 
@@ -294,11 +312,11 @@ To update these, run the orchestrator script. Manual edits will be overwritten.
 
 Before committing documentation:
 
-- [ ] File is in the correct directory for its type
+- [ ] File is in the correct directory for its type — and in the correct **home** (ADR-042 birth rule)
 - [ ] Filename follows naming convention (date prefix where required)
-- [ ] Required metadata is present (title, date, status for ADRs/plans)
-- [ ] No sensitive information (secrets, passwords, API keys, internal IPs)
-- [ ] Cross-links use relative paths and point to existing files
+- [ ] Frontmatter present: `type`, `title`, `description`, `sensitivity: public`, dates
+- [ ] No sensitive information (secrets, passwords, API keys, internal IPs) — the pre-commit gate rejects `sensitivity: internal|secret` markdown, but the gate is a backstop, not the check
+- [ ] Cross-links follow the three-zone policy (no paths/links into the vault)
 - [ ] `CLAUDE.md` updated if architecture or process changed
 
 ---
@@ -312,4 +330,6 @@ Before committing documentation:
 5. **Date prefix = immutable** -- if the filename has a date, don't edit the content
 6. **Check before creating** -- search for existing docs on the topic first
 7. **Auto-docs are hands-off** -- never manually edit `AUTO-*.md` files
-8. **When in doubt, journal it** -- a journal entry is always a safe choice for recording context
+8. **When in doubt, journal it** -- a journal entry is always a safe choice for recording context (vault-side)
+9. **Docs after the PR** -- write the record once the work is landed, in past tense
+10. **Sensitivity is per-document and never guessed** -- classify explicitly; when unsure, it's `internal` until reviewed


### PR DESCRIPTION
## Summary

Ratifies the documentation-boundary policy decided in the 2026-07-14 owner interview (deliberation record: the 2026-07-14 documentation-boundary plan, vault-resident). Amends the Huldr vault decision the way ADR-036 amends ADR-030: the vault created the private home; this ADR decides what belongs in each home and how documents and commits flow between them.

- **ADR-042** (new, `40-monitoring-and-documentation/decisions/`): boundary is a per-document `sensitivity:` frontmatter property. ADRs all stay public; runbooks pass a split test (IR-005 + nextcloud-operations will move to the vault with public stubs — executed in WP-C); remaining flagged files scrub in place; birth rule = type decides, repo-public default; three-zone link policy; docs written **after** the PR lands.
- **CONTRIBUTING v2**: new "Two Homes" section; vault-resident directories marked throughout; frontmatter requirements replace the loose metadata rule; link-zone policy; archiving-across-the-boundary procedure; pre-commit checklist updated.
- **CLAUDE.md**: ADR-042 registered in the design-guiding list; latest-ADR pointer bumped to 042.

## Not in this PR (sequenced work)

- WP-A: the four workflow skills (`/commit-push-pr` refresh, `/commit-push-docs`, `/journal`, `/session-close`)
- WP-C: 00-40 frontmatter backfill + 18-file scrub + runbook split execution
- WP-D: descriptions, `.obsidian/types.json`, Bases audit views
- htpc-mgmt: vault-architecture ADR (delegated)

## Verification

- Pre-commit hooks green (ADR-030 invariants, vault-boundary gate)
- No AUTO-* churn staged; diff touches exactly 3 files

🤖 Generated with [Claude Code](https://claude.com/claude-code)