### PR TITLE
fix(alerting): scope global critical→warning inhibit by component (closes #277)

### DIFF
--- a/config/alertmanager/alertmanager.yml
+++ b/config/alertmanager/alertmanager.yml
@@ -178,12 +178,18 @@ inhibit_rules:
       - alertname = "DiskSpaceWarning"
     equal: ['instance', 'mountpoint']
 
-  # Global: Critical alerts for a service silence warnings for same service
+  # Global: Critical alerts for a service silence warnings for the same service
+  # AND domain. `component` is in the equality key because every node_*/textfile
+  # alert inherits service="node_exporter" + instance="fedora-htpc" from the
+  # scrape job — without it, a critical backup alert would mute unrelated
+  # host-level warnings (SMART, db-dump, supply-chain nudges) for days (GH#277).
+  # All alert rules carry `component` (audited 2026-07-17); Alertmanager treats
+  # a label absent on BOTH sides as equal, so coverage must stay universal.
   - source_matchers:
       - severity = "critical"
     target_matchers:
       - severity = "warning"
-    equal: ['service', 'instance']
+    equal: ['service', 'instance', 'component']
 
   # If Traefik is down, suppress all service availability warnings
   # (nothing is accessible anyway)

--- a/config/prometheus/alerts/image-update-alerts.yml
+++ b/config/prometheus/alerts/image-update-alerts.yml
@@ -12,6 +12,7 @@ groups:
         for: 24h
         labels:
           severity: info
+          component: supply-chain
         annotations:
           summary: "{{ $value }} container updates baked and ready to adopt"
           description: "{{ $value }} image updates have passed their ADR-036 bake interval. Run: scripts/monthly-update.sh (or adopt-baked.sh --dry-run to review the plan)."
@@ -23,6 +24,7 @@ groups:
         for: 720h
         labels:
           severity: info
+          component: supply-chain
         annotations:
           summary: "Baked image updates waiting >30d"
           description: "{{ $value }} baked update(s) have been adoptable for over 30 days. Run: scripts/monthly-update.sh"
@@ -35,6 +37,7 @@ groups:
         for: 1h
         labels:
           severity: warning
+          component: supply-chain
         annotations:
           summary: "Image update feed has not run in >8 days"
           description: "check-image-updates.timer (Sun 10:00) appears broken — the ADR-036 update nudge is blind. Check: systemctl --user status check-image-updates.{timer,service}"

--- a/config/prometheus/alerts/infrastructure-critical.yml
+++ b/config/prometheus/alerts/infrastructure-critical.yml
@@ -34,6 +34,7 @@ groups:
         for: 5m
         labels:
           severity: critical
+          component: system
           category: availability
         annotations:
           summary: "Service {{ $labels.job }} on {{ $labels.instance }} is down"
@@ -82,6 +83,7 @@ groups:
         for: 1h
         labels:
           severity: critical
+          component: security
           category: security
         annotations:
           summary: "TLS certificate expires in less than 7 days"
@@ -95,6 +97,7 @@ groups:
         for: 5m
         labels:
           severity: critical
+          component: monitoring
           category: monitoring
         annotations:
           runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/40-monitoring-and-documentation/guides/monitoring-stack.md"
@@ -109,6 +112,7 @@ groups:
         for: 10m
         labels:
           severity: critical
+          component: monitoring
           category: monitoring
         annotations:
           runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/40-monitoring-and-documentation/guides/monitoring-stack.md"
@@ -123,6 +127,7 @@ groups:
         for: 5m
         labels:
           severity: critical
+          component: network
           category: networking
         annotations:
           summary: "Traefik reverse proxy is down"
@@ -136,6 +141,7 @@ groups:
         for: 10m
         labels:
           severity: critical
+          component: monitoring
           category: monitoring
         annotations:
           runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/40-monitoring-and-documentation/guides/monitoring-stack.md"
@@ -150,6 +156,7 @@ groups:
         for: 10m
         labels:
           severity: critical
+          component: monitoring
           category: monitoring
         annotations:
           runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/40-monitoring-and-documentation/guides/monitoring-stack.md"
@@ -164,6 +171,7 @@ groups:
         for: 5m
         labels:
           severity: critical
+          component: monitoring
           category: monitoring
         annotations:
           runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/40-monitoring-and-documentation/guides/monitoring-stack.md"
@@ -186,6 +194,7 @@ groups:
         for: 5m
         labels:
           severity: critical
+          component: monitoring
           category: monitoring
         annotations:
           runbook_url: "https://github.com/vonrobak/fedora-homelab-containers/blob/main/docs/40-monitoring-and-documentation/guides/monitoring-stack.md"

--- a/config/prometheus/alerts/infrastructure-warnings.yml
+++ b/config/prometheus/alerts/infrastructure-warnings.yml
@@ -65,6 +65,7 @@ groups:
         for: 6h
         labels:
           severity: info
+          component: security
           category: security
         annotations:
           summary: "TLS certificate renewal overdue for {{ $labels.cn }}"

--- a/config/prometheus/rules/log-based-alerts.yml
+++ b/config/prometheus/rules/log-based-alerts.yml
@@ -45,6 +45,7 @@ groups:
         for: 10m
         labels:
           severity: warning
+          component: immich
           category: media_processing
         annotations:
           summary: "Immich thumbnail generation failing"
@@ -64,6 +65,7 @@ groups:
         for: 2m
         labels:
           severity: critical
+          component: nextcloud
           category: background_jobs
         annotations:
           summary: "Nextcloud cron hasn't run in 10+ minutes"
@@ -124,6 +126,7 @@ groups:
         for: 30m
         labels:
           severity: warning
+          component: logging
           category: monitoring
         annotations:
           summary: "Promtail metric extraction may have failed"


### PR DESCRIPTION
## Summary

- Global inhibit rule's equality key tightened from `['service','instance']` to `['service','instance','component']` — blocks the cross-domain suppression where any host-level critical (e.g. `BackupFailed`) muted warnings in every other node_exporter-labeled domain (SMART, db-dump, `ImageUpdatesBaked*` nudges, egress staleness)
- Component-label audit executed as the issue required: 16 rules were missing `component` (13 in `alerts/`, 3 more found via the Prometheus rules API in `rules/log-based-alerts.yml`) — all filled with values from the existing vocabulary (`monitoring`, `system`, `network`, `security`, `supply-chain`, `immich`, `nextcloud`, `logging`)
- Incidental fix: `prometheus.yml` + `egress-filter-alerts.yml` had been rewritten mode 600 earlier today, unreadable to the in-container `nobody` user — prometheus crash-looped on restart until chmod 644

Closes #277.

## Acceptance criteria from the issue

- [x] All alert rules carry `component` — **148/148 loaded rules verified via `/api/v1/rules`** (file-level audit alone missed 3 in `rules/`)
- [x] `promtool check rules` + `amtool check-config` pass; both services restarted and healthy
- [x] Cross-domain: critical `component=backup` vs warning `component=storage` now differ on the equality key → no inhibition (deterministic config semantics)
- [x] Within-component critical→warning suppression preserved (same three labels equal)
- [x] DiskSpaceCritical/Warning, TraefikDown, HostDown, cAdvisor dedicated inhibit rules untouched
- [x] Live alertmanager config confirmed to carry the `component` key (api/v2/status)

## Test Plan

- [ ] Next real critical: confirm only same-component warnings are inhibited (Alertmanager UI shows inhibited alerts)
- [ ] Keep the label-coverage invariant in mind when adding alert rules — absent-on-both-sides counts as equal

🤖 Generated with [Claude Code](https://claude.com/claude-code)