### PR TITLE
docs: backfill OKF frontmatter across all 123 public docs/00-40 files (WP-C)

### DIFF
--- a/docs/00-foundation/decisions/2025-10-20-decision-001-rootless-containers.md
+++ b/docs/00-foundation/decisions/2025-10-20-decision-001-rootless-containers.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-001: Rootless Podman Containers"
+description: "ADR recording the choice to run all homelab services as rootless Podman containers under user patriark (UID 1000) rather than rootful Docker."
+sensitivity: public
+created: 2025-11-07
+updated: 2025-11-07
+---
+
 # ADR-001: Rootless Podman Containers
 
 **Date:** 2025-10-20

--- a/docs/00-foundation/decisions/2025-10-25-decision-002-systemd-quadlets-over-compose.md
+++ b/docs/00-foundation/decisions/2025-10-25-decision-002-systemd-quadlets-over-compose.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-002: Systemd Quadlets Over Docker Compose"
+description: "ADR recording the choice of systemd quadlets over Docker Compose, Kubernetes, or shell scripts for container orchestration."
+sensitivity: public
+created: 2025-11-07
+updated: 2025-12-31
+---
+
 # ADR-002: Systemd Quadlets Over Docker Compose
 
 **Date:** 2025-10-25

--- a/docs/00-foundation/decisions/2025-11-13-ADR-009-config-data-directory-strategy.md
+++ b/docs/00-foundation/decisions/2025-11-13-ADR-009-config-data-directory-strategy.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "Configuration vs Data Directory Strategy"
+description: "ADR deciding the config-versus-data directory split, using selective gitignore exceptions to track custom configs while excluding secrets and runtime data."
+sensitivity: public
+created: 2025-11-13
+updated: 2025-12-22
+---
+
 # Configuration vs Data Directory Strategy
 
 **Date:** 2025-11-13

