### PR TITLE
feat: restricted-egress tier — LAN-only network with in-netns nft filter (ADR-045)

### DIFF
--- a/config/authelia/configuration.yml
+++ b/config/authelia/configuration.yml
@@ -73,7 +73,7 @@ access_control:
     # Tier 1: Admin Services - YubiKey Required (two_factor)
     - domain:
         - 'grafana.patriark.org'
-        - 'prometheus.patriark.org'
+        # prometheus.patriark.org removed 2026-07-17 — Traefik router deleted (ADR-045)
         - 'traefik.patriark.org'
         - 'loki.patriark.org'
         - 'home.patriark.org'

--- a/config/prometheus/alerts/egress-filter-alerts.yml
+++ b/config/prometheus/alerts/egress-filter-alerts.yml
@@ -1,0 +1,54 @@
+# ADR-045 — restricted-egress nft filter drift detection.
+#
+# The filter is FAIL-OPEN (members run regardless of filter state — it is
+# defense-in-depth, not a containment boundary), so drift detection is the
+# mandatory complement: an unfiltered window must never pass silently.
+# Metrics come from egress-filter-apply.sh (1-min timer) via the node_exporter
+# textfile collector (honor_labels on that job — see prometheus.yml).
+groups:
+  - name: egress_filter_alerts
+    interval: 60s
+    rules:
+      # Warning: the rootless netns exists (containers are running) but the
+      # egress_filter table has not converged. Design gate is >5 min (the
+      # post-reboot unfiltered burst inside the first minute is explicitly
+      # accepted — ADR-045).
+      - alert: EgressFilterAbsent
+        expr: egress_filter_netns_present == 1 and egress_filter_table_present == 0
+        for: 5m
+        labels:
+          severity: warning
+          category: security
+          component: egress-filter
+        annotations:
+          summary: "Restricted-egress nft filter absent >5m while netns is up"
+          description: "The rootless netns exists but table inet egress_filter is missing — restricted-egress members (prometheus, unpoller, pihole-exporter) currently have UNFILTERED internet egress. Check: journalctl --user -u egress-filter.service -n 20; apply by hand: systemctl --user start egress-filter.service. See ADR-045."
+
+      # Warning: the enforcement timer itself is dead or wedged — without it
+      # there is neither enforcement nor the sensor above. Catches both a
+      # stale timestamp and the metric disappearing entirely.
+      - alert: EgressFilterCollectorStale
+        expr: (time() - egress_filter_last_run_timestamp) > 300 or absent(egress_filter_last_run_timestamp)
+        for: 2m
+        labels:
+          severity: warning
+          category: security
+          component: egress-filter
+        annotations:
+          summary: "egress-filter.timer has not reported for >5m"
+          description: "egress-filter-apply.sh last wrote its textfile more than 5 minutes ago (cadence is 1 min) — enforcement AND drift detection for the restricted-egress tier are blind. Check: systemctl --user status egress-filter.timer egress-filter.service. See ADR-045."
+
+      # Critical: the single-homing invariant is broken — a restricted-egress
+      # member joined another non-internal network, giving it a second default
+      # route around the filter. This is the 2026-02-02 incident topology;
+      # it must be impossible, not just filtered (ADR-045).
+      - alert: EgressFilterSingleHomingViolation
+        expr: egress_filter_singlehome_violations > 0
+        for: 2m
+        labels:
+          severity: critical
+          category: security
+          component: egress-filter
+        annotations:
+          summary: "Restricted-egress member is multi-homed onto a non-internal network"
+          description: "{{ $value }} membership(s) of the restricted-egress network also join another NON-internal network — that container has a default route that bypasses the egress filter (ADR-045 invariant, 2026-02-02 lesson). Identify: journalctl --user -u egress-filter.service | grep VIOLATION; fix the quadlet (or undo the podman network connect) immediately."

--- a/config/prometheus/prometheus.yml
+++ b/config/prometheus/prometheus.yml
@@ -63,9 +63,13 @@ scrape_configs:
         action: drop
 
   # Traefik monitoring (metrics enabled 2025-11-06)
+  # Pinned IP (ADR-045): prometheus moved to restricted-egress and shares no
+  # network with traefik — scraped cross-bridge via pinned reverse_proxy IP +
+  # kernel routing (deterministic, no DNS). Depends on isolate=false staying
+  # pinned in the .network quadlets.
   - job_name: 'traefik'
     static_configs:
-      - targets: ['traefik:8080']
+      - targets: ['10.89.2.69:8080']
         labels:
           instance: 'fedora-htpc'
           service: 'traefik'
@@ -95,9 +99,11 @@ scrape_configs:
           service: 'promtail'
 
   # CrowdSec security monitoring
+  # Pinned IP (ADR-045): scraped cross-bridge from restricted-egress — see
+  # the traefik job note.
   - job_name: 'crowdsec'
     static_configs:
-      - targets: ['crowdsec:6060']
+      - targets: ['10.89.2.70:6060']
         labels:
           instance: 'fedora-htpc'
           service: 'crowdsec'
@@ -125,10 +131,13 @@ scrape_configs:
   # Timeout (L-034 sweep 2026-06-12): measured p95 16ms / 7d-max 1.3s — the
   # exporter polls the UDM Pro synchronously, so a slow controller can stretch
   # a scrape. 10s explicit (was implicit default) gives >7x worst-case headroom.
+  # Pinned monitoring IP (ADR-045): unpoller and prometheus now share BOTH
+  # restricted-egress and monitoring, so the DNS name resolves ambiguously —
+  # pin the monitoring-network IP.
   - job_name: 'unpoller'
     scrape_timeout: 10s
     static_configs:
-      - targets: ['unpoller:9130']
+      - targets: ['10.89.4.97:9130']
         labels:
           instance: 'fedora-htpc'
           service: 'unpoller'
@@ -235,11 +244,13 @@ scrape_configs:
   # still caught by PiHoleExporterDown (warning, for:5m) + the watchdog timer.
   # 30s interval matches the exporter's own INTERVAL=30s and reduces Pi-hole API
   # login churn (also eases the GH#246 session leak). timeout must be ≤ interval.
+  # Pinned monitoring IP (ADR-045): shares two networks with prometheus
+  # post-swap — see the unpoller job note.
   - job_name: 'pihole'
     scrape_interval: 30s
     scrape_timeout: 20s
     static_configs:
-      - targets: ['pihole-exporter:9617']
+      - targets: ['10.89.4.96:9617']
         labels:
           instance: 'raspberrypi'
           service: 'pihole'

--- a/config/traefik/dynamic/routers.yml
+++ b/config/traefik/dynamic/routers.yml
@@ -161,18 +161,10 @@ http:
       tls:
         certResolver: letsencrypt
 
-    # Prometheus Metrics Database
-    prometheus-secure:
-      rule: "Host(`prometheus.patriark.org`)"
-      service: "prometheus"
-      entryPoints:
-        - websecure
-      middlewares:
-        - crowdsec-bouncer@file
-        - rate-limit@file
-        - authelia@file
-      tls:
-        certResolver: letsencrypt
+    # Prometheus - INTERNAL ONLY (router removed 2026-07-17, ADR-045)
+    # Unused since fall 2025; Grafana is the UI and queries prometheus over the
+    # monitoring network. Removing the route is what lets prometheus be
+    # single-homed on restricted-egress (GH#334 single-homing invariant).
 
     # Loki Log Aggregation
     loki-secure:
@@ -330,10 +322,7 @@ http:
         servers:
           - url: "http://grafana:3000"
 
-    prometheus:
-      loadBalancer:
-        servers:
-          - url: "http://prometheus:9090"
+    # prometheus: (removed 2026-07-17 — internal-only, see router note above)
 
     loki:
       loadBalancer:

--- a/docs/30-security/decisions/2026-07-17-ADR-045-restricted-egress-tier.md
+++ b/docs/30-security/decisions/2026-07-17-ADR-045-restricted-egress-tier.md
@@ -105,8 +105,10 @@ one default route — wrong-network egress becomes structurally impossible inste
 luck-dependent (the 2026-02-02 incident lesson encoded as topology). Policed
 **live** by the timer (enumerates the network's members and their networks — even a
 hand-run `podman network connect` is caught within a minute) and alerted as
-critical (`EgressFilterSingleHomingViolation`). A commit-time quadlet lint is the
-recommended declare-time complement (future work).
+critical (`EgressFilterSingleHomingViolation`). The declare-time complement is
+`scripts/check-single-homing.sh`, wired as pre-commit check 6: a `.container`
+declaring `systemd-restricted-egress` alongside any other non-internal network
+(unknown networks count as non-internal — fail safe) rejects the commit.
 
 Corollaries applied with this ADR:
 

--- a/docs/30-security/decisions/2026-07-17-ADR-045-restricted-egress-tier.md
+++ b/docs/30-security/decisions/2026-07-17-ADR-045-restricted-egress-tier.md
@@ -1,0 +1,149 @@
+---
+type: ADR
+title: "ADR-045: Restricted-Egress Tier — LAN-Only Network with In-Netns nft Filter"
+description: "ADR adding the missing middle tier of a three-tier egress model: a restricted-egress network whose members get LAN reachability but no internet, enforced by an nft filter inside the rootless netns with fail-open semantics and mandatory drift detection."
+sensitivity: public
+created: 2026-07-17
+updated: 2026-07-17
+---
+
+# ADR-045: Restricted-Egress Tier — LAN-Only Network with In-Netns nft Filter
+
+**Date:** 2026-07-17
+**Status:** Accepted. Executes GH#334 (design handoff from the htpc-mgmt wayfinder
+map #3, tickets #4–#8, private tracker — decision trail, research note, and prototype
+findings live there). Substrate side (host `nftables` package declared, coupling
+documented) shipped in htpc-mgmt on 2026-07-17. Complements ADR-030 T4 (egress
+observatory) and encodes the 2026-02-02 wrong-network-egress incident lesson as
+topology.
+
+---
+
+## Context
+
+A class of containers needs **LAN reachability but must never reach the internet**:
+today `pihole-exporter` (polls the Pi at 192.168.1.69), `unpoller` (polls the UDM Pro
+at 192.168.1.1), and `prometheus` (scrapes the Pi's node_exporter and, cross-bridge,
+pinned reverse_proxy IPs). All three sat on `reverse_proxy` **purely for the default
+route** — full internet egress they never legitimately use. `Internal=true` is not an
+option: internal networks contribute no default route at all, which would sever the
+LAN reach these services exist for (the "zero-egress candidates are not safe to
+internalize" finding).
+
+Host-level enforcement is impossible for rootless containers: pasta SNATs all egress
+to host-origin, so host nftables sees no per-container source to attribute
+(maintainer-acknowledged, podman discussion #27099). The only viable enforcement
+point is **inside the rootless netns**, where per-bridge subnets are still visible.
+
+All mechanism claims below were **runtime-proven in a live throwaway prototype
+(2026-07-17)**: a custom nft table in the rootless netns survives container
+restarts, network reloads, and network creates; netavark rewrites only its own
+`table inet netavark`; the DNS path keeps working; cross-bridge scrapes keep working.
+
+## Decision
+
+### D1 — Three-tier egress model
+
+| Tier | Mechanism | Egress | Members |
+|------|-----------|--------|---------|
+| `internal` | `Internal=true` networks | none (no default route) | DBs, backends (unchanged) |
+| **`restricted-egress`** | non-internal network + in-netns nft filter | **LAN + container bridges only** | pihole-exporter, unpoller, prometheus |
+| open | default-allow | unrestricted | rest of the fleet (unchanged) |
+
+The new network is pinned like every fleet network: `Subnet=10.89.11.0/24`,
+`Gateway=10.89.11.1`, `Internal=false` (quadlet `restricted-egress.network` →
+`systemd-restricted-egress`).
+
+### D2 — Enforcement: a separate nft table inside the rootless netns
+
+`table inet egress_filter`, defined in and applied by `egress-filter-apply.sh` as a
+single `podman unshare --rootless-netns nft '<commands>'` invocation — **argv, not
+stdin and not a file path**. File paths don't cross the userns mount namespace (as
+the handoff design noted), and deployment testing (2026-07-17) found the handoff's
+stdin route (`nft -f -`) is **racy through podman unshare**: `nft` intermittently
+read empty stdin and exited 0 — a successful parse of nothing, i.e. a silent
+enforcement no-op that only the drift metric caught. argv is deterministic. Never
+merged into `table inet netavark`: netavark rewrites its own table selectively; a
+separate table survives its churn (prototype-observed).
+
+Rules are **subnet-keyed** (members need no IP pinning for the filter):
+
+- `ip saddr 10.89.11.0/24 ip daddr { 192.168.1.0/24, 10.89.0.0/16, 169.254.1.1 } accept`
+- `ip saddr 10.89.11.0/24 counter drop`
+
+`169.254.1.1` is pasta's `--dns-forward` shim — DNS keeps resolving for members
+(aardvark forwards upstream itself). **Caveat: DNS tunneling remains an open
+channel**; the egress observatory (ADR-030 T4) is the alerting complement, not this
+filter. The LAN accept is deliberately the single flat VLAN the members actually
+need (192.168.1.0/24) — widen consciously if a member ever needs IoT/WireGuard
+ranges. No IPv6 egress path exists under pasta today; the `inet`-family table is
+where a v6 rule lands if one ever appears.
+
+### D3 — Reapply loop: user timer as enforcer AND sensor
+
+The netns and every rule in it **die with the last bridge container and on
+reboot** — reapply is the core problem, not the rules. `egress-filter.timer`
+(1-minute cadence) runs `egress-filter-apply.sh`: idempotent apply (add + flush
+prelude), then emits a textfile-collector metric set (netns/table presence,
+drop counters, member count, single-homing violations, run timestamp). Netns absent
+→ exit 0. No quadlet coupling, no `ExecStartPost` hooks, no path units.
+
+### D4 — Failure semantics: fail-open + mandatory drift detection
+
+Members run regardless of filter state — this is **defense-in-depth, not a
+containment boundary**; an unfiltered member is no worse than the default-allow
+fleet it just left. Convergence target: ≤1 min of the netns existing; **absence
+>5 min alerts** (`EgressFilterAbsent`, plus `EgressFilterCollectorStale` for a dead
+timer). The post-reboot unfiltered burst inside the first minute is explicitly
+accepted.
+
+### D5 — Single-homing invariant
+
+**A restricted-egress member must not join any other non-internal network.**
+Internal networks contribute no default route, so a compliant member has exactly
+one default route — wrong-network egress becomes structurally impossible instead of
+luck-dependent (the 2026-02-02 incident lesson encoded as topology). Policed
+**live** by the timer (enumerates the network's members and their networks — even a
+hand-run `podman network connect` is caught within a minute) and alerted as
+critical (`EgressFilterSingleHomingViolation`). A commit-time quadlet lint is the
+recommended declare-time complement (future work).
+
+Corollaries applied with this ADR:
+
+- **Prometheus's Traefik router is removed** (unused since fall 2025; Grafana is
+  the UI and queries prometheus over `monitoring`) — this is what makes all three
+  members single-homed-clean. Authelia's domain entry removed with it.
+- **Zero new multi-homing anywhere** — in particular Traefik stays single-homed on
+  `reverse_proxy`; multi-homing it with name-based backend URLs is the exact
+  2026-02-02 failure topology.
+
+### D6 — Deterministic scrape paths
+
+Prometheus now shares **no network** with traefik/crowdsec: those jobs scrape the
+pinned `reverse_proxy` IPs (10.89.2.69/.70) cross-bridge — pinned IP + kernel
+routing, no DNS. unpoller/pihole-exporter now share **two** networks with
+prometheus (names resolve ambiguously): those jobs scrape pinned `monitoring` IPs
+(10.89.4.97/.96). `Options=isolate=false` is pinned in the `restricted-egress` and
+`reverse_proxy` network quadlets, freezing today's cross-bridge forwarding against
+netavark 2.0's planned strict-isolation default flip (declare-time pin; applies on
+network recreation).
+
+## Validation gate
+
+1. LAN target reachable from a member-network container; a public IP **drops**.
+2. A non-member still reaches the internet (no collateral filtering).
+3. All prometheus targets healthy post-swap (traefik, crowdsec, unpoller, pihole,
+   node-exporter-pi, blackbox probes, navidrome, home-assistant).
+4. Timer metrics present; `egress_filter_singlehome_violations == 0`.
+5. Both survive a real reboot — timer reconverges ≤1 min of the netns existing.
+
+## Consequences
+
+- Compromise of an exporter/prometheus can no longer exfiltrate directly to the
+  internet (modulo DNS tunneling — observatory covers); lateral movement is
+  limited to LAN + bridges, which these services touch by design.
+- `prometheus.patriark.org` no longer routes (404 at Traefik); the DNS record can
+  be retired at leisure.
+- One more 1-minute user timer; cost is a few podman inspects + one nft apply.
+- Future members: join the network, stay single-homed — the filter needs no
+  per-member changes.

--- a/docs/AUTO-DEPENDENCY-GRAPH.md
+++ b/docs/AUTO-DEPENDENCY-GRAPH.md
@@ -1,6 +1,6 @@
 # Service Dependency Graph (Auto-Generated)
 
-**Generated:** 2026-07-01 22:04:54 UTC
+**Generated:** 2026-07-17 10:43:30 UTC
 **System:** fedora-htpc
 
 ---
@@ -88,11 +88,8 @@ graph TB
     traefik -.-> loki
     traefik -.-> navidrome
     traefik -.-> nextcloud
-    traefik -.-> pihole_exporter
-    traefik -.-> prometheus
     traefik -.-> proton_bridge
     traefik -.-> qbittorrent
-    traefik -.-> unpoller
     traefik -.-> vaultwarden
 
     %% Monitoring (Prometheus scrapes via monitoring network)
@@ -245,7 +242,9 @@ Services on the same network can communicate:
 
 **photos:** immich-ml,immich-server,postgres-exporter,postgresql-immich,redis-immich,redis-immich-exporter
 
-**reverse_proxy:** alert-discord-relay,alertmanager,audiobookshelf,authelia,blackbox-exporter,crowdsec,forgejo,gathio,grafana,home-assistant,immich-server,jellyfin,loki,navidrome,nextcloud,pihole-exporter,prometheus,proton-bridge,qbittorrent,traefik,unpoller,vaultwarden
+**restricted-egress:** pihole-exporter,prometheus,unpoller
+
+**reverse_proxy:** alert-discord-relay,alertmanager,audiobookshelf,authelia,blackbox-exporter,crowdsec,forgejo,gathio,grafana,home-assistant,immich-server,jellyfin,loki,navidrome,nextcloud,proton-bridge,qbittorrent,traefik,vaultwarden
 
 **syslog:** unifi-syslog
 

