### PR TITLE
docs: guide staleness sweep + vault-path boundary check

### DIFF
--- a/docs/00-foundation/guides/configuration-design-quick-reference.md
+++ b/docs/00-foundation/guides/configuration-design-quick-reference.md
@@ -4,7 +4,7 @@ title: "Configuration Design Quick Reference Card"
 description: "Quick-reference card companion to the configuration design principles — lookup tables for where ordering matters and common design decisions."
 sensitivity: public
 created: 2025-10-31
-updated: 2025-12-31
+updated: 2026-07-20
 ---
 
 # Configuration Design Quick Reference Card
@@ -271,7 +271,8 @@ Wants=network-online.target
 # CONTAINER CONFIGURATION
 # ═══════════════════════════════════════════════
 [Container]
-Image=docker.io/<image>:<tag>
+# Digest-pinned per ADR-030: tag = discovery handle, digest = execution contract
+Image=docker.io/<image>:<tag>@sha256:<digest>
 ContainerName=<service-name>
 User=<uid>:<gid>  # Non-root user
 
@@ -451,11 +452,11 @@ Network=systemd-database.network
 ```ini
 # WRONG: No health check
 [Container]
-Image=myapp:latest
+Image=myapp:v1.2.3@sha256:<digest>
 
 # RIGHT: With health check
 [Container]
-Image=myapp:latest
+Image=myapp:v1.2.3@sha256:<digest>
 HealthCmd=curl -f http://localhost:8080/health || exit 1
 HealthInterval=30s
 ```
@@ -464,11 +465,11 @@ HealthInterval=30s
 ```ini
 # WRONG: Implicit root
 [Container]
-Image=myapp:latest
+Image=myapp:v1.2.3@sha256:<digest>
 
 # RIGHT: Explicit non-root
 [Container]
-Image=myapp:latest
+Image=myapp:v1.2.3@sha256:<digest>
 User=1000:1000
 ```
 

--- a/docs/00-foundation/guides/middleware-configuration.md
+++ b/docs/00-foundation/guides/middleware-configuration.md
@@ -4,7 +4,7 @@ title: "Traefik Middleware Configuration: Analysis & Improvement Guide"
 description: "Guide to Traefik middleware configuration under the ADR-016 centralized dynamic-config model — CrowdSec integration, fail-fast ordering, and advanced patterns."
 sensitivity: public
 created: 2025-10-31
-updated: 2025-12-31
+updated: 2026-07-20
 ---
 
 # Traefik Middleware Configuration: Analysis & Improvement Guide
@@ -657,16 +657,20 @@ podman exec crowdsec cscli scenarios list
 http:
   routers:
     # ════════════════════════════════════════════════════
-    # Public service (no auth)
+    # Authelia-protected service (live example: Grafana)
+    # Mirrors the actual grafana-secure router in routers.yml
     # ════════════════════════════════════════════════════
-    homepage-router:
-      rule: "Host(`home.patriark.org`)"
+    grafana-secure:
+      rule: "Host(`grafana.patriark.org`)"
+      service: "grafana"
+      entryPoints:
+        - websecure
       middlewares:
         - crowdsec-bouncer@file
-        - rate-limit-public@file
-        - compression@file
-        - security-headers-public@file
-      service: homepage-service
+        - rate-limit@file
+        - authelia@file
+      tls:
+        certResolver: letsencrypt
     
     # ════════════════════════════════════════════════════
     # Standard authenticated service

--- a/docs/00-foundation/guides/quadlets-vs-generated-units-comparison.md
+++ b/docs/00-foundation/guides/quadlets-vs-generated-units-comparison.md
@@ -4,7 +4,7 @@ title: "Quadlets vs Generated Systemd Services"
 description: "Comparison guide arguing why systemd quadlets are preferable to podman-generated systemd units for declarative, maintainable container management."
 sensitivity: public
 created: 2025-10-31
-updated: 2025-12-22
+updated: 2026-07-20
 ---
 
 # Quadlets vs Generated Systemd Services
@@ -37,16 +37,19 @@ ExecStart=/usr/bin/podman run --cidfile=%t/%n.ctr-id --cgroups=no-conmon...
 ExecStop=/usr/bin/podman stop --ignore --cidfile=%t/%n.ctr-id
 ```
 
-### 4. **Auto-Update Support**
+### 4. **Auto-Update Support (capability — deliberately disabled here)**
+Quadlets support built-in auto-updates:
 ```ini
 [Container]
-AutoUpdate=registry  # Built-in support!
+AutoUpdate=registry  # Supported by quadlets — NOT used in this project
 ```
 
-Then use:
-```bash
-podman auto-update  # Updates all containers with AutoUpdate=registry
-```
+This project deliberately does **not** use it (ADR-030, Container Supply-Chain
+Trust Model). Every image is digest-pinned (`tag@sha256:...`), all
+`AutoUpdate=registry` lines are stripped, and updates happen through a
+deliberate monthly loop (`scripts/monthly-update.sh`) with a cooling-off bake
+policy — not `podman auto-update`. The capability exists; the trust model
+chooses not to exercise it.
 
 ### 5. **Better Dependency Management**
 ```ini

--- a/docs/10-services/guides/alert-discord-relay.md
+++ b/docs/10-services/guides/alert-discord-relay.md
@@ -4,7 +4,7 @@ title: "Alert Discord Relay"
 description: "Service guide for the custom-built Python relay that converts Alertmanager webhooks into color-coded Discord embeds, covering management and health checks."
 sensitivity: public
 created: 2026-02-05
-updated: 2026-02-05
+updated: 2026-07-20
 ---
 
 # Alert Discord Relay
@@ -171,13 +171,15 @@ The Discord webhook URL is injected via Podman secret:
 ```bash
 # View existing secret
 podman secret ls | grep discord
+```
 
-# Update the webhook URL
-echo "https://discord.com/api/webhooks/..." | podman secret create discord_webhook_url -
+The `discord_webhook_url` secret is provisioned from the OpenBao substrate and synced
+into podman secrets automatically (ADR-041). Update the webhook URL via the htpc-mgmt
+`secretctl` tool — never manual `podman secret create`/`rm`; the `Secret=` handle in
+the quadlet is unchanged. See `../../30-security/guides/secrets-management.md`.
+After rotation:
 
-# If updating, remove old secret first
-podman secret rm discord_webhook_url
-echo "https://discord.com/api/webhooks/..." | podman secret create discord_webhook_url -
+```bash
 systemctl --user restart alert-discord-relay.service
 ```
 

--- a/docs/10-services/guides/crowdsec.md
+++ b/docs/10-services/guides/crowdsec.md
@@ -4,7 +4,7 @@ title: "CrowdSec Security Engine"
 description: "Service guide for the CrowdSec security engine — crowdsourced IP-reputation blocking via the Traefik bouncer, with management and cscli reference."
 sensitivity: public
 created: 2025-11-07
-updated: 2025-12-23
+updated: 2026-07-20
 ---
 
 # CrowdSec Security Engine
@@ -193,13 +193,17 @@ podman exec crowdsec cscli scenarios list
 
 **Create/update:**
 ```bash
-# Inside CrowdSec
+# Inside CrowdSec — generates the bouncer API key
 podman exec crowdsec cscli bouncers add traefik-bouncer
+```
 
-# Returns API key - store in secret
-echo "KEY" | podman secret create crowdsec_api_key -
+The `crowdsec_api_key` podman secret is provisioned from the OpenBao substrate and
+synced automatically (ADR-041). Store the generated key via the htpc-mgmt `secretctl`
+tool — never manual `podman secret create`/`rm`; the `Secret=` handle in the Traefik
+quadlet is unchanged. See `../../30-security/guides/secrets-management.md`.
+Then restart Traefik to pick up the new key:
 
-# Restart Traefik to pick up new key
+```bash
 systemctl --user restart traefik.service
 ```
 

--- a/docs/10-services/guides/esp32-plejd-quick-start.md
+++ b/docs/10-services/guides/esp32-plejd-quick-start.md
@@ -4,7 +4,7 @@ title: "ESP32 Bluetooth Proxy - Quick Start Guide"
 description: "Quick-start for flashing an ESP32 as an ESPHome Bluetooth proxy to bridge Plejd lighting into Home Assistant across the IoT VLAN."
 sensitivity: public
 created: 2026-02-04
-updated: 2026-02-04
+updated: 2026-07-20
 ---
 
 # ESP32 Bluetooth Proxy - Quick Start Guide
@@ -143,4 +143,4 @@ After successful setup:
 
 ## Full Documentation
 
-See: `docs/98-journals/2026-02-04-esp32-bluetooth-proxy-for-plejd-integration.md`
+Full setup and decision analysis are recorded in the internal vault journal (2026-02-04).

--- a/docs/10-services/guides/home-assistant.md
+++ b/docs/10-services/guides/home-assistant.md
@@ -4,7 +4,7 @@ title: "Home Assistant - Production System Guide"
 description: "Production system guide for the Home Assistant deployment — its automations, integrated devices, integration strategy, and configuration structure."
 sensitivity: public
 created: 2026-01-31
-updated: 2026-02-01
+updated: 2026-07-20
 ---
 
 # Home Assistant - Production System Guide
@@ -452,6 +452,10 @@ podman logs home-assistant 2>&1 | grep -i error
 
 **Approach:** Matter motion sensors (Sep 2026 when Thread support mature)
 
+**Note (2026-07-20):** The python-matter-server container was decommissioned
+2026-05-18, pending a matter.js-based successor. The Matter-based trajectories
+(2 and 3) are on hold until that successor is deployed.
+
 **Steps:**
 1. **Install Matter motion sensors** (3-5 sensors for key rooms)
 2. **Room occupancy tracking:**
@@ -723,7 +727,6 @@ template:
 - Mill: https://www.home-assistant.io/integrations/mill/
 
 **Local Documentation:**
-- Journals: `/docs/98-journals/` (chronological history)
 - Roborock setup: `/docs/10-services/guides/roborock-room-cleaning-setup.md`
 - iOS Shortcuts: `/docs/10-services/guides/ios-shortcuts-quick-reference.md`
 - Completion summary: `/docs/ROBOROCK-IMPLEMENTATION-COMPLETE.md`

--- a/docs/10-services/guides/immich-configuration-review.md
+++ b/docs/10-services/guides/immich-configuration-review.md
@@ -4,7 +4,7 @@ title: "Immich Configuration Review & Optimization Report"
 description: "Configuration audit of the Immich deployment against design principles, scoring seven categories and flagging critical security and performance gaps."
 sensitivity: public
 created: 2025-11-23
-updated: 2026-02-28
+updated: 2026-07-20
 ---
 
 # Immich Configuration Review & Optimization Report
@@ -978,9 +978,10 @@ Wants=network-online.target
 Requires=photos-network.service postgresql-immich.service redis-immich.service
 
 [Container]
-Image=ghcr.io/immich-app/immich-server:v2.3.1
+# Digest-pinned per ADR-030 (tag = discovery handle, digest = execution contract);
+# updates flow through the deliberate monthly loop (scripts/monthly-update.sh), never AutoUpdate
+Image=ghcr.io/immich-app/immich-server@sha256:c15bff75068effb03f4355997d03dc7e0fc58720c2b54ad6f7f10d1bc57efaa5
 ContainerName=immich-server
-AutoUpdate=registry
 
 # ═══════════════════════════════════════════════
 # SECURITY: Run as non-root user

--- a/docs/10-services/guides/immich-deployment-checklist.md
+++ b/docs/10-services/guides/immich-deployment-checklist.md
@@ -4,7 +4,7 @@ title: "Immich Deployment Checklist"
 description: "Historical step-by-step checklist for the November 2025 Immich deployment, covering network, database, and storage setup (predates the Authelia migration)."
 sensitivity: public
 created: 2025-12-31
-updated: 2025-12-31
+updated: 2026-07-20
 ---
 
 # Immich Deployment Checklist
@@ -141,40 +141,20 @@ updated: 2025-12-31
   ls -la /mnt/btrfs-pool/subvol8-photos
   ```
 
-### Phase 3: Secrets Creation (15 minutes)
+### Phase 3: Secrets Provisioning (15 minutes)
 
-- [ ] **Generate strong passwords**
+- [ ] **Provision secrets via OpenBao substrate (ADR-041)**
 
-  ```bash
-  POSTGRES_PW=$(openssl rand -base64 32)
-  REDIS_PW=$(openssl rand -base64 32)
-  JWT_SECRET=$(openssl rand -base64 32)
+  Runtime secrets (`postgres-password`, `redis-password`, `immich-jwt-secret`) are
+  sourced from the OpenBao substrate and synced into podman secrets automatically.
+  Creation and rotation happen via the htpc-mgmt `secretctl` tool — never manual
+  `podman secret create`/`rm`. The `Secret=` handles in the quadlets below are
+  unchanged. See `../../30-security/guides/secrets-management.md`.
 
-  # Display for verification (DO NOT commit to Git)
-  echo "PostgreSQL password: $POSTGRES_PW"
-  echo "Redis password: $REDIS_PW"
-  echo "JWT secret: $JWT_SECRET"
-  ```
-
-- [ ] **Create Podman secrets**
-
-  ```bash
-  echo -n "$POSTGRES_PW" | podman secret create postgres-password -
-  echo -n "$REDIS_PW" | podman secret create redis-password -
-  echo -n "$JWT_SECRET" | podman secret create immich-jwt-secret -
-  ```
-
-- [ ] **Verify secrets created**
+- [ ] **Verify secrets present**
 
   ```bash
   podman secret ls | grep -E 'postgres-password|redis-password|immich-jwt-secret'
