### PR TITLE
fix: route Nextcloud self-dials via host.containers.internal

### DIFF
--- a/quadlets/nextcloud.container
+++ b/quadlets/nextcloud.container
@@ -58,6 +58,12 @@ Volume=/mnt/btrfs-pool/subvol5-music:/external/music:z
 Network=systemd-reverse_proxy:ip=10.89.2.82
 Network=systemd-nextcloud:ip=10.89.10.82
 
+# Self-referential URL fix: LAN DNS resolves nextcloud.patriark.org to the host
+# LAN IP, which is unreachable from the container netns (hairpin blocked), so
+# Nextcloud's setup self-checks report "HTTP headers not set". Route self-dials
+# to the host-bound Traefik sockets (ADR-022) via host.containers.internal.
+AddHost=nextcloud.patriark.org:169.254.1.2
+
 # Health check (verifies both reachability AND no pending DB upgrade)
 HealthCmd=curl -sf http://localhost:80/status.php | grep -q '"needsDbUpgrade":false'
 HealthInterval=30s


### PR DESCRIPTION
## Summary

- Nextcloud's admin panel flagged three items: missing DB indices, pending mimetype migrations, and "Strict-Transport-Security not set". The first two were fixed with one-off `occ` runs (no repo diff); this PR fixes the third.
- The HSTS warning was a false positive with a real defect underneath: the server-side setup check fetches the instance's own public URL, but inside the container `nextcloud.patriark.org` resolves (via LAN DNS) to the host LAN IP, which is unreachable from the container netns — so the check saw no headers at all. Real clients have received HSTS from Traefik (`hsts-only@file`) all along.
- Traefik's bridge IP can't be dialed either, since its 80/443 sockets are host-bound (ADR-022 socket activation). The fix adds `AddHost=nextcloud.patriark.org:169.254.1.2` (host.containers.internal) to the Nextcloud quadlet, steering self-initiated connections to the host sockets — valid TLS via SNI, full middleware chain, client paths untouched.
- Side benefit: self-referential traffic (federation to own domain, preview/DAV internals) that previously failed silently now works.

## Deployment Context

- Service: nextcloud
- Change: quadlet-only, one `AddHost=` line + comment (same hosts-override spirit as ADR-018/046, applied to a backend's own resolver instead of Traefik's)
- Applied live: daemon-reload + restart already done; worktree is running config

## Verification

- ✓ `occ setupchecks`: "HTTP headers: Your server is correctly configured to send security headers"
- ✓ In-container fetch of own URL via 169.254.1.2: HTTP/2 200 with HSTS, valid cert
- ✓ External: HTTP/2 200 + `strict-transport-security: max-age=31536000; includeSubDomains; preload` intact
- ✓ Container healthy; `status.php` reports `needsDbUpgrade: false` (v33.0.6)

## Test Plan

- [x] Setup check passes post-restart
- [x] External access + HSTS unchanged
- [ ] WebDAV sync clients reconnect normally over the next hours
- [ ] No new warnings in Nextcloud log over a few days

🤖 Generated with [Claude Code](https://claude.com/claude-code)