--- a/docs/AUTO-DOCUMENTATION-INDEX.md
+++ b/docs/AUTO-DOCUMENTATION-INDEX.md
@@ -1,7 +1,7 @@
 # Documentation Index (Auto-Generated)
 
-**Generated:** 2026-07-13 20:01:44 UTC
-**Total Documents:** 130
+**Generated:** 2026-07-17 10:43:31 UTC
+**Total Documents:** 133
 
 ---
 
@@ -137,7 +137,7 @@
 
 ---
 
-### 30-security/ (19 documents)
+### 30-security/ (20 documents)
 
 **Security architecture, configurations, and incident response**
 
@@ -158,6 +158,7 @@
 - ADR-008: [2025-11-12-ADR-008-crowdsec-security-architecture](30-security/decisions/2025-11-12-ADR-008-crowdsec-security-architecture.md)
 - ADR-040: [2026-06-14-ADR-040-secrets-substrate-operator-boundary](30-security/decisions/2026-06-14-ADR-040-secrets-substrate-operator-boundary.md)
 - ADR-041: [2026-06-14-ADR-041-secrets-openbao-substrate-boundary](30-security/decisions/2026-06-14-ADR-041-secrets-openbao-substrate-boundary.md)
+- ADR-045: [2026-07-17-ADR-045-restricted-egress-tier](30-security/decisions/2026-07-17-ADR-045-restricted-egress-tier.md)
 
 **Runbooks:**
 - [IR-001-brute-force-attack](30-security/runbooks/IR-001-brute-force-attack.md)
@@ -168,7 +169,7 @@
 
 ---
 
-### 40-monitoring-and-documentation/ (14 documents)
+### 40-monitoring-and-documentation/ (16 documents)
 
 **Monitoring stack, SLOs, and documentation practices**
 
@@ -213,117 +214,3 @@ Recent intelligence reports and resource forecasts. Updated automatically by aut
 
 ## Recently Updated (Last 7 Days)
 