--- a/docs/00-foundation/decisions/2025-12-22-ADR-015-container-update-strategy.md
+++ b/docs/00-foundation/decisions/2025-12-22-ADR-015-container-update-strategy.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-015: Container Update Strategy for State-of-the-Art Homelab"
+description: "ADR (superseded by ADR-030) setting the original container update strategy — :latest tags for most services, pinning only databases and breaking-change services."
+sensitivity: public
+created: 2025-12-22
+updated: 2026-05-23
+---
+
 # ADR-015: Container Update Strategy for State-of-the-Art Homelab
 
 **Status:** Superseded by ADR-030 (trust model; this ADR's BTRFS rollback + health-validation mechanisms remain valid)

--- a/docs/00-foundation/decisions/2025-12-31-ADR-016-configuration-design-principles.md
+++ b/docs/00-foundation/decisions/2025-12-31-ADR-016-configuration-design-principles.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-016: Configuration Design Principles"
+description: "ADR codifying six configuration design principles, most notably that all Traefik routing lives in dynamic config, never in container labels."
+sensitivity: public
+created: 2025-12-31
+updated: 2026-03-18
+---
+
 # ADR-016: Configuration Design Principles
 
 **Date:** 2025-12-31

--- a/docs/00-foundation/decisions/2026-01-05-ADR-017-slash-commands-and-subagents.md
+++ b/docs/00-foundation/decisions/2026-01-05-ADR-017-slash-commands-and-subagents.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-017: Slash Commands and Subagents for Claude Code Workflow"
+description: "ADR adopting Claude Code slash commands and subagents to standardize repetitive git, deployment-verification, design, and cleanup workflows."
+sensitivity: public
+created: 2026-01-05
+updated: 2026-01-05
+---
+
 # ADR-017: Slash Commands and Subagents for Claude Code Workflow
 
 **Date:** 2026-01-05

--- a/docs/00-foundation/decisions/2026-02-04-ADR-018-static-ip-multi-network-services.md
+++ b/docs/00-foundation/decisions/2026-02-04-ADR-018-static-ip-multi-network-services.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-018: Static IP Assignment for Multi-Network Services"
+description: "ADR mandating static IP assignment plus Traefik /etc/hosts override for multi-network services, working around Podman's undefined DNS ordering."
+sensitivity: public
+created: 2026-02-04
+updated: 2026-03-18
+---
+
 # ADR-018: Static IP Assignment for Multi-Network Services
 
 **Status:** Accepted

--- a/docs/00-foundation/decisions/2026-02-22-ADR-019-filesystem-permission-model.md
+++ b/docs/00-foundation/decisions/2026-02-22-ADR-019-filesystem-permission-model.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-019: Filesystem Permission Model"
+description: "ADR standardizing BTRFS subvolumes to patriark:patriark 0755 with POSIX ACLs for cross-UID container writes, decommissioning Samba-era permissions."
+sensitivity: public
+created: 2026-02-22
+updated: 2026-02-22
+---
+
 # ADR-019: Filesystem Permission Model
 
 **Status:** Accepted

--- a/docs/00-foundation/decisions/2026-03-21-ADR-020-daily-external-backups.md
+++ b/docs/00-foundation/decisions/2026-03-21-ADR-020-daily-external-backups.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-020: Daily External Backups with Incremental Sends"
+description: "ADR (superseded by ADR-021) moving external BTRFS backups from weekly-full to daily incremental sends with graduated Time Machine-style retention."
+sensitivity: public
+created: 2026-03-22
+updated: 2026-03-29
+---
+
 # ADR-020: Daily External Backups with Incremental Sends
 
 **Date:** 2026-03-21

--- a/docs/00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md
+++ b/docs/00-foundation/decisions/2026-03-28-ADR-021-urd-backup-tool.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-021: Urd Replaces Shell Script for BTRFS Backup Management"
+description: "ADR replacing the ~1700-line bash backup script with Urd, a purpose-built Rust tool for BTRFS snapshot lifecycle and offsite sends."
+sensitivity: public
+created: 2026-03-29
+updated: 2026-06-04
+---
+
 # ADR-021: Urd Replaces Shell Script for BTRFS Backup Management
 
 **Date:** 2026-03-28

--- a/docs/00-foundation/decisions/2026-04-16-ADR-022-traefik-socket-activation.md
+++ b/docs/00-foundation/decisions/2026-04-16-ADR-022-traefik-socket-activation.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-022: Systemd Socket Activation for Rootless Traefik"
+description: "ADR adopting systemd socket activation for rootless Traefik so it sees real client source IPs instead of rootlessport SNAT."
+sensitivity: public
+created: 2026-04-16
+updated: 2026-04-16
+---
+
 # ADR-022: Systemd Socket Activation for Rootless Traefik
 
 **Date:** 2026-04-16

--- a/docs/00-foundation/decisions/2026-04-18-ADR-024-database-dump-backup.md
+++ b/docs/00-foundation/decisions/2026-04-18-ADR-024-database-dump-backup.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-024: Application-Level Database Dump Backup"
+description: "ADR (superseded by ADR-029) adding a nightly application-consistent database dump job for the stateful DB engines, without moving any data."
+sensitivity: public
+created: 2026-04-21
+updated: 2026-05-22
+---
+
 # ADR-024: Application-Level Database Dump Backup
 
 **Date:** 2026-04-18

--- a/docs/00-foundation/decisions/2026-04-18-ADR-025-db-storage-migration-deferred.md
+++ b/docs/00-foundation/decisions/2026-04-18-ADR-025-db-storage-migration-deferred.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-025: Database Storage Migration to NOCOW Subvolume (Deferred)"
+description: "ADR (superseded by ADR-029) deferring the migration of five databases to a dedicated NOCOW subvol8-db pending 60 days of baseline measurements."
+sensitivity: public
+created: 2026-04-21
+updated: 2026-05-22
+---
+
 # ADR-025: Database Storage Migration to NOCOW Subvolume (Deferred)
 
 **Date:** 2026-04-18

--- a/docs/00-foundation/decisions/2026-04-21-ADR-023-monitoring-bind-propagation.md
+++ b/docs/00-foundation/decisions/2026-04-21-ADR-023-monitoring-bind-propagation.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-023: Shared Mount Propagation for Monitoring Containers"
+description: "ADR fixing LUKS drive-swap failures caused by cAdvisor and node_exporter recursively bind-mounting host root and capturing removable-drive submounts."
+sensitivity: public
+created: 2026-04-22
+updated: 2026-04-22
+---
+
 # ADR-023: Shared Mount Propagation for Monitoring Containers
 
 **Date:** 2026-04-21

--- a/docs/00-foundation/decisions/2026-04-21-ADR-026-nextcloud-pinned-major-version.md
+++ b/docs/00-foundation/decisions/2026-04-21-ADR-026-nextcloud-pinned-major-version.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-026: Pin Nextcloud to Major Version (amends ADR-015)"
+description: "ADR amending ADR-015 to require pinning Nextcloud to a major-version tag, treating it as a database-schema owner after an unattended-upgrade SLO collapse."
+sensitivity: public
+created: 2026-04-21
+updated: 2026-04-21
+---
+
 # ADR-026: Pin Nextcloud to Major Version (amends ADR-015)
 
 **Date:** 2026-04-21

--- a/docs/00-foundation/decisions/2026-04-22-ADR-027-forward-nocow-workloads-subvol8-db.md
+++ b/docs/00-foundation/decisions/2026-04-22-ADR-027-forward-nocow-workloads-subvol8-db.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-027: Forward-Only NOCOW Placement on subvol8-db (Policy)"
+description: "ADR (superseded by ADR-029) setting a forward-only policy that new write-hot, snapshot-hostile workloads land on subvol8-db from day one."
+sensitivity: public
+created: 2026-04-22
+updated: 2026-05-22
+---
+
 # ADR-027: Forward-Only NOCOW Placement on subvol8-db (Policy)
 
 **Date:** 2026-04-22

--- a/docs/00-foundation/decisions/2026-04-27-ADR-028-podman-secret-store-path-split.md
+++ b/docs/00-foundation/decisions/2026-04-27-ADR-028-podman-secret-store-path-split.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-028: Podman Secret-Store Path Split After Storage Migration"
+description: "ADR resolving a Podman secret-store path split where runtime secret mounts read the legacy XDG path after graphRoot was migrated to the BTRFS pool."
+sensitivity: public
+created: 2026-04-28
+updated: 2026-04-28
+---
+
 # ADR-028: Podman Secret-Store Path Split After Storage Migration
 
 **Date:** 2026-04-27

--- a/docs/00-foundation/decisions/2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md
+++ b/docs/00-foundation/decisions/2026-05-22-ADR-029-three-tier-db-storage-and-dump-backup.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-029: Three-Tier Database Storage + Dump Backup"
+description: "ADR consolidating three prior storage ADRs into a three-tier model (snapshot, dump, discard) organized by recovery model and shipping the dump backbone."
+sensitivity: public
+created: 2026-05-22
+updated: 2026-06-09
+---
+
 # ADR-029: Three-Tier Database Storage + Dump Backup
 
 **Date:** 2026-05-22

--- a/docs/00-foundation/decisions/2026-05-23-ADR-030-container-supply-chain-trust-model.md
+++ b/docs/00-foundation/decisions/2026-05-23-ADR-030-container-supply-chain-trust-model.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-030: Container Supply-Chain Trust Model"
+description: "ADR establishing the container supply-chain trust model — digest pinning, de-automated deliberate updates, cooling-off bake, and graduated signature verification."
+sensitivity: public
+created: 2026-05-23
+updated: 2026-05-23
+---
+
 # ADR-030: Container Supply-Chain Trust Model
 
 **Date:** 2026-05-23

--- a/docs/00-foundation/decisions/2026-05-25-ADR-031-dns-resolver-first-class-and-ha.md
+++ b/docs/00-foundation/decisions/2026-05-25-ADR-031-dns-resolver-first-class-and-ha.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-031: DNS Resolver — First-Class Integration & High Availability"
+description: "ADR making the Pi-hole DNS resolver a first-class, redundant service — managed-as-code, monitored, SSO admin, and a keepalived HA VIP."
+sensitivity: public
+created: 2026-05-25
+updated: 2026-05-25
+---
+
 # ADR-031: DNS Resolver — First-Class Integration & High Availability
 
 **Date:** 2026-05-25

--- a/docs/00-foundation/decisions/2026-06-05-ADR-032-forgejo-git-over-ssh-loopback.md
+++ b/docs/00-foundation/decisions/2026-06-05-ADR-032-forgejo-git-over-ssh-loopback.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-032: Forgejo Git-over-SSH — Loopback-Bound"
+description: "ADR enabling loopback-bound git-over-SSH on the Forgejo instance so headless SSH sessions can authenticate with an SSH key instead of a keyring-locked HTTPS token."
+sensitivity: public
+created: 2026-06-05
+updated: 2026-06-05
+---
+
 # ADR-032: Forgejo Git-over-SSH — Loopback-Bound
 
 **Date:** 2026-06-05

--- a/docs/00-foundation/decisions/2026-06-06-ADR-034-forgejo-instance-commit-signing-ssh.md
+++ b/docs/00-foundation/decisions/2026-06-06-ADR-034-forgejo-instance-commit-signing-ssh.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-034: Forgejo Instance Commit Signing (SSH)"
+description: "ADR configuring the Forgejo instance to SSH-sign the merge/squash commits it creates server-side, closing the unsigned-merge-commit gap on main."
+sensitivity: public
+created: 2026-06-06
+updated: 2026-06-06
+---
+
 # ADR-034: Forgejo Instance Commit Signing (SSH)
 
 **Date:** 2026-06-06

--- a/docs/00-foundation/decisions/2026-06-10-ADR-036-bake-policy-and-exception-lane.md
+++ b/docs/00-foundation/decisions/2026-06-10-ADR-036-bake-policy-and-exception-lane.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-036: Bake Policy Codification and Security-Release Exception Lane"
+description: "ADR amending ADR-030 to codify the image bake policy (egress 7d / internal 3d) with tooling verdicts and a security-release CVE exception lane."
+sensitivity: public
+created: 2026-06-11
+updated: 2026-06-11
+---
+
 # ADR-036: Bake Policy Codification and Security-Release Exception Lane
 
 **Date:** 2026-06-10

--- a/docs/00-foundation/decisions/2026-06-12-ADR-038-merge-commit-only-strategy.md
+++ b/docs/00-foundation/decisions/2026-06-12-ADR-038-merge-commit-only-strategy.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-038: Merge-Commit-Only Strategy (signature provenance + stacked-PR safety)"
+description: "ADR switching the containers repo to merge-commit-only merges, preserving owner-key signatures and avoiding stacked-PR breakage against the live-config worktree."
+sensitivity: public
+created: 2026-06-13
+updated: 2026-06-13
+---
+
 # ADR-038: Merge-Commit-Only Strategy (signature provenance + stacked-PR safety)
 
 **Date:** 2026-06-12

--- a/docs/00-foundation/decisions/2026-06-13-ADR-037-forge-center-of-gravity-per-repo.md
+++ b/docs/00-foundation/decisions/2026-06-13-ADR-037-forge-center-of-gravity-per-repo.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-037: Forge Center-of-Gravity — Per-Repo Placement"
+description: "ADR codifying a per-repo forge center-of-gravity rubric (GitHub-primary vs Forgejo-first) and the signing/merge consequences that follow from placement."
+sensitivity: public
+created: 2026-06-13
+updated: 2026-06-13
+---
+
 # ADR-037: Forge Center-of-Gravity — Per-Repo Placement
 
 **Date:** 2026-06-13

--- a/docs/00-foundation/decisions/2026-06-14-ADR-039-crowdsec-cloud-api-egress-scoping.md
+++ b/docs/00-foundation/decisions/2026-06-14-ADR-039-crowdsec-cloud-api-egress-scoping.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-039: Egress Baseline Scoping for High-Rotation Cloud-API Endpoints (CrowdSec CAPI)"
+description: "ADR amending ADR-030 P7 to generate CrowdSec's egress allowance from AWS-published eu-west-1 ranges, ending the re-baseline treadmill for its rotating cloud API."
+sensitivity: public
+created: 2026-06-14
+updated: 2026-06-14
+---
+
 # ADR-039: Egress Baseline Scoping for High-Rotation Cloud-API Endpoints (CrowdSec CAPI)
 
 **Date:** 2026-06-14

--- a/docs/00-foundation/decisions/2026-07-01-ADR-042-vpn-egress-sidecar-qbittorrent.md
+++ b/docs/00-foundation/decisions/2026-07-01-ADR-042-vpn-egress-sidecar-qbittorrent.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-042: VPN Egress Sidecar for qBittorrent (gluetun + ProtonVPN)"
+description: "ADR routing qBittorrent's egress through a gluetun ProtonVPN sidecar with a kill-switch via network-namespace sharing, off the home WAN IP."
+sensitivity: public
+created: 2026-07-01
+updated: 2026-07-02
+---
+
 # ADR-042: VPN Egress Sidecar for qBittorrent (gluetun + ProtonVPN)
 
 **Date:** 2026-07-01

--- a/docs/00-foundation/decisions/fixtures/README.md
+++ b/docs/00-foundation/decisions/fixtures/README.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "Decision fixtures"
+description: "Index of decision fixtures — canonical sample artifacts (e.g. Urd heartbeat payload) referenced from ADR amendments as external-contract examples."
+sensitivity: public
+created: 2026-05-16
+updated: 2026-05-16
+---
+
 # Decision fixtures
 
 Sample artifacts referenced from ADR amendments. Each file is the canonical

--- a/docs/00-foundation/decisions/withdrawn/2026-04-18-ADR-023-btrfs-storage-architecture-databases.md
+++ b/docs/00-foundation/decisions/withdrawn/2026-04-18-ADR-023-btrfs-storage-architecture-databases.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-023: BTRFS Storage Architecture for Database Workloads (WITHDRAWN)"
+description: "Withdrawn ADR that bundled database dumps with a NOCOW migration; split after adversarial review into ADR-024 and ADR-025, preserved for historical record."
+sensitivity: public
+created: 2026-04-21
+updated: 2026-04-21
+---
+
 # ADR-023: BTRFS Storage Architecture for Database Workloads (WITHDRAWN)
 
 **Date:** 2026-04-18

--- a/docs/00-foundation/guides/HOMELAB-FIELD-GUIDE.md
+++ b/docs/00-foundation/guides/HOMELAB-FIELD-GUIDE.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Homelab Field Guide"
+description: "Operator field guide for independently maintaining the homelab without LLM assistance — operations, troubleshooting, security, and disaster recovery."
+sensitivity: public
+created: 2025-11-14
+updated: 2026-06-22
+---
+
 # Homelab Field Guide
 
 **Purpose:** Operational manual for independently maintaining a healthy, secure homelab

--- a/docs/00-foundation/guides/configuration-design-quick-reference.md
+++ b/docs/00-foundation/guides/configuration-design-quick-reference.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Configuration Design Quick Reference Card"
+description: "Quick-reference card companion to the configuration design principles — lookup tables for where ordering matters and common design decisions."
+sensitivity: public
+created: 2025-10-31
+updated: 2025-12-31
+---
+
 # Configuration Design Quick Reference Card
 
 **Companion to:** CONFIGURATION-DESIGN-PRINCIPLES.md  

--- a/docs/00-foundation/guides/middleware-configuration.md
+++ b/docs/00-foundation/guides/middleware-configuration.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Traefik Middleware Configuration: Analysis & Improvement Guide"
+description: "Guide to Traefik middleware configuration under the ADR-016 centralized dynamic-config model — CrowdSec integration, fail-fast ordering, and advanced patterns."
+sensitivity: public
+created: 2025-10-31
+updated: 2025-12-31
+---
+
 # Traefik Middleware Configuration: Analysis & Improvement Guide
 
 **Current Config Analysis:** middleware.yml

--- a/docs/00-foundation/guides/podman-fundamentals.md
+++ b/docs/00-foundation/guides/podman-fundamentals.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Podman Cheatsheet"
+description: "Podman cheatsheet — common CLI commands for images, containers, networks, systemd generation, plus security flags to standardize on."
+sensitivity: public
+created: 2025-10-31
+updated: 2025-11-07
+---
+
 # Podman Cheatsheet
 
 ```bash

--- a/docs/00-foundation/guides/quadlets-vs-generated-units-comparison.md
+++ b/docs/00-foundation/guides/quadlets-vs-generated-units-comparison.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Quadlets vs Generated Systemd Services"
+description: "Comparison guide arguing why systemd quadlets are preferable to podman-generated systemd units for declarative, maintainable container management."
+sensitivity: public
+created: 2025-10-31
+updated: 2025-12-22
+---
+
 # Quadlets vs Generated Systemd Services
 
 ## Why Quadlets Are Better

--- a/docs/10-services/decisions/2025-11-08-ADR-004-immich-deployment-architecture.md
+++ b/docs/10-services/decisions/2025-11-08-ADR-004-immich-deployment-architecture.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR: Immich Deployment Architecture"
+description: "ADR selecting a multi-container Immich architecture (server, ML, PostgreSQL, Redis) on rootless Podman quadlets as the homelab's first database-backed, ML, and mobile-integrated service."
+sensitivity: public
+created: 2025-12-22
+updated: 2025-12-22
+---
+
 # ADR: Immich Deployment Architecture
 
 **Date:** 2025-11-08

--- a/docs/10-services/decisions/2025-11-12-ADR-007-vaultwarden-architecture.md
+++ b/docs/10-services/decisions/2025-11-12-ADR-007-vaultwarden-architecture.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-006: Vaultwarden Password Manager Architecture"
+description: "ADR adopting Vaultwarden with SQLite as the self-hosted, Bitwarden-compatible password manager, with YubiKey/WebAuthn 2FA and defense-in-depth middleware."
+sensitivity: public
+created: 2025-11-12
+updated: 2025-12-22
+---
+
 # ADR-006: Vaultwarden Password Manager Architecture
 
 **Date:** 2025-11-12

--- a/docs/10-services/decisions/2025-12-20-ADR-013-nextcloud-native-authentication.md
+++ b/docs/10-services/decisions/2025-12-20-ADR-013-nextcloud-native-authentication.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-013: Nextcloud Native Authentication Strategy"
+description: "ADR choosing Nextcloud native authentication over Authelia SSO to preserve CalDAV/CardDAV auto-discovery and mobile/desktop client compatibility."
+sensitivity: public
+created: 2025-12-21
+updated: 2025-12-22
+---
+
 # ADR-013: Nextcloud Native Authentication Strategy
 
 **Date:** 2025-12-20

--- a/docs/10-services/decisions/2025-12-20-ADR-014-nextcloud-passwordless-authentication.md
+++ b/docs/10-services/decisions/2025-12-20-ADR-014-nextcloud-passwordless-authentication.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-014: Nextcloud Passwordless Authentication with FIDO2/WebAuthn"
+description: "ADR adopting FIDO2/WebAuthn passwordless login for Nextcloud, weighing phishing resistance, usability, and device-loss recovery against traditional 2FA."
+sensitivity: public
+created: 2025-12-22
+updated: 2025-12-22
+---
+
 # ADR-014: Nextcloud Passwordless Authentication with FIDO2/WebAuthn
 
 **Date:** 2025-12-20

--- a/docs/10-services/guides/alert-discord-relay.md
+++ b/docs/10-services/guides/alert-discord-relay.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Alert Discord Relay"
+description: "Service guide for the custom-built Python relay that converts Alertmanager webhooks into color-coded Discord embeds, covering management and health checks."
+sensitivity: public
+created: 2026-02-05
+updated: 2026-02-05
+---
+
 # Alert Discord Relay
 
 **Last Updated:** 2026-02-05

--- a/docs/10-services/guides/apple-ecosystem-quick-reference.md
+++ b/docs/10-services/guides/apple-ecosystem-quick-reference.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Apple Ecosystem Integration - Quick Reference"
+description: "Quick-reference for Apple ecosystem integration with Home Assistant — Siri voice commands, Watch complications, Focus modes, and webhook URLs."
+sensitivity: public
+created: 2026-01-30
+updated: 2026-01-30
+---
+
 # Apple Ecosystem Integration - Quick Reference
 
 **Created:** 2026-01-30

--- a/docs/10-services/guides/authelia.md
+++ b/docs/10-services/guides/authelia.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Authelia SSO & MFA Service Guide"
+description: "Service guide for the Authelia SSO and MFA server — YubiKey/WebAuthn-first auth, TOTP fallback, Redis sessions, and Traefik integration."
+sensitivity: public
+created: 2025-11-11
+updated: 2026-03-09
+---
+
 # Authelia SSO & MFA Service Guide
 
 **Last Updated:** 2025-11-11

--- a/docs/10-services/guides/crowdsec.md
+++ b/docs/10-services/guides/crowdsec.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "CrowdSec Security Engine"
+description: "Service guide for the CrowdSec security engine — crowdsourced IP-reputation blocking via the Traefik bouncer, with management and cscli reference."
+sensitivity: public
+created: 2025-11-07
+updated: 2025-12-23
+---
+
 # CrowdSec Security Engine
 
 **Last Updated:** 2025-11-07

--- a/docs/10-services/guides/esp32-plejd-quick-start.md
+++ b/docs/10-services/guides/esp32-plejd-quick-start.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "ESP32 Bluetooth Proxy - Quick Start Guide"
+description: "Quick-start for flashing an ESP32 as an ESPHome Bluetooth proxy to bridge Plejd lighting into Home Assistant across the IoT VLAN."
+sensitivity: public
+created: 2026-02-04
+updated: 2026-02-04
+---
+
 # ESP32 Bluetooth Proxy - Quick Start Guide
 
 **Device:** ESP32 D1 Mini (m-d1-esp32)

--- a/docs/10-services/guides/gathio-email-setup.md
+++ b/docs/10-services/guides/gathio-email-setup.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Gathio Email Configuration Guide"
+description: "Configuration guide for Gathio event-editing links — running without email versus wiring up SMTP delivery for magic links."
+sensitivity: public
+created: 2026-01-15
+updated: 2026-01-15
+---
+
 # Gathio Email Configuration Guide
 
 **Created:** 2026-01-14

--- a/docs/10-services/guides/home-assistant.md
+++ b/docs/10-services/guides/home-assistant.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Home Assistant - Production System Guide"
+description: "Production system guide for the Home Assistant deployment — its automations, integrated devices, integration strategy, and configuration structure."
+sensitivity: public
+created: 2026-01-31
+updated: 2026-02-01
+---
+
 # Home Assistant - Production System Guide
 
 **Status:** Production (40 automations, 20+ devices)

--- a/docs/10-services/guides/immich-configuration-review.md
+++ b/docs/10-services/guides/immich-configuration-review.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Immich Configuration Review & Optimization Report"
+description: "Configuration audit of the Immich deployment against design principles, scoring seven categories and flagging critical security and performance gaps."
+sensitivity: public
+created: 2025-11-23
+updated: 2026-02-28
+---
+
 # Immich Configuration Review & Optimization Report
 
 **Date:** 2025-11-23

--- a/docs/10-services/guides/immich-deployment-checklist.md
+++ b/docs/10-services/guides/immich-deployment-checklist.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Immich Deployment Checklist"
+description: "Historical step-by-step checklist for the November 2025 Immich deployment, covering network, database, and storage setup (predates the Authelia migration)."
+sensitivity: public
+created: 2025-12-31
+updated: 2025-12-31
+---
+
 # Immich Deployment Checklist
 
 **Purpose:** Step-by-step checklist for deploying Immich photo management service

--- a/docs/10-services/guides/immich-ml-troubleshooting.md
+++ b/docs/10-services/guides/immich-ml-troubleshooting.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Immich ML Troubleshooting Guide"
+description: "Troubleshooting guide for the immich-ml machine-learning container reporting unhealthy status, with log-inspection and diagnostic steps."
+sensitivity: public
+created: 2025-11-09
+updated: 2025-11-09
+---
+
 # Immich ML Troubleshooting Guide
 
 **Date:** 2025-11-09

--- a/docs/10-services/guides/immich.md
+++ b/docs/10-services/guides/immich.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Immich Photo Management Service"
+description: "Service guide for the Immich photo/video management stack — its four containers, features, deployment details, and management commands."
+sensitivity: public
+created: 2025-11-10
+updated: 2026-02-08
+---
+
 # Immich Photo Management Service
 
 **Last Updated:** 2026-02-08

--- a/docs/10-services/guides/ios-shortcuts-quick-reference.md
+++ b/docs/10-services/guides/ios-shortcuts-quick-reference.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "iOS Shortcuts Quick Reference - Roborock Voice Commands"
+description: "Copy-paste reference for building nine iOS Shortcuts that trigger Roborock room-cleaning webhooks via Siri voice commands."
+sensitivity: public
+created: 2026-01-31
+updated: 2026-01-31
+---
+
 # iOS Shortcuts Quick Reference - Roborock Voice Commands
 
 **Purpose:** Quick copy-paste reference for creating 9 Roborock cleaning shortcuts

--- a/docs/10-services/guides/jellyfin-gpu-acceleration-troubleshooting.md
+++ b/docs/10-services/guides/jellyfin-gpu-acceleration-troubleshooting.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Jellyfin GPU Acceleration Troubleshooting Guide"
+description: "Troubleshooting guide for enabling AMD APU VA-API GPU transcoding in the rootless-Podman Jellyfin container, from hardware detection to validation."
+sensitivity: public
+created: 2025-11-17
+updated: 2025-11-17
+---
+
 # Jellyfin GPU Acceleration Troubleshooting Guide
 
 **Hardware:** AMD Ryzen 5 5600G (APU with integrated Radeon Vega Graphics)

--- a/docs/10-services/guides/jellyfin.md
+++ b/docs/10-services/guides/jellyfin.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Jellyfin Media Server"
+description: "Service guide for the Jellyfin media server — hardware-accelerated transcoding, Traefik HTTPS access, libraries, and management commands."
+sensitivity: public
+created: 2025-11-07
+updated: 2025-12-23
+---
+
 # Jellyfin Media Server
 
 **Last Updated:** 2025-11-14

--- a/docs/10-services/guides/matter-server.md
+++ b/docs/10-services/guides/matter-server.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Matter Server - Service Guide"
+description: "Service guide for the python-matter-server container (home_automation network) — management, health checks, and WebSocket connectivity."
+sensitivity: public
+created: 2026-02-05
+updated: 2026-02-05
+---
+
 # Matter Server - Service Guide
 
 **Status:** Production

--- a/docs/10-services/guides/nextcloud.md
+++ b/docs/10-services/guides/nextcloud.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Nextcloud Service Guide"
+description: "Service guide for the Nextcloud file-sync stack (Nextcloud + MariaDB + Redis) — access endpoints, CalDAV/CardDAV/WebDAV, and service management."
+sensitivity: public
+created: 2025-12-21
+updated: 2026-02-06
+---
+
 # Nextcloud Service Guide
 
 **Service:** Nextcloud File Sync and Collaboration

--- a/docs/10-services/guides/pattern-customization-guide.md
+++ b/docs/10-services/guides/pattern-customization-guide.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Pattern Customization Guide"
+description: "Guide for safely customizing pattern-generated quadlets after deployment, covering when to customize and how to preserve changes through updates."
+sensitivity: public
+created: 2025-11-14
+updated: 2025-12-31
+---
+
 # Pattern Customization Guide
 
 **Created:** 2025-11-14

--- a/docs/10-services/guides/pattern-selection-guide.md
+++ b/docs/10-services/guides/pattern-selection-guide.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Pattern Selection Guide"
+description: "Decision-tree guide for choosing the right homelab deployment pattern based on service type (media, web-app, database, auth, monitoring, etc.)."
+sensitivity: public
+created: 2025-11-14
+updated: 2026-06-12
+---
+
 # Pattern Selection Guide
 
 **Purpose:** Choose the right deployment pattern for your service

--- a/docs/10-services/guides/roborock-room-cleaning-setup.md
+++ b/docs/10-services/guides/roborock-room-cleaning-setup.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Roborock Room-Specific Cleaning - Implementation Guide"
+description: "Implementation guide for activating Home Assistant room-specific Roborock cleaning automations, including how to obtain room segment IDs."
+sensitivity: public
+created: 2026-01-31
+updated: 2026-01-31
+---
+
 # Roborock Room-Specific Cleaning - Implementation Guide
 
 **Created:** 2026-01-31

--- a/docs/10-services/guides/skill-integration-guide.md
+++ b/docs/10-services/guides/skill-integration-guide.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Claude Skills Integration Guide"
+description: "Guide for Claude Code on choosing and combining homelab skills, with a decision tree mapping request types to the right skill."
+sensitivity: public
+created: 2025-11-14
+updated: 2025-11-14
+---
+
 # Claude Skills Integration Guide
 
 **Purpose:** Help Claude Code choose and combine skills appropriately

--- a/docs/10-services/guides/skill-recommendation.md
+++ b/docs/10-services/guides/skill-recommendation.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Skill Recommendation Engine"
+description: "Reference for the recommend-skill.sh engine that classifies requests and scores confidence to suggest the most appropriate Claude skill."
+sensitivity: public
+created: 2025-11-30
+updated: 2025-11-30
+---
+
 # Skill Recommendation Engine
 
 **Status:** ✅ Production-Ready (Implemented 2025-11-30)

--- a/docs/10-services/guides/traefik.md
+++ b/docs/10-services/guides/traefik.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Traefik Reverse Proxy"
+description: "Service guide for the Traefik reverse proxy — HTTPS, Let's Encrypt, security middleware, and the ADR-016 rule that all routing lives in dynamic config."
+sensitivity: public
+created: 2025-11-07
+updated: 2025-12-31
+---
+
 # Traefik Reverse Proxy
 
 **Last Updated:** 2025-12-22

--- a/docs/10-services/guides/vaultwarden-deployment.md
+++ b/docs/10-services/guides/vaultwarden-deployment.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Vaultwarden Deployment Guide"
+description: "Deployment guide for Vaultwarden — SQLite backend, YubiKey/TOTP 2FA, strict rate limiting, and pattern-based versus manual deployment steps."
+sensitivity: public
+created: 2025-11-12
+updated: 2025-11-14
+---
+
 # Vaultwarden Deployment Guide
 
 **Date:** 2025-11-12 (Updated: 2025-11-14)

--- a/docs/20-operations/decisions/2025-11-14-ADR-010-pattern-based-deployment.md
+++ b/docs/20-operations/decisions/2025-11-14-ADR-010-pattern-based-deployment.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-007: Pattern-Based Deployment Automation"
+description: "ADR adopting pattern-based deployment as the primary method for new services — YAML templates, health gating, and drift detection replacing ad-hoc scripts."
+sensitivity: public
+created: 2025-11-14
+updated: 2025-12-31
+---
+
 # ADR-007: Pattern-Based Deployment Automation
 
 **Date:** 2025-11-14

--- a/docs/20-operations/decisions/2025-12-02-ADR-011-service-dependency-mapping.md
+++ b/docs/20-operations/decisions/2025-12-02-ADR-011-service-dependency-mapping.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-006: Service Dependency Mapping & Impact Analysis"
+description: "ADR implementing an automated multi-source dependency mapping system to discover, track, and visualize service relationships and blast radius."
+sensitivity: public
+created: 2025-12-02
+updated: 2025-12-22
+---
+
 # ADR-006: Service Dependency Mapping & Impact Analysis
 
 **Date:** 2025-12-02

--- a/docs/20-operations/decisions/2025-12-11-ADR-012-autonomous-operations-alert-quality.md
+++ b/docs/20-operations/decisions/2025-12-11-ADR-012-autonomous-operations-alert-quality.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-007: Autonomous Operations Alert Quality & Prediction System"
+description: "ADR on autonomous-operations alert quality — enabling swap cleanup, eliminating false-positive warnings, and repairing the resource-exhaustion prediction system."
+sensitivity: public
+created: 2025-12-11
+updated: 2025-12-22
+---
+
 # ADR-007: Autonomous Operations Alert Quality & Prediction System
 
 **Date:** 2025-12-11

--- a/docs/20-operations/decisions/2026-06-09-ADR-035-boot-time-io-tiering.md
+++ b/docs/20-operations/decisions/2026-06-09-ADR-035-boot-time-io-tiering.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-035: Boot-Time I/O Tiering for Service Startup"
+description: "ADR introducing boot-time I/O tiering via StartupIOWeight to demote heavy TSDB/WAL replayers (Prometheus, Loki, Grafana) during post-reboot storms."
+sensitivity: public
+created: 2026-06-09
+updated: 2026-06-09
+---
+
 # ADR-035: Boot-Time I/O Tiering for Service Startup
 
 **Date:** 2026-06-09

--- a/docs/20-operations/guides/architecture-diagrams.md
+++ b/docs/20-operations/guides/architecture-diagrams.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Homelab Architecture - Visual Diagrams"
+description: "Reference guide with visual diagrams of the homelab's network flow, request path, and service topology from internet through Traefik to backends."
+sensitivity: public
+created: 2025-10-31
+updated: 2025-12-22
+---
+
 # Homelab Architecture - Visual Diagrams
 
 **Last Updated:** 2025-12-22

--- a/docs/20-operations/guides/automation-reference.md
+++ b/docs/20-operations/guides/automation-reference.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Automation Reference Guide"
+description: "Authoritative reference cataloging all automation scripts, scheduled timers, deployment scripts, and remediation playbooks with a which-script-do-I-use decision tree."
+sensitivity: public
+created: 2025-11-28
+updated: 2026-06-22
+---
+
 # Automation Reference Guide
 
 **Last Updated:** 2026-02-27

--- a/docs/20-operations/guides/autonomous-operations.md
+++ b/docs/20-operations/guides/autonomous-operations.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Autonomous Operations Guide"
+description: "Guide to the autonomous-operations OODA-loop engine — daily timer, confidence-versus-risk decision matrix, and emergency pause/stop/resume controls."
+sensitivity: public
+created: 2025-11-29
+updated: 2026-06-12
+---
+
 # Autonomous Operations Guide
 
 The autonomous operations engine implements an OODA loop (Observe, Orient, Decide, Act) that monitors system health and takes corrective actions automatically.

--- a/docs/20-operations/guides/backup-automation-setup.md
+++ b/docs/20-operations/guides/backup-automation-setup.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Backup Automation Setup Guide"
+description: "Setup guide for automated BTRFS snapshot backups via systemd timers — daily local and weekly external schedules under the Single-profile no-redundancy constraint."
+sensitivity: public
+created: 2025-11-12
+updated: 2025-12-09
+---
+
 # Backup Automation Setup Guide
 
 **Date:** 2025-11-12 (Updated: 2025-12-09)

--- a/docs/20-operations/guides/backup-strategy.md
+++ b/docs/20-operations/guides/backup-strategy.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "BTRFS Backup Strategy Guide"
+description: "Guide to the BTRFS snapshot and incremental backup strategy — daily external sends, Time Machine-style retention, and offsite drive rotation (ADR-020)."
+sensitivity: public
+created: 2025-11-07
+updated: 2026-03-22
+---
+
 # BTRFS Backup Strategy Guide
 
 **Created:** 2025-11-07

--- a/docs/20-operations/guides/dependency-management.md
+++ b/docs/20-operations/guides/dependency-management.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Service Dependency Management Guide"
+description: "Guide to the service dependency mapping system — dependency types, discovery, drift checks, blast-radius queries, and the Grafana dashboard (ADR-006)."
+sensitivity: public
+created: 2025-12-02
+updated: 2025-12-02
+---
+
 # Service Dependency Management Guide
 
 **Last Updated:** 2025-12-02

--- a/docs/20-operations/guides/disaster-recovery.md
+++ b/docs/20-operations/guides/disaster-recovery.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Disaster Recovery Framework"
+description: "Overview of the disaster-recovery framework — backup tiers, coverage, retention, monthly restore testing, and links to the DR runbooks."
+sensitivity: public
+created: 2025-11-30
+updated: 2025-11-30
+---
+
 # Disaster Recovery Framework
 
 **Status:** Implemented (Phase 1 complete)

--- a/docs/20-operations/guides/drift-detection-workflow.md
+++ b/docs/20-operations/guides/drift-detection-workflow.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Configuration Drift Detection Workflow"
+description: "Guide to detecting and reconciling configuration drift between running containers and their quadlet definitions using check-drift.sh."
+sensitivity: public
+created: 2025-11-14
+updated: 2025-12-31
+---
+
 # Configuration Drift Detection Workflow
 
 **Created:** 2025-11-14

--- a/docs/20-operations/guides/external-systems/pihole-backup.md
+++ b/docs/20-operations/guides/external-systems/pihole-backup.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Pi-hole Backup and Restore Procedure"
+description: "Backup and restore procedure for the external Raspberry Pi Pi-hole DNS server — SSH archive, MacBook staging, then encrypted external drive."
+sensitivity: public
+created: 2025-11-05
+updated: 2025-12-22
+---
+
 # Pi-hole Backup and Restore Procedure
 
 **Last Updated:** 2025-11-05

--- a/docs/20-operations/guides/health-driven-operations.md
+++ b/docs/20-operations/guides/health-driven-operations.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Health-Driven Operations Guide"
+description: "Guide to using homelab-intel.sh health scoring (0-100) to inform deployment, maintenance, and troubleshooting decisions and to gate deployments."
+sensitivity: public
+created: 2025-11-14
+updated: 2025-11-14
+---
+
 # Health-Driven Operations Guide
 
 **Created:** 2025-11-14

--- a/docs/20-operations/guides/homelab-architecture.md
+++ b/docs/20-operations/guides/homelab-architecture.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Homelab Architecture Documentation"
+description: "Comprehensive architecture reference covering network, service stack, security layers, DNS, storage, backup, monitoring, and autonomous operations."
+sensitivity: public
+created: 2025-10-31
+updated: 2026-06-22
+---
+
 # Homelab Architecture Documentation
 
 **Last Updated:** February 5, 2026

--- a/docs/20-operations/guides/memory-management.md
+++ b/docs/20-operations/guides/memory-management.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Memory Management Guide"
+description: "Guide to optimizing memory and swap usage — per-container consumption breakdown, zram swap tuning, and reclamation strategy on the 30GB host."
+sensitivity: public
+created: 2025-11-28
+updated: 2025-11-28
+---
+
 # Memory Management Guide
 
 **Created:** 2025-11-28  

--- a/docs/20-operations/guides/permission-optimization-nextcloud.md
+++ b/docs/20-operations/guides/permission-optimization-nextcloud.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Permission Optimization for Nextcloud Migration"
+description: "Superseded guide (by ADR-019) analyzing subvolume ownership and rootless-Podman UID mapping for the Samba-to-Nextcloud file-storage migration."
+sensitivity: public
+created: 2025-12-29
+updated: 2026-02-22
+---
+
 # Permission Optimization for Nextcloud Migration
 
 **Date:** 2025-12-29

--- a/docs/20-operations/guides/remediation-chains.md
+++ b/docs/20-operations/guides/remediation-chains.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Remediation Chains - Multi-Playbook Orchestration"
+description: "Guide to multi-playbook remediation chains — orchestrating cleanup, maintenance, and recovery steps in sequence with conditional execution and failure strategies."
+sensitivity: public
+created: 2025-12-25
+updated: 2025-12-25
+---
+
 # Remediation Chains - Multi-Playbook Orchestration
 
 **Phase 5: Advanced Orchestration**

--- a/docs/20-operations/guides/resource-limits-configuration.md
+++ b/docs/20-operations/guides/resource-limits-configuration.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Resource Limits Configuration Guide"
+description: "Guide providing ready-to-use systemd resource-limit configurations for the most critical services to prevent memory exhaustion and OOM instability."
+sensitivity: public
+created: 2025-11-09
+updated: 2025-11-09
+---
+
 # Resource Limits Configuration Guide
 
 **Date:** 2025-11-09

--- a/docs/20-operations/guides/storage-health-monitoring.md
+++ b/docs/20-operations/guides/storage-health-monitoring.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Storage-Health Monitoring (btrfs dev-stats + SMART)"
+description: "Guide to storage-health monitoring — BTRFS dev-stats, SMART, and monthly scrub collectors feeding Prometheus and the Discord alert path (ADR-029)."
+sensitivity: public
+created: 2026-06-09
+updated: 2026-06-09
+---
+
 # Storage-Health Monitoring (btrfs dev-stats + SMART)
 
 **Status:** Both parts implemented. Part 1 (dev-stats + SMART) is deployed and live; Part 2

--- a/docs/20-operations/guides/storage-layout.md
+++ b/docs/20-operations/guides/storage-layout.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Storage Layout and Strategy"
+description: "Authoritative storage-layout guide — the 128GB system-drive constraint, BTRFS pool architecture, decision matrix, migration priorities, and NOCOW tuning."
+sensitivity: public
+created: 2025-10-31
+updated: 2025-12-09
+---
+
 # Storage Layout and Strategy
 
 **Last Updated:** 2025-12-09

--- a/docs/20-operations/guides/tier3-initial-backup.md
+++ b/docs/20-operations/guides/tier3-initial-backup.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Tier 3 Initial Backup Guide"
+description: "Operational guide for the manual initial backup of the large 5.8TB subvol4-multimedia volume before incremental automated backups take over."
+sensitivity: public
+created: 2025-12-11
+updated: 2025-12-11
+---
+
 # Tier 3 Initial Backup Guide
 
 **Date:** 2025-12-10

--- a/docs/20-operations/guides/unpoller-metrics-guide.md
+++ b/docs/20-operations/guides/unpoller-metrics-guide.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Unpoller Metrics Guide"
+description: "Reference guide for working with UnPoller UniFi metrics across Prometheus, Grafana, and Home Assistant — deployment details and metric queries."
+sensitivity: public
+created: 2026-01-28
+updated: 2026-01-28
+---
+
 # Unpoller Metrics Guide
 
 **Purpose:** Reference guide for working with Unpoller metrics in Prometheus, Grafana, and Home Assistant

--- a/docs/20-operations/runbooks/DR-001-system-ssd-failure.md
+++ b/docs/20-operations/runbooks/DR-001-system-ssd-failure.md
@@ -1,3 +1,12 @@
+---
+type: Runbook
+title: "DR-001: System SSD Failure"
+description: "Disaster-recovery runbook for complete system NVMe SSD failure — replacement, OS reinstall, and restore from weekly backup."
+sensitivity: public
+created: 2025-11-30
+updated: 2025-11-30
+---
+
 # DR-001: System SSD Failure
 
 **Severity:** Critical

--- a/docs/20-operations/runbooks/DR-002-btrfs-pool-corruption.md
+++ b/docs/20-operations/runbooks/DR-002-btrfs-pool-corruption.md
@@ -1,3 +1,12 @@
+---
+type: Runbook
+title: "DR-002: BTRFS Pool Corruption"
+description: "Disaster-recovery runbook for BTRFS storage-pool corruption or unmountable filesystem across all subvolumes."
+sensitivity: public
+created: 2025-11-30
+updated: 2025-11-30
+---
+
 # DR-002: BTRFS Pool Corruption
 
 **Severity:** Critical

--- a/docs/20-operations/runbooks/DR-003-accidental-deletion.md
+++ b/docs/20-operations/runbooks/DR-003-accidental-deletion.md
@@ -1,3 +1,12 @@
+---
+type: Runbook
+title: "DR-003: Accidental Deletion Recovery"
+description: "Disaster-recovery runbook for recovering accidentally deleted files or directories from daily snapshots and external backups."
+sensitivity: public
+created: 2025-11-30
+updated: 2026-01-03
+---
+
 # DR-003: Accidental Deletion Recovery
 
 **Severity:** Medium

--- a/docs/20-operations/runbooks/DR-004-total-catastrophe.md
+++ b/docs/20-operations/runbooks/DR-004-total-catastrophe.md
@@ -1,3 +1,12 @@
+---
+type: Runbook
+title: "DR-004: Total Catastrophe"
+description: "Disaster-recovery runbook for total catastrophe — simultaneous loss of primary system and backup drive, recovered via off-site backup."
+sensitivity: public
+created: 2025-11-30
+updated: 2026-01-03
+---
+
 # DR-004: Total Catastrophe
 
 **Severity:** Catastrophic

--- a/docs/20-operations/runbooks/nextcloud-operations.md
+++ b/docs/20-operations/runbooks/nextcloud-operations.md
@@ -1,3 +1,12 @@
+---
+type: Runbook
+title: "Nextcloud Operational Runbook"
+description: "Operational runbook for Nextcloud — user and FIDO2 device management, external storage, backup/restore, maintenance, and troubleshooting procedures."
+sensitivity: public
+created: 2025-12-21
+updated: 2025-12-21
+---
+
 # Nextcloud Operational Runbook
 
 **Service:** Nextcloud File Sync and Collaboration  

--- a/docs/30-security/decisions/2025-11-10-ADR-005-authelia-sso-mfa-architecture.md
+++ b/docs/30-security/decisions/2025-11-10-ADR-005-authelia-sso-mfa-architecture.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-004: Authelia SSO & MFA Architecture"
+description: "ADR proposing Authelia as the primary SSO and MFA provider to replace TinyAuth, with a phased service-migration approach."
+sensitivity: public
+created: 2025-11-10
+updated: 2025-12-22
+---
+
 # ADR-004: Authelia SSO & MFA Architecture
 
 **Status:** Proposed

--- a/docs/30-security/decisions/2025-11-11-ADR-006-authelia-sso-yubikey-deployment.md
+++ b/docs/30-security/decisions/2025-11-11-ADR-006-authelia-sso-yubikey-deployment.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-005: Authelia SSO with YubiKey-First Authentication"
+description: "ADR adopting Authelia 4.38 with YubiKey/WebAuthn as the primary authentication method and tiered per-service access policies."
+sensitivity: public
+created: 2025-11-11
+updated: 2025-12-22
+---
+
 # ADR-005: Authelia SSO with YubiKey-First Authentication
 
 **Date:** 2025-11-11

--- a/docs/30-security/decisions/2025-11-12-ADR-008-crowdsec-security-architecture.md
+++ b/docs/30-security/decisions/2025-11-12-ADR-008-crowdsec-security-architecture.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-006: CrowdSec Security Architecture for Homelab Defense"
+description: "ADR adopting CrowdSec as the fail-fast first line of defense for internet-facing services within the Traefik middleware chain."
+sensitivity: public
+created: 2025-11-12
+updated: 2025-12-22
+---
+
 # ADR-006: CrowdSec Security Architecture for Homelab Defense
 
 **Date:** 2025-11-12

--- a/docs/30-security/decisions/2026-06-14-ADR-040-secrets-substrate-operator-boundary.md
+++ b/docs/30-security/decisions/2026-06-14-ADR-040-secrets-substrate-operator-boundary.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-040: Secrets Substrate & Operator Boundary"
+description: "ADR (superseded by ADR-041) on the secrets substrate and operator boundary — findings that Podman's file driver is unencrypted, Vaultwarden cannot broker, and an LLM read-wall needs privilege separation."
+sensitivity: public
+created: 2026-06-14
+updated: 2026-06-14
+---
+
 # ADR-040: Secrets Substrate & Operator Boundary
 
 **Date:** 2026-06-14

--- a/docs/30-security/decisions/2026-06-14-ADR-041-secrets-openbao-substrate-boundary.md
+++ b/docs/30-security/decisions/2026-06-14-ADR-041-secrets-openbao-substrate-boundary.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-041: Runtime Secrets via OpenBao Substrate — Workload-Side Boundary"
+description: "ADR sourcing runtime secrets from a self-hosted OpenBao substrate service, keeping every Secret= handle byte-for-byte unchanged with the secret name as the sole cross-repo interface."
+sensitivity: public
+created: 2026-06-14
+updated: 2026-06-14
+---
+
 # ADR-041: Runtime Secrets via OpenBao Substrate — Workload-Side Boundary
 
 **Date:** 2026-06-14

--- a/docs/30-security/guides/crowdsec-phase1-field-manual.md
+++ b/docs/30-security/guides/crowdsec-phase1-field-manual.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "CrowdSec Phase 1: Configuration Audit & Fixes - Field Manual"
+description: "Field manual for CrowdSec Phase 1 — configuration audit, version pinning, middleware standardization, IP detection, and ban testing."
+sensitivity: public
+created: 2025-11-12
+updated: 2025-11-12
+---
+
 # CrowdSec Phase 1: Configuration Audit & Fixes - Field Manual
 
 **Version:** 1.0

--- a/docs/30-security/guides/crowdsec-phase2-and-5-advanced-features.md
+++ b/docs/30-security/guides/crowdsec-phase2-and-5-advanced-features.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "CrowdSec Phase 2 & 5: Advanced Features"
+description: "Guide to CrowdSec advanced features — Phase 2 Prometheus/Grafana observability integration and Phase 5 hardening with custom pages, notifications, and reputation."
+sensitivity: public
+created: 2025-11-12
+updated: 2025-11-12
+---
+
 # CrowdSec Phase 2 & 5: Advanced Features
 
 **Version:** 1.0

--- a/docs/30-security/guides/crowdsec-phase3-threat-intelligence.md
+++ b/docs/30-security/guides/crowdsec-phase3-threat-intelligence.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "CrowdSec Phase 3: Threat Intelligence Enhancement Plan"
+description: "Guide to CrowdSec Phase 3 threat intelligence — CAPI enrollment, global blocklists, and scenario collection expansion."
+sensitivity: public
+created: 2025-11-12
+updated: 2025-11-12
+---
+
 # CrowdSec Phase 3: Threat Intelligence Enhancement Plan
 
 **Version:** 1.0

--- a/docs/30-security/guides/crowdsec-phase4-configuration-management.md
+++ b/docs/30-security/guides/crowdsec-phase4-configuration-management.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "CrowdSec Phase 4: Configuration Management Plan"
+description: "Guide to CrowdSec Phase 4 configuration management — bringing config files under Git, templates, validation, and backup/restore."
+sensitivity: public
+created: 2025-11-12
+updated: 2025-11-12
+---
+
 # CrowdSec Phase 4: Configuration Management Plan
 
 **Version:** 1.0

--- a/docs/30-security/guides/esp32-vlan2-firewall-rule.md
+++ b/docs/30-security/guides/esp32-vlan2-firewall-rule.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "ESP32 Bluetooth Proxy - VLAN2 Firewall Configuration"
+description: "Guide to the VLAN2 firewall rule letting an ESP32 Bluetooth proxy on the IoT network reach Home Assistant over the ESPHome API (port 6053)."
+sensitivity: public
+created: 2026-02-04
+updated: 2026-02-04
+---
+
 # ESP32 Bluetooth Proxy - VLAN2 Firewall Configuration
 
 **Context:** ESP32 on IoT network (VLAN2) needs to communicate with Home Assistant on main network (VLAN1).

--- a/docs/30-security/guides/secrets-management.md
+++ b/docs/30-security/guides/secrets-management.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Secrets Management (workload side)"
+description: "Workload-side secrets-management guide describing the OpenBao substrate model and the Secret= name-based consumption contract this repo owns."
+sensitivity: public
+created: 2025-12-31
+updated: 2026-06-14
+---
+
 # Secrets Management (workload side)
 
 **Rewritten:** 2026-06-14. This replaces the previous version (2025-12-26), whose model was

--- a/docs/30-security/guides/security-audit.md
+++ b/docs/30-security/guides/security-audit.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Security Audit Guide"
+description: "Security audit guide covering the 53-check security-audit.sh across seven categories, audit levels, scoring, and the security-auditor skill."
+sensitivity: public
+created: 2026-01-08
+updated: 2026-03-08
+---
+
 # Security Audit Guide
 
 **Purpose:** Comprehensive security checklist for homelab infrastructure

--- a/docs/30-security/guides/ssh-hardening.md
+++ b/docs/30-security/guides/ssh-hardening.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "SSH Security Hardening Analysis - fedora-htpc"
+description: "SSH hardening analysis of fedora-htpc's OpenSSH config — key-only auth, FIDO2 hardware keys, crypto standards, and firewall posture."
+sensitivity: public
+created: 2025-11-06
+updated: 2025-11-07
+---
+
 # SSH Security Hardening Analysis - fedora-htpc
 
 **Date**: 2025-11-04

--- a/docs/30-security/guides/sshd-deployment-procedure.md
+++ b/docs/30-security/guides/sshd-deployment-procedure.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "SSH Server Hardening Deployment Procedure"
+description: "Procedure for deploying hardened sshd_config across pihole, fedora-htpc, and fedora-jern with safe rollout ordering and lockout safeguards."
+sensitivity: public
+created: 2025-11-05
+updated: 2025-11-07
+---
+
 # SSH Server Hardening Deployment Procedure
 
 **Created:** 2025-11-05

--- a/docs/30-security/runbooks/IR-001-brute-force-attack.md
+++ b/docs/30-security/runbooks/IR-001-brute-force-attack.md
@@ -1,3 +1,12 @@
+---
+type: Runbook
+title: "IR-001: Brute Force Attack Detected"
+description: "Incident-response runbook for brute-force authentication attacks detected by CrowdSec or Authelia logs."
+sensitivity: public
+created: 2025-11-29
+updated: 2025-11-29
+---
+
 # IR-001: Brute Force Attack Detected
 
 **Severity:** HIGH

--- a/docs/30-security/runbooks/IR-002-unauthorized-port.md
+++ b/docs/30-security/runbooks/IR-002-unauthorized-port.md
@@ -1,3 +1,12 @@
+---
+type: Runbook
+title: "IR-002: Unauthorized Port Exposed"
+description: "Incident-response runbook for an unexpected open port exposing internal services, with the expected-port whitelist and investigation steps."
+sensitivity: public
+created: 2025-11-29
+updated: 2025-11-29
+---
+
 # IR-002: Unauthorized Port Exposed
 
 **Severity:** CRITICAL

--- a/docs/30-security/runbooks/IR-003-critical-cve.md
+++ b/docs/30-security/runbooks/IR-003-critical-cve.md
@@ -1,3 +1,12 @@
+---
+type: Runbook
+title: "IR-003: Critical CVE in Running Container"
+description: "Incident-response runbook for a critical or high-severity CVE in a running container image, keyed to Trivy scans and severity-based response times."
+sensitivity: public
+created: 2025-11-29
+updated: 2025-11-29
+---
+
 # IR-003: Critical CVE in Running Container
 
 **Severity:** HIGH to CRITICAL (depends on CVE)

--- a/docs/30-security/runbooks/IR-004-compliance-failure.md
+++ b/docs/30-security/runbooks/IR-004-compliance-failure.md
@@ -1,3 +1,12 @@
+---
+type: Runbook
+title: "IR-004: Failed Compliance Check"
+description: "Incident-response runbook for failed compliance checks — ADR or security-policy violations flagged by security-audit.sh or drift detection."
+sensitivity: public
+created: 2025-11-29
+updated: 2025-11-29
+---
+
 # IR-004: Failed Compliance Check
 
 **Severity:** MEDIUM to HIGH (depends on ADR violated)

--- a/docs/30-security/runbooks/IR-005-network-security-event.md
+++ b/docs/30-security/runbooks/IR-005-network-security-event.md
@@ -1,3 +1,12 @@
+---
+type: Runbook
+title: "IR-005: Network Security Event"
+description: "Incident-response runbook for network-layer security events detected by the UDM Pro via Unpoller — DPI threats, bandwidth spikes, and firewall block surges."
+sensitivity: public
+created: 2026-01-08
+updated: 2026-01-08
+---
+
 # IR-005: Network Security Event
 
 **Severity:** CRITICAL

--- a/docs/40-monitoring-and-documentation/decisions/2025-11-06-ADR-003-monitoring-stack-architecture.md
+++ b/docs/40-monitoring-and-documentation/decisions/2025-11-06-ADR-003-monitoring-stack-architecture.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-001: Monitoring Stack Architecture (Prometheus + Grafana + Loki)"
+description: "ADR adopting the Prometheus + Grafana + Loki observability stack (with Promtail, Node Exporter, Alertmanager) for the homelab."
+sensitivity: public
+created: 2025-11-07
+updated: 2025-12-22
+---
+
 # ADR-001: Monitoring Stack Architecture (Prometheus + Grafana + Loki)
 
 **Date:** 2025-11-06

--- a/docs/40-monitoring-and-documentation/decisions/2026-07-14-ADR-043-documentation-boundary-per-document-sensitivity.md
+++ b/docs/40-monitoring-and-documentation/decisions/2026-07-14-ADR-043-documentation-boundary-per-document-sensitivity.md
@@ -1,3 +1,12 @@
+---
+type: ADR
+title: "ADR-043: Documentation Boundary as a Per-Document Sensitivity Property"
+description: "ADR deciding that documentation sensitivity is a per-document property governing public-repo versus private-vault placement, with frontmatter classification and flow rules."
+sensitivity: public
+created: 2026-07-14
+updated: 2026-07-14
+---
+
 # ADR-043: Documentation Boundary as a Per-Document Sensitivity Property
 
 **Date:** 2026-07-14

--- a/docs/40-monitoring-and-documentation/guides/daily-error-digest.md
+++ b/docs/40-monitoring-and-documentation/guides/daily-error-digest.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Daily Error Digest"
+description: "Guide to the daily error digest — an automated timer that queries Loki for 24h of errors across log sources and alerts Discord past a threshold."
+sensitivity: public
+created: 2026-01-11
+updated: 2026-01-11
+---
+
 # Daily Error Digest
 
 **Created:** 2026-01-11

--- a/docs/40-monitoring-and-documentation/guides/git-workflow.md
+++ b/docs/40-monitoring-and-documentation/guides/git-workflow.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Git Setup Guide for Homelab Project"
+description: "Introductory guide to initializing Git version control for the homelab's configuration and documentation, covering setup and identity configuration."
+sensitivity: public
+created: 2025-10-31
+updated: 2025-11-07
+---
+
 # Git Setup Guide for Homelab Project
 
 **Purpose:** Initialize version control for your homelab configuration and documentation

--- a/docs/40-monitoring-and-documentation/guides/homelab-snapshot-development.md
+++ b/docs/40-monitoring-and-documentation/guides/homelab-snapshot-development.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Homelab Snapshot Script: Developer Guide"
+description: "Developer guide to the homelab-snapshot.sh system-intelligence script — architecture, data flow, code walkthrough, and extension."
+sensitivity: public
+created: 2025-11-09
+updated: 2025-11-09
+---
+
 # Homelab Snapshot Script: Developer Guide
 ## Learn to Build, Understand, and Extend System Intelligence
 

--- a/docs/40-monitoring-and-documentation/guides/log-to-metric-dashboard-panels.md
+++ b/docs/40-monitoring-and-documentation/guides/log-to-metric-dashboard-panels.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Log-to-Metric Dashboard Panels"
+description: "Reference of Grafana dashboard panels visualizing log-derived metrics extracted by Promtail, with PromQL queries and thresholds."
+sensitivity: public
+created: 2026-01-11
+updated: 2026-01-11
+---
+
 # Log-to-Metric Dashboard Panels
 
 **Created:** 2026-01-11

--- a/docs/40-monitoring-and-documentation/guides/log-to-metric-implementation.md
+++ b/docs/40-monitoring-and-documentation/guides/log-to-metric-implementation.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Log-to-Metric Feedback Loop Implementation"
+description: "Guide to the log-to-metric feedback loop — extracting Prometheus counters from logs at Promtail ingestion for real-time error alerting."
+sensitivity: public
+created: 2026-01-11
+updated: 2026-01-11
+---
+
 # Log-to-Metric Feedback Loop Implementation
 
 **Created:** 2026-01-11

--- a/docs/40-monitoring-and-documentation/guides/loki-remediation-queries.md
+++ b/docs/40-monitoring-and-documentation/guides/loki-remediation-queries.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Loki Remediation Query Guide"
+description: "Guide of practical LogQL queries for analyzing autonomous remediation decision logs ingested into Loki."
+sensitivity: public
+created: 2025-12-26
+updated: 2025-12-26
+---
+
 # Loki Remediation Query Guide
 
 **Created:** 2025-12-26

--- a/docs/40-monitoring-and-documentation/guides/maximizing-workflow-impact.md
+++ b/docs/40-monitoring-and-documentation/guides/maximizing-workflow-impact.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Maximizing Impact from Claude Code Workflow Improvements"
+description: "Guide to extracting value from Claude Code workflow enhancements — slash commands, subagents, and the 7-level verification framework."
+sensitivity: public
+created: 2026-01-05
+updated: 2026-01-05
+---
+
 # Maximizing Impact from Claude Code Workflow Improvements
 
 **Version:** 1.0

--- a/docs/40-monitoring-and-documentation/guides/monitoring-stack.md
+++ b/docs/40-monitoring-and-documentation/guides/monitoring-stack.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Homelab Monitoring Stack Guide"
+description: "Comprehensive guide to the homelab's monitoring, alerting, and autonomous remediation infrastructure — components, usage, maintenance, and extension."
+sensitivity: public
+created: 2025-11-06
+updated: 2025-12-29
+---
+
 # Homelab Monitoring Stack Guide
 
 **Created:** 2025-11-06

--- a/docs/40-monitoring-and-documentation/guides/natural-language-queries.md
+++ b/docs/40-monitoring-and-documentation/guides/natural-language-queries.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Natural Language Query System - User Guide"
+description: "User guide to the natural-language query system (query-homelab.sh) that translates plain-English questions into cached system state answers."
+sensitivity: public
+created: 2025-11-21
+updated: 2025-11-30
+---
+
 # Natural Language Query System - User Guide
 
 **Created:** 2025-11-22

--- a/docs/40-monitoring-and-documentation/guides/slo-based-alerting.md
+++ b/docs/40-monitoring-and-documentation/guides/slo-based-alerting.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "SLO-Based Alerting - Implementation Guide"
+description: "Implementation guide for SLO-based alerting using Google SRE multi-window, multi-burn-rate methodology to alert on user impact rather than symptoms."
+sensitivity: public
+created: 2025-12-19
+updated: 2026-02-07
+---
+
 # SLO-Based Alerting - Implementation Guide
 
 **Created:** 2025-12-19

--- a/docs/40-monitoring-and-documentation/guides/slo-calibration-process.md
+++ b/docs/40-monitoring-and-documentation/guides/slo-calibration-process.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "SLO Target Calibration Process"
+description: "Guide to the process of calibrating SLO targets from observed performance data via daily snapshots and 95th-percentile analysis."
+sensitivity: public
+created: 2026-01-09
+updated: 2026-02-07
+---
+
 # SLO Target Calibration Process
 
 **Created:** 2026-01-09

--- a/docs/40-monitoring-and-documentation/guides/slo-framework.md
+++ b/docs/40-monitoring-and-documentation/guides/slo-framework.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "Service Level Objectives (SLO) Framework"
+description: "Guide defining the homelab's SLO framework — SLI/SLO/error-budget concepts, success-criteria policies, and multi-window burn-rate alerting."
+sensitivity: public
+created: 2025-11-28
+updated: 2026-05-25
+---
+
 # Service Level Objectives (SLO) Framework
 
 **Created:** 2025-11-27

--- a/docs/40-monitoring-and-documentation/guides/unifi-security-monitoring.md
+++ b/docs/40-monitoring-and-documentation/guides/unifi-security-monitoring.md
@@ -1,3 +1,12 @@
+---
+type: Guide
+title: "UniFi Security Monitoring Guide"
+description: "Guide to network-layer security monitoring via Unpoller and UDM Pro metrics — architecture, dashboards, recording rules, and alerts."
+sensitivity: public
+created: 2026-01-08
+updated: 2026-01-09
+---
+
 # UniFi Security Monitoring Guide
 
 **Created:** 2026-01-08

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -260,7 +260,7 @@ report yields a durable, generalizable lesson, promote it to `lessons.md` per it
 - **Vault → public:** free — GitHub PRs, commit hashes, URLs, repo paths in prose (vault-internal linking rules live in the vault's conventions doc)
 - Do not duplicate content across docs -- link instead
 
-**Metadata (frontmatter):** Every public document carries YAML frontmatter: `type`, `title`, `description`, `sensitivity: public` (explicit), and dates. Until the backfill completes (plan WP-C), legacy docs may still carry only a title and `Last Updated` — new documents must not. Guides additionally keep `Last Updated` current.
+**Metadata (frontmatter):** Every public document carries YAML frontmatter: `type`, `title`, `description`, `sensitivity: public` (explicit), and `created`/`updated` dates. Guides additionally keep the in-body `Last Updated` line current.
 
 ---
 


### PR DESCRIPTION
## What

Prepends OKF frontmatter to **every public document** in `docs/00-40` (123 files):

```yaml
---
type: <ADR | Guide | Runbook>     # from directory
title: <from the file's H1>
description: <one authored sentence>
sensitivity: public               # explicit
created: <git first-add date>
updated: <git last-commit date>
---
```

Implements ADR-043 **D1** — classification becomes universal and machine-checkable. The pre-commit vault-boundary gate can now assert every public doc is *affirmatively* `public` rather than merely unmarked.

## How

- **Mechanical fields** (`type`/`title`/`created`/`updated`) generated deterministically from directory + H1 + `git log`.
- **Descriptions** authored per-file (owner-facing, one sentence) — not machine-stubbed.
- Validated: all 123 parse as YAML, all carry the six required keys, all `sensitivity: public`.

## Scope notes

- **123, not 125:** the two gitignored `-private` docs (`ADR-033` signing policy, `ssh-commit-signing-yubikey`) are **excluded** — they're not public and can't be committed. They're leftover pre-vault private docs that should move to the Huldr vault (flagged for follow-up, not part of this PR).
- Drops the now-stale `CONTRIBUTING.md` note that legacy docs may carry only a title until the backfill lands.
- `AUTO-*` generated docs deliberately untouched.
- Depends on #329 (ADR renamed to 043) — already merged; this branches off updated `main`.

## Follow-up (later WP-C steps, separate PRs)

- Scrub-or-move review of the 32 RFC1918-carrying files
- Runbook split: IR-005 + nextcloud-operations → vault + public stubs

🤖 Generated with [Claude Code](https://claude.com/claude-code)