-  ```
-
-- [ ] **Store backup of secrets securely** (NOT in Git)
-
-  ```bash
-  # Example: Use password manager or encrypted vault
-  # DO NOT: echo "$POSTGRES_PW" > secrets.txt
   ```
 
 ### Phase 4: PostgreSQL Deployment (45 minutes)
@@ -190,9 +170,10 @@ updated: 2025-12-31
   Requires=systemd-photos-network.service
 
   [Container]
-  Image=ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0
+  # Digest-pinned per ADR-030 (tag = discovery handle, digest = execution contract);
+  # updates flow through the deliberate monthly loop (scripts/monthly-update.sh), never auto-update
+  Image=ghcr.io/immich-app/postgres@sha256:bcf63357191b76a916ae5eb93464d65c07511da41e3bf7a8416db519b40b1c23
   ContainerName=postgresql-immich
-  AutoUpdate=registry
 
   # Network
   Network=systemd-photos.network
@@ -273,9 +254,9 @@ updated: 2025-12-31
   Requires=systemd-photos-network.service
 
   [Container]
-  Image=docker.io/valkey/valkey:8
+  # Digest-pinned per ADR-030 — no AutoUpdate
+  Image=docker.io/valkey/valkey@sha256:4963247afc4cd33c7d3b2d2816b9f7f8eeebab148d29056c2ca4d7cbc966f2d9
   ContainerName=redis-immich
-  AutoUpdate=registry
 
   # Network
   Network=systemd-photos.network
@@ -378,9 +359,9 @@ updated: 2025-12-31
   Requires=postgresql-immich.service redis-immich.service
 
   [Container]
-  Image=ghcr.io/immich-app/immich-server:release
+  # Digest-pinned per ADR-030 — no AutoUpdate
+  Image=ghcr.io/immich-app/immich-server@sha256:c15bff75068effb03f4355997d03dc7e0fc58720c2b54ad6f7f10d1bc57efaa5
   ContainerName=immich-server
-  AutoUpdate=registry
 
   # Networks
   Network=systemd-photos.network
@@ -474,9 +455,9 @@ updated: 2025-12-31
   Requires=systemd-photos-network.service
 
   [Container]
-  Image=ghcr.io/immich-app/immich-machine-learning:release
+  # Digest-pinned per ADR-030 — no AutoUpdate
+  Image=ghcr.io/immich-app/immich-machine-learning@sha256:a2501141440f10516d329fdfba2c68082e19eb9ba6016c061ac80d23beadf7f3
   ContainerName=immich-ml
-  AutoUpdate=registry
 
   # Network
   Network=systemd-photos.network
@@ -786,6 +767,11 @@ updated: 2025-12-31
 
 ## Week 2 Day 5: Backup Integration (1 hour)
 
+> **Historical:** the `btrfs-snapshot-backup.sh` script below was retired when
+> [Urd](https://github.com/vonrobak/urd) (ADR-021) became the sole backup system
+> (2026-03-25); the pg_dump backbone is now governed by ADR-029. Kept as a record
+> of the original deployment.
+
 ### Backup Script Updates
 
 - [ ] **Update BTRFS backup script**
@@ -973,9 +959,8 @@ updated: 2025-12-31
   - Backup procedures
   - Upgrade process
 
-- [ ] **Update system state report**
+- [ ] **Update system state report** (internal vault)
 
-  `docs/99-reports/YYYY-MM-DD-system-state.md`:
   - Add Immich to service inventory
   - Update resource usage
   - Update backup strategy section

--- a/docs/10-services/guides/immich-ml-troubleshooting.md
+++ b/docs/10-services/guides/immich-ml-troubleshooting.md
@@ -4,7 +4,7 @@ title: "Immich ML Troubleshooting Guide"
 description: "Troubleshooting guide for the immich-ml machine-learning container reporting unhealthy status, with log-inspection and diagnostic steps."
 sensitivity: public
 created: 2025-11-09
-updated: 2025-11-09
+updated: 2026-07-20
 ---
 
 # Immich ML Troubleshooting Guide
@@ -398,7 +398,6 @@ Based on snapshot data and common Immich ML issues:
 - [Immich ML Documentation](https://immich.app/docs/features/ml-face-detection)
 - [Immich GitHub Issues - ML troubleshooting](https://github.com/immich-app/immich/issues?q=is%3Aissue+ml)
 - Project: `docs/10-services/decisions/2025-11-08-immich-deployment-architecture.md`
-- Snapshot: `docs/99-reports/snapshot-20251109-172016.json`
 
 ---
 

--- a/docs/10-services/guides/immich.md
+++ b/docs/10-services/guides/immich.md
@@ -4,7 +4,7 @@ title: "Immich Photo Management Service"
 description: "Service guide for the Immich photo/video management stack — its four containers, features, deployment details, and management commands."
 sensitivity: public
 created: 2025-11-10
-updated: 2026-02-08
+updated: 2026-07-20
 ---
 
 # Immich Photo Management Service
@@ -39,7 +39,7 @@ Immich is a **self-hosted photo and video management solution** designed as an a
 | immich-server | ghcr.io/immich-app/immich-server:v2.5.5 | 4G | ~280MB |
 | immich-ml | ghcr.io/immich-app/immich-machine-learning:v2.5.5 | 4G | ~19MB idle |
 | postgresql-immich | tensorchord/cloudnative-pgvecto.rs:14-v0.4.0 | 1G | ~32MB |
-| redis-immich | valkey:latest | 512M | ~13MB |
+| redis-immich | docker.io/valkey/valkey (digest-pinned, ADR-030) | 512M | ~13MB |
 
 ---
 

--- a/docs/10-services/guides/jellyfin.md
+++ b/docs/10-services/guides/jellyfin.md
@@ -4,13 +4,13 @@ title: "Jellyfin Media Server"
 description: "Service guide for the Jellyfin media server — hardware-accelerated transcoding, Traefik HTTPS access, libraries, and management commands."
 sensitivity: public
 created: 2025-11-07
-updated: 2025-12-23
+updated: 2026-07-20
 ---
 
 # Jellyfin Media Server
 
 **Last Updated:** 2025-11-14
-**Version:** Latest (auto-update enabled)
+**Version:** Digest-pinned (ADR-030 — deliberate updates via `scripts/monthly-update.sh`)
 **Status:** Production
 **Networks:** reverse_proxy, media_services
 
@@ -589,7 +589,7 @@ systemctl --user start jellyfin.service
 rsync jellyfin-config-*.tar.gz backup-server:/backups/
 ```
 