-- 2026-07-13: [AUTO-DEPENDENCY-GRAPH.md](AUTO-DEPENDENCY-GRAPH.md)
-- 2026-07-13: [AUTO-DOCUMENTATION-INDEX.md](AUTO-DOCUMENTATION-INDEX.md)
-- 2026-07-13: [AUTO-EGRESS-BASELINE-INDEX.md](AUTO-EGRESS-BASELINE-INDEX.md)
-- 2026-07-13: [AUTO-IMAGE-PIN-INDEX.md](AUTO-IMAGE-PIN-INDEX.md)
-- 2026-07-13: [AUTO-NETWORK-TOPOLOGY.md](AUTO-NETWORK-TOPOLOGY.md)
-- 2026-07-13: [AUTO-SERVICE-CATALOG.md](AUTO-SERVICE-CATALOG.md)
-
----
-
-## Quick Search by Service
-
-**Traefik:**
-- Guide: [traefik.md](10-services/guides/traefik.md)
-- ADR: [ADR-022](00-foundation/decisions/2026-04-16-ADR-022-traefik-socket-activation.md)
-- Config: `~/containers/config/traefik/`
-- Quadlet: `~/.config/containers/systemd/traefik.container`
-
-**Authelia:**
-- Guide: [authelia.md](10-services/guides/authelia.md)
-- ADR: [ADR-005](30-security/decisions/2025-11-10-ADR-005-authelia-sso-mfa-architecture.md)
-- ADR: [ADR-006](30-security/decisions/2025-11-11-ADR-006-authelia-sso-yubikey-deployment.md)
-- Config: `~/containers/config/authelia/`
-- Quadlet: `~/.config/containers/systemd/authelia.container`
-
-**Crowdsec:**
-- Guide: [crowdsec.md](10-services/guides/crowdsec.md)
-- ADR: [ADR-039](00-foundation/decisions/2026-06-14-ADR-039-crowdsec-cloud-api-egress-scoping.md)
-- ADR: [ADR-008](30-security/decisions/2025-11-12-ADR-008-crowdsec-security-architecture.md)
-- Quadlet: `~/.config/containers/systemd/crowdsec.container`
-
-**Jellyfin:**
-- Guide: [jellyfin.md](10-services/guides/jellyfin.md)
-- Related: [jellyfin-gpu-acceleration-troubleshooting.md](10-services/guides/jellyfin-gpu-acceleration-troubleshooting.md)
-- Quadlet: `~/.config/containers/systemd/jellyfin.container`
-
-**Immich Server:**
-- Guide: [immich.md](10-services/guides/immich.md)
-- Related: [immich-configuration-review.md](10-services/guides/immich-configuration-review.md)
-- Related: [immich-deployment-checklist.md](10-services/guides/immich-deployment-checklist.md)
-- Related: [immich-ml-troubleshooting.md](10-services/guides/immich-ml-troubleshooting.md)
-- Quadlet: `~/.config/containers/systemd/immich-server.container`
-
-**Nextcloud:**
-- Guide: [nextcloud.md](10-services/guides/nextcloud.md)
-- ADR: [ADR-026](00-foundation/decisions/2026-04-21-ADR-026-nextcloud-pinned-major-version.md)
-- ADR: [ADR-013](10-services/decisions/2025-12-20-ADR-013-nextcloud-native-authentication.md)
-- ADR: [ADR-014](10-services/decisions/2025-12-20-ADR-014-nextcloud-passwordless-authentication.md)
-- Quadlet: `~/.config/containers/systemd/nextcloud.container`
-
-**Vaultwarden:**
-- Related: [vaultwarden-deployment.md](10-services/guides/vaultwarden-deployment.md)
-- ADR: [ADR-007](10-services/decisions/2025-11-12-ADR-007-vaultwarden-architecture.md)
-- Config: `~/containers/config/vaultwarden/`
-- Quadlet: `~/.config/containers/systemd/vaultwarden.container`
-
-**Home Assistant:**
-- Guide: [home-assistant.md](10-services/guides/home-assistant.md)
-- Related: [home-assistant.md](10-services/guides/home-assistant.md)
-- Config: `~/containers/config/home-assistant/`
-- Quadlet: `~/.config/containers/systemd/home-assistant.container`
-
-**Gathio:**
-- Related: [gathio-email-setup.md](10-services/guides/gathio-email-setup.md)
-- Config: `~/containers/config/gathio/`
-- Quadlet: `~/.config/containers/systemd/gathio.container`
-
-**Prometheus:**
-- Config: `~/containers/config/prometheus/`
-- Quadlet: `~/.config/containers/systemd/prometheus.container`
-- Stack Guide: [monitoring-stack.md](40-monitoring-and-documentation/guides/monitoring-stack.md)
-- SLO Framework: [slo-framework.md](40-monitoring-and-documentation/guides/slo-framework.md)
-
-**Grafana:**
-- Config: `~/containers/config/grafana/`
-- Quadlet: `~/.config/containers/systemd/grafana.container`
-- Stack Guide: [monitoring-stack.md](40-monitoring-and-documentation/guides/monitoring-stack.md)
-- SLO Framework: [slo-framework.md](40-monitoring-and-documentation/guides/slo-framework.md)
-
-**Loki:**
-- Config: `~/containers/config/loki/`
-- Quadlet: `~/.config/containers/systemd/loki.container`
-- Stack Guide: [monitoring-stack.md](40-monitoring-and-documentation/guides/monitoring-stack.md)
-- SLO Framework: [slo-framework.md](40-monitoring-and-documentation/guides/slo-framework.md)
-
-**Alertmanager:**
-- Config: `~/containers/config/alertmanager/`
-- Quadlet: `~/.config/containers/systemd/alertmanager.container`
-- Stack Guide: [monitoring-stack.md](40-monitoring-and-documentation/guides/monitoring-stack.md)
-- SLO Framework: [slo-framework.md](40-monitoring-and-documentation/guides/slo-framework.md)
-
----
-
-## Documentation Practices
-
-### Directory Structure
-
-- **guides/** - Living reference documentation (updated in place)
-- **decisions/** - Architecture Decision Records (immutable, dated)
-- **runbooks/** - Operational procedures (DR, incident response)
-- **journal/** - Chronological entries (append-only, never edited)
-
-### File Naming Conventions
-
-- **Guides:** Descriptive names (e.g., `slo-framework.md`)
-- **ADRs:** `YYYY-MM-DD-ADR-NNN-description.md`
-- **Journals:** `YYYY-MM-DD-description.md`
-- **Reports:** `TYPE-YYYYMMDD-HHMMSS.json` or `.md`
-
-See [CONTRIBUTING.md](CONTRIBUTING.md) for full documentation guidelines.
-
----
-
-*Auto-generated by `scripts/generate-doc-index.sh`*
-*Updates daily to reflect documentation changes*

--- a/docs/AUTO-EGRESS-BASELINE-INDEX.md
+++ b/docs/AUTO-EGRESS-BASELINE-INDEX.md
@@ -1,6 +1,6 @@
 # Egress Observatory — Baseline Index (Auto-Generated)
 
-**Generated:** 2026-07-04 13:57:52 UTC
+**Generated:** 2026-07-17 05:03:29 UTC
 **Implements:** ADR-030 P7 (Tier 4) — egress detection. **Mode:** live (alerting)
 
 Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers (attributable, rootless, scratch-safe, DNS-method-agnostic). Detection, not prevention. See `config/supply-chain/known-egress.md` for method and residual/evasion scope.
@@ -9,8 +9,8 @@ Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers
 
 | Component | Last run | Detail |
 |---|---|---|
-| Collector (`egress-collector.service`) | 10s ago | 22 services sampled |
-| Classifier (`egress-detect.timer`) | 16s ago | mode=live (alerting); last window 8 dest(s) |
+| Collector (`egress-collector.service`) | 0s ago | 22 services sampled |
+| Classifier (`egress-detect.timer`) | 2m ago | mode=live (alerting); last window 7 dest(s) |
 
 ## Per-service egress
 
@@ -21,22 +21,22 @@ Host-side `/proc/<pid>/net/{tcp,tcp6}` sampling of reverse_proxy-tier containers
 | audiobookshelf | classify | — | — | — |
 | authelia | classify | — | — | — |
 | blackbox-exporter | classify | — | — | — |
-| crowdsec | classify | 231 | ✅ 0 | — |
+| crowdsec | classify | 265 | ✅ 0 | — |
 | forgejo | classify | — | — | — |
-| gathio | classify | 5 | ✅ 0 | — |
+| gathio | classify | 4 | ✅ 0 | — |
 | gluetun | classify | — | — | — |
-| grafana | classify | 3 | ✅ 0 | — |
-| home-assistant | classify | 63 | ✅ 0 | — |
-| immich-server | classify | 3 | ✅ 0 | — |
+| grafana | classify | 4 | ✅ 0 | — |
+| home-assistant | classify | 57 | ✅ 0 | — |
+| immich-server | classify | 2 | ✅ 0 | — |
 | jellyfin | classify | 17 | ✅ 0 | — |
-| loki | classify | 1 | ✅ 0 | — |
+| loki | classify | 2 | ✅ 0 | — |
 | navidrome | classify | 8 | ✅ 0 | — |
-| nextcloud | classify | 4 | ✅ 0 | — |
+| nextcloud | classify | 5 | ⚠️ 1 | — |
 | pihole-exporter | classify | — | — | — |
 | prometheus | classify | — | — | — |
 | proton-bridge | classify | 2 | ✅ 0 | — |
-| qbittorrent | peer-swarm (count-only) | — | — | 239 |
-| traefik | classify | 6 | ✅ 0 | — |
+| qbittorrent | peer-swarm (count-only) | — | — | 154 |
+| traefik | classify | 7 | ✅ 0 | — |
 | unpoller | classify | — | — | — |
 | vaultwarden | peer-swarm (count-only) | — | — | — |
 
@@ -54,409 +54,439 @@ Class legend: **✅ expected** (in allow-list) · **⚠️ active** (unexpected,
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `162.159.128.233` | 443 | ✅ expected | 37d ago | 2h ago | 140 |
-| `162.159.135.232` | 443 | ✅ expected | 40d ago | 21h ago | 126 |
-| `162.159.136.232` | 443 | ✅ expected | 33d ago | 112m ago | 119 |
-| `162.159.137.232` | 443 | ✅ expected | 29d ago | 8h ago | 111 |
-| `162.159.138.232` | 443 | ✅ expected | 40d ago | 49m ago | 137 |
+| `162.159.128.233` | 443 | ✅ expected | 50d ago | 3d ago | 190 |
+| `162.159.135.232` | 443 | ✅ expected | 53d ago | 2d ago | 197 |
+| `162.159.136.232` | 443 | ✅ expected | 46d ago | 2d ago | 159 |
+| `162.159.137.232` | 443 | ✅ expected | 42d ago | 2d ago | 147 |
+| `162.159.138.232` | 443 | ✅ expected | 52d ago | 2d ago | 191 |
 
 ### crowdsec
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.20.41.3` | 443 | ✅ expected | 21d ago | 21d ago | 2 |
-| `108.128.100.255` | 443 | ✅ expected | 40h ago | 15h ago | 15 |
-| `108.128.137.208` | 443 | ✅ expected | 36d ago | 28d ago | 486 |
-| `108.128.190.179` | 443 | ✅ expected | 37d ago | 28d ago | 515 |
-| `108.129.14.254` | 443 | ✅ expected | 7d ago | 33h ago | 190 |
-| `108.131.181.25` | 443 | ✅ expected | 35h ago | 35h ago | 5 |
-| `108.131.237.209` | 443 | ✅ expected | 20d ago | 17d ago | 45 |
-| `108.132.122.254` | 443 | ✅ expected | 36h ago | 36h ago | 5 |
-| `108.132.135.16` | 443 | ✅ expected | 26d ago | 25d ago | 68 |
-| `108.132.143.133` | 443 | ✅ expected | 20d ago | 15d ago | 29 |
-| `108.132.165.101` | 443 | ✅ expected | 18d ago | 18d ago | 10 |
-| `108.132.165.136` | 443 | ✅ expected | 32d ago | 27d ago | 237 |
-| `108.132.168.183` | 443 | ✅ expected | 15d ago | 12d ago | 20 |
-| `108.132.178.68` | 443 | ✅ expected | 20d ago | 20d ago | 5 |
-| `108.132.189.51` | 443 | ✅ expected | 9d ago | 6d ago | 59 |
-| `108.132.205.103` | 443 | ✅ expected | 2d ago | 16h ago | 15 |
-| `108.132.219.253` | 443 | ✅ expected | 17d ago | 15d ago | 20 |
-| `108.132.234.82` | 443 | ✅ expected | 9d ago | 8d ago | 15 |
-| `108.132.246.192` | 443 | ✅ expected | 19d ago | 13d ago | 362 |
-| `108.132.37.191` | 443 | ✅ expected | 2d ago | 4h ago | 14 |
-| `108.132.53.78` | 443 | ✅ expected | 9d ago | 6d ago | 74 |
-| `108.132.71.88` | 443 | ✅ expected | 2d ago | 33h ago | 15 |
-| `108.132.72.65` | 443 | ✅ expected | 21d ago | 19d ago | 10 |
-| `108.132.99.107` | 443 | ✅ expected | 2d ago | 2d ago | 5 |
-| `108.133.21.194` | 443 | ✅ expected | 21d ago | 18d ago | 35 |
-| `108.133.25.161` | 443 | ✅ expected | 3d ago | 26h ago | 19 |
-| `108.133.25.40` | 443 | ✅ expected | 21d ago | 15d ago | 39 |
-| `108.133.30.139` | 443 | ✅ expected | 15d ago | 14d ago | 74 |
-| `108.133.31.148` | 443 | ✅ expected | 2d ago | 41h ago | 10 |
-| `108.133.5.78` | 443 | ✅ expected | 2d ago | 37h ago | 14 |
-| `108.133.51.235` | 443 | ✅ expected | 2d ago | 38h ago | 10 |
-| `172.66.154.109` | 443 | ✅ expected | 21d ago | 21d ago | 2 |
-| `176.34.92.0` | 443 | ✅ expected | 22d ago | 22d ago | 43 |
-| `18.200.39.45` | 443 | ✅ expected | 2d ago | 24h ago | 15 |
-| `18.200.43.102` | 443 | ✅ expected | 21d ago | 21d ago | 5 |
-| `18.202.146.153` | 443 | ✅ expected | 21d ago | 15d ago | 30 |
-| `18.202.172.107` | 443 | ✅ expected | 13d ago | 13d ago | 25 |
-| `18.203.121.198` | 443 | ✅ expected | 21d ago | 16d ago | 40 |
-| `18.203.183.142` | 443 | ✅ expected | 28h ago | 28h ago | 4 |
-| `3.248.159.68` | 443 | ✅ expected | 33h ago | 91m ago | 94 |
-| `3.248.169.249` | 443 | ✅ expected | 9d ago | 7d ago | 25 |
-| `3.250.250.65` | 443 | ✅ expected | 9d ago | 7d ago | 20 |
-| `3.253.202.159` | 443 | ✅ expected | 3d ago | 3d ago | 5 |
-| `34.240.192.79` | 443 | ✅ expected | 46h ago | 46h ago | 5 |
-| `34.240.248.6` | 443 | ✅ expected | 12d ago | 16s ago | 723 |
-| `34.240.98.252` | 443 | ✅ expected | 30d ago | 26d ago | 252 |
-| `34.241.148.96` | 443 | ✅ expected | 2d ago | 2d ago | 5 |
-| `34.241.216.41` | 443 | ✅ expected | 21d ago | 16d ago | 39 |
-| `34.241.56.54` | 443 | ✅ expected | 16d ago | 14d ago | 30 |
-| `34.242.107.114` | 443 | ✅ expected | 21d ago | 20d ago | 8 |
-| `34.242.194.148` | 443 | ✅ expected | 34d ago | 28d ago | 406 |
-| `34.243.213.166` | 443 | ✅ expected | 8d ago | 3d ago | 175 |
-| `34.246.147.139` | 443 | ✅ expected | 6d ago | 29m ago | 417 |
-| `34.246.166.99` | 443 | ✅ expected | 20d ago | 18d ago | 30 |
-| `34.246.188.122` | 443 | ✅ expected | 15d ago | 15d ago | 10 |
-| `34.247.101.158` | 443 | ✅ expected | 17d ago | 10d ago | 59 |
-| `34.247.127.233` | 443 | ✅ expected | 6d ago | 29m ago | 360 |
-| `34.247.193.23` | 443 | ✅ expected | 81m ago | 70m ago | 5 |
-| `34.248.190.12` | 443 | ✅ expected | 22d ago | 21d ago | 71 |
-| `34.249.149.68` | 443 | ✅ expected | 31d ago | 25d ago | 277 |
-| `34.249.156.29` | 443 | ✅ expected | 9d ago | 7d ago | 39 |
-| `34.249.172.50` | 443 | ✅ expected | 21d ago | 20d ago | 20 |
-| `34.249.35.132` | 443 | ✅ expected | 10d ago | 9d ago | 30 |
-| `34.249.38.225` | 443 | ✅ expected | 2d ago | 2d ago | 10 |
-| `34.250.187.53` | 443 | ✅ expected | 21d ago | 18d ago | 15 |
-| `34.250.233.53` | 443 | ✅ expected | 19d ago | 19d ago | 5 |
-| `34.250.39.237` | 443 | ✅ expected | 28d ago | 22d ago | 255 |
-| `34.251.4.204` | 443 | ✅ expected | 6h ago | 6h ago | 5 |
-| `34.251.83.134` | 443 | ✅ expected | 23d ago | 23d ago | 42 |
-| `34.251.85.31` | 443 | ✅ expected | 10d ago | 10d ago | 45 |
-| `34.252.238.164` | 443 | ✅ expected | 17d ago | 11d ago | 80 |
-| `34.252.67.120` | 443 | ✅ expected | 16d ago | 11d ago | 59 |
-| `34.252.99.143` | 443 | ✅ expected | 3d ago | 3h ago | 20 |
-| `34.253.20.222` | 443 | ✅ expected | 18d ago | 17d ago | 15 |
-| `34.253.250.27` | 443 | ✅ expected | 3d ago | 2d ago | 10 |
-| `34.254.73.132` | 443 | ✅ expected | 28d ago | 22d ago | 421 |
-| `34.255.101.100` | 443 | ✅ expected | 21d ago | 20d ago | 20 |
-| `34.255.13.211` | 443 | ✅ expected | 9d ago | 7d ago | 25 |
-| `34.255.143.231` | 443 | ✅ expected | 25d ago | 24d ago | 73 |
-| `34.255.187.129` | 443 | ✅ expected | 3d ago | 2d ago | 10 |
-| `34.255.211.7` | 443 | ✅ expected | 2d ago | 24h ago | 10 |
-| `46.137.116.145` | 443 | ✅ expected | 17d ago | 14d ago | 15 |
-| `46.137.119.216` | 443 | ✅ expected | 2d ago | 2d ago | 10 |
-| `46.137.188.185` | 443 | ✅ expected | 19d ago | 18d ago | 10 |
-| `46.137.35.14` | 443 | ✅ expected | 18d ago | 16d ago | 20 |
-| `52.16.198.105` | 443 | ✅ expected | 14d ago | 13d ago | 12 |
-| `52.16.198.79` | 443 | ✅ expected | 2d ago | 11h ago | 15 |
-| `52.16.239.210` | 443 | ✅ expected | 2d ago | 2d ago | 5 |
-| `52.16.244.133` | 443 | ✅ expected | 19d ago | 17d ago | 35 |
-| `52.16.64.132` | 443 | ✅ expected | 21d ago | 19d ago | 15 |
-| `52.17.118.72` | 443 | ✅ expected | 15d ago | 13d ago | 15 |
-| `52.17.17.55` | 443 | ✅ expected | 23d ago | 23d ago | 20 |
-| `52.17.173.66` | 443 | ✅ expected | 17d ago | 15d ago | 20 |
-| `52.17.182.227` | 443 | ✅ expected | 3d ago | 37h ago | 14 |
-| `52.17.27.193` | 443 | ✅ expected | 2d ago | 36h ago | 15 |
-| `52.17.91.120` | 443 | ✅ expected | 9d ago | 7d ago | 30 |
-| `52.18.160.54` | 443 | ✅ expected | 38h ago | 38h ago | 5 |
-| `52.18.248.216` | 443 | ✅ expected | 23h ago | 23h ago | 5 |
-| `52.18.95.48` | 443 | ✅ expected | 10d ago | 9d ago | 25 |
-| `52.19.134.40` | 443 | ✅ expected | 20d ago | 6d ago | 794 |
-| `52.19.255.174` | 443 | ✅ expected | 9d ago | 8d ago | 40 |
-| `52.19.31.182` | 443 | ✅ expected | 17d ago | 15d ago | 159 |
-| `52.19.64.236` | 443 | ✅ expected | 27d ago | 22d ago | 191 |
-| `52.19.72.100` | 443 | ✅ expected | 20d ago | 20d ago | 5 |
-| `52.19.97.17` | 443 | ✅ expected | 3d ago | 3d ago | 5 |
-| `52.208.44.16` | 443 | ✅ expected | 3d ago | 3d ago | 5 |
-| `52.208.53.18` | 443 | ✅ expected | 39h ago | 39h ago | 4 |
-| `52.209.0.64` | 443 | ✅ expected | 17d ago | 10d ago | 97 |
-| `52.209.173.58` | 443 | ✅ expected | 14d ago | 12d ago | 139 |
-| `52.210.122.225` | 443 | ✅ expected | 16d ago | 15d ago | 44 |
-| `52.210.147.72` | 443 | ✅ expected | 21d ago | 19d ago | 10 |
-| `52.210.229.63` | 443 | ✅ expected | 32d ago | 26d ago | 370 |
-| `52.211.111.6` | 443 | ✅ expected | 10d ago | 10d ago | 45 |
-| `52.211.142.180` | 443 | ✅ expected | 8h ago | 8h ago | 5 |
-| `52.211.152.103` | 443 | ✅ expected | 21d ago | 19d ago | 20 |
-| `52.211.29.30` | 443 | ✅ expected | 12d ago | 6d ago | 305 |
-| `52.211.56.189` | 443 | ✅ expected | 3d ago | 2d ago | 9 |
-| `52.212.199.20` | 443 | ✅ expected | 20d ago | 20d ago | 5 |
-| `52.212.47.49` | 443 | ✅ expected | 19d ago | 15d ago | 49 |
-| `52.212.98.6` | 443 | ✅ expected | 2d ago | 31h ago | 13 |
-| `52.213.226.37` | 443 | ✅ expected | 15d ago | 13d ago | 25 |
-| `52.213.228.152` | 443 | ✅ expected | 26d ago | 19d ago | 408 |
-| `52.213.66.10` | 443 | ✅ expected | 23d ago | 21d ago | 154 |
-| `52.214.21.105` | 443 | ✅ expected | 13d ago | 13d ago | 5 |
-| `52.214.255.194` | 443 | ✅ expected | 22h ago | 22h ago | 5 |
-| `52.214.54.249` | 443 | ✅ expected | 17d ago | 14d ago | 15 |
-| `52.215.173.209` | 443 | ✅ expected | 13d ago | 49m ago | 755 |
-| `52.30.165.11` | 443 | ✅ expected | 16d ago | 12d ago | 25 |
-| `52.30.212.227` | 443 | ✅ expected | 3d ago | 112m ago | 20 |
-| `52.30.231.178` | 443 | ✅ expected | 17d ago | 11d ago | 63 |
-| `52.30.63.171` | 443 | ✅ expected | 21d ago | 18d ago | 20 |
-| `52.31.252.131` | 443 | ✅ expected | 16d ago | 13d ago | 64 |
-| `52.31.58.24` | 443 | ✅ expected | 15d ago | 14d ago | 74 |
-| `52.31.8.86` | 443 | ✅ expected | 36h ago | 19h ago | 10 |
-| `52.48.142.125` | 443 | ✅ expected | 9d ago | 6d ago | 89 |
-| `52.48.23.149` | 443 | ✅ expected | 28d ago | 25d ago | 232 |
-| `52.48.238.219` | 443 | ✅ expected | 25d ago | 19d ago | 349 |
-| `52.48.65.76` | 443 | ✅ expected | 22d ago | 13d ago | 598 |
-| `52.48.90.106` | 443 | ✅ expected | 16d ago | 16d ago | 15 |
-| `52.48.93.17` | 443 | ✅ expected | 22d ago | 22d ago | 35 |
-| `52.49.140.16` | 443 | ✅ expected | 19d ago | 15d ago | 30 |
-| `52.49.212.201` | 443 | ✅ expected | 21d ago | 19d ago | 24 |
-| `52.49.3.35` | 443 | ✅ expected | 20d ago | 20d ago | 10 |
-| `52.49.4.206` | 443 | ✅ expected | 21d ago | 20d ago | 10 |
-| `52.50.153.113` | 443 | ✅ expected | 18h ago | 13h ago | 9 |
-| `52.50.163.172` | 443 | ✅ expected | 3d ago | 44h ago | 10 |
-| `52.50.224.74` | 443 | ✅ expected | 23d ago | 23d ago | 29 |
-| `52.51.137.54` | 443 | ✅ expected | 9d ago | 3d ago | 193 |
-| `52.51.148.109` | 443 | ✅ expected | 13d ago | 12d ago | 81 |
-| `52.51.31.247` | 443 | ✅ expected | 3d ago | 3d ago | 5 |
-| `52.51.5.37` | 443 | ✅ expected | 9d ago | 9d ago | 10 |
-| `52.51.57.14` | 443 | ✅ expected | 3d ago | 12h ago | 15 |
-| `52.84.50.42` | 443 | ✅ expected | 21d ago | 21d ago | 2 |
-| `54.154.135.155` | 443 | ✅ expected | 20d ago | 20d ago | 5 |
-| `54.154.67.102` | 443 | ✅ expected | 25h ago | 16s ago | 53 |
-| `54.155.120.106` | 443 | ✅ expected | 6h ago | 6h ago | 5 |
-| `54.155.206.188` | 443 | ✅ expected | 43h ago | 43h ago | 5 |
-| `54.155.54.37` | 443 | ✅ expected | 47h ago | 47h ago | 5 |
-| `54.170.104.57` | 443 | ✅ expected | 23d ago | 23d ago | 15 |
-| `54.170.163.78` | 443 | ✅ expected | 19d ago | 18d ago | 115 |
-| `54.171.2.48` | 443 | ✅ expected | 41h ago | 41h ago | 5 |
-| `54.171.78.236` | 443 | ✅ expected | 17d ago | 12d ago | 40 |
-| `54.194.125.196` | 443 | ✅ expected | 3d ago | 3d ago | 5 |
-| `54.194.168.166` | 443 | ✅ expected | 2d ago | 2d ago | 5 |
-| `54.194.218.193` | 443 | ✅ expected | 15d ago | 15d ago | 5 |
-| `54.194.222.175` | 443 | ✅ expected | 16d ago | 16d ago | 5 |
-| `54.194.85.107` | 443 | ✅ expected | 15d ago | 10d ago | 94 |
-| `54.195.147.237` | 443 | ✅ expected | 17d ago | 12d ago | 60 |
-| `54.195.186.68` | 443 | ✅ expected | 29d ago | 26d ago | 249 |
-| `54.195.255.109` | 443 | ✅ expected | 8d ago | 8d ago | 5 |
-| `54.195.58.94` | 443 | ✅ expected | 2d ago | 26h ago | 10 |
-| `54.216.223.16` | 443 | ✅ expected | 9d ago | 7d ago | 29 |
-| `54.216.63.170` | 443 | ✅ expected | 45h ago | 45h ago | 5 |
-| `54.220.110.244` | 443 | ✅ expected | 9d ago | 8d ago | 9 |
-| `54.220.232.45` | 443 | ✅ expected | 2d ago | 20h ago | 10 |
-| `54.220.4.25` | 443 | ✅ expected | 9d ago | 6d ago | 39 |
-| `54.228.169.234` | 443 | ✅ expected | 10d ago | 10d ago | 30 |
-| `54.228.220.78` | 443 | ✅ expected | 23d ago | 22d ago | 30 |
-| `54.228.49.194` | 443 | ✅ expected | 21d ago | 21d ago | 5 |
-| `54.228.72.44` | 443 | ✅ expected | 24h ago | 24h ago | 5 |
-| `54.229.184.213` | 443 | ✅ expected | 21d ago | 18d ago | 20 |
-| `54.229.234.23` | 443 | ✅ expected | 17d ago | 14d ago | 30 |
-| `54.246.207.199` | 443 | ✅ expected | 31d ago | 29d ago | 113 |
-| `54.247.128.112` | 443 | ✅ expected | 13d ago | 34h ago | 772 |
-| `54.72.135.60` | 443 | ✅ expected | 21d ago | 18d ago | 23 |
-| `54.72.222.86` | 443 | ✅ expected | 20d ago | 19d ago | 9 |
-| `54.72.42.56` | 443 | ✅ expected | 10d ago | 9d ago | 33 |
-| `54.72.47.167` | 443 | ✅ expected | 20d ago | 19d ago | 15 |
-| `54.73.182.236` | 443 | ✅ expected | 2d ago | 30h ago | 15 |
-| `54.73.186.227` | 443 | ✅ expected | 3h ago | 3h ago | 5 |
-| `54.73.47.207` | 443 | ✅ expected | 25h ago | 10h ago | 10 |
-| `54.73.67.52` | 443 | ✅ expected | 21d ago | 18d ago | 30 |
-| `54.74.43.116` | 443 | ✅ expected | 17d ago | 14d ago | 30 |
-| `54.75.182.87` | 443 | ✅ expected | 15d ago | 13d ago | 25 |
-| `54.75.245.133` | 443 | ✅ expected | 22d ago | 20d ago | 140 |
-| `54.75.8.192` | 443 | ✅ expected | 2d ago | 8h ago | 15 |
-| `54.75.92.29` | 443 | ✅ expected | 2d ago | 12h ago | 10 |
-| `54.76.118.150` | 443 | ✅ expected | 14d ago | 14d ago | 5 |
-| `54.76.150.103` | 443 | ✅ expected | 9d ago | 8d ago | 10 |
-| `54.76.169.38` | 443 | ✅ expected | 25d ago | 24d ago | 64 |
-| `54.76.192.134` | 443 | ✅ expected | 33d ago | 28d ago | 337 |
-| `54.76.217.37` | 443 | ✅ expected | 17d ago | 15d ago | 19 |
-| `54.76.82.20` | 443 | ✅ expected | 21d ago | 20d ago | 54 |
-| `54.77.106.61` | 443 | ✅ expected | 19d ago | 15d ago | 20 |
-| `54.77.130.113` | 443 | ✅ expected | 20d ago | 20d ago | 5 |
-| `54.77.155.168` | 443 | ✅ expected | 3d ago | 3d ago | 10 |
-| `54.77.193.254` | 443 | ✅ expected | 31h ago | 31h ago | 5 |
-| `54.77.221.81` | 443 | ✅ expected | 17d ago | 14d ago | 30 |
-| `54.77.231.123` | 443 | ✅ expected | 8d ago | 7d ago | 25 |
-| `54.77.24.165` | 443 | ✅ expected | 23d ago | 23d ago | 23 |
-| `54.78.108.19` | 443 | ✅ expected | 2d ago | 2d ago | 5 |
-| `54.78.116.49` | 443 | ✅ expected | 3d ago | 3d ago | 5 |
-| `54.78.186.64` | 443 | ✅ expected | 44h ago | 35h ago | 10 |
-| `54.78.193.70` | 443 | ✅ expected | 16d ago | 12d ago | 49 |
-| `63.32.11.219` | 443 | ✅ expected | 41h ago | 31h ago | 10 |
-| `63.32.184.247` | 443 | ✅ expected | 3d ago | 2d ago | 15 |
-| `63.32.217.27` | 443 | ✅ expected | 17d ago | 14d ago | 19 |
-| `63.33.187.119` | 443 | ✅ expected | 2d ago | 2d ago | 10 |
-| `63.33.5.76` | 443 | ✅ expected | 21d ago | 17d ago | 232 |
-| `63.34.177.147` | 443 | ✅ expected | 18d ago | 28h ago | 1035 |
-| `63.35.170.229` | 443 | ✅ expected | 28d ago | 24d ago | 228 |
-| `63.35.34.90` | 443 | ✅ expected | 16d ago | 9d ago | 53 |
-| `79.125.93.93` | 443 | ✅ expected | 21d ago | 17d ago | 30 |
-| `99.80.124.24` | 443 | ✅ expected | 22d ago | 21d ago | 49 |
-| `99.80.153.48` | 443 | ✅ expected | 3d ago | 3d ago | 10 |
-| `99.80.232.1` | 443 | ✅ expected | 21d ago | 18d ago | 19 |
-| `99.80.39.243` | 443 | ✅ expected | 17d ago | 14d ago | 40 |
-| `99.81.112.7` | 443 | ✅ expected | 43h ago | 43h ago | 5 |
-| `99.81.12.92` | 443 | ✅ expected | 25d ago | 24d ago | 67 |
-| `99.81.142.82` | 443 | ✅ expected | 2d ago | 2d ago | 5 |
-| `99.81.28.139` | 443 | ✅ expected | 8d ago | 8d ago | 9 |
+| `108.128.100.255` | 443 | ✅ expected | 14d ago | 12d ago | 20 |
+| `108.128.5.151` | 443 | ✅ expected | 10d ago | 9d ago | 11 |
+| `108.128.75.34` | 443 | ✅ expected | 12d ago | 12d ago | 5 |
+| `108.129.14.254` | 443 | ✅ expected | 20d ago | 14d ago | 190 |
+| `108.131.181.25` | 443 | ✅ expected | 14d ago | 9d ago | 10 |
+| `108.132.121.20` | 443 | ✅ expected | 11d ago | 10d ago | 10 |
+| `108.132.122.254` | 443 | ✅ expected | 14d ago | 9d ago | 25 |
+| `108.132.137.184` | 443 | ✅ expected | 12d ago | 12d ago | 10 |
+| `108.132.143.133` | 443 | ✅ expected | 33d ago | 27d ago | 29 |
+| `108.132.165.84` | 443 | ✅ expected | 11d ago | 11d ago | 5 |
+| `108.132.168.183` | 443 | ✅ expected | 28d ago | 25d ago | 20 |
+| `108.132.183.8` | 443 | ✅ expected | 8d ago | 8d ago | 5 |
+| `108.132.189.51` | 443 | ✅ expected | 22d ago | 18d ago | 59 |
+| `108.132.205.103` | 443 | ✅ expected | 14d ago | 8d ago | 30 |
+| `108.132.205.140` | 443 | ✅ expected | 3d ago | 2d ago | 53 |
+| `108.132.213.83` | 443 | ✅ expected | 5d ago | 4d ago | 20 |
+| `108.132.219.253` | 443 | ✅ expected | 30d ago | 28d ago | 20 |
+| `108.132.221.3` | 443 | ✅ expected | 8d ago | 5d ago | 15 |
+| `108.132.234.82` | 443 | ✅ expected | 22d ago | 20d ago | 15 |
+| `108.132.246.192` | 443 | ✅ expected | 32d ago | 26d ago | 362 |
+| `108.132.37.191` | 443 | ✅ expected | 15d ago | 12d ago | 14 |
+| `108.132.53.78` | 443 | ✅ expected | 22d ago | 18d ago | 74 |
+| `108.132.71.88` | 443 | ✅ expected | 15d ago | 14d ago | 15 |
+| `108.132.92.167` | 443 | ✅ expected | 6d ago | 5d ago | 10 |
+| `108.132.99.107` | 443 | ✅ expected | 15d ago | 15d ago | 5 |
+| `108.133.21.137` | 443 | ✅ expected | 10d ago | 8d ago | 115 |
+| `108.133.25.161` | 443 | ✅ expected | 16d ago | 13d ago | 19 |
+| `108.133.25.40` | 443 | ✅ expected | 33d ago | 28d ago | 39 |
+| `108.133.29.186` | 443 | ✅ expected | 11d ago | 9d ago | 20 |
+| `108.133.3.16` | 443 | ✅ expected | 11d ago | 11d ago | 5 |
+| `108.133.30.139` | 443 | ✅ expected | 28d ago | 27d ago | 74 |
+| `108.133.31.148` | 443 | ✅ expected | 14d ago | 8d ago | 30 |
+| `108.133.5.78` | 443 | ✅ expected | 15d ago | 11d ago | 19 |
+| `108.133.51.235` | 443 | ✅ expected | 15d ago | 14d ago | 10 |
+| `176.34.181.119` | 443 | ✅ expected | 8d ago | 8d ago | 5 |
+| `18.200.110.20` | 443 | ✅ expected | 14h ago | 43m ago | 63 |
+| `18.200.123.226` | 443 | ✅ expected | 11d ago | 3d ago | 485 |
+| `18.200.39.45` | 443 | ✅ expected | 15d ago | 13d ago | 15 |
+| `18.202.146.153` | 443 | ✅ expected | 34d ago | 28d ago | 30 |
+| `18.202.164.218` | 443 | ✅ expected | 10d ago | 3d ago | 478 |
+| `18.202.172.107` | 443 | ✅ expected | 26d ago | 25d ago | 25 |
+| `18.202.182.46` | 443 | ✅ expected | 12d ago | 12d ago | 5 |
+| `18.202.70.248` | 443 | ✅ expected | 8d ago | 6d ago | 25 |
+| `18.203.121.198` | 443 | ✅ expected | 33d ago | 29d ago | 40 |
+| `18.203.183.142` | 443 | ✅ expected | 13d ago | 13d ago | 4 |
+| `3.248.159.68` | 443 | ✅ expected | 14d ago | 5d ago | 539 |
+| `3.248.169.249` | 443 | ✅ expected | 22d ago | 20d ago | 25 |
+| `3.250.250.65` | 443 | ✅ expected | 21d ago | 20d ago | 20 |
+| `3.253.202.159` | 443 | ✅ expected | 15d ago | 12d ago | 10 |
+| `34.240.192.79` | 443 | ✅ expected | 14d ago | 14d ago | 5 |
+| `34.240.248.6` | 443 | ✅ expected | 24d ago | 11d ago | 772 |
+| `34.240.99.65` | 443 | ✅ expected | 5d ago | 44h ago | 64 |
+| `34.241.148.96` | 443 | ✅ expected | 15d ago | 15d ago | 5 |
+| `34.241.216.41` | 443 | ✅ expected | 34d ago | 29d ago | 39 |
+| `34.241.218.127` | 443 | ✅ expected | 6d ago | 3d ago | 45 |
+| `34.241.33.70` | 443 | ✅ expected | 13h ago | 3h ago | 35 |
+| `34.241.45.245` | 443 | ✅ expected | 6d ago | 6d ago | 5 |
+| `34.241.56.54` | 443 | ✅ expected | 29d ago | 26d ago | 30 |
+| `34.242.110.163` | 443 | ✅ expected | 8d ago | 6d ago | 15 |
+| `34.242.13.27` | 443 | ✅ expected | 9d ago | 3d ago | 37 |
+| `34.243.209.239` | 443 | ✅ expected | 12d ago | 9d ago | 25 |
+| `34.243.213.166` | 443 | ✅ expected | 21d ago | 16d ago | 175 |
+| `34.246.147.139` | 443 | ✅ expected | 18d ago | 10d ago | 556 |
+| `34.246.188.122` | 443 | ✅ expected | 28d ago | 28d ago | 10 |
+| `34.246.232.161` | 443 | ✅ expected | 7d ago | 5d ago | 15 |
+| `34.246.54.177` | 443 | ✅ expected | 7d ago | 5d ago | 163 |
+| `34.247.101.158` | 443 | ✅ expected | 29d ago | 23d ago | 59 |
+| `34.247.127.233` | 443 | ✅ expected | 19d ago | 12d ago | 370 |
+| `34.247.193.23` | 443 | ✅ expected | 12d ago | 12d ago | 10 |
+| `34.248.135.223` | 443 | ✅ expected | 11d ago | 11d ago | 5 |
+| `34.248.252.15` | 443 | ✅ expected | 11d ago | 8d ago | 224 |
+| `34.249.156.29` | 443 | ✅ expected | 22d ago | 19d ago | 39 |
+| `34.249.175.76` | 443 | ✅ expected | 11d ago | 10d ago | 20 |
+| `34.249.35.132` | 443 | ✅ expected | 22d ago | 22d ago | 30 |
+| `34.249.38.225` | 443 | ✅ expected | 14d ago | 14d ago | 10 |
+| `34.249.74.158` | 443 | ✅ expected | 7d ago | 4d ago | 25 |
+| `34.250.219.167` | 443 | ✅ expected | 3d ago | 2h ago | 188 |
+| `34.250.246.103` | 443 | ✅ expected | 7d ago | 6d ago | 10 |
+| `34.250.94.23` | 443 | ✅ expected | 5d ago | 75m ago | 336 |
+| `34.251.4.204` | 443 | ✅ expected | 12d ago | 12d ago | 5 |
+| `34.251.48.106` | 443 | ✅ expected | 8d ago | 18h ago | 471 |
+| `34.251.85.31` | 443 | ✅ expected | 23d ago | 22d ago | 45 |
+| `34.252.105.132` | 443 | ✅ expected | 8d ago | 6d ago | 10 |
+| `34.252.238.164` | 443 | ✅ expected | 29d ago | 24d ago | 80 |
+| `34.252.249.34` | 443 | ✅ expected | 6d ago | 2d ago | 57 |
+| `34.252.67.120` | 443 | ✅ expected | 29d ago | 24d ago | 59 |
+| `34.252.99.143` | 443 | ✅ expected | 15d ago | 12d ago | 20 |
+| `34.253.250.27` | 443 | ✅ expected | 15d ago | 14d ago | 10 |
+| `34.253.80.226` | 443 | ✅ expected | 8d ago | 2d ago | 33 |
+| `34.253.95.189` | 443 | ✅ expected | 10d ago | 10d ago | 25 |
+| `34.254.128.0` | 443 | ✅ expected | 7d ago | 7d ago | 5 |
+| `34.254.31.214` | 443 | ✅ expected | 7d ago | 7d ago | 10 |
+| `34.254.5.251` | 443 | ✅ expected | 7d ago | 7d ago | 5 |
+| `34.255.101.228` | 443 | ✅ expected | 7d ago | 6d ago | 10 |
+| `34.255.13.211` | 443 | ✅ expected | 22d ago | 20d ago | 25 |
+| `34.255.171.152` | 443 | ✅ expected | 9h ago | 12m ago | 25 |
+| `34.255.187.129` | 443 | ✅ expected | 15d ago | 15d ago | 10 |
+| `34.255.211.7` | 443 | ✅ expected | 15d ago | 9d ago | 19 |
+| `34.255.33.254` | 443 | ✅ expected | 8d ago | 5d ago | 8 |
+| `46.137.116.145` | 443 | ✅ expected | 30d ago | 26d ago | 15 |
+| `46.137.119.216` | 443 | ✅ expected | 14d ago | 10d ago | 35 |
+| `46.137.166.0` | 443 | ✅ expected | 12d ago | 12d ago | 5 |
+| `46.137.35.14` | 443 | ✅ expected | 31d ago | 29d ago | 20 |
+| `52.16.143.245` | 443 | ✅ expected | 7d ago | 5d ago | 15 |
+| `52.16.181.166` | 443 | ✅ expected | 8d ago | 4d ago | 15 |
+| `52.16.198.105` | 443 | ✅ expected | 26d ago | 26d ago | 12 |
+| `52.16.198.79` | 443 | ✅ expected | 14d ago | 12d ago | 20 |
+| `52.16.239.210` | 443 | ✅ expected | 15d ago | 15d ago | 5 |
+| `52.16.97.104` | 443 | ✅ expected | 6d ago | 6d ago | 5 |
+| `52.17.118.72` | 443 | ✅ expected | 28d ago | 26d ago | 15 |
+| `52.17.173.66` | 443 | ✅ expected | 30d ago | 27d ago | 20 |
+| `52.17.182.227` | 443 | ✅ expected | 16d ago | 14d ago | 14 |
+| `52.17.27.193` | 443 | ✅ expected | 15d ago | 11d ago | 25 |
+| `52.17.91.120` | 443 | ✅ expected | 22d ago | 20d ago | 30 |
+| `52.18.160.54` | 443 | ✅ expected | 14d ago | 9d ago | 30 |
+| `52.18.248.216` | 443 | ✅ expected | 13d ago | 13d ago | 5 |
+| `52.18.50.168` | 443 | ✅ expected | 6d ago | 5d ago | 20 |
+| `52.18.95.48` | 443 | ✅ expected | 22d ago | 22d ago | 25 |
+| `52.19.134.40` | 443 | ✅ expected | 32d ago | 18d ago | 794 |
+| `52.19.210.92` | 443 | ✅ expected | 8d ago | 6d ago | 20 |
+| `52.19.255.174` | 443 | ✅ expected | 22d ago | 21d ago | 40 |
+| `52.19.31.182` | 443 | ✅ expected | 30d ago | 28d ago | 159 |
+| `52.19.97.17` | 443 | ✅ expected | 15d ago | 12d ago | 10 |
+| `52.208.44.16` | 443 | ✅ expected | 16d ago | 16d ago | 5 |
+| `52.208.53.18` | 443 | ✅ expected | 14d ago | 9d ago | 14 |
+| `52.209.0.64` | 443 | ✅ expected | 30d ago | 23d ago | 97 |
+| `52.209.111.217` | 443 | ✅ expected | 6d ago | 6d ago | 5 |
+| `52.209.173.58` | 443 | ✅ expected | 27d ago | 25d ago | 139 |
+| `52.209.205.217` | 443 | ✅ expected | 3d ago | 17h ago | 73 |
+| `52.210.122.225` | 443 | ✅ expected | 29d ago | 28d ago | 44 |
+| `52.211.111.6` | 443 | ✅ expected | 23d ago | 23d ago | 45 |
+| `52.211.142.180` | 443 | ✅ expected | 12d ago | 12d ago | 5 |
+| `52.211.195.171` | 443 | ✅ expected | 10d ago | 35h ago | 582 |
+| `52.211.29.30` | 443 | ✅ expected | 24d ago | 19d ago | 305 |
+| `52.211.56.189` | 443 | ✅ expected | 16d ago | 14d ago | 9 |
+| `52.212.47.49` | 443 | ✅ expected | 31d ago | 27d ago | 49 |
+| `52.212.98.6` | 443 | ✅ expected | 15d ago | 11d ago | 18 |
+| `52.213.226.37` | 443 | ✅ expected | 28d ago | 26d ago | 25 |
+| `52.214.21.105` | 443 | ✅ expected | 26d ago | 26d ago | 5 |
+| `52.214.255.194` | 443 | ✅ expected | 13d ago | 10d ago | 15 |
+| `52.214.54.249` | 443 | ✅ expected | 30d ago | 27d ago | 15 |
+| `52.215.162.174` | 443 | ✅ expected | 6d ago | 6d ago | 5 |
+| `52.215.173.209` | 443 | ✅ expected | 25d ago | 11d ago | 809 |
+| `52.215.19.191` | 443 | ✅ expected | 8d ago | 6d ago | 15 |
+| `52.215.215.102` | 443 | ✅ expected | 8d ago | 3d ago | 35 |
+| `52.30.165.11` | 443 | ✅ expected | 29d ago | 25d ago | 25 |
+| `52.30.169.249` | 443 | ✅ expected | 5d ago | 3d ago | 10 |
+| `52.30.176.43` | 443 | ✅ expected | 7d ago | 2d ago | 31 |
+| `52.30.212.227` | 443 | ✅ expected | 16d ago | 12d ago | 20 |
+| `52.30.231.178` | 443 | ✅ expected | 30d ago | 24d ago | 63 |
+| `52.31.121.137` | 443 | ✅ expected | 8d ago | 5d ago | 10 |
+| `52.31.252.131` | 443 | ✅ expected | 28d ago | 25d ago | 64 |
+| `52.31.58.24` | 443 | ✅ expected | 28d ago | 27d ago | 74 |
+| `52.31.76.36` | 443 | ✅ expected | 8d ago | 8d ago | 5 |
+| `52.31.8.86` | 443 | ✅ expected | 14d ago | 11d ago | 15 |
+| `52.48.115.130` | 443 | ✅ expected | 12d ago | 10d ago | 126 |
+| `52.48.142.125` | 443 | ✅ expected | 21d ago | 18d ago | 89 |
+| `52.48.65.76` | 443 | ✅ expected | 34d ago | 25d ago | 598 |
+| `52.48.90.106` | 443 | ✅ expected | 29d ago | 28d ago | 15 |
+| `52.49.1.39` | 443 | ✅ expected | 9d ago | 5d ago | 20 |
+| `52.49.140.16` | 443 | ✅ expected | 32d ago | 28d ago | 30 |
+| `52.49.67.224` | 443 | ✅ expected | 6d ago | 6d ago | 5 |
+| `52.50.153.113` | 443 | ✅ expected | 13d ago | 9d ago | 29 |
+| `52.50.163.172` | 443 | ✅ expected | 15d ago | 14d ago | 10 |
+| `52.50.177.36` | 443 | ✅ expected | 7d ago | 6d ago | 10 |
+| `52.51.137.54` | 443 | ✅ expected | 22d ago | 16d ago | 193 |
+| `52.51.148.109` | 443 | ✅ expected | 26d ago | 24d ago | 81 |
+| `52.51.193.26` | 443 | ✅ expected | 6d ago | 19h ago | 134 |
+| `52.51.224.28` | 443 | ✅ expected | 7d ago | 3d ago | 24 |
+| `52.51.30.23` | 443 | ✅ expected | 4d ago | 4d ago | 5 |
+| `52.51.31.247` | 443 | ✅ expected | 15d ago | 15d ago | 5 |
+| `52.51.5.37` | 443 | ✅ expected | 21d ago | 21d ago | 10 |
+| `52.51.57.14` | 443 | ✅ expected | 16d ago | 13d ago | 15 |
+| `54.154.137.37` | 443 | ✅ expected | 5d ago | 4d ago | 9 |
+| `54.154.143.162` | 443 | ✅ expected | 9d ago | 5d ago | 25 |
+| `54.154.67.102` | 443 | ✅ expected | 13d ago | 11d ago | 135 |
+| `54.154.68.208` | 443 | ✅ expected | 5d ago | 4d ago | 10 |
+| `54.155.120.106` | 443 | ✅ expected | 12d ago | 10d ago | 15 |
+| `54.155.184.143` | 443 | ✅ expected | 6d ago | 6d ago | 5 |
+| `54.155.206.188` | 443 | ✅ expected | 14d ago | 14d ago | 5 |
+| `54.155.54.37` | 443 | ✅ expected | 14d ago | 11d ago | 15 |
+| `54.171.2.48` | 443 | ✅ expected | 14d ago | 14d ago | 5 |
+| `54.171.238.201` | 443 | ✅ expected | 7d ago | 5d ago | 23 |
+| `54.171.33.36` | 443 | ✅ expected | 3d ago | 19h ago | 117 |
+| `54.171.78.236` | 443 | ✅ expected | 30d ago | 25d ago | 40 |
+| `54.194.125.196` | 443 | ✅ expected | 16d ago | 16d ago | 5 |
+| `54.194.161.226` | 443 | ✅ expected | 9d ago | 6d ago | 20 |
+| `54.194.168.166` | 443 | ✅ expected | 14d ago | 10d ago | 20 |
+| `54.194.218.193` | 443 | ✅ expected | 27d ago | 27d ago | 5 |
+| `54.194.222.175` | 443 | ✅ expected | 29d ago | 29d ago | 5 |
+| `54.194.85.107` | 443 | ✅ expected | 28d ago | 23d ago | 94 |
+| `54.195.147.237` | 443 | ✅ expected | 30d ago | 24d ago | 60 |
+| `54.195.255.109` | 443 | ✅ expected | 21d ago | 21d ago | 5 |
+| `54.195.58.94` | 443 | ✅ expected | 15d ago | 13d ago | 10 |
+| `54.216.174.169` | 443 | ✅ expected | 2d ago | 43m ago | 120 |
+| `54.216.223.16` | 443 | ✅ expected | 22d ago | 20d ago | 29 |
+| `54.216.63.170` | 443 | ✅ expected | 14d ago | 14d ago | 5 |
+| `54.217.73.238` | 443 | ✅ expected | 8d ago | 8d ago | 5 |
+| `54.220.106.227` | 443 | ✅ expected | 7d ago | 4d ago | 25 |
+| `54.220.110.244` | 443 | ✅ expected | 21d ago | 21d ago | 9 |
+| `54.220.129.146` | 443 | ✅ expected | 7d ago | 6d ago | 15 |
+| `54.220.232.45` | 443 | ✅ expected | 14d ago | 9d ago | 50 |
+| `54.220.4.25` | 443 | ✅ expected | 22d ago | 19d ago | 39 |
+| `54.228.169.234` | 443 | ✅ expected | 23d ago | 22d ago | 30 |
+| `54.228.72.44` | 443 | ✅ expected | 13d ago | 11d ago | 10 |
+| `54.229.234.23` | 443 | ✅ expected | 30d ago | 27d ago | 30 |
+| `54.246.87.25` | 443 | ✅ expected | 7d ago | 7d ago | 5 |
+| `54.247.128.112` | 443 | ✅ expected | 26d ago | 14d ago | 772 |
+| `54.247.91.245` | 443 | ✅ expected | 10d ago | 10d ago | 5 |
+| `54.72.105.85` | 443 | ✅ expected | 11d ago | 10d ago | 23 |
+| `54.72.42.56` | 443 | ✅ expected | 22d ago | 22d ago | 33 |
+| `54.73.182.236` | 443 | ✅ expected | 15d ago | 13d ago | 15 |
+| `54.73.186.227` | 443 | ✅ expected | 12d ago | 12d ago | 5 |
+| `54.73.47.207` | 443 | ✅ expected | 13d ago | 13d ago | 10 |
+| `54.73.72.206` | 443 | ✅ expected | 8d ago | 46h ago | 53 |
+| `54.74.43.116` | 443 | ✅ expected | 29d ago | 26d ago | 30 |
+| `54.75.140.194` | 443 | ✅ expected | 7d ago | 5d ago | 10 |
+| `54.75.182.87` | 443 | ✅ expected | 27d ago | 25d ago | 25 |
+| `54.75.8.192` | 443 | ✅ expected | 14d ago | 10d ago | 24 |
+| `54.75.92.29` | 443 | ✅ expected | 14d ago | 11d ago | 20 |
+| `54.76.118.150` | 443 | ✅ expected | 27d ago | 27d ago | 5 |
+| `54.76.150.103` | 443 | ✅ expected | 21d ago | 21d ago | 10 |
+| `54.76.164.80` | 443 | ✅ expected | 9d ago | 6d ago | 15 |
+| `54.76.217.37` | 443 | ✅ expected | 30d ago | 28d ago | 19 |
+| `54.76.23.94` | 443 | ✅ expected | 8d ago | 6d ago | 15 |
+| `54.77.106.61` | 443 | ✅ expected | 32d ago | 27d ago | 20 |
+| `54.77.155.168` | 443 | ✅ expected | 15d ago | 11d ago | 20 |
+| `54.77.193.254` | 443 | ✅ expected | 13d ago | 10d ago | 20 |
+| `54.77.221.81` | 443 | ✅ expected | 29d ago | 26d ago | 30 |
+| `54.77.231.123` | 443 | ✅ expected | 21d ago | 20d ago | 25 |
+| `54.77.236.172` | 443 | ✅ expected | 33h ago | 3h ago | 84 |
+| `54.77.253.10` | 443 | ✅ expected | 12d ago | 12d ago | 10 |
+| `54.77.6.216` | 443 | ✅ expected | 10d ago | 10d ago | 5 |
+| `54.78.108.19` | 443 | ✅ expected | 15d ago | 15d ago | 5 |
+| `54.78.116.49` | 443 | ✅ expected | 15d ago | 11d ago | 10 |
+| `54.78.124.255` | 443 | ✅ expected | 7d ago | 4d ago | 19 |
+| `54.78.137.34` | 443 | ✅ expected | 8d ago | 4d ago | 33 |
+| `54.78.186.64` | 443 | ✅ expected | 14d ago | 11d ago | 25 |
+| `54.78.193.70` | 443 | ✅ expected | 28d ago | 24d ago | 49 |
+| `54.78.26.191` | 443 | ✅ expected | 7d ago | 7d ago | 5 |
+| `63.32.11.219` | 443 | ✅ expected | 14d ago | 12d ago | 15 |
+| `63.32.184.247` | 443 | ✅ expected | 16d ago | 9d ago | 44 |
+| `63.32.213.125` | 443 | ✅ expected | 9d ago | 9d ago | 5 |
+| `63.32.217.27` | 443 | ✅ expected | 30d ago | 27d ago | 19 |
+| `63.33.187.119` | 443 | ✅ expected | 15d ago | 14d ago | 10 |
+| `63.33.229.19` | 443 | ✅ expected | 7d ago | 5d ago | 15 |
+| `63.33.5.76` | 443 | ✅ expected | 33d ago | 29d ago | 232 |
+| `63.34.17.221` | 443 | ✅ expected | 9d ago | 7d ago | 15 |
+| `63.34.177.147` | 443 | ✅ expected | 31d ago | 13d ago | 1035 |
+| `63.34.189.230` | 443 | ✅ expected | 4d ago | 2d ago | 53 |
+| `63.34.43.204` | 443 | ✅ expected | 7d ago | 7d ago | 10 |
+| `63.34.48.116` | 443 | ✅ expected | 5d ago | 12m ago | 278 |
+| `63.34.64.15` | 443 | ✅ expected | 14h ago | 2h ago | 44 |
+| `63.34.86.48` | 443 | ✅ expected | 8d ago | 8d ago | 5 |
+| `63.35.34.90` | 443 | ✅ expected | 29d ago | 22d ago | 53 |
+| `63.35.47.18` | 443 | ✅ expected | 8d ago | 8d ago | 5 |
+| `63.35.7.115` | 443 | ✅ expected | 12d ago | 12d ago | 5 |
+| `99.80.153.48` | 443 | ✅ expected | 15d ago | 15d ago | 10 |
+| `99.80.188.173` | 443 | ✅ expected | 9d ago | 6d ago | 15 |
+| `99.80.39.243` | 443 | ✅ expected | 30d ago | 27d ago | 40 |
+| `99.81.112.7` | 443 | ✅ expected | 14d ago | 14d ago | 5 |
+| `99.81.142.82` | 443 | ✅ expected | 15d ago | 15d ago | 5 |
+| `99.81.28.139` | 443 | ✅ expected | 21d ago | 21d ago | 9 |
+| `99.81.76.162` | 443 | ✅ expected | 7d ago | 6d ago | 10 |
+| `99.81.77.108` | 443 | ✅ expected | 6d ago | 6d ago | 9 |
 
 ### gathio
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.16.1.34` | 443 | ✅ expected | 21d ago | 21d ago | 6 |
-| `104.16.11.34` | 443 | ✅ expected | 10d ago | 10d ago | 4 |
-| `104.16.4.34` | 443 | ✅ expected | 37d ago | 23d ago | 34 |
-| `104.16.7.34` | 443 | ✅ expected | 25d ago | 25d ago | 4 |
-| `104.16.8.34` | 443 | ✅ expected | 10d ago | 10d ago | 14 |
+| `104.16.11.34` | 443 | ✅ expected | 23d ago | 23d ago | 4 |
+| `104.16.7.34` | 443 | ✅ expected | 3d ago | 3d ago | 16 |
+| `104.16.8.34` | 443 | ✅ expected | 23d ago | 23d ago | 14 |
+| `104.16.9.34` | 443 | ✅ expected | 3d ago | 3d ago | 4 |
 
 ### grafana
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `192.0.73.2` | 443 | ✅ expected | 39d ago | 21h ago | 14 |
-| `34.120.177.193` | 443 | ✅ expected | 40d ago | 16s ago | 29184 |
-| `34.96.126.106` | 443 | ✅ expected | 40d ago | 3h ago | 199 |
+| `34.49.170.206` | 443 | 🕒 retained | 6d ago | 3d ago | 20 |
+| `192.0.73.2` | 443 | ✅ expected | 52d ago | 11h ago | 34 |
+| `34.120.177.193` | 443 | ✅ expected | 53d ago | 3d ago | 35691 |
+| `34.96.126.106` | 443 | ✅ expected | 52d ago | 7d ago | 224 |
 
 ### home-assistant
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.26.4.238` | 443 | ✅ expected | 40d ago | 14h ago | 74 |
-| `104.26.5.238` | 443 | ✅ expected | 40d ago | 5h ago | 78 |
-| `151.101.1.195` | 443 | ✅ expected | 40d ago | 16h ago | 53 |
-| `151.101.65.195` | 443 | ✅ expected | 38d ago | 41h ago | 24 |
-| `157.249.81.141` | 443 | ✅ expected | 40d ago | 2h ago | 510 |
-| `172.67.68.90` | 443 | ✅ expected | 40d ago | 8h ago | 83 |
-| `18.156.89.194` | 443 | ✅ expected | 28d ago | 6d ago | 2066 |
-| `18.157.213.101` | 8883 | ✅ expected | 19d ago | 18d ago | 2771 |
-| `18.158.11.29` | 8883 | ✅ expected | 24d ago | 22d ago | 5654 |
-| `18.158.133.191` | 8883 | ✅ expected | 21d ago | 20d ago | 3683 |
-| `18.158.136.104` | 8883 | ✅ expected | 22d ago | 21d ago | 1129 |
-| `18.158.217.49` | 8883 | ✅ expected | 27d ago | 26d ago | 2668 |
-| `18.158.224.141` | 8883 | ✅ expected | 31d ago | 29d ago | 5641 |
-| `18.159.150.123` | 8883 | ✅ expected | 2d ago | 36h ago | 2872 |
-| `18.159.166.33` | 8883 | ✅ expected | 10d ago | 9d ago | 2774 |
-| `18.159.77.159` | 8883 | ✅ expected | 29d ago | 29d ago | 755 |
-| `18.184.121.56` | 8883 | ✅ expected | 10d ago | 10d ago | 1224 |
-| `18.184.210.149` | 8883 | ✅ expected | 29h ago | 16s ago | 3453 |
-| `18.184.241.150` | 8883 | ✅ expected | 27d ago | 27d ago | 58 |
-| `18.184.90.143` | 8883 | ✅ expected | 18d ago | 17d ago | 2820 |
-| `18.185.10.145` | 8883 | ✅ expected | 14d ago | 10d ago | 9731 |
-| `18.185.208.158` | 443 | ✅ expected | 10d ago | 10d ago | 1 |
-| `18.185.51.38` | 8883 | ✅ expected | 9d ago | 8d ago | 3631 |
-| `18.193.176.220` | 8883 | ✅ expected | 3d ago | 2d ago | 2775 |
-| `18.193.19.139` | 8883 | ✅ expected | 22d ago | 22d ago | 1 |
-| `18.193.191.4` | 8883 | ✅ expected | 36h ago | 29h ago | 756 |
-| `18.194.166.209` | 8883 | ✅ expected | 25d ago | 24d ago | 3094 |
-| `18.195.182.246` | 8883 | ✅ expected | 16d ago | 15d ago | 3620 |
-| `18.195.53.77` | 8883 | ✅ expected | 22d ago | 22d ago | 760 |
-| `18.197.66.183` | 8883 | ✅ expected | 14d ago | 14d ago | 1 |
-| `18.198.121.88` | 8883 | ✅ expected | 6d ago | 5d ago | 2734 |
-| `18.198.144.131` | 8883 | ✅ expected | 8d ago | 8d ago | 354 |
-| `18.198.169.78` | 8883 | ✅ expected | 15d ago | 15d ago | 357 |
-| `18.198.177.41` | 8883 | ✅ expected | 15d ago | 14d ago | 1795 |
-| `18.198.200.175` | 8883 | ✅ expected | 17d ago | 16d ago | 2777 |
-| `3.120.211.84` | 8883 | ✅ expected | 29d ago | 27d ago | 4832 |
-| `3.120.216.195` | 443 | ✅ expected | 37d ago | 28d ago | 800 |
-| `3.121.101.237` | 8883 | ✅ expected | 26d ago | 25d ago | 2420 |
-| `3.121.111.53` | 443 | ✅ expected | 32d ago | 26d ago | 599 |
-| `3.122.171.67` | 443 | ✅ expected | 36d ago | 28d ago | 708 |
-| `3.125.16.42` | 443 | ✅ expected | 28d ago | 26d ago | 239 |
-| `3.64.157.17` | 8883 | ✅ expected | 5d ago | 3d ago | 5594 |
-| `3.64.241.12` | 8883 | ✅ expected | 20d ago | 19d ago | 2709 |
-| `3.71.130.230` | 443 | ✅ expected | 21d ago | 21d ago | 1 |
-| `3.72.199.54` | 443 | ✅ expected | 18d ago | 5d ago | 1156 |
-| `3.74.79.125` | 443 | ✅ expected | 6d ago | 7m ago | 591 |
-| `3.76.164.97` | 443 | ✅ expected | 21d ago | 29m ago | 1955 |
-| `35.156.210.53` | 8883 | ✅ expected | 8d ago | 6d ago | 4480 |
-| `35.156.5.143` | 443 | ✅ expected | 31d ago | 28d ago | 254 |
-| `35.158.64.12` | 443 | ✅ expected | 31d ago | 23d ago | 693 |
-| `51.102.84.196` | 443 | ✅ expected | 22h ago | 16s ago | 76 |
-| `52.28.32.0` | 443 | ✅ expected | 26d ago | 21d ago | 500 |
-| `52.29.1.243` | 443 | ✅ expected | 25d ago | 18d ago | 702 |
-| `52.58.153.107` | 443 | ✅ expected | 32d ago | 26d ago | 542 |
-| `52.58.33.43` | 443 | ✅ expected | 26d ago | 21d ago | 507 |
-| `52.59.138.18` | 443 | ✅ expected | 21d ago | 8d ago | 1142 |
-| `63.181.101.136` | 443 | ✅ expected | 8d ago | 81m ago | 743 |
-| `63.181.21.188` | 443 | ✅ expected | 28d ago | 6d ago | 1972 |
-| `63.182.123.150` | 443 | ✅ expected | 23d ago | 22h ago | 2053 |
-| `63.182.206.75` | 443 | ✅ expected | 5d ago | 16s ago | 535 |
-| `63.185.122.149` | 443 | ✅ expected | 21d ago | 21d ago | 1 |
-| `63.186.78.77` | 443 | ✅ expected | 6d ago | 16s ago | 562 |
-| `91.98.4.78` | 443 | ✅ expected | 21d ago | 21d ago | 1 |
+| `104.26.4.238` | 443 | ✅ expected | 53d ago | 11h ago | 97 |
+| `104.26.5.238` | 443 | ✅ expected | 53d ago | 2h ago | 102 |
+| `151.101.1.195` | 443 | ✅ expected | 53d ago | 8h ago | 69 |
+| `151.101.65.195` | 443 | ✅ expected | 51d ago | 2d ago | 36 |
+| `157.249.81.141` | 443 | ✅ expected | 53d ago | 2h ago | 702 |
+| `172.67.68.90` | 443 | ✅ expected | 52d ago | 8h ago | 109 |
+| `18.156.61.178` | 443 | ✅ expected | 4d ago | 2m ago | 601 |
+| `18.156.89.194` | 443 | ✅ expected | 41d ago | 19d ago | 2066 |
+| `18.157.239.155` | 8883 | ✅ expected | 6d ago | 5d ago | 2789 |
+| `18.158.114.127` | 8883 | ✅ expected | 5d ago | 3d ago | 3088 |
+| `18.158.226.141` | 443 | ✅ expected | 9d ago | 5d ago | 381 |
+| `18.159.150.123` | 8883 | ✅ expected | 15d ago | 14d ago | 2872 |
+| `18.159.166.33` | 8883 | ✅ expected | 23d ago | 22d ago | 2774 |
+| `18.159.63.103` | 8883 | ✅ expected | 11d ago | 10d ago | 711 |
+| `18.184.121.56` | 8883 | ✅ expected | 23d ago | 23d ago | 1224 |
+| `18.184.176.116` | 443 | ✅ expected | 12h ago | 2m ago | 79 |
+| `18.184.210.149` | 8883 | ✅ expected | 13d ago | 12d ago | 4827 |
+| `18.185.10.145` | 8883 | ✅ expected | 27d ago | 23d ago | 9731 |
+| `18.185.208.158` | 443 | ✅ expected | 23d ago | 23d ago | 1 |
+| `18.185.51.38` | 8883 | ✅ expected | 22d ago | 20d ago | 3631 |
+| `18.192.191.83` | 8883 | ✅ expected | 8d ago | 6d ago | 3626 |
+| `18.193.176.220` | 8883 | ✅ expected | 16d ago | 15d ago | 2775 |
+| `18.193.191.4` | 8883 | ✅ expected | 14d ago | 13d ago | 756 |
+| `18.194.113.144` | 8883 | ✅ expected | 10d ago | 9d ago | 2818 |
+| `18.194.246.231` | 8883 | ✅ expected | 3d ago | 3d ago | 126 |
+| `18.195.182.246` | 8883 | ✅ expected | 29d ago | 27d ago | 3620 |
+| `18.195.195.66` | 443 | ✅ expected | 5d ago | 2m ago | 763 |
+| `18.196.186.252` | 8883 | ✅ expected | 3d ago | 2d ago | 3162 |
+| `18.197.183.115` | 8883 | ✅ expected | 3d ago | 2m ago | 1931 |
+| `18.197.42.5` | 8883 | ✅ expected | 4d ago | 4d ago | 354 |
+| `18.197.66.183` | 8883 | ✅ expected | 27d ago | 27d ago | 1 |
+| `18.198.121.88` | 8883 | ✅ expected | 19d ago | 18d ago | 2734 |
+| `18.198.144.131` | 8883 | ✅ expected | 20d ago | 11d ago | 3089 |
+| `18.198.169.78` | 8883 | ✅ expected | 27d ago | 27d ago | 357 |
+| `18.198.177.41` | 8883 | ✅ expected | 27d ago | 27d ago | 1795 |
+| `18.198.200.175` | 8883 | ✅ expected | 30d ago | 29d ago | 2777 |
+| `3.120.114.20` | 8883 | ✅ expected | 10d ago | 6d ago | 2838 |
+| `3.121.91.88` | 8883 | ✅ expected | 9d ago | 8d ago | 2774 |
+| `3.64.157.17` | 8883 | ✅ expected | 18d ago | 16d ago | 5594 |
+| `3.65.85.145` | 8883 | ✅ expected | 2d ago | 3h ago | 5650 |
+| `3.70.88.116` | 443 | ✅ expected | 10d ago | 12m ago | 1212 |
+| `3.72.199.54` | 443 | ✅ expected | 30d ago | 18d ago | 1156 |
+| `3.74.79.125` | 443 | ✅ expected | 19d ago | 8d ago | 999 |
+| `3.76.164.97` | 443 | ✅ expected | 33d ago | 11d ago | 2060 |
+| `3.78.82.168` | 443 | ✅ expected | 35h ago | 2m ago | 225 |
+| `35.156.210.53` | 8883 | ✅ expected | 20d ago | 19d ago | 4480 |
+| `51.102.149.208` | 443 | ✅ expected | 8d ago | 4d ago | 417 |
+| `51.102.84.196` | 443 | ✅ expected | 13d ago | 35h ago | 1258 |
+| `52.58.62.182` | 443 | ✅ expected | 8d ago | 5d ago | 312 |
+| `52.59.138.18` | 443 | ✅ expected | 33d ago | 21d ago | 1142 |
+| `63.181.101.136` | 443 | ✅ expected | 21d ago | 10d ago | 985 |
+| `63.181.21.188` | 443 | ✅ expected | 40d ago | 18d ago | 1972 |
+| `63.182.123.150` | 443 | ✅ expected | 36d ago | 13d ago | 2053 |
+| `63.182.206.75` | 443 | ✅ expected | 18d ago | 10d ago | 828 |
+| `63.186.5.221` | 443 | ✅ expected | 5d ago | 2m ago | 714 |
+| `63.186.71.169` | 443 | ✅ expected | 11d ago | 12h ago | 1205 |
+| `63.186.78.77` | 443 | ✅ expected | 18d ago | 8d ago | 978 |
 
 ### immich-server
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.21.71.92` | 443 | ✅ expected | 40d ago | 29m ago | 1132 |
-| `172.67.170.79` | 443 | ✅ expected | 40d ago | 3h ago | 973 |
-| `188.114.97.4` | 443 | ✅ expected | 23d ago | 23d ago | 2 |
+| `104.21.71.92` | 443 | ✅ expected | 53d ago | 117m ago | 1439 |
+| `172.67.170.79` | 443 | ✅ expected | 53d ago | 54m ago | 1308 |
 
 ### jellyfin
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.17.207.5` | 443 | ✅ expected | 40d ago | 47h ago | 34 |
-| `104.17.208.5` | 443 | ✅ expected | 39d ago | 9d ago | 41 |
-| `139.59.139.28` | 443 | ✅ expected | 37d ago | 4d ago | 26 |
-| `140.82.121.3` | 443 | ✅ expected | 10d ago | 10d ago | 1 |
-| `146.190.237.6` | 443 | ✅ expected | 35d ago | 2d ago | 29 |
-| `151.101.1.229` | 443 | ✅ expected | 35d ago | 13d ago | 12 |
-| `151.101.129.229` | 443 | ✅ expected | 34d ago | 22h ago | 17 |
-| `151.101.193.229` | 443 | ✅ expected | 38d ago | 5d ago | 19 |
-| `151.101.65.229` | 443 | ✅ expected | 25d ago | 6d ago | 10 |
-| `157.245.38.19` | 443 | ✅ expected | 36d ago | 47h ago | 32 |
-| `161.35.245.42` | 443 | ✅ expected | 34d ago | 22h ago | 17 |
-| `165.227.169.147` | 443 | ✅ expected | 40d ago | 5d ago | 41 |
-| `165.227.244.161` | 443 | ✅ expected | 39d ago | 47h ago | 48 |
-| `178.105.98.131` | 443 | ✅ expected | 40d ago | 3d ago | 35 |
-| `185.199.109.133` | 443 | ✅ expected | 10d ago | 10d ago | 2 |
-| `206.189.97.173` | 443 | ✅ expected | 33d ago | 22h ago | 56 |
-| `68.183.204.194` | 443 | ✅ expected | 40d ago | 22h ago | 24 |
+| `104.17.207.5` | 443 | ✅ expected | 53d ago | 5d ago | 39 |
+| `104.17.208.5` | 443 | ✅ expected | 52d ago | 41h ago | 80 |
+| `139.59.139.28` | 443 | ✅ expected | 50d ago | 2d ago | 45 |
+| `140.82.121.3` | 443 | ✅ expected | 23d ago | 11d ago | 2 |
+| `146.190.237.6` | 443 | ✅ expected | 48d ago | 11d ago | 38 |
+| `151.101.1.229` | 443 | ✅ expected | 48d ago | 26d ago | 12 |
+| `151.101.129.229` | 443 | ✅ expected | 47d ago | 4d ago | 22 |
+| `151.101.193.229` | 443 | ✅ expected | 51d ago | 17h ago | 22 |
+| `151.101.65.229` | 443 | ✅ expected | 38d ago | 19d ago | 10 |
+| `157.245.38.19` | 443 | ✅ expected | 49d ago | 6d ago | 36 |
+| `161.35.245.42` | 443 | ✅ expected | 47d ago | 17h ago | 38 |
+| `165.227.169.147` | 443 | ✅ expected | 53d ago | 17h ago | 63 |
+| `165.227.244.161` | 443 | ✅ expected | 52d ago | 2d ago | 55 |
+| `178.105.98.131` | 443 | ✅ expected | 53d ago | 4d ago | 40 |
+| `185.199.109.133` | 443 | ✅ expected | 23d ago | 11d ago | 4 |
+| `206.189.97.173` | 443 | ✅ expected | 46d ago | 3d ago | 60 |
+| `68.183.204.194` | 443 | ✅ expected | 53d ago | 17h ago | 32 |
 
 ### loki
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `34.96.126.106` | 443 | ✅ expected | 40d ago | 3h ago | 1206 |
+| `34.49.170.206` | 443 | ✅ expected | 7d ago | 2h ago | 189 |
+| `34.96.126.106` | 443 | ✅ expected | 53d ago | 42h ago | 1389 |
 
 ### navidrome
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.21.43.229` | 443 | ✅ expected | 25d ago | 25d ago | 1 |
-| `130.211.19.189` | 443 | ✅ expected | 5d ago | 5d ago | 31 |
-| `151.101.237.188` | 443 | ✅ expected | 5d ago | 5d ago | 7 |
-| `151.101.238.53` | 443 | ✅ expected | 5d ago | 5d ago | 7 |
-| `151.101.238.79` | 443 | ✅ expected | 5d ago | 5d ago | 18 |
-| `172.67.186.189` | 443 | ✅ expected | 21d ago | 5d ago | 15 |
-| `209.141.42.198` | 443 | ✅ expected | 40d ago | 22h ago | 126 |
-| `23.0.161.107` | 443 | ✅ expected | 5d ago | 5d ago | 8 |
+| `104.21.43.229` | 443 | ✅ expected | 3d ago | 3d ago | 5 |
+| `130.211.19.189` | 443 | ✅ expected | 18d ago | 18d ago | 31 |
+| `151.101.237.188` | 443 | ✅ expected | 18d ago | 18d ago | 7 |
+| `151.101.238.53` | 443 | ✅ expected | 18d ago | 18d ago | 7 |
+| `151.101.238.79` | 443 | ✅ expected | 18d ago | 18d ago | 18 |
+| `172.67.186.189` | 443 | ✅ expected | 34d ago | 3d ago | 35 |
+| `209.141.42.198` | 443 | ✅ expected | 53d ago | 16h ago | 164 |
+| `23.0.161.107` | 443 | ✅ expected | 18d ago | 18d ago | 8 |
 
 ### nextcloud
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `65.108.197.113` | 443 | ✅ expected | 38d ago | 28h ago | 22 |
-| `65.109.114.179` | 443 | ✅ expected | 40d ago | 4h ago | 39 |
-| `65.21.231.50` | 443 | ✅ expected | 32d ago | 22d ago | 3 |
-| `95.217.53.153` | 443 | ✅ expected | 39d ago | 28h ago | 39 |
+| `5.9.202.145` | 443 | ⚠️ active | 3h ago | 3h ago | 1 |
+| `65.108.197.113` | 443 | ✅ expected | 50d ago | 18h ago | 30 |
+| `65.109.114.179` | 443 | ✅ expected | 52d ago | 3d ago | 48 |
+| `65.21.231.50` | 443 | ✅ expected | 4d ago | 2d ago | 6 |
+| `95.217.53.153` | 443 | ✅ expected | 51d ago | 18h ago | 53 |
 
 ### proton-bridge
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `185.70.42.41` | 443 | ✅ expected | 40d ago | 16s ago | 33257 |
-| `185.70.42.45` | 443 | ✅ expected | 40d ago | 70m ago | 1076 |
+| `185.70.42.41` | 443 | ✅ expected | 53d ago | 2m ago | 44024 |
+| `185.70.42.45` | 443 | ✅ expected | 53d ago | 23m ago | 1373 |
 
 ### traefik
 
 | Destination | Port | Class | First seen | Last seen | Obs |
 |---|---|---|---|---|---|
-| `104.19.193.29` | 443 | ✅ expected | 3d ago | 3d ago | 10 |
-| `104.26.3.101` | 443 | ✅ expected | 39d ago | 21d ago | 24 |
-| `140.82.121.5` | 443 | ✅ expected | 39d ago | 23d ago | 13 |
-| `140.82.121.6` | 443 | ✅ expected | 40d ago | 24d ago | 11 |
-| `172.65.32.248` | 443 | ✅ expected | 3d ago | 3d ago | 17 |
-| `172.67.75.8` | 443 | ✅ expected | 25d ago | 10d ago | 13 |
+| `104.19.192.174` | 443 | ✅ expected | 9d ago | 9d ago | 5 |
+| `104.19.192.176` | 443 | ✅ expected | 7d ago | 7d ago | 6 |
+| `104.19.192.177` | 443 | ✅ expected | 11d ago | 4d ago | 18 |
+| `104.19.192.29` | 443 | ✅ expected | 41h ago | 41h ago | 6 |
+| `104.19.193.29` | 443 | ✅ expected | 16d ago | 16d ago | 10 |
+| `172.65.32.248` | 443 | ✅ expected | 16d ago | 41h ago | 87 |
+| `172.67.75.8` | 443 | ✅ expected | 38d ago | 23d ago | 13 |
 
 ---
 

--- a/docs/AUTO-IMAGE-PIN-INDEX.md
+++ b/docs/AUTO-IMAGE-PIN-INDEX.md
@@ -1,6 +1,6 @@
 # Container Image Pin Index (Auto-Generated)
 
-**Generated:** 2026-07-13 10:23:02 UTC
+**Generated:** 2026-07-17 05:03:28 UTC
 **Source:** `/home/patriark/containers/quadlets` — ADR-030 (Container Supply-Chain Trust Model)
 
 Pins live in each quadlet's `Image=` line (where Podman reads them); this is

--- a/docs/AUTO-NETWORK-TOPOLOGY.md
+++ b/docs/AUTO-NETWORK-TOPOLOGY.md
@@ -1,7 +1,7 @@
 # Network Topology (Auto-Generated)
 
-**Generated:** 2026-07-01 22:04:48 UTC
-**System:** fedora-htpc | **Networks:** 11 | **Containers:** 37
+**Generated:** 2026-07-17 10:43:25 UTC
+**System:** fedora-htpc | **Networks:** 12 | **Containers:** 37
 
 ---
 
@@ -23,7 +23,6 @@ graph TB
     Authelia -->|Proxy| grafana[grafana]
     Authelia -->|Proxy| home_assistant[home-assistant]
     Authelia -->|Proxy| loki[loki]
-    Authelia -->|Proxy| prometheus[prometheus]
     Authelia -->|Proxy| qbittorrent[qbittorrent]
 
     %% Services with native authentication (bypass Authelia)
@@ -36,9 +35,7 @@ graph TB
     CrowdSec -->|Rate Limit| jellyfin[jellyfin]
     CrowdSec -->|Rate Limit| navidrome[navidrome]
     CrowdSec -->|Rate Limit| nextcloud[nextcloud]
-    CrowdSec -->|Rate Limit| pihole_exporter[pihole-exporter]
     CrowdSec -->|Rate Limit| proton_bridge[proton-bridge]
-    CrowdSec -->|Rate Limit| unpoller[unpoller]
     CrowdSec -->|Rate Limit| vaultwarden[vaultwarden]
 
     %% Styling
@@ -131,6 +128,13 @@ graph TB
         photos_redis_immich_exporter[redis-immich-exporter]
     end
 
+    subgraph restricted-egress["restricted-egress<br/>10.89.11.0/24"]
+        direction LR
+        restricted-egress_pihole_exporter[pihole-exporter]
+        restricted-egress_prometheus[prometheus]
+        restricted-egress_unpoller[unpoller]
+    end
+
     subgraph reverse_proxy["reverse_proxy<br/>10.89.2.0/24"]
         direction LR
         reverse_proxy_alert_discord_relay[alert-discord-relay]
@@ -148,12 +152,9 @@ graph TB
         reverse_proxy_loki[loki]
         reverse_proxy_navidrome[navidrome]
         reverse_proxy_nextcloud[nextcloud]
-        reverse_proxy_pihole_exporter[pihole-exporter]
-        reverse_proxy_prometheus[prometheus]
         reverse_proxy_proton_bridge[proton-bridge]
         reverse_proxy_qbittorrent[qbittorrent]
         reverse_proxy_traefik[traefik]
-        reverse_proxy_unpoller[unpoller]
         reverse_proxy_vaultwarden[vaultwarden]
     end
 
@@ -178,49 +179,49 @@ graph TB
 
 Shows which services belong to which networks. Dynamically generated from running container state.
 
-| Service | auth_services | forgejo | gathio | home_automation | mail | media_services | monitoring | nextcloud | photos | reverse_proxy | syslog |
-|---------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| Service | auth_services | forgejo | gathio | home_automation | mail | media_services | monitoring | nextcloud | photos | restricted-egress | reverse_proxy | syslog |
+|---------|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
 | **Gateway & Security** |
-| authelia | ✅ | - | - | - | ✅ | - | - | - | - | ✅ | - |
-| crowdsec | - | - | - | - | - | - | - | - | - | ✅ | - |
-| redis-authelia | ✅ | - | - | - | - | - | - | - | - | - | - |
-| traefik | - | - | - | - | - | - | - | - | - | ✅ | - |
+| authelia | ✅ | - | - | - | ✅ | - | - | - | - | - | ✅ | - |
+| crowdsec | - | - | - | - | - | - | - | - | - | - | ✅ | - |
+| redis-authelia | ✅ | - | - | - | - | - | - | - | - | - | - | - |
+| traefik | - | - | - | - | - | - | - | - | - | - | ✅ | - |
 | **Public Services** |
-| alert-discord-relay | - | - | - | - | - | - | ✅ | - | - | ✅ | - |
-| audiobookshelf | - | - | - | - | - | - | - | - | - | ✅ | - |
-| blackbox-exporter | - | - | - | - | - | - | ✅ | - | - | ✅ | - |
-| forgejo | - | ✅ | - | - | - | - | - | - | - | ✅ | - |
-| gathio | - | - | ✅ | - | - | - | - | - | - | ✅ | - |
-| home-assistant | - | - | - | ✅ | - | - | - | - | - | ✅ | - |
-| immich-server | - | - | - | - | - | - | - | - | ✅ | ✅ | - |
-| jellyfin | - | - | - | - | - | ✅ | - | - | - | ✅ | - |
-| navidrome | - | - | - | - | - | - | - | - | - | ✅ | - |
-| nextcloud | - | - | - | - | - | - | - | ✅ | - | ✅ | - |
-| pihole-exporter | - | - | - | - | - | - | ✅ | - | - | ✅ | - |
-| proton-bridge | - | - | - | - | ✅ | - | - | - | - | ✅ | - |
-| qbittorrent | - | - | - | - | - | - | - | - | - | ✅ | - |
-| unpoller | - | - | - | - | - | - | ✅ | - | - | ✅ | - |
-| vaultwarden | - | - | - | - | - | - | - | - | - | ✅ | - |
+| alert-discord-relay | - | - | - | - | - | - | ✅ | - | - | - | ✅ | - |
+| audiobookshelf | - | - | - | - | - | - | - | - | - | - | ✅ | - |
+| blackbox-exporter | - | - | - | - | - | - | ✅ | - | - | - | ✅ | - |
+| forgejo | - | ✅ | - | - | - | - | - | - | - | - | ✅ | - |
+| gathio | - | - | ✅ | - | - | - | - | - | - | - | ✅ | - |
+| home-assistant | - | - | - | ✅ | - | - | - | - | - | - | ✅ | - |
+| immich-server | - | - | - | - | - | - | - | - | ✅ | - | ✅ | - |
+| jellyfin | - | - | - | - | - | ✅ | - | - | - | - | ✅ | - |
+| navidrome | - | - | - | - | - | - | - | - | - | - | ✅ | - |
+| nextcloud | - | - | - | - | - | - | - | ✅ | - | - | ✅ | - |
+| proton-bridge | - | - | - | - | ✅ | - | - | - | - | - | ✅ | - |
+| qbittorrent | - | - | - | - | - | - | - | - | - | - | ✅ | - |
+| vaultwarden | - | - | - | - | - | - | - | - | - | - | ✅ | - |
 | **Monitoring** |
-| alertmanager | - | - | - | - | - | - | ✅ | - | - | ✅ | - |
-| cadvisor | - | - | - | - | - | - | ✅ | - | - | - | - |
-| grafana | - | - | - | - | - | - | ✅ | - | - | ✅ | - |
-| loki | - | - | - | - | - | - | ✅ | - | - | ✅ | - |
-| node_exporter | - | - | - | - | - | - | ✅ | - | - | - | - |
-| prometheus | - | - | - | - | - | - | ✅ | - | - | ✅ | - |
-| promtail | - | - | - | - | - | - | ✅ | - | - | - | - |
+| alertmanager | - | - | - | - | - | - | ✅ | - | - | - | ✅ | - |
+| cadvisor | - | - | - | - | - | - | ✅ | - | - | - | - | - |
+| grafana | - | - | - | - | - | - | ✅ | - | - | - | ✅ | - |
+| loki | - | - | - | - | - | - | ✅ | - | - | - | ✅ | - |
+| node_exporter | - | - | - | - | - | - | ✅ | - | - | - | - | - |
+| prometheus | - | - | - | - | - | - | ✅ | - | - | ✅ | - | - |
+| promtail | - | - | - | - | - | - | ✅ | - | - | - | - | - |
+| unpoller | - | - | - | - | - | - | ✅ | - | - | ✅ | - | - |
 | **Backend Services** |
-| forgejo-db | - | ✅ | - | - | - | - | - | - | - | - | - |
-| gathio-db | - | - | ✅ | - | - | - | - | - | - | - | - |
-| immich-ml | - | - | - | - | - | - | - | - | ✅ | - | - |
-| nextcloud-db | - | - | - | - | - | - | - | ✅ | - | - | - |
-| nextcloud-redis | - | - | - | - | - | - | - | ✅ | - | - | - |
-| postgres-exporter | - | - | - | - | - | - | ✅ | - | ✅ | - | - |
-| postgresql-immich | - | - | - | - | - | - | - | - | ✅ | - | - |
-| redis-authelia-exporter | ✅ | - | - | - | - | - | ✅ | - | - | - | - |
-| redis-immich-exporter | - | - | - | - | - | - | ✅ | - | ✅ | - | - |
-| redis-immich | - | - | - | - | - | - | - | - | ✅ | - | - |
-| unifi-syslog | - | - | - | - | - | - | - | - | - | - | ✅ |
+| forgejo-db | - | ✅ | - | - | - | - | - | - | - | - | - | - |
+| gathio-db | - | - | ✅ | - | - | - | - | - | - | - | - | - |
+| immich-ml | - | - | - | - | - | - | - | - | ✅ | - | - | - |
+| nextcloud-db | - | - | - | - | - | - | - | ✅ | - | - | - | - |
+| nextcloud-redis | - | - | - | - | - | - | - | ✅ | - | - | - | - |
+| pihole-exporter | - | - | - | - | - | - | ✅ | - | - | ✅ | - | - |
+| postgres-exporter | - | - | - | - | - | - | ✅ | - | ✅ | - | - | - |
+| postgresql-immich | - | - | - | - | - | - | - | - | ✅ | - | - | - |
+| redis-authelia-exporter | ✅ | - | - | - | - | - | ✅ | - | - | - | - | - |
+| redis-immich-exporter | - | - | - | - | - | - | ✅ | - | ✅ | - | - | - |
+| redis-immich | - | - | - | - | - | - | - | - | ✅ | - | - | - |
+| unifi-syslog | - | - | - | - | - | - | - | - | - | - | - | ✅ |
 
 ---
 
@@ -388,11 +389,23 @@ sequenceDiagram
 - redis-immich-exporter
 
 
+### restricted-egress
+
+- **Full Name:** `systemd-restricted-egress`
+- **Subnet:** 10.89.11.0/24
+- **Services:** 3
+
+**Members:**
+- pihole-exporter
+- prometheus
+- unpoller
+
+
 ### reverse_proxy
 
 - **Full Name:** `systemd-reverse_proxy`
 - **Subnet:** 10.89.2.0/24
-- **Services:** 22
+- **Services:** 19
 
 **Members:**
 - alert-discord-relay
@@ -410,12 +423,9 @@ sequenceDiagram
 - loki
 - navidrome
 - nextcloud
-- pihole-exporter
-- prometheus
 - proton-bridge
 - qbittorrent
 - traefik
-- unpoller
 - vaultwarden
 
 

--- a/docs/AUTO-SERVICE-CATALOG.md
+++ b/docs/AUTO-SERVICE-CATALOG.md
@@ -1,6 +1,6 @@
 # Service Catalog (Auto-Generated)
 
-**Generated:** 2026-07-01 22:04:47 UTC
+**Generated:** 2026-07-17 10:43:24 UTC
 **System:** fedora-htpc | **Services:** 37/37 running | **Health:** 32/32 healthy (5 without healthcheck)
 
 ---
@@ -9,83 +9,83 @@
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| audiobookshelf | advplyr/audiobookshelf@sha256:89276ff2e0b3d2f | ✅ healthy | 8d | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
-| blackbox-exporter | quay.io/prometheus/blackbox-exporter@sha256:e | ✅ healthy | 8d | — | — |
-| forgejo | codeberg.org/forgejo/forgejo@sha256:55bb42bec | ✅ healthy | 8d | [git.patriark.org](https://git.patriark.org) | — |
-| forgejo-db | postgres@sha256:e013e867e712fec275706a6c51c96 | ✅ healthy | 8d | — | — |
-| navidrome | deluan/navidrome@sha256:c4b5cb36a790b3eb63ca6 | ✅ healthy | 8d | [musikk.patriark.org](https://musikk.patriark.org) | — |
-| pihole-exporter | ekofr/pihole-exporter@sha256:a890cc731a39da71 | — no check | 8d | — | — |
-| postgres-exporter | quay.io/prometheuscommunity/postgres-exporter | ✅ healthy | 8d | — | — |
-| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | 8d | — | — |
-| qbittorrent | linuxserver/qbittorrent@sha256:f76c4363cce083 | ✅ healthy | 8d | [torrent.patriark.org](https://torrent.patriark.org) | — |
-| redis-authelia-exporter | quay.io/oliver006/redis_exporter@sha256:2e979 | — no check | 8d | — | — |
-| redis-immich-exporter | quay.io/oliver006/redis_exporter@sha256:2e979 | — no check | 8d | — | — |
-| unifi-syslog | linuxserver/syslog-ng@sha256:53d71945a46f2fa0 | ✅ healthy | 8d | — | — |
+| audiobookshelf | advplyr/audiobookshelf@sha256:89276ff2e0b3d2f | ✅ healthy | 3d | [audiobookshelf.patriark.org](https://audiobookshelf.patriark.org) | — |
+| blackbox-exporter | quay.io/prometheus/blackbox-exporter@sha256:e | ✅ healthy | 3d | — | — |
+| forgejo | codeberg.org/forgejo/forgejo@sha256:55bb42bec | ✅ healthy | 3d | [git.patriark.org](https://git.patriark.org) | — |
+| forgejo-db | postgres@sha256:57c72fd2a128e416c7fcc49995886 | ✅ healthy | 3d | — | — |
+| navidrome | deluan/navidrome@sha256:c4b5cb36a790b3eb63ca6 | ✅ healthy | 3d | [musikk.patriark.org](https://musikk.patriark.org) | — |
+| pihole-exporter | ekofr/pihole-exporter@sha256:a890cc731a39da71 | — no check | 20m | — | — |
+| postgres-exporter | quay.io/prometheuscommunity/postgres-exporter | ✅ healthy | 3d | — | — |
+| proton-bridge | localhost/proton-bridge:3.23.1 | ✅ healthy | 3d | — | — |
+| qbittorrent | linuxserver/qbittorrent@sha256:f76c4363cce083 | ✅ healthy | 3d | [torrent.patriark.org](https://torrent.patriark.org) | — |
+| redis-authelia-exporter | quay.io/oliver006/redis_exporter@sha256:2e979 | — no check | 3d | — | — |
+| redis-immich-exporter | quay.io/oliver006/redis_exporter@sha256:2e979 | — no check | 3d | — | — |
+| unifi-syslog | linuxserver/syslog-ng@sha256:b4ab00e399207db8 | ✅ healthy | 3d | — | — |
 
 ## Core Infrastructure (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| authelia | authelia/authelia@sha256:1b363e9279e742397966 | ✅ healthy | 8d | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
-| crowdsec | crowdsecurity/crowdsec@sha256:2f527c9bb8b3671 | ✅ healthy | 8d | — | [guide](10-services/guides/crowdsec.md) |
-| redis-authelia | redis@sha256:6ab0b6e7381779332f97b8ca76193e45 | ✅ healthy | 8d | — | — |
-| traefik | traefik@sha256:6b9cbca6fac42ab0075f5437d8dc16 | ✅ healthy | 8d | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
+| authelia | authelia/authelia@sha256:1b363e9279e742397966 | ✅ healthy | 9m | [sso.patriark.org](https://sso.patriark.org) | [guide](10-services/guides/authelia.md) |
+| crowdsec | crowdsecurity/crowdsec@sha256:2f527c9bb8b3671 | ✅ healthy | 3d | — | [guide](10-services/guides/crowdsec.md) |
+| redis-authelia | redis@sha256:6ab0b6e7381779332f97b8ca76193e45 | ✅ healthy | 3d | — | — |
+| traefik | traefik@sha256:6b9cbca6fac42ab0075f5437d8dc16 | ✅ healthy | 3d | [traefik.patriark.org](https://traefik.patriark.org) | [guide](10-services/guides/traefik.md) |
 
 ## Nextcloud (3)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| nextcloud-db | mariadb@sha256:be1ef4fe5f14589325c08a41c76334 | ✅ healthy | 8d | — | [guide](10-services/guides/nextcloud.md) |
-| nextcloud | nextcloud@sha256:fe5166b04f217c9e3a263bfe76ee | ✅ healthy | 5d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
-| nextcloud-redis | redis@sha256:6ab0b6e7381779332f97b8ca76193e45 | ✅ healthy | 8d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-db | mariadb@sha256:efb4959ef2c835cd735dbc388eb9ad | ✅ healthy | 3d | — | [guide](10-services/guides/nextcloud.md) |
+| nextcloud | nextcloud@sha256:35170a1c67e759ef874eaa0fde74 | ✅ healthy | 3d | [nextcloud.patriark.org](https://nextcloud.patriark.org) | [guide](10-services/guides/nextcloud.md) |
+| nextcloud-redis | redis@sha256:6ab0b6e7381779332f97b8ca76193e45 | ✅ healthy | 3d | — | [guide](10-services/guides/nextcloud.md) |
 
 ## Immich (4)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| immich-ml | immich-app/immich-machine-learning@sha256:a25 | ✅ healthy | 8d | — | [guide](10-services/guides/immich.md) |
-| immich-server | immich-app/immich-server@sha256:c15bff75068ef | ✅ healthy | 8d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
-| postgresql-immich | immich-app/postgres@sha256:bcf63357191b76a916 | ✅ healthy | 8d | — | — |
-| redis-immich | valkey/valkey@sha256:4963247afc4cd33c7d3b2d28 | ✅ healthy | 8d | — | — |
+| immich-ml | immich-app/immich-machine-learning@sha256:a25 | ✅ healthy | 3d | — | [guide](10-services/guides/immich.md) |
+| immich-server | immich-app/immich-server@sha256:c15bff75068ef | ✅ healthy | 3d | [photos.patriark.org](https://photos.patriark.org) | [guide](10-services/guides/immich.md) |
+| postgresql-immich | immich-app/postgres@sha256:bcf63357191b76a916 | ✅ healthy | 3d | — | — |
+| redis-immich | valkey/valkey@sha256:4963247afc4cd33c7d3b2d28 | ✅ healthy | 3d | — | — |
 
 ## Jellyfin (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| jellyfin | jellyfin/jellyfin@sha256:aefb67e6a7ff1debdd15 | ✅ healthy | 8d | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
+| jellyfin | jellyfin/jellyfin@sha256:aefb67e6a7ff1debdd15 | ✅ healthy | 3d | [jellyfin.patriark.org](https://jellyfin.patriark.org) | [guide](10-services/guides/jellyfin.md) |
 
 ## Vaultwarden (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| vaultwarden | vaultwarden/server@sha256:d626d04934cd1192ad8 | ✅ healthy | 8d | [vault.patriark.org](https://vault.patriark.org) | — |
+| vaultwarden | vaultwarden/server@sha256:d626d04934cd1192ad8 | ✅ healthy | 3d | [vault.patriark.org](https://vault.patriark.org) | — |
 
 ## Home Automation (1)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| home-assistant | home-assistant/home-assistant@sha256:d4fbec16 | ✅ healthy | 8d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
+| home-assistant | home-assistant/home-assistant@sha256:d4fbec16 | ✅ healthy | 3d | [ha.patriark.org](https://ha.patriark.org) | [guide](10-services/guides/home-assistant.md) |
 
 ## Gathio (2)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| gathio-db | mongo@sha256:8ecb514b00bdcc0bde67ef4e6c330385 | ✅ healthy | 8d | — | — |
-| gathio | lowercasename/gathio@sha256:ff66a8d2cc522568c | ✅ healthy | 8d | [events.patriark.org](https://events.patriark.org) | — |
+| gathio-db | mongo@sha256:d5b3ca8c3f3cdce78d44870dc0871b76 | ✅ healthy | 3d | — | — |
+| gathio | lowercasename/gathio@sha256:ff66a8d2cc522568c | ✅ healthy | 3d | [events.patriark.org](https://events.patriark.org) | — |
 
 ## Monitoring (9)
 
 | Service | Image | Health | Uptime | URL | Docs |
 |---------|-------|--------|--------|-----|------|
-| alert-discord-relay | localhost/alert-discord-relay:2026-05-23 | ✅ healthy | 8d | — | [guide](10-services/guides/alert-discord-relay.md) |
-| alertmanager | quay.io/prometheus/alertmanager@sha256:af26fb | ✅ healthy | 8d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| cadvisor | gcr.io/cadvisor/cadvisor@sha256:3de2bd5203120 | ✅ healthy | 8d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| grafana | grafana/grafana@sha256:5dad0df181cb644a14e136 | ✅ healthy | 8d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| loki | grafana/loki@sha256:191d4fdfb7264f16989f0a57f | — no check | 8d | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| node_exporter | quay.io/prometheus/node-exporter@sha256:0f422 | ✅ healthy | 8d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| prometheus | quay.io/prometheus/prometheus@sha256:69f52414 | ✅ healthy | 8d | [prometheus.patriark.org](https://prometheus.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| promtail | grafana/promtail@sha256:6cfa64ec432b24a912d64 | ✅ healthy | 8d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
-| unpoller | unpoller/unpoller@sha256:bf7bdcc59fcdaa469968 | — no check | 8d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| alert-discord-relay | localhost/alert-discord-relay:2026-05-23 | ✅ healthy | 3d | — | [guide](10-services/guides/alert-discord-relay.md) |
+| alertmanager | quay.io/prometheus/alertmanager@sha256:9e0829 | ✅ healthy | 3d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| cadvisor | gcr.io/cadvisor/cadvisor@sha256:3de2bd5203120 | ✅ healthy | 3d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| grafana | grafana/grafana@sha256:121a7a9ece6dc10b969f1f | ✅ healthy | 3d | [grafana.patriark.org](https://grafana.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| loki | grafana/loki@sha256:70b9f699fc9bb868b62f1cfd4 | — no check | 3d | [loki.patriark.org](https://loki.patriark.org) | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| node_exporter | quay.io/prometheus/node-exporter@sha256:0f422 | ✅ healthy | 3d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| prometheus | quay.io/prometheus/prometheus@sha256:69f52414 | ✅ healthy | 12m | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| promtail | grafana/promtail@sha256:6cfa64ec432b24a912d64 | ✅ healthy | 3d | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
+| unpoller | unpoller/unpoller@sha256:9dcccdc931a6830735f6 | — no check | 20m | — | [guide](40-monitoring-and-documentation/guides/monitoring-stack.md) |
 
 ---
 
@@ -93,7 +93,7 @@
 
 - **Total Running:** 37
 - **Total Defined:** 37
-- **System Load:** 3,11, 3,41, 2,77
+- **System Load:** 0,59, 0,84, 0,90
 
 ---
 

--- a/quadlets/pihole-exporter.container
+++ b/quadlets/pihole-exporter.container
@@ -1,8 +1,8 @@
 [Unit]
 Description=Pi-hole Exporter (Prometheus) — query/block metrics from the LAN resolver
 Documentation=https://github.com/eko/pihole-exporter
-After=network-online.target reverse_proxy-network.service monitoring-network.service traefik.service
-Wants=network-online.target reverse_proxy-network.service monitoring-network.service
+After=network-online.target restricted-egress-network.service monitoring-network.service traefik.service
+Wants=network-online.target restricted-egress-network.service monitoring-network.service
 
 [Container]
 # ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-27.
@@ -12,9 +12,12 @@ Image=docker.io/ekofr/pihole-exporter@sha256:a890cc731a39da719ba19cfd717427d9336
 ContainerName=pihole-exporter
 HostName=pihole-exporter
 
-# reverse_proxy first → default route to LAN (the Pi at 192.168.1.69).
-# monitoring → Prometheus scrapes :9617.
-Network=systemd-reverse_proxy:ip=10.89.2.91
+# restricted-egress first → default route to LAN (the Pi at 192.168.1.69),
+# internet egress dropped by the netns nft filter (ADR-045). Single-homing
+# invariant: this must stay the ONLY non-internal network on this container.
+# monitoring → Prometheus scrapes :9617 (pinned IP; name resolves ambiguously
+# across the two shared networks post-swap).
+Network=systemd-restricted-egress
 Network=systemd-monitoring:ip=10.89.4.96
 
 Environment=PIHOLE_HOSTNAME=192.168.1.69

--- a/quadlets/prometheus.container
+++ b/quadlets/prometheus.container
@@ -1,7 +1,7 @@
 [Unit]
 Description=Prometheus Metrics Database
-After=network-online.target monitoring-network.service node_exporter.service traefik.service
-Wants=monitoring-network.service network-online.target node_exporter.service
+After=network-online.target restricted-egress-network.service monitoring-network.service node_exporter.service traefik.service
+Wants=restricted-egress-network.service monitoring-network.service network-online.target node_exporter.service
 
 [Container]
 # ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-06-10 (index digest, multi-arch)
@@ -10,8 +10,13 @@ Image=quay.io/prometheus/prometheus@sha256:69f5241418838263316593f7274a304b095c4
 ContainerName=prometheus
 NoNewPrivileges=true
 HostName=prometheus
-# Static IPs assigned to ensure consistent DNS resolution
-Network=systemd-reverse_proxy:ip=10.89.2.79
+# restricted-egress first → default route for LAN scrapes (Pi node_exporter,
+# blackbox DNS targets) with internet egress dropped by the netns nft filter
+# (ADR-045). Cross-bridge scrapes to reverse_proxy targets (traefik, crowdsec,
+# navidrome, HA) use pinned IPs + kernel routing — no DNS, no shared network.
+# Single-homing invariant: restricted-egress must stay the ONLY non-internal
+# network on this container. monitoring IP pinned for ADR-018-style determinism.
+Network=systemd-restricted-egress
 Network=systemd-monitoring:ip=10.89.4.79
 
 # Prometheus configuration and data

--- a/quadlets/restricted-egress.network
+++ b/quadlets/restricted-egress.network
@@ -1,0 +1,21 @@
+[Unit]
+Description=Restricted Egress Network (LAN-only, nft-filtered — ADR-045)
+Documentation=file:///home/patriark/containers/docs/30-security/decisions/2026-07-17-ADR-045-restricted-egress-tier.md
+
+[Network]
+# Middle tier of the three-tier egress model (ADR-045):
+#   internal (no egress) → restricted-egress (LAN-only, filtered) → open (default-allow)
+# Internal=false so members get a default route and LAN reachability; internet
+# egress from 10.89.11.0/24 is dropped by egress-filter.timer inside the
+# rootless netns (table inet egress_filter — see scripts/egress-filter-apply.sh).
+Subnet=10.89.11.0/24
+Gateway=10.89.11.1
+IPRange=10.89.11.2-10.89.11.68
+DNS=192.168.1.69
+# Pin cross-bridge forwarding open (prometheus on this network scrapes pinned
+# reverse_proxy IPs). netavark 2.0 plans to flip the isolation default — this
+# freezes today's behavior at declare time (applies on network recreation).
+Options=isolate=false
+
+[Install]
+WantedBy=default.target

--- a/quadlets/reverse_proxy.network
+++ b/quadlets/reverse_proxy.network
@@ -6,3 +6,7 @@ Subnet=10.89.2.0/24
 Gateway=10.89.2.1
 IPRange=10.89.2.2-10.89.2.68
 DNS=192.168.1.69
+# Pin cross-bridge forwarding open (prometheus scrapes traefik/crowdsec pinned IPs
+# from restricted-egress — ADR-045). netavark 2.0 plans to flip the isolation
+# default; this freezes today's behavior at declare time (applies on recreation).
+Options=isolate=false

--- a/quadlets/unpoller.container
+++ b/quadlets/unpoller.container
@@ -1,8 +1,8 @@
 [Unit]
 Description=Unpoller - UniFi Metrics Exporter for Prometheus
 Documentation=https://unpoller.com/docs/
-After=network-online.target reverse_proxy-network.service prometheus.service traefik.service
-Wants=network-online.target reverse_proxy-network.service
+After=network-online.target restricted-egress-network.service prometheus.service traefik.service
+Wants=network-online.target restricted-egress-network.service
 
 [Container]
 # ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-07-13 (index digest, multi-arch)
@@ -24,9 +24,13 @@ Secret=unpoller_pass,type=env,target=UP_UNIFI_DEFAULT_PASS
 Environment=TZ=Europe/Oslo
 
 # Network configuration
-# reverse_proxy first for default route (UDM Pro polling at 192.168.1.1)
-Network=systemd-reverse_proxy:ip=10.89.2.87
-Network=systemd-monitoring
+# restricted-egress first for default route (UDM Pro polling at 192.168.1.1);
+# internet egress dropped by the netns nft filter (ADR-045). Single-homing
+# invariant: this must stay the ONLY non-internal network on this container.
+# monitoring IP pinned — Prometheus scrapes 10.89.4.97:9130 (name resolves
+# ambiguously across the two shared networks post-swap).
+Network=systemd-restricted-egress
+Network=systemd-monitoring:ip=10.89.4.97
 
 # Prometheus metrics exposed on systemd-monitoring network (port 9130)
 # No PublishPort needed - Prometheus can reach unpoller:9130 directly

--- a/scripts/check-single-homing.sh
+++ b/scripts/check-single-homing.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+################################################################################
+# check-single-homing.sh — declare-time ADR-045 single-homing lint
+#
+# Invariant: a container on the restricted-egress network must not join any
+# other NON-internal network. Internal networks contribute no default route,
+# so a compliant member has exactly one default route — wrong-network egress
+# is structurally impossible (the 2026-02-02 incident lesson as topology).
+#
+# This is the commit-time complement to the RUNTIME check in
+# egress-filter-apply.sh (which catches even a hand-run `podman network
+# connect` within a minute). Runs as pre-commit check 6 over every quadlet in
+# the committing tree — cheap enough to skip staged-file filtering.
+#
+# A network is non-internal iff its quadlet lacks Internal=true. A Network=
+# value with no matching .network quadlet (e.g. host) counts as non-internal:
+# fail safe, since it may carry a default route.
+################################################################################
+set -uo pipefail
+
+REPO_ROOT="${REPO_ROOT:-$(git rev-parse --show-toplevel)}"
+QUADLET_DIR="${REPO_ROOT}/quadlets"
+RESTRICTED="systemd-restricted-egress"
+fail=0
+
+# network name (systemd-<basename>) -> internal? (default no)
+is_internal() {
+    local name="$1" file
+    file="${QUADLET_DIR}/${name#systemd-}.network"
+    [[ -f "$file" ]] && grep -q '^Internal=true' "$file"
+}
+
+for c in "${QUADLET_DIR}"/*.container; do
+    nets=$(grep -oP '^Network=\K[^:]+' "$c")
+    grep -qx "$RESTRICTED" <<< "$nets" || continue
+    while IFS= read -r net; do
+        [[ "$net" == "$RESTRICTED" ]] && continue
+        if ! is_internal "$net"; then
+            echo "  ✗ $(basename "$c"): restricted-egress member also joins non-internal network '${net}'" >&2
+            echo "    (ADR-045 single-homing invariant — a second default route bypasses the egress filter)" >&2
+            fail=1
+        fi
+    done <<< "$nets"
+done
+
+if [[ $fail -eq 0 ]]; then
+    echo "  ✓ All restricted-egress members are single-homed (ADR-045)"
+fi
+exit $fail

--- a/scripts/egress-filter-apply.sh
+++ b/scripts/egress-filter-apply.sh
@@ -1,0 +1,153 @@
+#!/bin/bash
+################################################################################
+# egress-filter-apply.sh — enforce + observe the restricted-egress nft filter
+#
+# Enforcer AND sensor for the restricted-egress tier (ADR-045, GH#334):
+#
+#   ENFORCE  Apply the ruleset below inside the rootless netns via a single
+#            `podman unshare --rootless-netns nft '<commands>'` invocation.
+#            argv, NOT stdin and NOT a file path: file paths don't cross the
+#            userns mount namespace, and stdin through podman unshare is RACY —
+#            deployment testing (2026-07-17) showed `nft -f -` intermittently
+#            reading EMPTY stdin and exiting 0 (a successful parse of nothing),
+#            i.e. a silent enforcement no-op. argv is deterministic (5/5).
+#            The netns and every rule in it die with the last bridge container
+#            and on reboot, so a 1-minute timer reapplies; add+flush makes
+#            every tick idempotent. Netns absent -> nothing to filter -> exit 0
+#            (fail-open by design; members are no worse than the default-allow
+#            fleet during a window, and the alert below bounds the window).
+#
+#   OBSERVE  Emit a node_exporter textfile with: netns/table presence, drop
+#            counter, member count, single-homing violations, run timestamp.
+#            Alerting (egress-filter-alerts.yml): table absent >5 min while the
+#            netns exists; collector stale; any single-homing violation.
+#
+#   INVARIANT (ADR-045) A restricted-egress member must not join any other
+#            non-internal network — internal networks contribute no default
+#            route, so a clean member has exactly ONE default route and
+#            wrong-network egress is structurally impossible (the 2026-02-02
+#            incident lesson encoded as topology). Enumerated live from the
+#            network's member list, so even a hand-run `podman network connect`
+#            is caught within a minute.
+#
+# Root-free: nft runs inside the user-owned netns; no host tables are touched.
+# NEVER touch `table inet netavark` — see the NFT_CMDS note below.
+#
+# Schedule: egress-filter.timer @ every 1 min.
+################################################################################
+set -uo pipefail
+export XDG_RUNTIME_DIR="/run/user/$(id -u)"
+
+TEXTFILE_DIR="${HOME}/containers/data/backup-metrics"
+OUT="${TEXTFILE_DIR}/egress-filter.prom"
+NETNS_REF="${XDG_RUNTIME_DIR}/containers/networks/rootless-netns/rootless-netns"
+NETWORK="systemd-restricted-egress"
+RUN_TS="$(date +%s)"
+
+# The ruleset (ADR-045). A SEPARATE table — never touch `table inet netavark`
+# (netavark rewrites its own table selectively; a custom table survives
+# container restarts, network reloads, and network creates — runtime-proven).
+# Subnet-keyed: members need no IP pinning for the filter. Accept set:
+#   192.168.1.0/24 — patriark-lan (Pi-hole .69, UDM .1, host .70; widen
+#                    deliberately if a member ever needs IoT/WG VLANs)
+#   10.89.0.0/16   — container bridges (cross-bridge scrapes to pinned IPs)
+#   169.254.1.1    — pasta's --dns-forward shim (DNS keeps resolving; DNS
+#                    tunneling stays open — egress observatory is the
+#                    alerting complement, ADR-030 T4)
+# Everything else from the subnet drops (named counter survives reapply).
+# No IPv6 egress path exists under pasta today; the inet-family table is
+# where a v6 rule lands if one ever appears.
+NFT_CMDS='add table inet egress_filter
+flush table inet egress_filter
+add counter inet egress_filter dropped
+add chain inet egress_filter forward { type filter hook forward priority filter ; policy accept ; }
+add rule inet egress_filter forward ip saddr 10.89.11.0/24 ip daddr { 192.168.1.0/24, 10.89.0.0/16, 169.254.1.1 } accept
+add rule inet egress_filter forward ip saddr 10.89.11.0/24 counter name dropped drop'
+
+netns_present=0
+table_present=0
+apply_ok=0
+members=0
+violations=0
+drop_pkts=0
+drop_bytes=0
+
+if [[ -e "$NETNS_REF" ]]; then
+    netns_present=1
+
+    if podman unshare --rootless-netns nft "$NFT_CMDS" 2>/dev/null; then
+        apply_ok=1
+    fi
+
+    if podman unshare --rootless-netns nft list table inet egress_filter &>/dev/null; then
+        table_present=1
+        # counter line looks like: counter dropped { packets 12 bytes 720 ... }
+        read -r drop_pkts drop_bytes < <(
+            podman unshare --rootless-netns nft list counter inet egress_filter dropped 2>/dev/null \
+                | awk '/packets/ {print $2, $4; found=1} END {if (!found) print 0, 0}'
+        )
+    fi
+
+    # Single-homing invariant: every container on the restricted subnet must
+    # have restricted-egress as its ONLY non-internal network.
+    declare -A NONINTERNAL=()
+    while read -r net internal; do
+        [[ "$internal" == "false" ]] && NONINTERNAL["$net"]=1
+    done < <(podman network ls --format '{{.Name}}' \
+             | xargs -r -n1 -I{} sh -c 'printf "%s %s\n" "{}" "$(podman network inspect {} --format "{{.Internal}}")"')
+
+    for c in $(podman network inspect "$NETWORK" --format '{{range .Containers}}{{.Name}} {{end}}' 2>/dev/null); do
+        members=$((members + 1))
+        for net in $(podman inspect "$c" --format '{{range $k, $v := .NetworkSettings.Networks}}{{$k}} {{end}}' 2>/dev/null); do
+            if [[ "$net" != "$NETWORK" && -n "${NONINTERNAL[$net]:-}" ]]; then
+                violations=$((violations + 1))
+                echo "VIOLATION: ${c} is on non-internal network ${net} besides ${NETWORK}" >&2
+            fi
+        done
+    done
+fi
+
+emit() {
+    cat <<EOF
+# HELP egress_filter_netns_present Rootless netns exists (1) — the filter has somewhere to live.
+# TYPE egress_filter_netns_present gauge
+egress_filter_netns_present ${netns_present}
+# HELP egress_filter_table_present table inet egress_filter exists in the rootless netns.
+# TYPE egress_filter_table_present gauge
+egress_filter_table_present ${table_present}
+# HELP egress_filter_apply_ok Last nft ruleset application succeeded (1).
+# TYPE egress_filter_apply_ok gauge
+egress_filter_apply_ok ${apply_ok}
+# HELP egress_filter_members Containers currently on the restricted-egress network.
+# TYPE egress_filter_members gauge
+egress_filter_members ${members}
+# HELP egress_filter_singlehome_violations Members joined to another non-internal network (must be 0 — ADR-045 invariant).
+# TYPE egress_filter_singlehome_violations gauge
+egress_filter_singlehome_violations ${violations}
+# HELP egress_filter_dropped_packets_total Packets from 10.89.11.0/24 denied internet egress (netns-lifetime counter).
+# TYPE egress_filter_dropped_packets_total counter
+egress_filter_dropped_packets_total ${drop_pkts}
+# HELP egress_filter_dropped_bytes_total Bytes from 10.89.11.0/24 denied internet egress (netns-lifetime counter).
+# TYPE egress_filter_dropped_bytes_total counter
+egress_filter_dropped_bytes_total ${drop_bytes}
+# HELP egress_filter_last_run_timestamp Unix time of the last enforcement run.
+# TYPE egress_filter_last_run_timestamp gauge
+egress_filter_last_run_timestamp ${RUN_TS}
+EOF
+}
+
+mkdir -p "$TEXTFILE_DIR"
+tmp="$(mktemp "${TEXTFILE_DIR}/.egress-filter.XXXXXX")" || exit 1
+trap 'rm -f "$tmp"' EXIT
+emit > "$tmp"
+chmod 644 "$tmp"
+mv -f "$tmp" "$OUT"
+trap - EXIT
+
+# Fail the unit (visible in journal) only on a real enforcement failure:
+# netns present but the ruleset would not apply.
+if [[ "$netns_present" -eq 1 && "$apply_ok" -ne 1 ]]; then
+    echo "ERROR: rootless netns present but nft ruleset failed to apply" >&2
+    exit 1
+fi
+exit 0

--- a/systemd/egress-filter.service
+++ b/systemd/egress-filter.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Restricted-egress nft filter — reapply + drift metrics (ADR-045)
+Documentation=file:///home/patriark/containers/docs/30-security/decisions/2026-07-17-ADR-045-restricted-egress-tier.md
+
+[Service]
+Type=oneshot
+ExecStart=%h/containers/scripts/egress-filter-apply.sh
+TimeoutStartSec=1m
+
+# Cheap (a few podman inspects + one nft apply) — stay polite anyway
+Nice=10
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=default.target

--- a/systemd/egress-filter.timer
+++ b/systemd/egress-filter.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Reapply restricted-egress nft filter every minute (enforcer + sensor, ADR-045)
+
+[Timer]
+# The netns (and every rule in it) dies with the last bridge container and on
+# reboot — 1-minute cadence bounds the unfiltered window; the ruleset prelude
+# makes each tick idempotent. Tight accuracy so the cadence stays real.
+OnBootSec=1min
+OnUnitActiveSec=1min
+AccuracySec=15s
+
+[Install]
+WantedBy=timers.target


### PR DESCRIPTION
## Summary

Executes **#334** (design handoff from the htpc-mgmt wayfinder map). Adds the middle tier of a three-tier egress model — **ADR-045**:

- **New `restricted-egress` network** (10.89.11.0/24, `Internal=false`, `isolate=false` pinned): members get LAN reachability + a default route, but internet egress is dropped.
- **Members swapped**: `pihole-exporter`, `unpoller`, `prometheus` moved off `reverse_proxy`. All three are now single-homed on non-internal networks (the ADR-045 invariant — 2026-02-02 lesson encoded as topology).
- **Enforcement**: `table inet egress_filter` inside the rootless netns (the only viable point under pasta — SNAT hides per-container sources from host nft). `egress-filter.timer` (1-min) is enforcer **and** sensor: idempotent apply + textfile metrics (presence, drop counters, member count, live single-homing check).
- **Fail-open + drift alerts**: filter absent >5 min while the netns exists → warning; collector stale → warning; single-homing violation → **critical**.
- **Prometheus public router removed** (unused since fall 2025; Grafana is the UI) — Traefik router + service + Authelia domain entry deleted.
- **Deterministic scrape paths**: traefik/crowdsec jobs → pinned reverse_proxy IPs (cross-bridge, no shared network, no DNS); unpoller/pihole jobs → pinned monitoring IPs (names ambiguous across two shared networks post-swap).

### Deviation from the handoff design (worth review)

The handoff specified feeding the ruleset via **stdin** (`nft -f -`). Deployment testing showed stdin through `podman unshare` is **racy**: `nft` intermittently read *empty* stdin and exited 0 — a successful parse of nothing, i.e. a silent enforcement no-op (0/5 in one test pattern). Only the drift metric caught it (`apply_ok=1, table_present=0`). File paths indeed don't cross the userns, so the ruleset now lives in `egress-filter-apply.sh` and is applied as a single **`nft '<commands>'` argv invocation** — 5/5 deterministic. ADR-045 records the finding.

## Verification (live, deployed)

- ✓ All **20 Prometheus targets up** post-swap (incl. cross-bridge traefik/crowdsec, pinned unpoller/pihole, Pi node_exporter, blackbox probes)
- ✓ Member-network container: LAN target reachable, public IP **blocked** (drop counter incremented by exactly the test SYNs)
- ✓ Non-member (reverse_proxy) container: internet unaffected
- ✓ DNS resolves for members (aardvark/pasta shim path accepted)
- ✓ `egress_filter_singlehome_violations 0`, metrics ingested by Prometheus, alert group loaded
- ✓ `prometheus.patriark.org` → 404 at Traefik; Authelia restarted clean
- ✓ Real workload data flowing: `pihole_domains_being_blocked` live, 932 unpoller series

## Test Plan

- [ ] **Reboot gate (owner window)**: filter + members survive a real reboot; timer reconverges ≤1 min of the netns existing (post-reboot unfiltered burst ≤1 min is accepted per ADR-045)
- [ ] Optionally retire the `prometheus.patriark.org` DNS record at leisure
- [ ] Watch `EgressFilter*` alerts stay silent over a few days of normal operation

🤖 Generated with [Claude Code](https://claude.com/claude-code)
