### PR TITLE
feat(network): migrate 4 zero-egress services to restricted-egress tier (GH#274)

### DIFF
--- a/config/authelia/configuration.yml
+++ b/config/authelia/configuration.yml
@@ -21,6 +21,14 @@ log:
   level: info
   format: text
 
+# NTP startup sanity-check disabled (ADR-045/GH#274): authelia sits on the
+# restricted-egress tier, so its default probe of time.cloudflare.com:123 would
+# be dropped by the egress filter and fail the startup check. The container
+# clock is the host clock (chronyd-disciplined), which is what TOTP time-step
+# correctness actually depends on — the probe adds nothing here.
+ntp:
+  disable_startup_check: true
+
 # JWT secret for tokens (from Podman secret)
 # Set via environment variable: AUTHELIA_JWT_SECRET
 

--- a/config/traefik/hosts
+++ b/config/traefik/hosts
@@ -13,17 +13,25 @@
 # See: docs/98-journals/2026-02-02-ROOT-CAUSE-CONFIRMED-dns-resolution-order.md
 # Date: 2026-03-01
 # Status: PRODUCTION
+#
+# NOTE (2026-07-17): this file is bind-mounted single-file into traefik
+# (/etc/hosts, inode-pinned) — edits do NOT propagate to the running container.
+# After ANY change here: systemctl --user restart traefik.service
+#
+# Tier note (ADR-045/GH#274): 10.89.11.x entries are restricted-egress members.
+# Traefik reaches them cross-bridge (both bridges isolate=false); the entry here
+# is what makes the router dial the right bridge. Inbound exposure is governed
+# solely by routers.yml — the tier only limits the member's OUTBOUND traffic.
 
 # Core Services
 10.89.2.76  home-assistant
-10.89.2.78  authelia
+10.89.11.78 authelia
 10.89.2.77  grafana
-10.89.2.79  prometheus
 
 # Media & Collaboration
 10.89.2.81  jellyfin
 10.89.2.82  nextcloud
-10.89.2.74  audiobookshelf
+10.89.11.74 audiobookshelf
 10.89.2.75  navidrome
 
 # Photos & Events
@@ -31,7 +39,7 @@
 10.89.2.84  gathio
 
 # Development
-10.89.2.89  forgejo
+10.89.11.89 forgejo
 
 # Monitoring & Logging
 10.89.2.83  loki

--- a/docs/30-security/decisions/2026-07-17-ADR-045-restricted-egress-tier.md
+++ b/docs/30-security/decisions/2026-07-17-ADR-045-restricted-egress-tier.md
@@ -1,13 +1,36 @@
 ---
 type: ADR
-title: "ADR-045: Restricted-Egress Tier — LAN-Only Network with In-Netns nft Filter"
-description: "ADR adding the missing middle tier of a three-tier egress model: a restricted-egress network whose members get LAN reachability but no internet, enforced by an nft filter inside the rootless netns with fail-open semantics and mandatory drift detection."
+title: "ADR-045: Restricted-Egress Tier — Outbound-Restricted Network with In-Netns nft Filter"
+description: "ADR adding the missing middle tier of a three-tier egress model: a restricted-egress network whose members can dial only LAN + container fabric (no internet), enforced by an nft filter inside the rootless netns with fail-open semantics and mandatory drift detection. The tier constrains OUTBOUND traffic only — inbound reachability is governed solely by Traefik routing and is unaffected."
 sensitivity: public
 created: 2026-07-17
 updated: 2026-07-17
 ---
 
-# ADR-045: Restricted-Egress Tier — LAN-Only Network with In-Netns nft Filter
+# ADR-045: Restricted-Egress Tier — Outbound-Restricted Network with In-Netns nft Filter
+
+> **Clarification (2026-07-17 evening, GH#274):** the tier's original shorthand
+> "LAN-only" conflated two independent axes and is retired from all artifacts:
+>
+> - **Inbound reachability** — *who can dial the container.* Governed solely by
+>   the UDM port-forward (80/443 → Traefik) and Traefik's routers + middleware.
+>   **This tier says nothing about inbound.** A member with no router (prometheus)
+>   is unreachable from the internet; a member with a router (audiobookshelf,
+>   forgejo, authelia) remains fully internet-reachable through its unchanged
+>   middleware chain — Traefik dials it cross-bridge (both bridges
+>   `isolate=false`), and replies to Traefik's 10.89.2.69 are inside the
+>   filter's `10.89.0.0/16` accept set.
+> - **Outbound egress** — *who the container can dial.* This is what the tier
+>   restricts: LAN + container fabric only, internet dropped.
+>
+> For Traefik-routed members this is the classic DMZ posture: **guarded front
+> door, no back door** — and egress restriction is *most* valuable for exactly
+> those internet-exposed services, since they are the likeliest to be
+> compromised and the filter denies the resulting exfiltration/C2 callback.
+> Lateral movement between the two non-internal bridges (reverse_proxy members
+> can dial restricted-egress members' ports) is explicitly OUT OF SCOPE here —
+> identical to the exposure the members had while sitting on reverse_proxy
+> itself — and remains a separate future hardening item.
 
 **Date:** 2026-07-17
 **Status:** Accepted. Executes GH#334 (design handoff from the htpc-mgmt wayfinder
@@ -47,7 +70,7 @@ restarts, network reloads, and network creates; netavark rewrites only its own
 | Tier | Mechanism | Egress | Members |
 |------|-----------|--------|---------|
 | `internal` | `Internal=true` networks | none (no default route) | DBs, backends (unchanged) |
-| **`restricted-egress`** | non-internal network + in-netns nft filter | **LAN + container bridges only** | pihole-exporter, unpoller, prometheus |
+| **`restricted-egress`** | non-internal network + in-netns nft filter | **LAN + container bridges only** | pihole-exporter, unpoller, prometheus, blackbox-exporter, audiobookshelf, forgejo, authelia (last four: GH#274, 2026-07-17) |
 | open | default-allow | unrestricted | rest of the fleet (unchanged) |
 
 The new network is pinned like every fleet network: `Subnet=10.89.11.0/24`,

--- a/quadlets/audiobookshelf.container
+++ b/quadlets/audiobookshelf.container
@@ -9,8 +9,8 @@
 [Unit]
 Description=Audiobookshelf Audiobook & Podcast Server
 Documentation=https://github.com/advplyr/audiobookshelf
-After=network-online.target traefik.service
-Wants=network-online.target traefik.service
+After=network-online.target restricted-egress-network.service traefik.service
+Wants=network-online.target restricted-egress-network.service traefik.service
 
 # ═══════════════════════════════════════════════════════════
 # CONTAINER CONFIGURATION
@@ -23,8 +23,18 @@ ContainerName=audiobookshelf
 NoNewPrivileges=true
 HostName=audiobookshelf
 
-# Network (single network - standalone service, no inter-service communication)
-Network=systemd-reverse_proxy:ip=10.89.2.74
+# Network: restricted-egress (ADR-045, GH#274) — outbound limited to LAN + container
+# fabric; INBOUND is unchanged and governed solely by the Traefik router (remote
+# access from anywhere still works — Traefik dials in cross-bridge via the pinned
+# IP in config/traefik/hosts; replies to 10.89.2.69 are in the filter's accept set).
+# Zero internet egress observed in the 18-day baseline (podcasts are archived local
+# files: feedURL empty, autoDownloadEpisodes=0 for all 32).
+# CEREMONY (accepted 2026-07-17): "Match" metadata lookups and adding a LIVE podcast
+# feed need internet → temporarily revert this line to
+#   Network=systemd-reverse_proxy:ip=10.89.2.74  (+ hosts file entry back to 10.89.2.74)
+# restart, do the fetch, then re-apply this line and restart again.
+# Single-homing invariant: restricted-egress must stay the ONLY non-internal network.
+Network=systemd-restricted-egress:ip=10.89.11.74
 
 # Environment
 Environment=TZ=Europe/Oslo

--- a/quadlets/authelia.container
+++ b/quadlets/authelia.container
@@ -1,7 +1,7 @@
 [Unit]
 Description=Authelia - SSO & MFA Authentication Server (YubiKey-First)
-After=network-online.target redis-authelia.service reverse_proxy-network.service auth_services-network.service mail-network.service
-Wants=auth_services-network.service network-online.target reverse_proxy-network.service mail-network.service
+After=network-online.target redis-authelia.service restricted-egress-network.service auth_services-network.service mail-network.service
+Wants=auth_services-network.service network-online.target restricted-egress-network.service mail-network.service
 Requires=redis-authelia.service
 
 [Container]
@@ -14,7 +14,16 @@ NoNewPrivileges=true
 
 # Multi-network: Serves SSO portal + handles auth verification
 # Static IPs assigned to ensure consistent DNS resolution
-Network=systemd-reverse_proxy:ip=10.89.2.78
+# Networks (ADR-045/GH#274): restricted-egress FIRST = default route, outbound
+# limited to LAN + container fabric. INBOUND unchanged: sso.patriark.org portal and
+# every forward-auth check are Traefik DIALING IN (cross-bridge, pinned IP in
+# config/traefik/hosts) — session cookies ride back through Traefik's responses.
+# Authelia's only self-initiated connections: redis-authelia (auth_services,
+# internal) and the NTP startup check (disabled in configuration.yml — host
+# chronyd owns time). SMTP, if ever re-enabled, goes to proton-bridge over the
+# internal mail network — proton-bridge does the internet leg.
+# Single-homing invariant: restricted-egress must stay the ONLY non-internal network.
+Network=systemd-restricted-egress:ip=10.89.11.78
 Network=systemd-auth_services:ip=10.89.3.78
 Network=systemd-mail:ip=10.89.9.78
 

--- a/quadlets/blackbox-exporter.container
+++ b/quadlets/blackbox-exporter.container
@@ -1,8 +1,8 @@
 [Unit]
 Description=Blackbox Exporter (Prometheus) - HTTP/DNS/ICMP/TCP probes
 Documentation=https://github.com/prometheus/blackbox_exporter
-After=network-online.target reverse_proxy-network.service monitoring-network.service traefik.service
-Wants=network-online.target reverse_proxy-network.service monitoring-network.service
+After=network-online.target restricted-egress-network.service monitoring-network.service traefik.service
+Wants=network-online.target restricted-egress-network.service monitoring-network.service
 
 [Container]
 # ADR-030 P2: digest-pinned (integrity). tag: latest, resolved 2026-05-27 (multi-arch index digest).
@@ -11,9 +11,12 @@ Image=quay.io/prometheus/blackbox-exporter@sha256:e753ff9f3fc458d02cca5eddab5a77
 ContainerName=blackbox-exporter
 HostName=blackbox-exporter
 
-# reverse_proxy first → default route (reach LAN .69 DNS, .1 ICMP, internet for external probes).
+# restricted-egress first → default route for LAN-only probes (ADR-045: all probe
+# targets are LAN/container — .69 DNS, .1 ICMP, nextcloud status.php; no internet).
 # monitoring → scraped by Prometheus on :9115.
-Network=systemd-reverse_proxy:ip=10.89.2.90
+# Single-homing invariant: restricted-egress must stay the ONLY non-internal
+# network on this container (pre-commit check 6 + egress-filter alerts police this).
+Network=systemd-restricted-egress
 Network=systemd-monitoring:ip=10.89.4.95
 
 Volume=%h/containers/config/blackbox-exporter/blackbox.yml:/etc/blackbox_exporter/config.yml:Z,ro

--- a/quadlets/forgejo.container
+++ b/quadlets/forgejo.container
@@ -1,6 +1,6 @@
 [Unit]
 Description=Forgejo Git Forge
-After=network-online.target forgejo-db.service reverse_proxy-network.service forgejo-network.service
+After=network-online.target forgejo-db.service restricted-egress-network.service forgejo-network.service
 Wants=network-online.target
 Requires=forgejo-db.service
 
@@ -42,6 +42,14 @@ Environment=FORGEJO__service__DISABLE_REGISTRATION=true
 Environment=FORGEJO__service__REQUIRE_SIGNIN_VIEW=true
 Environment=FORGEJO__session__COOKIE_SECURE=true
 
+# No third-party references in rendered pages (GH#274, with the restricted-egress move).
+# OFFLINE_MODE does NOT affect access/visibility (that's REQUIRE_SIGNIN_VIEW above) —
+# it means pages reference no external CDN assets. DISABLE_GRAVATAR stops avatar URLs
+# that the VISITOR'S BROWSER would fetch (leaking visitor IP + email-hash to Gravatar)
+# — a privacy leak the server-side egress filter structurally cannot see.
+Environment=FORGEJO__server__OFFLINE_MODE=true
+Environment=FORGEJO__picture__DISABLE_GRAVATAR=true
+
 # Instance commit signing (ADR-034): the FORGE signs its own server-side merge/
 # squash commits so `main` stays fully verifiable. Authors sign their commits with
 # their FIDO2 YubiKeys (ADR-033); a server can't tap a key, so the instance uses a
@@ -70,8 +78,15 @@ Secret=forgejo_signing_key_pub,type=mount,target=/run/secrets/forgejo_signing_ke
 # Storage (repos/LFS/data on container pool; not a DB, no NOCOW)
 Volume=/mnt/btrfs-pool/subvol7-containers/forgejo:/data:Z
 
-# Networks (reverse_proxy FIRST = default route for internet; static IPs per ADR-018)
-Network=systemd-reverse_proxy:ip=10.89.2.89
+# Networks (ADR-045/GH#274): restricted-egress FIRST = default route, outbound
+# limited to LAN + container fabric. INBOUND unchanged: git.patriark.org still
+# arrives via Traefik (cross-bridge dial to the pinned IP in config/traefik/hosts);
+# the hourly repo mirror is a PUSH INTO forgejo from the host — also inbound.
+# CEREMONY: migrating/mirror-PULLING a repo FROM an external forge needs internet →
+# temporarily revert this line to Network=systemd-reverse_proxy:ip=10.89.2.89
+# (+ hosts entry back to 10.89.2.89 + traefik restart), pull, then re-apply.
+# Single-homing invariant: restricted-egress must stay the ONLY non-internal network.
+Network=systemd-restricted-egress:ip=10.89.11.89
 Network=systemd-forgejo:ip=10.89.8.89
 
 # git-over-SSH published to LOOPBACK ONLY — htpc-local; reached via agent-forwarded SSH sessions

--- a/quadlets/restricted-egress.network
+++ b/quadlets/restricted-egress.network
@@ -1,10 +1,12 @@
 [Unit]
-Description=Restricted Egress Network (LAN-only, nft-filtered — ADR-045)
+Description=Restricted Egress Network (outbound LAN+fabric only, nft-filtered — ADR-045)
 Documentation=file:///home/patriark/containers/docs/30-security/decisions/2026-07-17-ADR-045-restricted-egress-tier.md
 
 [Network]
 # Middle tier of the three-tier egress model (ADR-045):
-#   internal (no egress) → restricted-egress (LAN-only, filtered) → open (default-allow)
+#   internal (no egress) → restricted-egress (outbound LAN+fabric only) → open (default-allow)
+# NOTE: the tier restricts OUTBOUND only. Inbound is governed solely by Traefik
+# routing — Traefik-routed members stay internet-reachable (cross-bridge dial).
 # Internal=false so members get a default route and LAN reachability; internet
 # egress from 10.89.11.0/24 is dropped by egress-filter.timer inside the
 # rootless netns (table inet egress_filter — see scripts/egress-filter-apply.sh).


### PR DESCRIPTION
## What

Completes GH#274 by moving the four remaining zero-egress candidates onto the ADR-045 restricted-egress tier (now 7 members): **blackbox-exporter, audiobookshelf, forgejo, authelia**. Each showed zero internet egress across the 18-day observatory baseline — this PR converts that observation into an enforced invariant (nft filter in the rootless netns).

## The key clarification (ADR-045 amendment)

The tier's "LAN-only" shorthand conflated two independent axes and is retired:

- **Inbound reachability** (who can dial the container) — governed solely by Traefik routers + middleware. Unchanged by this PR: `audiobookshelf.patriark.org`, `git.patriark.org`, `sso.patriark.org` remain fully internet-reachable; Traefik dials members cross-bridge (`isolate=false`) via repointed `10.89.11.x` hosts entries.
- **Outbound egress** (who the container can dial) — what the tier restricts: LAN + fabric only. For internet-exposed services this is the DMZ posture: *guarded front door, no back door* — no C2 callback or exfiltration if compromised.

Lateral movement between the two non-internal bridges is explicitly out of scope (identical exposure to what members had on reverse_proxy itself) and remains a future hardening item.

## Accepted trade-offs (the review surface)

| Service | On-demand feature now requiring the temporary-revert ceremony |
|---|---|
| audiobookshelf | adding a live podcast feed; "Match" metadata/cover lookups |
| forgejo | migrating/mirror-pulling a repo from an external forge |
| authelia | none (NTP startup check disabled — host chronyd owns time) |
| blackbox-exporter | none (all probe targets are LAN/container) |

forgejo additionally gets `OFFLINE_MODE=true` + `DISABLE_GRAVATAR=true` — page-reference semantics only (access control untouched); closes a visitor-IP/email-hash leak to Gravatar that the server-side filter structurally cannot see.

## Validation

- All 4 healthy on new networks; egress probe to 1.1.1.1 dropped from each (drop counters incremented by exactly the test traffic)
- **End-to-end from a 5G client (owner-tested):** ABS login + playback ✅, git.patriark.org ✅, grafana → sso.patriark.org YubiKey forward-auth round-trip ✅
- Forgejo: loopback SSH :2222 open, ledger mirror push succeeded post-move
- Prometheus: all blackbox probe jobs up; single-homing: 7 members, 0 violations; pre-commit check 6 green
- Gotcha found + documented: `config/traefik/hosts` is a single-file bind mount (inode-pinned) — edits require a Traefik restart; noted in the file header and ceremony docs

Closes #274

🤖 Generated with [Claude Code](https://claude.com/claude-code)