-**Automated:** Use `scripts/btrfs-snapshot-backup.sh` (backs up relevant subvolumes)
+**Automated:** [Urd](https://github.com/vonrobak/urd) (ADR-021) snapshots and backs up the relevant subvolumes
 
 ### Restore Procedure
 
@@ -708,35 +708,34 @@ Dashboard → Playback:
 
 ## Upgrade Procedure
 
-**Auto-update enabled** (`AutoUpdate=registry` in quadlet)
+**Digest-pinned, deliberate updates (ADR-030/036).** The quadlet pins the image by
+digest (`Image=docker.io/jellyfin/jellyfin@sha256:...` — tag is the discovery handle,
+digest the execution contract). `AutoUpdate` is stripped fleet-wide; nothing updates
+automatically.
 
-**Automatic upgrades:**
-- Podman auto-update.timer checks daily
-- Pulls new `jellyfin/jellyfin:latest` image
-- Restarts container if new version available
-
-**Manual upgrade:**
+**Monthly update loop:**
 ```bash
-# 1. Pull latest image
-podman pull docker.io/jellyfin/jellyfin:latest
+# Single entry point (discover → bake → adopt, interactive)
+~/containers/scripts/monthly-update.sh
 
-# 2. Restart service
+# Or the individual steps:
+~/containers/scripts/check-image-updates.sh          # discover (notify-only, bake policy annotated)
+~/containers/scripts/adopt-baked.sh --dry-run        # adopt baked updates (wave-ordered)
+```
+
+**Single-service update:**
+```bash
+~/containers/scripts/pin-container-image.sh jellyfin --adopt <digest> --apply
+systemctl --user daemon-reload
 systemctl --user restart jellyfin.service
 
-# 3. Verify new version
+# Verify new version
 curl http://localhost:8096/System/Info/Public | grep Version
 ```
 
 **Rollback if issues:**
 ```bash
-# 1. Find previous image
-podman images | grep jellyfin
-
-# 2. Update quadlet to specific version
-# Change: Image=docker.io/jellyfin/jellyfin:latest
-# To: Image=docker.io/jellyfin/jellyfin:10.8.13
-
-# 3. Restart
+# git revert the digest line in the quadlet, then:
 systemctl --user daemon-reload
 systemctl --user restart jellyfin.service
 ```

--- a/docs/10-services/guides/nextcloud.md
+++ b/docs/10-services/guides/nextcloud.md
@@ -4,7 +4,7 @@ title: "Nextcloud Service Guide"
 description: "Service guide for the Nextcloud file-sync stack (Nextcloud + MariaDB + Redis) — access endpoints, CalDAV/CardDAV/WebDAV, and service management."
 sensitivity: public
 created: 2025-12-21
-updated: 2026-02-06
+updated: 2026-07-20
 ---
 
 # Nextcloud Service Guide
@@ -296,24 +296,20 @@ podman secret inspect nextcloud_db_password
 ```
 
 **Rotate Secret:**
+
+Runtime secrets are provisioned from the OpenBao substrate and synced into podman
+secrets automatically (ADR-041). Creation and rotation happen via the htpc-mgmt
+`secretctl` tool — never manual `podman secret create`/`rm` on this host. The
+`Secret=` handles in the quadlets are unchanged. After rotating
+`nextcloud_db_password` via `secretctl`, update the database to match and restart:
+
 ```bash
-# 1. Generate new password
-NEW_PASSWORD=$(openssl rand -base64 32)
-
-# 2. Remove old secret
-systemctl --user stop nextcloud.service
-podman secret rm nextcloud_db_password
-
-# 3. Create new secret
-echo -n "${NEW_PASSWORD}" | podman secret create nextcloud_db_password -
-
-# 4. Update database password
-podman exec nextcloud-db mysql -u root -e "ALTER USER 'nextcloud'@'%' IDENTIFIED BY '${NEW_PASSWORD}';"
-
-# 5. Restart services
-systemctl --user daemon-reload
-systemctl --user start nextcloud.service
+# Update database password to the rotated value, then:
+podman exec nextcloud-db mysql -u root -e "ALTER USER 'nextcloud'@'%' IDENTIFIED BY '<rotated-password>';"
+systemctl --user restart nextcloud.service
 ```
+
+See `../../30-security/guides/secrets-management.md`.
 
 ---
 
@@ -638,8 +634,8 @@ podman exec crowdsec cscli decisions list
 # Vulnerability scanning
 ~/containers/scripts/scan-vulnerabilities.sh --severity CRITICAL,HIGH
 
-# Check for updates
-podman auto-update --dry-run
+# Check for image updates (ADR-030/036 deliberate update loop — notify-only)
+~/containers/scripts/check-image-updates.sh
 ```
 
 ---

--- a/docs/10-services/guides/pattern-customization-guide.md
+++ b/docs/10-services/guides/pattern-customization-guide.md
@@ -4,7 +4,7 @@ title: "Pattern Customization Guide"
 description: "Guide for safely customizing pattern-generated quadlets after deployment, covering when to customize and how to preserve changes through updates."
 sensitivity: public
 created: 2025-11-14
-updated: 2025-12-31
+updated: 2026-07-20
 ---
 
 # Pattern Customization Guide
@@ -125,12 +125,12 @@ AddDevice=/dev/dri/renderD128
 
 # Before:
 # [Container]
-# Image=jellyfin/jellyfin:latest
+# Image=docker.io/jellyfin/jellyfin@sha256:aefb67e6a7ff1debdd154a78a7bbb780fd0c873d8639210a7f6a2016ad2b35db
 # ...
 
 # After:
 # [Container]
-# Image=jellyfin/jellyfin:latest
+# Image=docker.io/jellyfin/jellyfin@sha256:aefb67e6a7ff1debdd154a78a7bbb780fd0c873d8639210a7f6a2016ad2b35db
 # AddDevice=/dev/dri/renderD128
 # ...
 
@@ -593,7 +593,7 @@ grep "AddDevice" ~/.config/containers/systemd/jellyfin.container
 **Documentation example:**
 ```ini
 [Container]
-Image=jellyfin/jellyfin:latest
+Image=docker.io/jellyfin/jellyfin@sha256:aefb67e6a7ff1debdd154a78a7bbb780fd0c873d8639210a7f6a2016ad2b35db
 # CUSTOMIZATION: GPU passthrough for hardware transcoding
 AddDevice=/dev/dri/renderD128
 ```
@@ -607,7 +607,7 @@ AddDevice=/dev/dri/renderD128
 **Add comments to quadlet:**
 ```ini
 [Container]
-Image=jellyfin/jellyfin:latest
+Image=docker.io/jellyfin/jellyfin@sha256:aefb67e6a7ff1debdd154a78a7bbb780fd0c873d8639210a7f6a2016ad2b35db
 
 # CUSTOMIZATION 2025-11-14: GPU transcoding
 AddDevice=/dev/dri/renderD128

--- a/docs/10-services/guides/roborock-room-cleaning-setup.md
+++ b/docs/10-services/guides/roborock-room-cleaning-setup.md
@@ -460,7 +460,6 @@ curl -X GET "https://ha.patriark.org/api/webhook/clean_living_room"
 ## Related Documentation
 
 - [Home Assistant Automation Catalog](./home-assistant-automations.md) - Complete automation reference
-- [Learning Journey Journal](../../98-journals/2026-01-31-learning-journey-completion.md) - Implementation summary
 - [Roborock Room Cleaning - HA Community](https://community.home-assistant.io/t/roborock-room-cleaning/589015) - Community discussion
 - [Control Roborock with Siri via HA](https://noahtallen.com/2025/05/18/controlling-roborock-vacuums-with-siri-nfc-via-home-assistant/) - External guide
 

--- a/docs/10-services/guides/skill-recommendation.md
+++ b/docs/10-services/guides/skill-recommendation.md
@@ -4,7 +4,7 @@ title: "Skill Recommendation Engine"
 description: "Reference for the recommend-skill.sh engine that classifies requests and scores confidence to suggest the most appropriate Claude skill."
 sensitivity: public
 created: 2025-11-30
-updated: 2025-11-30
+updated: 2026-07-20
 ---
 
 # Skill Recommendation Engine
@@ -298,6 +298,5 @@ new-skill)
 
 ## References
 
-- Session 5D Plan: `docs/99-reports/SESSION-5D-SKILL-RECOMMENDATION-ENGINE-PLAN.md`
 - Autonomous Operations: `docs/20-operations/guides/autonomous-operations.md`
 - Available Skills: `.claude/skills/*/SKILL.md`

--- a/docs/10-services/guides/traefik.md
+++ b/docs/10-services/guides/traefik.md
@@ -4,7 +4,7 @@ title: "Traefik Reverse Proxy"
 description: "Service guide for the Traefik reverse proxy — HTTPS, Let's Encrypt, security middleware, and the ADR-016 rule that all routing lives in dynamic config."
 sensitivity: public
 created: 2025-11-07
-updated: 2025-12-31
+updated: 2026-07-20
 ---
 
 # Traefik Reverse Proxy
@@ -483,13 +483,13 @@ podman healthcheck run traefik  # If health check defined
 - **Never commit to git!**
 
 **Create/update secret:**
-```bash
-# Create
-echo "your-api-key" | podman secret create crowdsec_api_key -
 
-# Update (must recreate)
-podman secret rm crowdsec_api_key
-echo "new-api-key" | podman secret create crowdsec_api_key -
+The `crowdsec_api_key` podman secret is provisioned from the OpenBao substrate and
+synced automatically (ADR-041). Create/rotate it via the htpc-mgmt `secretctl` tool —
+never manual `podman secret create`/`rm`; the `Secret=` handle in the quadlet is
+unchanged. See `../../30-security/guides/secrets-management.md`. After rotation:
+
+```bash
 systemctl --user restart traefik.service
 ```
 

--- a/docs/10-services/guides/vaultwarden-deployment.md
+++ b/docs/10-services/guides/vaultwarden-deployment.md
@@ -4,7 +4,7 @@ title: "Vaultwarden Deployment Guide"
 description: "Deployment guide for Vaultwarden — SQLite backend, YubiKey/TOTP 2FA, strict rate limiting, and pattern-based versus manual deployment steps."
 sensitivity: public
 created: 2025-11-12
-updated: 2025-11-14
+updated: 2026-07-20
 ---
 
 # Vaultwarden Deployment Guide
@@ -320,8 +320,7 @@ systemctl --user is-enabled vaultwarden.service
 ### Step 13: Verify Backups Include Vaultwarden
 
 ```bash
-# Run backup manually (with local-only flag)
-~/fedora-homelab-containers/scripts/btrfs-snapshot-backup.sh --local-only --verbose
+# Backups run automatically via Urd (ADR-021) — verify the latest snapshot exists
 
 # Check snapshot includes Vaultwarden data
 sudo btrfs subvolume list /mnt/btrfs-pool | grep containers
@@ -613,14 +612,19 @@ nano ~/.config/containers/systemd/vaultwarden.container
 
 ## Updating Vaultwarden
 
-Vaultwarden is configured for automatic updates (`AutoUpdate=registry` in quadlet).
+Vaultwarden's image is digest-pinned in the quadlet
+(`Image=docker.io/vaultwarden/server@sha256:...` — tag is the discovery handle,
+digest the execution contract). `AutoUpdate` is stripped fleet-wide (ADR-030);
+updates happen through the deliberate monthly loop (ADR-036).
 
-**Manual update:**
+**Update:**
 ```bash
-# Pull latest image
-podman pull docker.io/vaultwarden/server:latest
+# Monthly loop (discover → bake → adopt)
+~/containers/scripts/monthly-update.sh
 
-# Recreate container with new image
+# Or single-service:
+~/containers/scripts/pin-container-image.sh vaultwarden --adopt <digest> --apply
+systemctl --user daemon-reload
 systemctl --user restart vaultwarden.service
 
 # Verify update
@@ -630,7 +634,7 @@ podman logs vaultwarden | grep -i version
 
 **Update process:**
 1. Automatic backup (happens daily at 02:00 AM)
-2. Pull new image
+2. Adopt the new digest (baked per `config/supply-chain/bake-policy.yml`)
 3. Restart service
 4. Verify service healthy
 5. Test login with 2FA

--- a/docs/20-operations/guides/architecture-diagrams.md
+++ b/docs/20-operations/guides/architecture-diagrams.md
@@ -391,113 +391,35 @@ Legend:
 ```
 /home/patriark/containers/
 │
-├── config/                          # Service configurations
+├── quadlets/                        # Systemd quadlet unit files (37 containers,
+│   │                                #  12 .network files) — the deployment layer
+│   ├── <service>.container          # One quadlet per container, digest-pinned images
+│   └── <name>.network               # Podman network definitions
+│
+├── config/                          # Service configurations (one dir per service)
 │   ├── traefik/
-│   │   ├── traefik.yml             # Static configuration
-│   │   ├── dynamic/                # Dynamic configurations
-│   │   │   ├── routers.yml         # Route definitions
-│   │   │   ├── middleware.yml      # Security & auth
-│   │   │   ├── tls.yml             # TLS options
-│   │   │   └── rate-limit.yml      # Rate limiting rules
-│   │   ├── letsencrypt/            # SSL certificates
-│   │   │   └── acme.json           # Let's Encrypt data
-│   │   └── certs/                  # (deprecated)
-│   │
-│   ├── crowdsec/                   # CrowdSec config (auto-generated)
-│   ├── jellyfin/                   # Jellyfin configuration
-│   └── tinyauth/                   # (config via env vars)
+│   │   ├── traefik.yml              # Static configuration
+│   │   └── dynamic/                 # Dynamic config (auto-reloads)
+│   │       ├── routers.yml          # ALL routing rules (ADR-016: never in labels)
+│   │       ├── middleware.yml       # CrowdSec, rate limiting, auth, headers
+│   │       └── tls.yml              # TLS options
+│   ├── prometheus/ | grafana/ | loki/ | alertmanager/   # Monitoring stack
+│   ├── supply-chain/                # Bake policy, egress baselines (ADR-030/036/039)
+│   └── <service>/                   # Per-service config dirs
 │
-├── data/                           # Persistent service data
-│   ├── crowdsec/
-│   │   ├── db/                     # Decision database
-│   │   └── config/                 # Runtime config
-│   ├── jellyfin/                   # Media library metadata
-│   └── nextcloud/                  # (to be created)
+├── scripts/                         # Automation (85 scripts — see automation-reference.md)
 │
-├── scripts/                        # Automation scripts
-│   ├── cloudflare-ddns.sh         # DNS updater - with cron or systemd (do not remember) jobs to update every 30 mins
-│   ├── security-audit.sh          # Security checker
-│   └── health-check.sh            # System health
+├── data/                            # Persistent service data (bind mounts, :Z labels)
 │
-├── secrets/                        # Sensitive data (chmod 600)
-│   ├── cloudflare_token           # API token
-│   └── cloudflare_zone_id         # Zone ID
+├── docs/                            # Public documentation (this tree — see docs/README.md)
+│   ├── 00-40 sections               # Guides + ADRs + runbooks
+│   └── AUTO-*.md                    # Auto-generated daily views
 │
-├── backups/                        # Configuration backups
-│   ├── phase1-TIMESTAMP/          # Authelia migration backup
-│   ├── config-YYYYMMDD/           # Regular config backups
-│   └── pre-change-TIMESTAMP/      # Pre-change snapshots
-│
-├── docs/                  # Documentation
-├──     00-foundation/
-│       ├── day01-learnings.md
-│       ├── day02-networking.md
-│       ├── day03-pod-commands.md
-│       ├── day03-pods.md
-│       ├── day03-pods-vs-containers.md
-│       └── podman-cheatsheet.md
-├──     10-services/
-│       ├── day04-jellyfin-final.md
-│       ├── day06-complete.md
-│       ├── day06-quadlet-success.md
-│       ├── day06-traefik-routing.md
-│       ├── day07-yubikey-inventory.md
-│       └── quadlets-vs-generated.md
-├──     20-operations/
-│       ├── 20251023-storage_data_architecture_revised.md
-│       ├── DAILY-PROGRESS-2025-10-23.md
-│       ├── HOMELAB-ARCHITECTURE-DIAGRAMS.md
-│       ├── HOMELAB-ARCHITECTURE-DOCUMENTATION.md
-│       ├── NEXTCLOUD-INSTALLATION-GUIDE.md
-│       ├── QUICK-REFERENCE.md
-│       ├── readme-week02.md
-│       ├── storage-layout.md
-│       └── TODAYS-ACHIEVEMENTS.md
-├──     30-security/
-│       └── TINYAUTH-GUIDE.md
-├──     90-archive/
-│       ├── 20251024-storage_data_architecture-and-2fa-proposal.md
-│       ├── 2025-10-24-storage_data_architecture_tailored_addendum.md
-│       ├── checklist-week02.md
-│       ├── DOMAIN-CHANGE-SUMMARY.md
-│       ├── progress.md
-│       ├── quick-reference.bak-20251021-172023.md
-│       ├── quick-reference.bak-20251021-221915.md
-│       ├── quick-reference.md
-│       ├── quick-reference-v2.md
-│       ├── quick-start-guide-week02.md
-│       ├── readme.bak-20251021-172023.md
-│       ├── readme.bak-20251021-221915.md
-│       ├── readme.md
-│       ├── revised-learning-plan.md
-│       ├── SCRIPT-EXPLANATION.md
-│       ├── summary-revised.md
-│       ├── TOMORROW-QUICK-START.md
-│       ├── week02-failed-authelia-but-tinyauth-goat.md
-│       ├── week02-implementation-plan.md
-│       └── week02-security-and-tls.md
-└── 99-reports/
-        ├── 20251024-configurations-quadlets-and-more.md
-        ├── 20251025-storage-architecture-authoritative.md
-        ├── 20251025-storage-architecture-authoritative-rev2.md
-        ├── authelia-diag-20251020-183321.txt
-        ├── failed-authelia-adventures-of-week-02-current-state-of-system.md
-        ├── homelab-diagnose-20251021-165859.txt
-        ├── latest-summary.md
-        ├── pre-letsencrypt-diag-20251022-161247.txt
-        ├── script2-week2-authelia-dual-domain.md
-        └── system-state-20251022-213400.txt
-
-/home/patriark/.config/containers/systemd/          # quadlet configuration directory
-├── auth_services.network           # podman bridge network - currently idle with no services
-├── crowdsec.container              # CrowdSec service definition
-├── jellyfin.container              # Jellyfin service definition
-├── media_services.network          # Media Services podman bridge network
-├── reverse_proxy.network           # Reverse Proxy podman bridge network - members: all
-├── authelia.container              # Authelia SSO service definition
-├── redis-authelia.container        # Redis for Authelia sessions
-└── traefik.container               # Traefik service definition
+├── builds/                          # Local image builds (Tier 2, digest-pinned bases)
+├── backups/  cache/  systemd/       # Operational directories
+└── secrets/                         # Gitignored (runtime secrets come from OpenBao, ADR-041)
 ```
+
 
 ---
 

--- a/docs/20-operations/guides/automation-reference.md
+++ b/docs/20-operations/guides/automation-reference.md
@@ -4,7 +4,7 @@ title: "Automation Reference Guide"
 description: "Authoritative reference cataloging all automation scripts, scheduled timers, deployment scripts, and remediation playbooks with a which-script-do-I-use decision tree."
 sensitivity: public
 created: 2025-11-28
-updated: 2026-06-22
+updated: 2026-07-20
 ---
 
 # Automation Reference Guide
@@ -55,8 +55,7 @@ What do you need to do?
 │       (orchestrates: state manifest → graceful shutdown → pinned-image presence → prune)
 │
 ├─ Manage backups?
-│   ├─ Daily/weekly snapshots → ./scripts/btrfs-snapshot-backup.sh
-│   ├─ Monitor transfer → ./scripts/monitor-btrfs-transfer.sh
+│   ├─ Snapshots + external sync → Urd (https://github.com/vonrobak/urd, ADR-021; urd-backup.timer)
 │   └─ Test restore → ./scripts/test-backup-restore.sh
 │
 ├─ Regenerate documentation?
@@ -100,7 +99,7 @@ systemctl --user start <name>.service                 # Trigger manually
 | Timer | Schedule | Script | Purpose |
 |-------|----------|--------|---------|
 | `daily-slo-snapshot` | 23:50 | `daily-slo-snapshot.sh` | Capture SLO metrics for trend analysis |
-| `btrfs-backup-daily` | 02:00 | `btrfs-snapshot-backup.sh --local-only` | Local BTRFS snapshots |
+| `urd-backup` | ~04:00 | Urd (ADR-021) | BTRFS snapshots + external sync |
 | `predictive-maintenance-check` | 06:00 | Remediation: `predictive-maintenance` | Forecast resource exhaustion 7-14 days ahead |
 | `daily-drift-check` | ~06:00 | `daily-drift-check.sh` | Config drift detection → digest |
 | `dependency-discovery` | ~06:00 | `discover-dependencies.sh` | Map service dependencies from quadlets + networks |
@@ -115,8 +114,6 @@ systemctl --user start <name>.service                 # Trigger manually
 
 | Timer | Schedule | Script | Purpose |
 |-------|----------|--------|---------|
-| `btrfs-backup-weekly` | Sat 04:00 | `btrfs-snapshot-backup.sh` | Sync snapshots to external drive |
-| `podman-auto-update-weekly` | Sun 03:00 | `podman auto-update` (with pre/post health checks) | Container image updates |
 | `database-maintenance` | Sun ~03:00 | Remediation: `database-maintenance` | PostgreSQL VACUUM, Redis analysis |
 | `maintenance-cleanup` | Sun ~03:00 | `maintenance-cleanup.sh` | Prune containers, rotate logs |
 | `vulnerability-scan` | Sun ~06:00 | `scan-vulnerabilities.sh --all --notify --quiet` | Trivy CVE scanning → Discord |
@@ -139,7 +136,7 @@ The daily automation follows a deliberate sequence:
 
 ```
 23:50  daily-slo-snapshot       (capture yesterday's SLO data)
-02:00  btrfs-backup-daily       (local snapshots while system quiet)
+04:00  urd-backup               (Urd snapshots + sync while system quiet)
 06:00  predictive-maintenance   (forecast before OODA loop)
 06:00  daily-drift-check        (detect drift → write digest status)
 06:00  dependency-discovery     (refresh dependency graph)
@@ -227,10 +224,9 @@ prepare-for-reboot.sh (orchestrator)
 
 | Script | Purpose | Notes |
 |--------|---------|-------|
-| `btrfs-snapshot-backup.sh` | Create snapshots, sync to external drive | Timer: daily + weekly |
+| [Urd](https://github.com/vonrobak/urd) | Snapshots + external sync (sole backup system, ADR-021) | Timer: `urd-backup` daily |
 | `test-backup-restore.sh` | Validate backup integrity via restore test | Timer: monthly last Sunday |
 | `collect-storage-info.sh` | Storage diagnostics | On-demand |
-| `monitor-btrfs-transfer.sh` | Monitor btrfs send/receive progress | On-demand helper |
 | `backup-pihole.sh` | Backup Pi-hole config to external drive | Manual |
 
 ### Security & Compliance

--- a/docs/20-operations/guides/autonomous-operations.md
+++ b/docs/20-operations/guides/autonomous-operations.md
@@ -4,7 +4,7 @@ title: "Autonomous Operations Guide"
 description: "Guide to the autonomous-operations OODA-loop engine — daily timer, confidence-versus-risk decision matrix, and emergency pause/stop/resume controls."
 sensitivity: public
 created: 2025-11-29
-updated: 2026-06-12
+updated: 2026-07-20
 ---
 
 # Autonomous Operations Guide
@@ -231,7 +231,6 @@ execute_disk_cleanup() {
 
 **See:**
 - Remediation framework: `~/containers/.claude/remediation/README.md`
-- Implementation report: `docs/99-reports/2025-11-30-remediation-integration-implementation.md`
 
 ## Troubleshooting
 

--- a/docs/20-operations/guides/drift-detection-workflow.md
+++ b/docs/20-operations/guides/drift-detection-workflow.md
@@ -4,7 +4,7 @@ title: "Configuration Drift Detection Workflow"
 description: "Guide to detecting and reconciling configuration drift between running containers and their quadlet definitions using check-drift.sh."
 sensitivity: public
 created: 2025-11-14
-updated: 2025-12-31
+updated: 2026-07-20
 ---
 
 # Configuration Drift Detection Workflow
@@ -22,8 +22,12 @@ updated: 2025-12-31
 
 - Quadlet file is edited but service not restarted
 - Container manually modified via `podman` commands
-- Image updated without quadlet update
+- Container running an image other than the quadlet's pinned digest (e.g. manual pull/run; there is no auto-update path anymore — ADR-030)
 - Networks or volumes changed outside quadlet
+
+In other words: drift now means the running container diverges from the worktree's
+declared (digest-pinned) config — the old "image auto-updated under us" cause no
+longer exists.
 
 **Drift detection** compares running containers against their quadlet definitions and identifies mismatches that require reconciliation.
 
@@ -339,25 +343,26 @@ done
 
 ## Common Drift Scenarios
 
-### Scenario 1: Image Update Without Quadlet Change
+### Scenario 1: Running Image Differs from Pinned Digest
 
 **Detection:**
 ```
 Service: jellyfin
   ✗ Image: DRIFT
-    Quadlet: jellyfin/jellyfin:latest
-    Running: jellyfin/jellyfin:10.8.13
+    Quadlet: docker.io/jellyfin/jellyfin:10.10.7@sha256:aefb67e6...
+    Running: docker.io/jellyfin/jellyfin@sha256:1b2c3d4e...
 ```
 
-**Cause:** Image was pulled manually or auto-updated without updating quadlet
+**Cause:** The quadlet's pinned digest was updated (e.g. `pin-container-image.sh
+--adopt` or `adopt-baked.sh`) but the service was not restarted — or the container
+was started manually from a different image. Since ADR-030 the fleet is fully
+digest-pinned with no auto-update path, so an image mismatch always means the
+running container has fallen behind (or diverged from) the applied config.
 
 **Fix:**
 ```bash
-# Option A: Update quadlet to match running
-nano ~/.config/containers/systemd/jellyfin.container
-# Change: Image=jellyfin/jellyfin:10.8.13
-
-# Option B: Restart to pull latest
+# Restart to run the digest declared in the quadlet
+systemctl --user daemon-reload
 systemctl --user restart jellyfin.service
 ```
 

--- a/docs/20-operations/guides/health-driven-operations.md
+++ b/docs/20-operations/guides/health-driven-operations.md
@@ -4,7 +4,7 @@ title: "Health-Driven Operations Guide"
 description: "Guide to using homelab-intel.sh health scoring (0-100) to inform deployment, maintenance, and troubleshooting decisions and to gate deployments."
 sensitivity: public
 created: 2025-11-14
-updated: 2025-11-14
+updated: 2026-07-20
 ---
 
 # Health-Driven Operations Guide
@@ -44,8 +44,8 @@ updated: 2025-11-14
 # JSON output (for automation)
 ./scripts/homelab-intel.sh --json
 
-# Latest report location
-ls -lt ~/containers/docs/99-reports/intel-*.json | head -1
+# JSON reports (intel-*.json) are written to the internal vault reports
+# directory (untracked) — list the newest one there to see the latest run.
 ```
 
 ### Health Score Interpretation
@@ -295,10 +295,12 @@ systemctl --user restart prometheus.service
 
 ```bash
 # Weekly health tracking
+# REPORTS_DIR = the internal vault reports directory (untracked), where
+# homelab-intel.sh writes its intel-*.json files
 for i in {1..4}; do
   date=$(date +%Y%m%d --date="$i weeks ago")
   echo "=== Week $i ==="
-  cat ~/containers/docs/99-reports/intel-${date}*.json | jq '{
+  cat "$REPORTS_DIR"/intel-${date}*.json | jq '{
     health_score: .health_score,
     disk_system: .metrics.disk_usage_system,
     disk_btrfs: .metrics.disk_usage_btrfs,
@@ -493,7 +495,8 @@ Description=Run Homelab Intelligence Scan
 
 [Service]
 Type=oneshot
-ExecStart=/home/user/containers/scripts/homelab-intel.sh --json --output /home/user/containers/docs/99-reports/intel-%Y%m%d.json
+# --output points at the internal vault reports directory (untracked)
+ExecStart=/home/user/containers/scripts/homelab-intel.sh --json --output <reports-dir>/intel-%Y%m%d.json
 
 # Enable timer
 systemctl --user enable --now health-check.timer

--- a/docs/20-operations/guides/homelab-architecture.md
+++ b/docs/20-operations/guides/homelab-architecture.md
@@ -4,14 +4,13 @@ title: "Homelab Architecture Documentation"
 description: "Comprehensive architecture reference covering network, service stack, security layers, DNS, storage, backup, monitoring, and autonomous operations."
 sensitivity: public
 created: 2025-10-31
-updated: 2026-06-22
+updated: 2026-07-20
 ---
 
 # Homelab Architecture Documentation
 
-**Last Updated:** February 5, 2026
+**Last Updated:** July 20, 2026
 **Status:** Production Ready
-**Health Score:** 100/100 (as of 2026-02-05)
 
 ---
 
@@ -36,7 +35,7 @@ updated: 2026-06-22
 
 ### Current State
 
-**Infrastructure:** 28 rootless Podman containers across 14 service groups on Fedora Linux
+**Infrastructure:** 37 rootless Podman containers across 17 service groups on Fedora Linux
 **Orchestration:** Systemd quadlets with pattern-based deployment
 **Accessibility:** Internet-accessible with 7-layer defense-in-depth security
 **Autonomous:** Daily OODA loop, predictive maintenance, drift detection
@@ -75,9 +74,9 @@ UDM Pro (gateway/firewall)
         └── Other devices
 ```
 
-### Container Networks (8 custom networks)
+### Container Networks (12 custom networks)
 
-Services are segmented across 8 Podman bridge networks based on trust boundaries.
+Services are segmented across 12 Podman bridge networks based on trust boundaries.
 Key principle: **First `Network=` line in a quadlet gets the default route** (determines internet access).
 
 ```
@@ -85,41 +84,66 @@ Key principle: **First `Network=` line in a quadlet gets the default route** (de
 │  reverse_proxy (10.89.2.0/24) — 15 containers              │
 │  Internet-facing services. Traefik routes to all backends.  │
 │  Has default route (internet access).                       │
-│  Members: traefik, crowdsec, authelia, homepage, jellyfin,  │
-│           immich-server, nextcloud, vaultwarden, grafana,   │
-│           prometheus, loki, alertmanager, gathio,           │
-│           home-assistant, alert-discord-relay                │
+│  Members: traefik, crowdsec, jellyfin, immich-server,       │
+│           nextcloud, vaultwarden, grafana, loki,            │
+│           alertmanager, gathio, home-assistant, navidrome,  │
+│           qbittorrent, proton-bridge, alert-discord-relay   │
 └─────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────┐
-│  monitoring (10.89.1.0/24) — 17 containers                 │
-│  Observability stack. Cross-network scraping.               │
+│  monitoring (10.89.4.0/24) — 14 containers                 │
+│  Observability stack (Internal=true, no internet).          │
 │  Members: prometheus, grafana, loki, promtail, alertmanager,│
-│           cadvisor, node_exporter, unpoller,                │
-│           alert-discord-relay, + most services for scraping │
+│           cadvisor, node_exporter, unpoller, blackbox-      │
+│           exporter, pihole-exporter, postgres-exporter,     │
+│           redis-authelia-exporter, redis-immich-exporter,   │
+│           alert-discord-relay                                │
+└─────────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────────┐
+│  restricted-egress (10.89.11.0/24) — 7 members (ADR-045)   │
+│  Outbound-restricted tier: internet egress dropped by an    │
+│  nft filter in the rootless netns; INBOUND still governed   │
+│  solely by Traefik routing (members stay reachable via      │
+│  cross-bridge dial).                                        │
+│  Members: prometheus, unpoller, pihole-exporter,            │
+│           blackbox-exporter, audiobookshelf, forgejo,       │
+│           authelia                                           │
 └─────────────────────────────────────────────────────────────┘
 
 ┌───────────────────────────┐  ┌──────────────────────────────┐
 │  auth_services            │  │  media_services              │
-│  (10.89.3.0/24) — 3      │  │  Jellyfin media isolation    │
-│  authelia, traefik,       │  │  Members: jellyfin           │
-│  redis-authelia           │  │                              │
+│  (10.89.3.0/24) — 3      │  │  (10.89.1.0/24)             │
+│  authelia, redis-authelia,│  │  Jellyfin media isolation    │
+│  redis-authelia-exporter  │  │  Members: jellyfin           │
 └───────────────────────────┘  └──────────────────────────────┘
 
 ┌───────────────────────────┐  ┌──────────────────────────────┐
-│  photos                   │  │  nextcloud                   │
+│  photos (10.89.5.0/24)    │  │  nextcloud (10.89.10.0/24)   │
 │  Immich stack isolation   │  │  Nextcloud ecosystem         │
-│  Members: immich-server,  │  │  Members: nextcloud,         │
-│  immich-ml, postgresql-   │  │  collabora, nextcloud-db,    │
-│  immich, redis-immich     │  │  nextcloud-redis             │
+│  immich-server, immich-ml,│  │  Members: nextcloud,         │
+│  postgresql-immich,       │  │  nextcloud-db,               │
+│  redis-immich + exporters │  │  nextcloud-redis             │
 └───────────────────────────┘  └──────────────────────────────┘
 
 ┌───────────────────────────┐  ┌──────────────────────────────┐
-│  home_automation          │  │  gathio                      │
-│  Smart home stack         │  │  Event management            │
-│  Members: home-assistant, │  │  Members: gathio, gathio-db  │
-│  matter-server            │  │                              │
+│  home_automation          │  │  gathio (10.89.0.0/24)       │
+│  (10.89.6.0/24)          │  │  Event management            │
+│  Members: home-assistant  │  │  Members: gathio, gathio-db  │
 └───────────────────────────┘  └──────────────────────────────┘
+
+┌───────────────────────────┐  ┌──────────────────────────────┐
+│  forgejo (10.89.8.0/24)   │  │  mail (10.89.9.0/24)         │
+│  Git forge backend        │  │  SMTP relay path             │
+│  Members: forgejo,        │  │  Members: authelia,          │
+│  forgejo-db               │  │  proton-bridge               │
+└───────────────────────────┘  └──────────────────────────────┘
+
+┌───────────────────────────┐
+│  syslog (10.89.7.0/24)    │
+│  UDM Pro log ingestion    │
+│  Members: unifi-syslog    │
+└───────────────────────────┘
 ```
 
 ### Logical Request Flow
@@ -150,54 +174,61 @@ Services on multiple networks use static IP assignment + Traefik /etc/hosts over
 
 ## Service Stack
 
-### Production Services (14 service groups, 28 containers)
+### Production Services (17 service groups, 37 containers)
 
 #### Core Infrastructure
 
 | Service | Container(s) | Network(s) | Purpose |
 |---------|-------------|------------|---------|
-| **Traefik** | traefik | reverse_proxy, auth_services, monitoring | Reverse proxy, SSL termination, routing |
-| **CrowdSec** | crowdsec | reverse_proxy, monitoring | IP reputation, threat intelligence |
-| **Authelia** | authelia, redis-authelia | reverse_proxy, auth_services, monitoring | SSO + YubiKey MFA |
+| **Traefik** | traefik | reverse_proxy | Reverse proxy, SSL termination, routing |
+| **CrowdSec** | crowdsec | reverse_proxy | IP reputation, threat intelligence |
+| **Authelia** | authelia, redis-authelia | auth_services, mail, restricted-egress | SSO + YubiKey MFA |
 
 #### User Applications
 
 | Service | Container(s) | Network(s) | Auth Method | URL Pattern |
 |---------|-------------|------------|-------------|-------------|
-| **Homepage** | homepage | reverse_proxy, monitoring | Authelia | home.* |
-| **Jellyfin** | jellyfin | reverse_proxy, media_services, monitoring | Native | jellyfin.* |
-| **Immich** | immich-server, immich-ml, postgresql-immich, redis-immich | reverse_proxy, photos, monitoring | Native | photos.* |
-| **Nextcloud** | nextcloud, collabora, nextcloud-db, nextcloud-redis | reverse_proxy, nextcloud, monitoring | Native | nextcloud.* |
-| **Vaultwarden** | vaultwarden | reverse_proxy, monitoring | Native | vault.* |
-| **Gathio** | gathio, gathio-db | reverse_proxy, gathio, monitoring | Authelia | events.* |
-| **Home Assistant** | home-assistant, matter-server | reverse_proxy, home_automation, monitoring | Native | ha.* |
+| **Jellyfin** | jellyfin | reverse_proxy, media_services | Native | jellyfin.* |
+| **Immich** | immich-server, immich-ml, postgresql-immich, redis-immich | reverse_proxy, photos | Native | photos.* |
+| **Nextcloud** | nextcloud, nextcloud-db, nextcloud-redis | reverse_proxy, nextcloud | Native | nextcloud.* |
+| **Vaultwarden** | vaultwarden | reverse_proxy | Native | vault.* |
+| **Gathio** | gathio, gathio-db | reverse_proxy, gathio | Authelia | events.* |
+| **Home Assistant** | home-assistant | reverse_proxy, home_automation | Native | ha.* |
+| **Navidrome** | navidrome | reverse_proxy | Native | musikk.* |
+| **Audiobookshelf** | audiobookshelf | restricted-egress | Native | audiobookshelf.* |
+| **qBittorrent** | qbittorrent | reverse_proxy | Authelia | torrent.* |
+| **Forgejo** | forgejo, forgejo-db | forgejo, restricted-egress | Native | git.* |
+| **Proton Bridge** | proton-bridge | reverse_proxy, mail | N/A (SMTP relay) | — |
 
 #### Monitoring & Observability
 
 | Service | Container(s) | Network(s) | Purpose |
 |---------|-------------|------------|---------|
-| **Prometheus** | prometheus | reverse_proxy, monitoring | Metrics collection |
+| **Prometheus** | prometheus | monitoring, restricted-egress | Metrics collection (internal-only since 2026-07) |
 | **Grafana** | grafana | reverse_proxy, monitoring | Dashboards & visualization |
 | **Loki** | loki | reverse_proxy, monitoring | Log aggregation |
-| **Alertmanager** | alertmanager | monitoring | Alert routing (Discord) |
+| **Alertmanager** | alertmanager | reverse_proxy, monitoring | Alert routing (Discord) |
 | **Promtail** | promtail | monitoring | Log shipping to Loki |
 | **cAdvisor** | cadvisor | monitoring | Container metrics |
 | **Node Exporter** | node_exporter | monitoring | Host system metrics |
-| **UnPoller** | unpoller | monitoring | UniFi network metrics |
+| **UnPoller** | unpoller | monitoring, restricted-egress | UniFi network metrics |
+| **Blackbox Exporter** | blackbox-exporter | monitoring, restricted-egress | Endpoint probing |
+| **Pi-hole Exporter** | pihole-exporter | monitoring, restricted-egress | Pi-hole DNS metrics |
+| **DB/Redis Exporters** | postgres-exporter, redis-authelia-exporter, redis-immich-exporter | monitoring + backend nets | Database metrics |
+| **UniFi Syslog** | unifi-syslog | syslog | UDM Pro log ingestion |
 | **Alert Discord Relay** | alert-discord-relay | reverse_proxy, monitoring | Alertmanager → Discord |
 
 ### Internal-Only Services (no public route)
 
-- **Collabora** - Document editing server (accessed by Nextcloud internally)
-- **Alertmanager** - Alert routing (access via Grafana or direct container exec)
+- **Prometheus** - Queried by Grafana over the monitoring network (public router removed, ADR-045)
 - **All databases/Redis instances** - Backend-only, no Traefik routing
 
 ### Authentication Model
 
 | Auth Method | Services | Rationale |
 |-------------|----------|-----------|
-| **Authelia SSO** | Homepage, Traefik Dashboard, Grafana, Prometheus, Loki, Gathio | Admin/monitoring tools — centralized auth |
-| **Native auth** | Jellyfin, Immich, Nextcloud, Vaultwarden, Home Assistant | Mobile apps, WebDAV clients need direct auth |
+| **Authelia SSO** | Traefik Dashboard, Grafana, Loki, Gathio, qBittorrent | Admin/monitoring tools — centralized auth |
+| **Native auth** | Jellyfin, Immich, Nextcloud, Vaultwarden, Home Assistant, Navidrome, Audiobookshelf, Forgejo | Mobile apps, WebDAV/git clients need direct auth |
 
 ---
 
@@ -247,7 +278,7 @@ cd .claude/skills/homelab-deployment
 
 ```
 Layer 7: Container Isolation (rootless, SELinux enforcing, UID 1000)
-Layer 6: Network Segmentation (8 isolated Podman networks)
+Layer 6: Network Segmentation (12 isolated Podman networks + restricted-egress outbound filter, ADR-045)
 Layer 5: Security Headers (HSTS, CSP, X-Frame-Options)
 Layer 4: Authentication (Authelia YubiKey/WebAuthn + TOTP, or native)
 Layer 3: Rate Limiting (tiered: 50-400 req/min by service type)
@@ -273,7 +304,7 @@ Layer 1: Port Filtering (UDM Pro firewall, only 80/443 exposed)
 ### Vulnerability Management
 
 - **Weekly:** Automated CVE scanning (Sundays 06:00)
-- **Monthly:** Security audit (`scripts/security-audit.sh`, 40+ checks)
+- **Biweekly (1st/15th):** Security audit (`scripts/security-audit.sh`, 53 checks)
 - **Continuous:** CrowdSec behavioral analysis + global threat intelligence
 
 ---
@@ -311,15 +342,14 @@ Layer 1: Port Filtering (UDM Pro firewall, only 80/443 exposed)
 │   ├── crowdsec/          # Threat detection config
 │   ├── prometheus/        # Scrape targets, recording rules, alerts
 │   ├── grafana/           # Provisioned dashboards & datasources
-│   ├── loki/              # Log aggregation config
-│   └── homepage/          # Dashboard widget config
+│   └── loki/              # Log aggregation config
 │
 ├── data/                   # Runtime data (gitignored, on BTRFS pool)
 │   ├── crowdsec/          # Threat database
 │   └── backup-logs/       # Backup operation logs
 │
 ├── quadlets/              # Symlink → ~/.config/containers/systemd/
-│                           # All 28 .container files + .network files
+│                           # All 37 .container files + .network files
 │
 ├── scripts/               # 65+ automation scripts (git-tracked)
 ├── secrets/               # API tokens, passwords (gitignored, chmod 600)
@@ -346,7 +376,10 @@ Layer 1: Port Filtering (UDM Pro firewall, only 80/443 exposed)
 
 ### Three Pillars
 
-1. **Local BTRFS Snapshots**
+Backups are managed by **[Urd](https://github.com/vonrobak/urd)** (ADR-021), a Rust-based
+BTRFS Time Machine that replaced the earlier shell scripts.
+
+1. **Local BTRFS Snapshots (Urd)**
    - Daily automated, 14+ day retention
    - RTO: <10 minutes (validated)
    - RPO: 24 hours
@@ -355,7 +388,7 @@ Layer 1: Port Filtering (UDM Pro firewall, only 80/443 exposed)
    - Configs, quadlets, docs, scripts tracked on GitHub
    - Full history, instant config recovery
 
-3. **External Backup**
+3. **External Backup (Urd)**
    - WD-18TB drive, validated restore (81,716 files)
    - Off-site capability for catastrophic recovery
 
@@ -427,10 +460,10 @@ Daily automated cycle: **Observe → Orient → Decide → Act**
 Key scheduled operations:
 - Every 5 min: Nextcloud cron, dependency metrics
 - Every 30 min: Cloudflare DDNS
-- Hourly: Journal log rotation
-- Daily: BTRFS backup, SLO snapshot, drift check, resource forecast, error digest, auto-doc
-- Weekly: Intelligence report, vulnerability scan, podman auto-update, database maintenance
-- Monthly: SLO report, remediation report, skill usage report
+- Hourly: Journal log rotation, Forgejo mirror
+- Daily: Urd backup, SLO snapshot, drift check, resource forecast, error digest, auto-doc
+- Weekly: Intelligence report, vulnerability scan, database maintenance, image-update discovery (notify-only)
+- Monthly: Deliberate image-update loop (`monthly-update.sh`, ADR-036), SLO report, remediation report, skill usage report
 - Biweekly: Backup restore test
 
 ---
@@ -470,7 +503,7 @@ Network=systemd-reverse_proxy.network
 - CrowdSec threat updates (continuous)
 - Container health checks (every 10-30s)
 - SSL certificate renewal (Let's Encrypt)
-- BTRFS snapshots (daily)
+- BTRFS snapshots via Urd (daily)
 - Log rotation (hourly)
 - Documentation regeneration (daily 07:00)
 
@@ -493,5 +526,4 @@ Network=systemd-reverse_proxy.network
 
 ---
 
-**Document Version:** 3.0
-**Previous versions:** [v1.0 archived from Nov 2025](../../90-archive/)
+**Document Version:** 3.0 (previous versions archived internally)

--- a/docs/20-operations/guides/remediation-chains.md
+++ b/docs/20-operations/guides/remediation-chains.md
@@ -4,7 +4,7 @@ title: "Remediation Chains - Multi-Playbook Orchestration"
 description: "Guide to multi-playbook remediation chains — orchestrating cleanup, maintenance, and recovery steps in sequence with conditional execution and failure strategies."
 sensitivity: public
 created: 2025-12-25
-updated: 2025-12-25
+updated: 2026-07-20
 ---
 
 # Remediation Chains - Multi-Playbook Orchestration
@@ -697,7 +697,6 @@ systemctl --user list-timers  # Verify scheduled
 
 - **Playbooks:** `.claude/remediation/README.md` - Individual playbook documentation
 - **Autonomous Operations:** `docs/20-operations/guides/autonomous-operations.md`
-- **Roadmap:** `docs/97-plans/2025-12-23-remediation-phase-3-roadmap.md`
 - **Metrics:** `docs/40-monitoring-and-documentation/guides/prometheus-metrics.md`
 
 ---

--- a/docs/20-operations/guides/resource-limits-configuration.md
+++ b/docs/20-operations/guides/resource-limits-configuration.md
@@ -4,7 +4,7 @@ title: "Resource Limits Configuration Guide"
 description: "Guide providing ready-to-use systemd resource-limit configurations for the most critical services to prevent memory exhaustion and OOM instability."
 sensitivity: public
 created: 2025-11-09
-updated: 2025-11-09
+updated: 2026-07-20
 ---
 
 # Resource Limits Configuration Guide
@@ -259,7 +259,7 @@ If you prefer manual edits:
 2. **Find the [Service] section:**
    ```ini
    [Container]
-   Image=quay.io/prometheus/prometheus:latest
+   Image=quay.io/prometheus/prometheus:<tag>@sha256:<digest>  # digest-pinned (ADR-030)
    ...
 
    [Service]

--- a/docs/20-operations/guides/unpoller-metrics-guide.md
+++ b/docs/20-operations/guides/unpoller-metrics-guide.md
@@ -4,7 +4,7 @@ title: "Unpoller Metrics Guide"
 description: "Reference guide for working with UnPoller UniFi metrics across Prometheus, Grafana, and Home Assistant — deployment details and metric queries."
 sensitivity: public
 created: 2026-01-28
-updated: 2026-01-28
+updated: 2026-07-20
 ---
 
 # Unpoller Metrics Guide
@@ -27,7 +27,7 @@ UniFi Controller → Unpoller (scraper) → Prometheus (storage) → Grafana/Hom
 
 **Current Deployment:**
 - **Service:** `unpoller.service` (systemd quadlet)
-- **Container:** `ghcr.io/unpoller/unpoller:latest`
+- **Container:** `ghcr.io/unpoller/unpoller` (digest-pinned per ADR-030)
 - **Network:** `systemd-monitoring` (10.89.4.0/24)
 - **Metrics Endpoint:** `http://unpoller:9130/metrics`
 - **Config:** `~/containers/config/unpoller/up.conf`
@@ -522,7 +522,8 @@ scrape_configs:
 **Key directives:**
 ```ini
 [Container]
-Image=ghcr.io/unpoller/unpoller:latest
+# Digest-pinned (ADR-030) — updated via the deliberate monthly loop, never auto
+Image=ghcr.io/unpoller/unpoller@sha256:9dcccdc931a6830735f6978caf8cd67699b0dc33e37cf9ef4638611791c4df62
 Network=systemd-monitoring
 Secret=unpoller_url,type=env,target=UP_UNIFI_DEFAULT_URL
 Secret=unpoller_user,type=env,target=UP_UNIFI_DEFAULT_USER
@@ -687,7 +688,6 @@ sum by (name) (rate(unpoller_client_receive_bytes_total[5m]))
 **Homelab-Specific:**
 - Recording Rules: `~/containers/config/prometheus/rules/unifi-recording-rules.yml`
 - Grafana Dashboards: `~/containers/config/grafana/provisioning/dashboards/json/unifi-*.json`
-- Deployment Journal: `docs/98-journals/2026-01-28-matter-hybrid-week2-matter-server-deployment.md`
 
 **Community Resources:**
 - Unpoller GitHub: https://github.com/unpoller/unpoller

--- a/docs/30-security/guides/crowdsec-phase1-field-manual.md
+++ b/docs/30-security/guides/crowdsec-phase1-field-manual.md
@@ -7,6 +7,13 @@ created: 2025-11-12
 updated: 2025-11-12
 ---
 
+<!-- allow-vault-paths: historical record; citations were accurate when written -->
+
+> **Historical (2025-11):** this field manual records the Phase 1 remediation as
+> executed, including the then-current `:latest` → version-tag pinning. The fleet
+> has since moved to full digest pinning (ADR-030); read this as history, not
+> current procedure.
+
 # CrowdSec Phase 1: Configuration Audit & Fixes - Field Manual
 
 **Version:** 1.0

--- a/docs/30-security/guides/crowdsec-phase4-configuration-management.md
+++ b/docs/30-security/guides/crowdsec-phase4-configuration-management.md
@@ -4,13 +4,13 @@ title: "CrowdSec Phase 4: Configuration Management Plan"
 description: "Guide to CrowdSec Phase 4 configuration management — bringing config files under Git, templates, validation, and backup/restore."
 sensitivity: public
 created: 2025-11-12
-updated: 2025-11-12
+updated: 2026-07-20
 ---
 
 # CrowdSec Phase 4: Configuration Management Plan
 
 **Version:** 1.0
-**Last Updated:** 2025-11-12
+**Last Updated:** 2026-07-20
 **Prerequisites:** Phase 1 and optionally Phase 3 completed
 **Estimated Time:** 45-60 minutes
 **Risk Level:** Low (documentation and templates, no service changes)
@@ -310,7 +310,7 @@ cat > ~/crowdsec-phase4-inventory/configuration-decisions.md <<'EOF'
 - **Standard threats (4 hours):** Proportional response to low-severity issues
 
 **References:**
-- ADR: See `docs/99-reports/2025-11-12-crowdsec-security-enhancements.md`
+- Report: 2025-11-12 CrowdSec security enhancements (internal vault report)
 - Design principle: Fail-fast, defense in depth
 
 **Trade-offs:**
@@ -598,7 +598,7 @@ cat > config/crowdsec/templates/profiles.yaml.template <<'EOF'
 # CrowdSec Ban Profiles - Tiered Duration Strategy
 #
 # This configuration implements a 3-tier ban system based on threat severity.
-# See: docs/99-reports/2025-11-12-crowdsec-security-enhancements.md
+# See: the 2025-11-12 CrowdSec security enhancements report (internal vault)
 #
 # Template Variables:
 #   (none - this template uses static values)
@@ -1548,7 +1548,7 @@ All configuration changes should follow this workflow:
 ### Configuration Change Documentation
 
 Store change documentation in:
-- `docs/99-reports/` for significant changes
+- the internal vault reports directory for significant changes
 - Git commit messages for minor changes
 
 ### Git Commit Message Format

--- a/docs/30-security/guides/esp32-vlan2-firewall-rule.md
+++ b/docs/30-security/guides/esp32-vlan2-firewall-rule.md
@@ -4,7 +4,7 @@ title: "ESP32 Bluetooth Proxy - VLAN2 Firewall Configuration"
 description: "Guide to the VLAN2 firewall rule letting an ESP32 Bluetooth proxy on the IoT network reach Home Assistant over the ESPHome API (port 6053)."
 sensitivity: public
 created: 2026-02-04
-updated: 2026-02-04
+updated: 2026-07-20
 ---
 
 # ESP32 Bluetooth Proxy - VLAN2 Firewall Configuration
@@ -260,4 +260,3 @@ nc -zv 192.168.2.x 6053
 ## Related Documentation
 
 - Quick Start Guide: `docs/10-services/guides/esp32-plejd-quick-start.md`
-- Journal Entry: `docs/98-journals/2026-02-04-esp32-bluetooth-proxy-for-plejd-integration.md`

--- a/docs/30-security/guides/security-audit.md
+++ b/docs/30-security/guides/security-audit.md
@@ -4,14 +4,14 @@ title: "Security Audit Guide"
 description: "Security audit guide covering the 53-check security-audit.sh across seven categories, audit levels, scoring, and the security-auditor skill."
 sensitivity: public
 created: 2026-01-08
-updated: 2026-03-08
+updated: 2026-07-20
 ---
 
 # Security Audit Guide
 
 **Purpose:** Comprehensive security checklist for homelab infrastructure
 **Frequency:** Biweekly automated (1st/15th) + on-demand deep audits via Claude Code skill
-**Last Updated:** 2026-03-08
+**Last Updated:** 2026-07-20
 
 ---
 
@@ -38,7 +38,7 @@ This guide provides a structured approach to auditing the security posture of yo
 
 **Scoring:** Start at 100. L1 fail: -15, L2 fail: -5, L3 fail: -2. Warnings: half penalty.
 
-**History:** `data/security-audit/audit-YYYY-MM-DD.json` | **Reports:** `docs/99-reports/security-audit-YYYY-MM-DD.md`
+**History:** `data/security-audit/audit-YYYY-MM-DD.json` | **Reports:** `security-audit-YYYY-MM-DD.md` in the internal vault reports directory (untracked, vault-side)
 
 ---
 
@@ -588,7 +588,7 @@ git status --short
 **Process:**
 1. Review this checklist section by section
 2. Execute verification commands for Level 1 and Level 2 items
-3. Document findings in `docs/99-reports/security-audit-YYYY-MM.md`
+3. Document findings in a `security-audit-YYYY-MM.md` report in the internal vault reports directory
 4. Create remediation tasks for failures
 5. Update this guide if new checks are identified
 
@@ -606,7 +606,7 @@ git status --short
 
 ### Reporting
 
-**Template:** `docs/99-reports/security-audit-YYYY-MM.md`
+**Template:** `security-audit-YYYY-MM.md` (internal vault reports directory)
 
 ```markdown
 # Security Audit Report: YYYY-MM

--- a/docs/40-monitoring-and-documentation/guides/homelab-snapshot-development.md
+++ b/docs/40-monitoring-and-documentation/guides/homelab-snapshot-development.md
@@ -4,13 +4,15 @@ title: "Homelab Snapshot Script: Developer Guide"
 description: "Developer guide to the homelab-snapshot.sh system-intelligence script — architecture, data flow, code walkthrough, and extension."
 sensitivity: public
 created: 2025-11-09
-updated: 2025-11-09
+updated: 2026-07-20
 ---
+
+<!-- allow-vault-paths: code listings below faithfully show the script's real output paths -->
 
 # Homelab Snapshot Script: Developer Guide
 ## Learn to Build, Understand, and Extend System Intelligence
 
-**Last Updated:** 2025-11-09
+**Last Updated:** 2026-07-20
 **Target Audience:** Developers learning bash scripting, system intelligence, infrastructure as code
 **Prerequisites:** Basic bash knowledge, understanding of containers and systemd
 
@@ -65,7 +67,7 @@ The script collects 14 categories of information:
 
 ### Output
 
-A single JSON file in `docs/99-reports/snapshot-TIMESTAMP.json` containing:
+A single JSON file (`snapshot-TIMESTAMP.json`), written to the internal vault reports directory (untracked, vault-side), containing:
 - **820 lines** of structured data (for 16-service homelab)
 - **Complete state** that can be diff'd over time
 - **Machine-readable** for programmatic analysis
@@ -189,7 +191,7 @@ homelab-snapshot.sh
          ▼
 ┌─────────────────────────────────────┐
 │  Output                             │
-│  docs/99-reports/snapshot-*.json    │
+│  snapshot-*.json (vault reports dir)│
 └─────────────────────────────────────┘
 ```
 
@@ -1076,7 +1078,7 @@ Use this guide as a reference when extending the script or building similar inte
 
 ---
 
-**Last Updated:** 2025-11-09
+**Last Updated:** 2026-07-20
 **Version:** 1.0
 **Maintained By:** Homelab Documentation Team
-**Related:** `scripts/homelab-snapshot.sh`, `docs/99-reports/snapshot-*.json`
+**Related:** `scripts/homelab-snapshot.sh`; `snapshot-*.json` outputs in the internal vault reports directory

--- a/docs/40-monitoring-and-documentation/guides/log-to-metric-implementation.md
+++ b/docs/40-monitoring-and-documentation/guides/log-to-metric-implementation.md
@@ -4,7 +4,7 @@ title: "Log-to-Metric Feedback Loop Implementation"
 description: "Guide to the log-to-metric feedback loop — extracting Prometheus counters from logs at Promtail ingestion for real-time error alerting."
 sensitivity: public
 created: 2026-01-11
-updated: 2026-01-11
+updated: 2026-07-20
 ---
 
 # Log-to-Metric Feedback Loop Implementation
@@ -402,7 +402,7 @@ nano ~/containers/config/promtail/promtail-config.yml
 
 # Validate config
 podman run --rm -v ~/containers/config/promtail:/etc/promtail:Z \
-  grafana/promtail:latest \
+  docker.io/grafana/promtail@sha256:6cfa64ec432b24a912d640e2edb940eeae2666f61861a66c121d763dd7241381 \
   -config.file=/etc/promtail/promtail-config.yml \
   -dry-run
 
@@ -464,7 +464,7 @@ journalctl --user -u promtail.service -n 50
 
 # 3. Validate Promtail config
 podman run --rm -v ~/containers/config/promtail:/etc/promtail:Z \
-  grafana/promtail:latest \
+  docker.io/grafana/promtail@sha256:6cfa64ec432b24a912d640e2edb940eeae2666f61861a66c121d763dd7241381 \
   -config.file=/etc/promtail/promtail-config.yml \
   -dry-run
 ```

--- a/docs/40-monitoring-and-documentation/guides/monitoring-stack.md
+++ b/docs/40-monitoring-and-documentation/guides/monitoring-stack.md
@@ -4,13 +4,13 @@ title: "Homelab Monitoring Stack Guide"
 description: "Comprehensive guide to the homelab's monitoring, alerting, and autonomous remediation infrastructure — components, usage, maintenance, and extension."
 sensitivity: public
 created: 2025-11-06
-updated: 2025-12-29
+updated: 2026-07-20
 ---
 
 # Homelab Monitoring Stack Guide
 
 **Created:** 2025-11-06
-**Last Updated:** 2025-12-26
+**Last Updated:** 2026-07-20
 
 ## Overview
 
@@ -816,7 +816,7 @@ global:
 - **Rootless containers** - All services run as user processes (UID 1000), not root
 - **Network isolation** - Monitoring network isolated from reverse proxy network
 - **Secrets management** - Three-tier approach:
-  - Podman secrets for containerized services (encrypted at rest)
+  - Podman secrets for containerized services, sourced from the self-hosted OpenBao vault (barrier-encrypted at rest there) and synced into a tmpfs-only podman secret cache (ADR-041; the podman `file` driver itself is only base64, not encryption)
   - EnvironmentFile for systemd services (remediation webhook)
   - Strict file permissions (mode 600) for all secrets
 - **Webhook authentication** - Token-based auth (fail-closed, 256-bit tokens)

--- a/docs/40-monitoring-and-documentation/guides/natural-language-queries.md
+++ b/docs/40-monitoring-and-documentation/guides/natural-language-queries.md
@@ -4,14 +4,14 @@ title: "Natural Language Query System - User Guide"
 description: "User guide to the natural-language query system (query-homelab.sh) that translates plain-English questions into cached system state answers."
 sensitivity: public
 created: 2025-11-21
-updated: 2025-11-30
+updated: 2026-07-20
 ---
 
 # Natural Language Query System - User Guide
 
 **Created:** 2025-11-22
 **Status:** ✅ Production-Ready
-**Safety Audit:** [docs/99-reports/2025-11-22-query-system-safety-audit.md](../../99-reports/2025-11-22-query-system-safety-audit.md)
+**Safety Audit:** 2025-11-22 query-system safety audit (internal vault report)
 
 ---
 
@@ -431,7 +431,7 @@ Network members:
 $ ~/containers/scripts/query-homelab.sh "What's jellyfin's configuration?"
 Configuration:
   service: jellyfin
-  image: docker.io/jellyfin/jellyfin:latest
+  image: docker.io/jellyfin/jellyfin@sha256:aefb67e6a7ff1debdd154a78a7bbb780fd0c873d8639210a7f6a2016ad2b35db
   memory_limit: 4G
   networks: systemd-reverse_proxy.network,systemd-media_services.network
 ```
@@ -466,8 +466,7 @@ Potential improvements (not yet implemented):
 
 ## See Also
 
-- **Safety Audit**: `docs/99-reports/2025-11-22-query-system-safety-audit.md`
-- **Session 5C Plan**: `docs/99-reports/SESSION-5C-NATURAL-LANGUAGE-QUERIES-PLAN.md`
+- **Safety Audit**: 2025-11-22 query-system safety audit (internal vault report)
 - **Homelab Intelligence Skill**: `.claude/skills/homelab-intelligence/SKILL.md`
 - **CLAUDE.md**: Main homelab reference guide
 

--- a/docs/40-monitoring-and-documentation/guides/unifi-security-monitoring.md
+++ b/docs/40-monitoring-and-documentation/guides/unifi-security-monitoring.md
@@ -439,7 +439,6 @@ systemctl --user restart grafana.service
 - [SLO Framework](./slo-framework.md) - SLO targets and burn rate calculations
 - [Loki Remediation Queries](./loki-remediation-queries.md) - LogQL correlation patterns
 - [Security Audit Guide](../../../30-security/guides/security-audit.md) - Network monitoring checklist
-- [Matter Home Automation Plan](../../../97-plans/2025-12-30-matter-home-automation-implementation-plan.md) - VPN presence detection integration
 
 ---
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -8,12 +8,13 @@ This guide covers when, where, and how to write documentation. It does not repea
 
 ## The Two Homes (ADR-043)
 
+<!-- allow-vault-paths: this file documents the boundary itself -->
 Documentation lives in two places, and the boundary is a **per-document property**, not a directory convention:
 
-- **This repo (`docs/00-40`)** — public on GitHub. Guides, ADRs, runbooks, patterns. Every document carries frontmatter with `sensitivity: public` explicit.
+- **This repo (`docs/00-40`)** — public on GitHub. Guides, ADRs, runbooks, patterns. Every document carries frontmatter with `sensitivity: public` explicit. The public tree is a **curated reference for readers building comparable homelabs** — not a dumping ground for everything non-sensitive. System-decision ADRs live here; project-process meta-ADRs (how the owner runs docs, repos, workflow) are vault-resident. ADR numbering is one shared sequence across both homes, so gaps in the public sequence are expected, not errors.
 - **The private vault** — journals, plans, reports, supervisor docs, archive, and any document classified `internal` or `secret`. The `docs/9x` paths still resolve (gitignored symlinks), but the content is physically unstageable here; a pre-commit gate (`scripts/check-vault-boundary.sh`) rejects staged markdown carrying `sensitivity: internal|secret`. The vault has its own conventions document — consult it there.
 
-**Birth rule (type decides, repo-public default):** guides, ADRs, and patterns are born here, public, with frontmatter from day one. A document whose *first draft* needs internal specifics (incident post-mortems, host-specific runbooks) is born in the vault; publishing it later is a deliberate copy-and-scrub. Do not word public docs for an external audience — write for the owner; the public reader is a welcome eavesdropper.
+**Birth rule (two tests, in order — ADR-048, internal):** first the *sensitivity* test: a document whose first draft needs internal specifics (incident post-mortems, host-specific runbooks) is born in the vault; publishing later is a deliberate copy-and-scrub. Then the *audience* test: even a non-sensitive document belongs in the vault when it is owner-operational — written to run *this* system — rather than transferable reference a reader could apply to their own homelab. Public docs serve the external reader: prefer linking the auto-generated views over hardcoding counts and inventories that drift.
 
 **Runbook split test:** a runbook stays public when the procedure is generic and specifics are incidental (scrub stray IPs/hostnames to placeholders). It lives in the vault when specificity *is* its value — leaving a public stub here: title, one-line purpose, "operational specifics live in the private vault."
 
@@ -279,8 +280,15 @@ Note: `90-archive/` is **vault-resident** (symlink). Archiving a *public* doc th
 
 ### How to Archive
 
+Archiving a public doc crosses the boundary (see note above), so it is a two-step move — vault first, so the file is never homeless:
+
 ```bash
-git mv docs/<category>/<file>.md docs/90-archive/
+# 1. Vault side: copy into the archive and commit there
+cp docs/<category>/<file>.md ~/Huldr/projects/homelab/90-archive/
+# (set frontmatter: sensitivity: internal, status: archived; then commit via the vault's bare-repo workflow)
+
+# 2. Public side: remove from this repo (PR or trivia lane)
+git rm docs/<category>/<file>.md
 ```
 
 Add an archival header to the top of the moved file:

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,64 +1,27 @@
 # Homelab Documentation
 
-**Last Updated:** 2025-12-18
 **System:** fedora-htpc production environment
-**Documentation Files:** 200+ files across structured directories
 **Status:** 🎯 Production | 🔐 SSO with YubiKey | 📊 Full Observability | 🤖 Autonomous Operations
 
 ---
 
-## 🚀 Quick Start
+## Quick Start
 
-**New to this homelab?** Start here:
-1. Read this index (you are here)
-2. Review [CONTRIBUTING.md](CONTRIBUTING.md) for documentation conventions
-3. Browse [98-journals/](98-journals/) for chronological project history
-4. Check [97-plans/](97-plans/) for active planning documents
-5. Explore service guides in `*/guides/` subdirectories
+**New to this homelab?** Start with the [repository README](../README.md) — it has the recommended reading path. Then:
 
-**Common tasks:**
-- **Health check:** `./scripts/homelab-intel.sh`
-- **Natural language query:** `./scripts/query-homelab.sh "your question"`
-- **System diagnostics:** `./scripts/homelab-diagnose.sh`
+1. Review [CONTRIBUTING.md](CONTRIBUTING.md) for documentation conventions
+2. Explore service guides in `*/guides/` subdirectories
+3. Read the ADRs in `*/decisions/` for the *why* behind the architecture
+
+**Live system views (auto-generated daily):**
+[Service Catalog](AUTO-SERVICE-CATALOG.md) · [Network Topology](AUTO-NETWORK-TOPOLOGY.md) · [Dependency Graph](AUTO-DEPENDENCY-GRAPH.md) · [Documentation Index](AUTO-DOCUMENTATION-INDEX.md)
 
 ---
 
-## 📖 Documentation Structure
-
-### Three-Tier Organization
-
-This documentation uses a **clear separation of concerns**:
-
-1. **Forward-looking** (`97-plans/`) - Strategic plans and roadmaps
-2. **Historical** (`98-journals/`) - Chronological project timeline
-3. **Current state** (`*/guides/`) - Living reference documentation
-4. **Synthesis** (`96-project-supervisor/`) - Distilled lessons and situational awareness (local-only, gitignored)
-
-### Directory Overview
+## Structure
 
 ```
 docs/
-├── 96-project-supervisor/              # Situational awareness (curated synthesis; LOCAL-ONLY, gitignored)
-│   ├── lessons.md                      # Distilled lessons (L-NNN, incl. superseded)
-│   ├── roadmap.md / status.md          # Strategy & arc state
-│   └── README.md                       # Directory role and conventions
-│
-├── 97-plans/                           # Strategic planning documents
-│   ├── PROJECT-A-DISASTER-RECOVERY-PLAN.md
-│   ├── SESSION-5-MULTI-SERVICE-ORCHESTRATION-PLAN.md
-│   └── [Status: Proposed | In Progress | Implemented]
-│
-├── 98-journals/                        # Complete chronological history (FLAT)
-│   ├── 2025-10-20-day01-foundation-learnings.md
-│   ├── 2025-11-09-strategic-assessment.md
-│   ├── 2025-12-18-quarterly-documentation-review.md
-│   └── [92 entries - sessions, deployments, strategic thinking]
-│
-├── 99-reports/                         # System state snapshots
-│   ├── intel-*.json                    (94 automated health reports)
-│   ├── resource-forecast-*.json        (predictive analytics)
-│   └── SYSTEM-STATE-2025-11-06.md      (formal infrastructure snapshot)
-│
 ├── 00-foundation/                      # Core concepts
 │   ├── guides/                         # Podman, networking, design patterns
 │   └── decisions/                      # Fundamental ADRs
@@ -68,7 +31,7 @@ docs/
 │   └── decisions/                      # Service architecture ADRs
 │
 ├── 20-operations/                      # Operations procedures
-│   ├── guides/                         # Backup, monitoring, maintenance
+│   ├── guides/                         # Storage, monitoring, maintenance
 │   ├── decisions/                      # Operational policy ADRs
 │   └── runbooks/                       # DR and incident response
 │
@@ -81,299 +44,34 @@ docs/
 │   ├── guides/                         # Prometheus, Grafana, Loki, SLOs
 │   └── decisions/                      # Monitoring decisions
 │
-└── 90-archive/                         # Superseded documentation
+└── AUTO-*.md                           # Generated daily from the live system
 ```
+
+Internal working notes (journals, plans, reports, archive) live in a private
+knowledge vault outside this repository — see the boundary section of
+[CONTRIBUTING.md](CONTRIBUTING.md). What you see here is the curated, public layer:
+every document carries `sensitivity: public` frontmatter.
 
 ---
 
-## 🎯 Finding What You Need
+## Finding What You Need
 
-### Current System Information
+**Frequently used guides:**
+- **Architecture overview:** `20-operations/guides/homelab-architecture.md`
+- **Immich / Jellyfin / Traefik / Authelia:** `10-services/guides/`
+- **Monitoring stack:** `40-monitoring-and-documentation/guides/monitoring-stack.md`
+- **Secrets model:** `30-security/guides/secrets-management.md`
+- **Backups:** [Urd](https://github.com/vonrobak/urd) (ADR-021)
 
-**System health:**
+**Operational tooling** (run from the repo root):
 ```bash
 ./scripts/homelab-intel.sh              # Health score (0-100) + recommendations
 ./scripts/query-homelab.sh "status?"    # Natural language queries
+./scripts/security-audit.sh             # 53-check security audit
 ```
 
-**Service guides:** All in `*/guides/` subdirectories
-- **Immich:** `10-services/guides/immich.md`
-- **Jellyfin:** `10-services/guides/jellyfin.md`
-- **Traefik:** `10-services/guides/traefik.md`
-- **Authelia:** `10-services/guides/authelia.md` (SSO + YubiKey MFA)
-- **Monitoring:** `40-monitoring-and-documentation/guides/monitoring-stack.md`
-- **Backup:** [Urd](https://github.com/vonrobak/urd) (ADR-021)
-
-### Understanding Project History
-
-**Chronological timeline:** Browse `98-journals/` sorted by date
-```bash
-# What happened in November?
-ls -1 98-journals/2025-11-*.md
-
-# Recent work (last 10 entries)
-ls -1t 98-journals/*.md | head -10
-
-# Find strategic assessments
-grep -l "strategic" 98-journals/*.md
-```
-
-**Key milestones:**
-- 2025-10-20: Foundation learnings (Podman, networking)
-- 2025-10-23: First service deployment (Jellyfin)
-- 2025-11-06: Monitoring stack operational
-- 2025-11-11: Authelia SSO with YubiKey deployed
-- 2025-11-28: Autonomous operations activated
-- 2025-12-18: Documentation structure reorganized
-
-### Planning Documents
-
-**Active plans:** See `97-plans/`
-- Disaster recovery testing framework
-- Security hardening roadmap
-- Autonomous operations expansion
-- Multi-service orchestration
-
-Plans include status metadata (Proposed | In Progress | Implemented).
-
-### Architecture Decisions
-
-**Why certain choices were made:** See `*/decisions/` subdirectories
-
-**Key ADRs:**
-- **ADR-001:** Rootless containers (00-foundation)
-- **ADR-002:** Systemd quadlets over Docker Compose (00-foundation)
-- **ADR-003:** Monitoring stack architecture (40-monitoring)
-- **ADR-004:** Authelia SSO with YubiKey-first authentication (30-security)
-- **ADR-006:** Service dependency mapping (20-operations)
-- **ADR-008:** Autonomous operations alert quality (20-operations)
+Full script catalog: `20-operations/guides/automation-reference.md`
 
 ---
 
-## 📂 Directory Details
-
-### 97-plans: Strategic Planning
-
-**Purpose:** Forward-looking plans, proposals, and roadmaps
-
-**Contents:**
-- Project proposals (PROJECT-A, PROJECT-B, etc.)
-- Session planning documents
-- Implementation roadmaps
-- Strategic initiatives
-
-**Lifecycle:**
-- Plans stay in 97-plans throughout their lifecycle
-- Status updated via metadata in file header
-- Implementation documented in 98-journals
-- Manually archived by user when no longer relevant
-
-**Naming:** Will be migrating to `YYYY-MM-DD-description.md` format
-
-### 98-journals: Chronological History
-
-**Purpose:** Complete project timeline in one place
-
-**Contents:**
-- Daily/weekly work logs
-- Deployment summaries
-- Strategic assessments
-- Implementation notes
-- Session summaries
-- Troubleshooting logs
-- Incident reports
-
-**Characteristics:**
-- **Flat structure** - All 92 files in one directory
-- **Chronologically sorted** - YYYY-MM-DD prefix enables natural sorting
-- **Immutable** - Never edited after creation (append-only log)
-- **Complete timeline** - Shows both tactical work AND strategic thinking
-
-**Why flat?**
-- Easier to browse chronologically: `ls 98-journals/2025-11-*.md`
-- Single source of truth for "what happened when"
-- Simplifies navigation vs. multi-directory search
-
-### 99-reports: System State Snapshots
-
-**Purpose:** Machine-generated reports and formal state documentation
-
-**Contents:**
-- **Automated JSON reports:**
-  - `intel-YYYYMMDD-HHMMSS.json` - Daily system health (used by automation)
-  - `resource-forecast-YYYYMMDD-HHMMSS.json` - Predictive analytics
-  - `weekly-latest.json` - Weekly rollup
-- **Formal snapshots:**
-  - `SYSTEM-STATE-YYYY-MM-DD.md` - Infrastructure state documentation
-
-**Automation dependencies:**
-- `weekly-intelligence-report.sh` reads last 7 `intel-*.json` files
-- `autonomous-check.sh` reads latest `intel-*.json`
-- **DO NOT rename JSON files** - glob patterns are hardcoded
-
----
-
-## 🛠️ Common Tasks
-
-### Deploying a New Service
-
-1. Check architectural fit (networking, security, resources)
-2. Create journal entry: `98-journals/YYYY-MM-DD-<service>-deployment.md`
-3. Deploy and test (use deployment patterns from `.claude/skills/homelab-deployment/`)
-4. Create/update service guide: `10-services/guides/<service>.md`
-5. If architectural decision made, create ADR: `*/decisions/YYYY-MM-DD-decision-NNN-<title>.md`
-
-### Planning a New Project
-
-1. Create plan: `97-plans/<descriptive-name>.md` (will migrate to dated format)
-2. Add status metadata in file header
-3. As work progresses, document in `98-journals/YYYY-MM-DD-<work-log>.md`
-4. Update plan status when completed
-
-### Regular Maintenance
-
-**Weekly:**
-- Review `podman ps` for service health
-- Check disk usage: `df -h / /mnt/btrfs-pool`
-- Review monitoring dashboards
-
-**Monthly:**
-- Update service guides if configurations changed
-- Review planning documents for progress
-- Check for documentation needing archival
-
-**Quarterly:**
-- Full documentation audit (review all guides for accuracy)
-- Update documentation index (this file)
-- Review and clean up journals for potential archival
-
----
-
-## 🔍 Search Tips
-
-### Finding Files by Topic
-
-```bash
-# Search all documentation for a keyword
-grep -r "traefik" docs/ --include="*.md"
-
-# Find all guides
-find docs/*/guides -name "*.md"
-
-# Find journals from specific month
-ls -1 docs/98-journals/2025-11-*.md
-
-# Find all ADRs
-find docs/*/decisions -name "*.md"
-```
-
-### Finding Latest Information
-
-```bash
-# Most recently updated files
-find docs/ -name "*.md" -type f -mtime -7
-
-# Latest system health report
-./scripts/homelab-intel.sh
-
-# Most recent journal entries
-ls -1t docs/98-journals/*.md | head -10
-```
-
----
-
-## 📚 External Resources
-
-### Project Documentation
-- **CLAUDE.md** - AI assistant context and common commands
-- **CONTRIBUTING.md** - Documentation contribution guide
-- **README.md** - This file
-
-### Key Scripts
-- `scripts/homelab-intel.sh` - System health scoring + recommendations
-- `scripts/homelab-diagnose.sh` - Comprehensive diagnostics
-- `scripts/query-homelab.sh` - Natural language queries (cached)
-- `scripts/autonomous-check.sh` - OODA loop assessment
-
-See `docs/20-operations/guides/automation-reference.md` for complete script catalog.
-
----
-
-## 🎓 Learning Path
-
-### New to Homelabs
-
-Read journals chronologically to follow the learning journey:
-
-1. **Foundation** (Oct 20-22, 2025)
-   - 2025-10-20: Day 1 foundation learnings
-   - 2025-10-21: Day 2 networking exploration
-   - 2025-10-22: Day 3 pods exploration
-
-2. **First Services** (Oct 23-25)
-   - 2025-10-23: Jellyfin deployment
-   - 2025-10-25: Traefik quadlet migration
-
-3. **Security** (Oct 26-30)
-   - 2025-10-26: YubiKey inventory
-   - 2025-10-30: YubiKey success summary
-
-4. **Operational Maturity** (Nov 2025)
-   - 2025-11-06: Monitoring stack deployment
-   - 2025-11-07: Backup automation
-   - 2025-11-11: Authelia SSO deployment
-   - 2025-11-28: Autonomous operations activated
-
----
-
-## ❓ FAQ
-
-**Q: Where do I find the latest system state?**
-A: Run `./scripts/homelab-intel.sh` for current health, or check latest `99-reports/intel-*.json`
-
-**Q: Should I update an existing doc or create a new one?**
-A: Update guides (living docs), create new journal entries (dated logs). See CONTRIBUTING.md for details.
-
-**Q: Where do I document a new service deployment?**
-A: Create journal entry in `98-journals/YYYY-MM-DD-<service>-deployment.md`, then create/update guide in `10-services/guides/<service>.md`
-
-**Q: What's the difference between plans and journals?**
-A: Plans are forward-looking (what we'll do). Journals are historical (what we did). Plans stay in 97-plans; implementation gets documented in 98-journals.
-
----
-
-## 🎯 Documentation Maturity
-
-**Current Status (Dec 18, 2025):**
-- ✅ Three-tier structure implemented (plans / journals / reports)
-- ✅ Flat journal directory for chronological browsing
-- ✅ 92 journal entries consolidated
-- ✅ 13 planning documents organized
-- ✅ Automated reports separated from human docs
-- ✅ Core service guides complete
-- ✅ Key ADRs written (ADR-001 through ADR-008)
-- ⏳ Plan files need YYYY-MM-DD prefix migration
-- ⏳ Next quarterly audit: March 2026
-
----
-
-## 📞 Getting Help
-
-**System issues:**
-- `./scripts/homelab-intel.sh` for health assessment
-- `./scripts/homelab-diagnose.sh` for diagnostics
-- Service guides in `10-services/guides/`
-
-**Natural language queries:**
-```bash
-./scripts/query-homelab.sh "what services are using the most memory?"
-./scripts/query-homelab.sh "is jellyfin running?"
-```
-
----
-
-**Remember:** Documentation is a love letter to your future self. Keep it current, clear, and kind. 💙
-
-**Last maintained:** 2025-12-18 by Claude Code
-**Review frequency:** Quarterly
-**Next review:** 2026-03-18
+*Documentation conventions, frontmatter schema, and the public/private boundary are specified in [CONTRIBUTING.md](CONTRIBUTING.md).*

--- a/scripts/check-vault-boundary.sh
+++ b/scripts/check-vault-boundary.sh
@@ -7,7 +7,8 @@
 # any staged markdown whose frontmatter declares it internal, no matter how it
 # got staged (copied out of the vault, symlink replaced by a real dir, ...).
 #
-# Exit 0 = clean, exit 1 = at least one staged file is marked internal/secret.
+# Exit 0 = clean, exit 1 = at least one staged file is marked internal/secret
+# or references a vault directory by path (ADR-043 link policy / ADR-048).
 
 set -euo pipefail
 
@@ -16,9 +17,19 @@ FAILED=0
 while IFS= read -r file; do
     [[ "$file" == *.md ]] || continue
     # Read the staged blob, not the worktree file
-    if git show ":$file" 2>/dev/null | head -30 \
+    staged=$(git show ":$file" 2>/dev/null) || continue
+    if head -30 <<<"$staged" \
         | grep -qE '^sensitivity:[[:space:]]*(internal|secret)[[:space:]]*$'; then
         echo "  ✗ $file is marked 'sensitivity: internal|secret' — belongs in the Huldr vault, not the public repo"
+        FAILED=1
+    fi
+    # Vault dirs must not be referenced by path in public docs — drop the
+    # reference or mention the doc by name only (ADR-043 D5). Files that must
+    # show such a path (boundary docs, faithful code listings) opt out with an
+    # <!-- allow-vault-paths --> comment anywhere in the file.
+    if ! grep -q 'allow-vault-paths' <<<"$staged" \
+        && grep -qE '9[0-9]-(archive|project-supervisor|plans|journals|reports)/' <<<"$staged"; then
+        echo "  ✗ $file references a private vault directory by path (docs/9x) — drop it or use a name-only mention; add <!-- allow-vault-paths --> only if the path is inside a boundary doc or faithful code listing"
         FAILED=1
     fi
 done < <(git diff --cached --name-only --diff-filter=ACM)


### PR DESCRIPTION
## Summary

Follow-up to #344 — the correction half of the public-docs refresh. Two commits: the sweep (36 guide files) and the enforcement/index pieces.

**Sweep (commit 1)** — four classes of stale claims corrected across the surviving public guides:
- **Secrets (ADR-041):** every `podman secret create/rm` instruction replaced with the OpenBao/`secretctl` consumption model (5 guides)
- **Updates (ADR-030/036):** `AutoUpdate=registry` examples, "auto-update enabled" claims, and `:latest` upgrade paths replaced with digest-pinning + the deliberate monthly loop; `automation-reference.md`'s timer table de-contradicted (auto-update and btrfs-backup rows out, `urd-backup` in, verified against live timers); ephemeral `podman run --rm` diagnostics deliberately kept as-is
- **Backups (ADR-021):** residual `btrfs-snapshot-backup.sh` instructions routed to Urd; the Immich checklist's backup section banner'd as historical
- **Vault paths (ADR-043):** `docs/9x` references dropped or reduced to name-only mentions
- Highlights: `monitoring-stack.md`'s false "podman secrets encrypted at rest" claim retracted; `homelab-architecture.md` refreshed to 37 containers / 17 groups / 12 networks incl. restricted-egress, decommissioned services removed, auth-model table corrected against routers.yml; `architecture-diagrams.md`'s October-2025 directory tree replaced; `crowdsec-phase1-field-manual.md` marked historical rather than modernized; `middleware-configuration.md`'s worked example moved from decommissioned Homepage to Grafana

**Enforcement + index (commit 2):**
- `check-vault-boundary.sh` gains a second check: staged public markdown referencing vault dirs by path is rejected; `<!-- allow-vault-paths -->` pragma for boundary docs and faithful code listings (3 files carry it). Tested both directions; commit 1's 36 files passed through the new check live.
- `CONTRIBUTING.md`: birth rule now sensitivity-then-audience (ADR-048, internal); meta-ADR placement + shared numbering documented; archive recipe fixed to the two-step vault-first move
- `docs/README.md`: rewritten as a curated index of the public 00-40 tree (the old index described journals/plans/reports as browsable repo content)

**Deliberately out of scope** (deferred work packages): DR runbooks (`DR-001` still references btrfs timers — goes with the Urd DR rewrite), historical ADRs, the 60-guide audience audit, per-guide version-number drift (e.g. Immich table versions).

## Test Plan

- [ ] Spot-check `homelab-architecture.md` network/auth tables against `AUTO-NETWORK-TOPOLOGY.md`
- [ ] `grep -rE '9[0-9]-(plans|journals|reports|archive)/' docs/{00,10,20,30,40}*` → only pragma'd files and historical ADRs
- [ ] Attempt to commit a doc containing a `docs/98-journals/...` path → pre-commit rejects it

🤖 Generated with [Claude Code](https://claude.com/claude-code)