### PR TITLE
docs: scrub genuine incidental leaks — WAN IP + personal emails (WP-C task 3)

### DIFF
--- a/docs/10-services/guides/authelia.md
+++ b/docs/10-services/guides/authelia.md
@@ -1031,7 +1031,7 @@ log:
 
 **Successful authentication:**
 ```
-level=info msg="Successful authentication" username=patriark remote_ip=62.249.184.112
+level=info msg="Successful authentication" username=patriark remote_ip=203.0.113.42
 ```
 
 **Failed authentication:**

--- a/docs/10-services/guides/gathio-email-setup.md
+++ b/docs/10-services/guides/gathio-email-setup.md
@@ -68,7 +68,7 @@ https://events.patriark.org/edit/abc123?e=generated-password
 
 3. **Verify Sender Email:**
    - Settings → Sender Authentication → Single Sender Verification
-   - Add: surfaceideology@proton.me
+   - Add: your-account@example.com
    - Check Proton inbox for verification link
 
 4. **Update Gathio Config:**
@@ -80,7 +80,7 @@ nano ~/containers/config/gathio/config.toml
 Update these sections:
 ```toml
 [general]
-email = "surfaceideology@proton.me"
+email = "your-account@example.com"
 mail_service = "sendgrid"
 
 [sendgrid]
@@ -112,7 +112,7 @@ systemctl --user restart gathio.service
 3. **Update config.toml:**
 ```toml
 [general]
-email = "surfaceideology@proton.me"
+email = "your-account@example.com"
 mail_service = "nodemailer"
 
 [nodemailer]
@@ -132,7 +132,7 @@ Your current Gmail/Outlook won't work (passwordless auth = no app passwords).
 
 **Workaround:** Create a **new** Gmail account specifically for Gathio:
 
-1. **Create new Gmail:** gathio.events.patriark@gmail.com (example)
+1. **Create new Gmail:** gathio-service@example.com (example)
 2. **Enable 2FA:** Required for app passwords
 3. **Generate App Password:**
    - Google Account → Security → 2-Step Verification → App passwords
@@ -140,13 +140,13 @@ Your current Gmail/Outlook won't work (passwordless auth = no app passwords).
 4. **Update config.toml:**
 ```toml
 [general]
-email = "gathio.events.patriark@gmail.com"
+email = "gathio-service@example.com"
 mail_service = "nodemailer"
 
 [nodemailer]
 smtp_server = "smtp.gmail.com"
 smtp_port = "587"
-smtp_username = "gathio.events.patriark@gmail.com"
+smtp_username = "gathio-service@example.com"
 smtp_password = "xxxx xxxx xxxx xxxx"  # 16-character app password
 ```
 

--- a/docs/20-operations/guides/architecture-diagrams.md
+++ b/docs/20-operations/guides/architecture-diagrams.md
@@ -20,7 +20,7 @@ updated: 2025-12-22
                              │ DNS Query
                              ↓
                     ┌────────────────┐
-                    │   Cloudflare   │ patriark.org → 62.249.184.112
+                    │   Cloudflare   │ patriark.org → 203.0.113.42
                     │   DNS Server   │
                     └────────────────┘
                              │
@@ -28,7 +28,7 @@ updated: 2025-12-22
                              ↓
                 ┌────────────────────────┐
                 │   ISP / Public IP      │
-                │   62.249.184.112       │
+                │   203.0.113.42         │
                 └────────────────────────┘
                              │
                              │ Port Forward
@@ -186,7 +186,7 @@ Host: fedora-htpc (192.168.1.70)
 └─── Host Network
      ├─ DNS: 192.168.1.69 (Pi-hole)
      ├─ Gateway: 192.168.1.1 (UDM Pro)
-     └─ Public IP: 62.249.184.112 (Dynamic)
+     └─ Public IP: 203.0.113.42 (Dynamic)
 ```
 
 ---
@@ -199,7 +199,7 @@ Host: fedora-htpc (192.168.1.70)
    
 2. DNS Resolution
    Browser → Pi-hole (192.168.1.69) → 192.168.1.70 (LAN)
-   Browser → Cloudflare → 62.249.184.112 (WAN)
+   Browser → Cloudflare → 203.0.113.42 (WAN)
    
 3. TLS Handshake
    Browser ←TLS→ Traefik


### PR DESCRIPTION
## The premise changed

WP-C planned a scrub-in-place of 34 RFC1918-carrying files. Investigating first (rather than mechanically scrubbing) showed the premise doesn't hold:

- `192.168.1.69` (Pi-hole) and the rest of the LAN topology live in **41 config/quadlet files** as operational code — `DNS=192.168.1.69` in every `.network`, `routers.yml`, prometheus targets, a grafana dashboard.
- Podman `10.89.x` subnets are defined in the public `.network` quadlets (`Subnet=10.89.x.0/24`).
- All of it is in **git history** (15+ commits) on an **already-public GitHub repo**.

Scrubbing those IPs from 34 docs while they remain in 41 config files + history is security theater. The frontmatter backfill already did the honest thing — marked these docs `sensitivity: public`, which is correct.

**Owner decision:** drop the pointless IP scrub; hunt for content that *isn't* already public-as-code.

## What this PR actually scrubs

| Leak | Files | Fix |
|---|---|---|
| Public WAN IP `62.249.184.112` | `authelia.md`, `architecture-diagrams.md` | → `203.0.113.42` (RFC5737 example) |
| Personal Brevo/admin email + gathio service Gmail | `gathio-email-setup.md` | → `example.com` placeholders |

## What came back clean

- **Secrets:** every hit was a `Secret=<name>` handle (ADR-041 interface is names, not values), a `*redacted*`/`STRONG_PASSWORD` placeholder, or advice. No real credentials in docs.
- **`blyhode@hotmail.com`:** only in the two gitignored `-private` files (not in the public repo; already in commit signatures).
- **Vault moves:** none needed — no public doc's specificity was load-bearing-internal (it was all already-public topology).

## Follow-up flagged (not in this PR)

The two gitignored `-private` docs — `ADR-033-per-host-commit-signing-policy-private.md` and `ssh-commit-signing-yubikey-private.md` — are internal/secret content sitting as gitignored files inside a public repo. They belong in the Huldr vault. Recommend moving them there (owner call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)