### PR TITLE
fix: add loopback entries to Traefik /etc/hosts override

### DIFF
--- a/config/traefik/hosts
+++ b/config/traefik/hosts
@@ -23,6 +23,14 @@
 # is what makes the router dial the right bridge. Inbound exposure is governed
 # solely by routers.yml — the tier only limits the member's OUTBOUND traffic.
 
+# Loopback — this file fully REPLACES podman's generated /etc/hosts, so the
+# standard localhost entries must be carried here. Without them the container
+# healthcheck's `wget http://localhost:8080/ping` (every 10s) falls through to
+# DNS and leaks A/AAAA localhost queries to the LAN resolver (~16k/day observed
+# in Pi-hole, 2026-07-17).
+127.0.0.1  localhost
+::1        localhost
+
 # Core Services
 10.89.2.76  home-assistant
 10.89.11.78 authelia


### PR DESCRIPTION
## Summary

- Adds `127.0.0.1 localhost` / `::1 localhost` to `config/traefik/hosts` (the ADR-018 override), with a comment explaining why they must be carried there.
- Root cause: the override fully replaces podman's generated `/etc/hosts`, so the quadlet healthcheck (`wget http://localhost:8080/ping` every 10s) fell through to DNS — musl → aardvark-dns → pasta → Pi-hole — leaking an A+AAAA `localhost` pair every ~11s (~16k queries/day; Pi-hole's #1 permitted domain, all attributed to fedora-htpc).
- Fleet swept: Traefik is the only container with an `/etc/hosts` override; no siblings affected.

## Verification

- ✓ Traefik healthy post-restart (`podman inspect` health: healthy)
- ✓ Routing intact: grafana/jellyfin → 302 to SSO, vault.patriark.org → 200
- ✓ Leak stopped: 40s `tcpdump` inside the rootless netns spanning 4 healthcheck cycles shows zero `localhost` DNS queries
- ✓ Pi-hole query log confirms the ~11s A+AAAA metronome stopped after restart

## Test Plan

- [x] Restart traefik (inode-pinned single-file mount — edits don't propagate live)
- [x] End-to-end route checks via SSO
- [ ] Confirm Pi-hole "localhost" count flatlines over next 24h

Follow-up: an ADR is being drafted to retire the hosts-override half of ADR-018 (original aardvark ordering bug no longer reproducible on Podman 5.7.1; the file is now load-bearing only for ADR-045 cross-bridge dial).

🤖 Generated with [Claude Code](https://claude.com/claude-code)